### PR TITLE
Migrate all ability callbacks to WP_Error returns

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -102,20 +102,14 @@ function datamachine_code_register_system_abilities() {
 			),
 			'execute_callback'    => function ( array $input ) {
 				if ( ! class_exists( 'DataMachine\Engine\AI\System\TaskScheduler' ) ) {
-					return array(
-						'success' => false,
-						'error'   => 'TaskScheduler not available.',
-					);
+					return new \WP_Error( 'scheduler_unavailable', 'TaskScheduler not available.', array( 'status' => 500 ) );
 				}
 
 				$scheduler = new \DataMachine\Engine\AI\System\TaskScheduler();
 				$job_id    = $scheduler->schedule( 'github_create_issue', $input );
 
 				if ( is_wp_error( $job_id ) ) {
-					return array(
-						'success' => false,
-						'error'   => $job_id->get_error_message(),
-					);
+					return $job_id;
 				}
 
 				return $job_id;

--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -334,10 +334,10 @@ class GitHubAbilities {
 	// Ability Callbacks
 	// -------------------------------------------------------------------------
 
-	public static function listIssues( array $input ): array {
+	public static function listIssues( array $input ): array|\WP_Error {
 		$repo = sanitize_text_field( $input['repo'] ?? '' );
 		if ( empty( $repo ) ) {
-			return array( 'success' => false, 'error' => 'Repository is required (owner/repo format).' );
+			return new \WP_Error( 'missing_repo', 'Repository is required (owner/repo format).', array( 'status' => 400 ) );
 		}
 
 		$pat = self::getPat();
@@ -364,7 +364,7 @@ class GitHubAbilities {
 		$url      = sprintf( '%s/repos/%s/issues', self::API_BASE, $repo );
 		$response = self::apiGet( $url, $query_params, $pat );
 
-		if ( ! $response['success'] ) {
+		if ( is_wp_error( $response ) ) {
 			return $response;
 		}
 
@@ -376,12 +376,12 @@ class GitHubAbilities {
 		return array( 'success' => true, 'issues' => $normalized, 'count' => count( $normalized ) );
 	}
 
-	public static function getIssue( array $input ): array {
+	public static function getIssue( array $input ): array|\WP_Error {
 		$repo         = sanitize_text_field( $input['repo'] ?? '' );
 		$issue_number = (int) ( $input['issue_number'] ?? 0 );
 
 		if ( empty( $repo ) || $issue_number <= 0 ) {
-			return array( 'success' => false, 'error' => 'Repository (owner/repo) and issue_number are required.' );
+			return new \WP_Error( 'missing_params', 'Repository (owner/repo) and issue_number are required.', array( 'status' => 400 ) );
 		}
 
 		$pat = self::getPat();
@@ -392,19 +392,19 @@ class GitHubAbilities {
 		$url      = sprintf( '%s/repos/%s/issues/%d', self::API_BASE, $repo, $issue_number );
 		$response = self::apiGet( $url, array(), $pat );
 
-		if ( ! $response['success'] ) {
+		if ( is_wp_error( $response ) ) {
 			return $response;
 		}
 
 		return array( 'success' => true, 'issue' => self::normalizeIssue( $response['data'] ) );
 	}
 
-	public static function updateIssue( array $input ): array {
+	public static function updateIssue( array $input ): array|\WP_Error {
 		$repo         = sanitize_text_field( $input['repo'] ?? '' );
 		$issue_number = (int) ( $input['issue_number'] ?? 0 );
 
 		if ( empty( $repo ) || $issue_number <= 0 ) {
-			return array( 'success' => false, 'error' => 'Repository (owner/repo) and issue_number are required.' );
+			return new \WP_Error( 'missing_params', 'Repository (owner/repo) and issue_number are required.', array( 'status' => 400 ) );
 		}
 
 		$pat = self::getPat();
@@ -430,13 +430,13 @@ class GitHubAbilities {
 		}
 
 		if ( empty( $body ) ) {
-			return array( 'success' => false, 'error' => 'No fields to update. Provide title, body, state, labels, or assignees.' );
+			return new \WP_Error( 'no_fields', 'No fields to update. Provide title, body, state, labels, or assignees.', array( 'status' => 400 ) );
 		}
 
 		$url      = sprintf( '%s/repos/%s/issues/%d', self::API_BASE, $repo, $issue_number );
 		$response = self::apiRequest( 'PATCH', $url, $body, $pat );
 
-		if ( ! $response['success'] ) {
+		if ( is_wp_error( $response ) ) {
 			return $response;
 		}
 
@@ -447,15 +447,15 @@ class GitHubAbilities {
 		);
 	}
 
-	public static function createIssue( array $input ): array {
+	public static function createIssue( array $input ): array|\WP_Error {
 		$repo = self::resolveRepo( sanitize_text_field( $input['repo'] ?? '' ) );
 		if ( empty( $repo ) ) {
-			return array( 'success' => false, 'error' => 'Repository (owner/repo) is required or configure a default repo.' );
+			return new \WP_Error( 'missing_repo', 'Repository (owner/repo) is required or configure a default repo.', array( 'status' => 400 ) );
 		}
 
 		$title = sanitize_text_field( $input['title'] ?? '' );
 		if ( empty( $title ) ) {
-			return array( 'success' => false, 'error' => 'Issue title is required.' );
+			return new \WP_Error( 'missing_title', 'Issue title is required.', array( 'status' => 400 ) );
 		}
 
 		$pat = self::getPat();
@@ -478,7 +478,7 @@ class GitHubAbilities {
 		$url      = sprintf( '%s/repos/%s/issues', self::API_BASE, $repo );
 		$response = self::apiRequest( 'POST', $url, $body, $pat );
 
-		if ( ! $response['success'] ) {
+		if ( is_wp_error( $response ) ) {
 			return $response;
 		}
 
@@ -494,13 +494,13 @@ class GitHubAbilities {
 		);
 	}
 
-	public static function commentOnIssue( array $input ): array {
+	public static function commentOnIssue( array $input ): array|\WP_Error {
 		$repo         = sanitize_text_field( $input['repo'] ?? '' );
 		$issue_number = (int) ( $input['issue_number'] ?? 0 );
 		$body         = $input['body'] ?? '';
 
 		if ( empty( $repo ) || $issue_number <= 0 || empty( $body ) ) {
-			return array( 'success' => false, 'error' => 'Repository, issue_number, and body are required.' );
+			return new \WP_Error( 'missing_params', 'Repository, issue_number, and body are required.', array( 'status' => 400 ) );
 		}
 
 		$pat = self::getPat();
@@ -511,7 +511,7 @@ class GitHubAbilities {
 		$url      = sprintf( '%s/repos/%s/issues/%d/comments', self::API_BASE, $repo, $issue_number );
 		$response = self::apiRequest( 'POST', $url, array( 'body' => $body ), $pat );
 
-		if ( ! $response['success'] ) {
+		if ( is_wp_error( $response ) ) {
 			return $response;
 		}
 
@@ -526,10 +526,10 @@ class GitHubAbilities {
 		);
 	}
 
-	public static function listPulls( array $input ): array {
+	public static function listPulls( array $input ): array|\WP_Error {
 		$repo = sanitize_text_field( $input['repo'] ?? '' );
 		if ( empty( $repo ) ) {
-			return array( 'success' => false, 'error' => 'Repository is required (owner/repo format).' );
+			return new \WP_Error( 'missing_repo', 'Repository is required (owner/repo format).', array( 'status' => 400 ) );
 		}
 
 		$pat = self::getPat();
@@ -546,7 +546,7 @@ class GitHubAbilities {
 		$url      = sprintf( '%s/repos/%s/pulls', self::API_BASE, $repo );
 		$response = self::apiGet( $url, $query_params, $pat );
 
-		if ( ! $response['success'] ) {
+		if ( is_wp_error( $response ) ) {
 			return $response;
 		}
 
@@ -555,10 +555,10 @@ class GitHubAbilities {
 		return array( 'success' => true, 'pulls' => $normalized, 'count' => count( $normalized ) );
 	}
 
-	public static function listRepos( array $input ): array {
+	public static function listRepos( array $input ): array|\WP_Error {
 		$owner = sanitize_text_field( $input['owner'] ?? '' );
 		if ( empty( $owner ) ) {
-			return array( 'success' => false, 'error' => 'Owner (user or org) is required.' );
+			return new \WP_Error( 'missing_owner', 'Owner (user or org) is required.', array( 'status' => 400 ) );
 		}
 
 		$pat = self::getPat();
@@ -579,11 +579,11 @@ class GitHubAbilities {
 		$url      = sprintf( '%s/orgs/%s/repos', self::API_BASE, $owner );
 		$response = self::apiGet( $url, $query_params, $pat );
 
-		if ( ! $response['success'] ) {
+		if ( is_wp_error( $response ) ) {
 			$url      = sprintf( '%s/users/%s/repos', self::API_BASE, $owner );
 			$response = self::apiGet( $url, $query_params, $pat );
 
-			if ( ! $response['success'] ) {
+			if ( is_wp_error( $response ) ) {
 				return $response;
 			}
 		}
@@ -597,7 +597,7 @@ class GitHubAbilities {
 	// HTTP Helpers
 	// -------------------------------------------------------------------------
 
-	public static function apiGet( string $url, array $query_params, string $pat ): array {
+	public static function apiGet( string $url, array $query_params, string $pat ): array|\WP_Error {
 		if ( ! empty( $query_params ) ) {
 			$url = add_query_arg( $query_params, $url );
 		}
@@ -610,7 +610,7 @@ class GitHubAbilities {
 		return self::parseResponse( $response );
 	}
 
-	public static function apiRequest( string $method, string $url, array $body, string $pat ): array {
+	public static function apiRequest( string $method, string $url, array $body, string $pat ): array|\WP_Error {
 		$response = wp_remote_request( $url, array(
 			'method'  => $method,
 			'headers' => self::getHeaders( $pat ),
@@ -621,9 +621,9 @@ class GitHubAbilities {
 		return self::parseResponse( $response );
 	}
 
-	private static function parseResponse( $response ): array {
+	private static function parseResponse( $response ): array|\WP_Error {
 		if ( is_wp_error( $response ) ) {
-			return array( 'success' => false, 'error' => 'GitHub API request failed: ' . $response->get_error_message() );
+			return new \WP_Error( 'github_request_failed', 'GitHub API request failed: ' . $response->get_error_message(), array( 'status' => 500 ) );
 		}
 
 		$status_code = wp_remote_retrieve_response_code( $response );
@@ -631,7 +631,8 @@ class GitHubAbilities {
 
 		if ( $status_code >= 400 ) {
 			$message = $body['message'] ?? 'Unknown error';
-			return array( 'success' => false, 'error' => sprintf( 'GitHub API error (%d): %s', $status_code, $message ) );
+			$code    = $status_code >= 500 ? 'github_server_error' : ( 404 === $status_code ? 'github_not_found' : 'github_api_error' );
+			return new \WP_Error( $code, sprintf( 'GitHub API error (%d): %s', $status_code, $message ), array( 'status' => $status_code ) );
 		}
 
 		return array( 'success' => true, 'data' => $body );
@@ -766,8 +767,8 @@ class GitHubAbilities {
 		return '';
 	}
 
-	private static function patError(): array {
-		return array( 'success' => false, 'error' => 'GitHub Personal Access Token not configured. Set github_pat in Data Machine settings.' );
+	private static function patError(): \WP_Error {
+		return new \WP_Error( 'pat_not_configured', 'GitHub Personal Access Token not configured. Set github_pat in Data Machine settings.', array( 'status' => 403 ) );
 	}
 
 	private static function clampPerPage( $per_page ): int {

--- a/inc/Cli/Commands/GitHubCommand.php
+++ b/inc/Cli/Commands/GitHubCommand.php
@@ -73,8 +73,8 @@ class GitHubCommand extends BaseCommand {
 
 		$result = GitHubAbilities::listIssues( $input );
 
-		if ( empty( $result['success'] ) ) {
-			WP_CLI::error( $result['error'] ?? 'Failed to list issues.' );
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
 			return;
 		}
 
@@ -150,8 +150,8 @@ class GitHubCommand extends BaseCommand {
 
 		$result = GitHubAbilities::getIssue( $input );
 
-		if ( empty( $result['success'] ) ) {
-			WP_CLI::error( $result['error'] ?? 'Failed to fetch issue.' );
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
 			return;
 		}
 
@@ -227,16 +227,16 @@ class GitHubCommand extends BaseCommand {
 				'body'         => $assoc_args['comment'],
 			) );
 
-			if ( empty( $comment_result['success'] ) ) {
-				WP_CLI::warning( 'Failed to add comment: ' . ( $comment_result['error'] ?? 'Unknown error' ) );
+			if ( is_wp_error( $comment_result ) ) {
+				WP_CLI::warning( 'Failed to add comment: ' . $comment_result->get_error_message() );
 			}
 		}
 
 		$input['state'] = 'closed';
 		$result         = GitHubAbilities::updateIssue( $input );
 
-		if ( empty( $result['success'] ) ) {
-			WP_CLI::error( $result['error'] ?? 'Failed to close issue.' );
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
 			return;
 		}
 
@@ -282,8 +282,8 @@ class GitHubCommand extends BaseCommand {
 
 		$result = GitHubAbilities::commentOnIssue( $input );
 
-		if ( empty( $result['success'] ) ) {
-			WP_CLI::error( $result['error'] ?? 'Failed to add comment.' );
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
 			return;
 		}
 
@@ -331,8 +331,8 @@ class GitHubCommand extends BaseCommand {
 
 		$result = GitHubAbilities::listPulls( $input );
 
-		if ( empty( $result['success'] ) ) {
-			WP_CLI::error( $result['error'] ?? 'Failed to list pull requests.' );
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
 			return;
 		}
 
@@ -422,8 +422,8 @@ class GitHubCommand extends BaseCommand {
 
 		$result = GitHubAbilities::listRepos( $input );
 
-		if ( empty( $result['success'] ) ) {
-			WP_CLI::error( $result['error'] ?? 'Failed to list repositories.' );
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
 			return;
 		}
 

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -184,8 +184,8 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 
-		if ( ! $result['success'] ) {
-			WP_CLI::error( $result['message'] );
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
 			return;
 		}
 
@@ -242,8 +242,8 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 
-		if ( ! $result['success'] ) {
-			WP_CLI::error( $result['message'] );
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
 			return;
 		}
 
@@ -284,8 +284,8 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 
-		if ( ! $result['success'] ) {
-			WP_CLI::error( $result['message'] );
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
 			return;
 		}
 
@@ -376,8 +376,8 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 
-		if ( ! $result['success'] ) {
-			WP_CLI::error( $result['message'] );
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
 			return;
 		}
 
@@ -448,8 +448,8 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 
-		if ( ! $result['success'] ) {
-			WP_CLI::error( $result['message'] );
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
 			return;
 		}
 
@@ -552,8 +552,8 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 
-		if ( ! $result['success'] ) {
-			WP_CLI::error( $result['message'] );
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
 			return;
 		}
 
@@ -632,8 +632,8 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 
-		if ( ! $result['success'] ) {
-			WP_CLI::error( $result['message'] );
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
 			return;
 		}
 
@@ -842,8 +842,8 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 
-		if ( empty( $result['success'] ) ) {
-			WP_CLI::error( $result['message'] ?? 'Workspace git operation failed.' );
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
 			return;
 		}
 

--- a/inc/Handlers/GitHub/GitHub.php
+++ b/inc/Handlers/GitHub/GitHub.php
@@ -92,8 +92,8 @@ class GitHub extends FetchHandler {
 			$items  = $result['issues'] ?? array();
 		}
 
-		if ( ! $result['success'] ) {
-			$context->log( 'error', 'GitHub: API error — ' . ( $result['error'] ?? 'Unknown' ) );
+		if ( is_wp_error( $result ) ) {
+			$context->log( 'error', 'GitHub: API error — ' . $result->get_error_message() );
 			return array();
 		}
 

--- a/inc/Tasks/GitHubIssueTask.php
+++ b/inc/Tasks/GitHubIssueTask.php
@@ -30,8 +30,8 @@ class GitHubIssueTask extends SystemTask {
 	public function execute( int $jobId, array $params ): void {
 		$result = GitHubAbilities::createIssue( $params );
 
-		if ( ! $result['success'] ) {
-			$this->failJob( $jobId, $result['error'] ?? 'Unknown error creating GitHub issue' );
+		if ( is_wp_error( $result ) ) {
+			$this->failJob( $jobId, $result->get_error_message() );
 			return;
 		}
 

--- a/inc/Tools/GitHubIssueTool.php
+++ b/inc/Tools/GitHubIssueTool.php
@@ -41,7 +41,7 @@ class GitHubIssueTool extends BaseTool {
 	 * @return array Result with pending status on success.
 	 */
 	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
-		$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'datamachine/create-github-issue' ) : null;
+		$ability = wp_get_ability( 'datamachine/create-github-issue' );
 
 		if ( ! $ability ) {
 			return $this->buildErrorResponse(

--- a/inc/Tools/GitHubTools.php
+++ b/inc/Tools/GitHubTools.php
@@ -101,8 +101,8 @@ class GitHubTools extends BaseTool {
 	public function handleListIssues( array $parameters, array $tool_def = array() ): array {
 		$result = GitHubAbilities::listIssues( $parameters );
 
-		if ( empty( $result['success'] ) ) {
-			return $this->buildErrorResponse( $result['error'] ?? 'Failed to list issues.', 'list_github_issues' );
+		if ( is_wp_error( $result ) ) {
+			return $this->buildErrorResponse( $result->get_error_message(), 'list_github_issues' );
 		}
 
 		return array(
@@ -161,8 +161,8 @@ class GitHubTools extends BaseTool {
 	public function handleGetIssue( array $parameters, array $tool_def = array() ): array {
 		$result = GitHubAbilities::getIssue( $parameters );
 
-		if ( empty( $result['success'] ) ) {
-			return $this->buildErrorResponse( $result['error'] ?? 'Failed to get issue.', 'get_github_issue' );
+		if ( is_wp_error( $result ) ) {
+			return $this->buildErrorResponse( $result->get_error_message(), 'get_github_issue' );
 		}
 
 		return array(
@@ -223,8 +223,8 @@ class GitHubTools extends BaseTool {
 			$result = GitHubAbilities::updateIssue( $parameters );
 		}
 
-		if ( empty( $result['success'] ) ) {
-			return $this->buildErrorResponse( $result['error'] ?? 'Failed to manage issue.', 'manage_github_issue' );
+		if ( is_wp_error( $result ) ) {
+			return $this->buildErrorResponse( $result->get_error_message(), 'manage_github_issue' );
 		}
 
 		return array(
@@ -293,8 +293,8 @@ class GitHubTools extends BaseTool {
 	public function handleListPulls( array $parameters, array $tool_def = array() ): array {
 		$result = GitHubAbilities::listPulls( $parameters );
 
-		if ( empty( $result['success'] ) ) {
-			return $this->buildErrorResponse( $result['error'] ?? 'Failed to list pull requests.', 'list_github_pulls' );
+		if ( is_wp_error( $result ) ) {
+			return $this->buildErrorResponse( $result->get_error_message(), 'list_github_pulls' );
 		}
 
 		return array(
@@ -343,8 +343,8 @@ class GitHubTools extends BaseTool {
 	public function handleListRepos( array $parameters, array $tool_def = array() ): array {
 		$result = GitHubAbilities::listRepos( $parameters );
 
-		if ( empty( $result['success'] ) ) {
-			return $this->buildErrorResponse( $result['error'] ?? 'Failed to list repos.', 'list_github_repos' );
+		if ( is_wp_error( $result ) ) {
+			return $this->buildErrorResponse( $result->get_error_message(), 'list_github_repos' );
 		}
 
 		return array(

--- a/inc/Tools/WorkspaceTools.php
+++ b/inc/Tools/WorkspaceTools.php
@@ -23,7 +23,7 @@ class WorkspaceTools extends BaseTool {
 	 * @return bool
 	 */
 	public static function is_configured(): bool {
-		return function_exists( 'wp_get_ability' );
+		return (bool) wp_get_ability( 'datamachine/workspace-path' );
 	}
 
 	/**
@@ -101,13 +101,6 @@ class WorkspaceTools extends BaseTool {
 			return $this->buildErrorResponse( $result->get_error_message(), 'workspace_path' );
 		}
 
-		if ( ! $this->isAbilitySuccess( $result ) ) {
-			return $this->buildErrorResponse(
-				$this->getAbilityError( $result, 'Failed to get workspace path.' ),
-				'workspace_path'
-			);
-		}
-
 		return array(
 			'success'   => true,
 			'data'      => $result,
@@ -131,13 +124,6 @@ class WorkspaceTools extends BaseTool {
 
 		if ( is_wp_error( $result ) ) {
 			return $this->buildErrorResponse( $result->get_error_message(), 'workspace_list' );
-		}
-
-		if ( ! $this->isAbilitySuccess( $result ) ) {
-			return $this->buildErrorResponse(
-				$this->getAbilityError( $result, 'Failed to list workspace repositories.' ),
-				'workspace_list'
-			);
 		}
 
 		return array(
@@ -170,13 +156,6 @@ class WorkspaceTools extends BaseTool {
 			return $this->buildErrorResponse( $result->get_error_message(), 'workspace_show' );
 		}
 
-		if ( ! $this->isAbilitySuccess( $result ) ) {
-			return $this->buildErrorResponse(
-				$this->getAbilityError( $result, 'Failed to get workspace repository details.' ),
-				'workspace_show'
-			);
-		}
-
 		return array(
 			'success'   => true,
 			'data'      => $result,
@@ -206,13 +185,6 @@ class WorkspaceTools extends BaseTool {
 
 		if ( is_wp_error( $result ) ) {
 			return $this->buildErrorResponse( $result->get_error_message(), 'workspace_ls' );
-		}
-
-		if ( ! $this->isAbilitySuccess( $result ) ) {
-			return $this->buildErrorResponse(
-				$this->getAbilityError( $result, 'Failed to list workspace directory.' ),
-				'workspace_ls'
-			);
 		}
 
 		return array(
@@ -256,13 +228,6 @@ class WorkspaceTools extends BaseTool {
 
 		if ( is_wp_error( $result ) ) {
 			return $this->buildErrorResponse( $result->get_error_message(), 'workspace_read' );
-		}
-
-		if ( ! $this->isAbilitySuccess( $result ) ) {
-			return $this->buildErrorResponse(
-				$this->getAbilityError( $result, 'Failed to read workspace file.' ),
-				'workspace_read'
-			);
 		}
 
 		return array(

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -86,17 +86,13 @@ class Workspace {
 	/**
 	 * Ensure the workspace directory exists with correct permissions.
 	 *
-	 * @return array{success: bool, path: string, message?: string, created?: bool}
+	 * @return array{success: bool, path: string, created?: bool}|\WP_Error
 	 */
-	public function ensure_exists(): array {
+	public function ensure_exists(): array|\WP_Error {
 		$path = $this->workspace_path;
 
 		if ( '' === $path ) {
-			return array(
-				'success' => false,
-				'path'    => '',
-				'message' => 'Workspace unavailable: no writable path outside the web root. Define DATAMACHINE_WORKSPACE_PATH in wp-config.php or ensure /var/lib/datamachine/ is writable.',
-			);
+			return new \WP_Error( 'workspace_unavailable', 'Workspace unavailable: no writable path outside the web root. Define DATAMACHINE_WORKSPACE_PATH in wp-config.php or ensure /var/lib/datamachine/ is writable.', array( 'status' => 500 ) );
 		}
 
 		if ( is_dir( $path ) ) {
@@ -111,11 +107,7 @@ class Workspace {
 		$created = wp_mkdir_p( $path );
 
 		if ( ! $created ) {
-			return array(
-				'success' => false,
-				'path'    => $path,
-				'message' => sprintf( 'Failed to create workspace directory: %s', $path ),
-			);
+			return new \WP_Error( 'workspace_create_failed', sprintf( 'Failed to create workspace directory: %s', $path ), array( 'status' => 500 ) );
 		}
 
 		// Set permissions for multi-user access (web server group).
@@ -194,25 +186,19 @@ class Workspace {
 	 *
 	 * @param string      $url  Git clone URL.
 	 * @param string|null $name Directory name override (derived from URL if null).
-	 * @return array{success: bool, name?: string, path?: string, message?: string}
+	 * @return array{success: bool, name?: string, path?: string, message?: string}|\WP_Error
 	 */
-	public function clone_repo( string $url, ?string $name = null ): array {
+	public function clone_repo( string $url, ?string $name = null ): array|\WP_Error {
 		// Validate URL.
 		if ( empty( $url ) ) {
-			return array(
-				'success' => false,
-				'message' => 'Repository URL is required.',
-			);
+			return new \WP_Error( 'missing_url', 'Repository URL is required.', array( 'status' => 400 ) );
 		}
 
 		// Derive name from URL if not provided.
 		if ( null === $name || '' === $name ) {
 			$name = $this->derive_repo_name( $url );
 			if ( null === $name ) {
-				return array(
-					'success' => false,
-					'message' => sprintf( 'Could not derive repository name from URL: %s. Use --name to specify.', $url ),
-				);
+				return new \WP_Error( 'invalid_url', sprintf( 'Could not derive repository name from URL: %s. Use --name to specify.', $url ), array( 'status' => 400 ) );
 			}
 		}
 
@@ -221,17 +207,12 @@ class Workspace {
 
 		// Check if already exists.
 		if ( is_dir( $repo_path ) ) {
-			return array(
-				'success' => false,
-				'name'    => $name,
-				'path'    => $repo_path,
-				'message' => sprintf( 'Directory already exists: %s. Use "remove" first to re-clone.', $name ),
-			);
+			return new \WP_Error( 'repo_exists', sprintf( 'Directory already exists: %s. Use "remove" first to re-clone.', $name ), array( 'status' => 400 ) );
 		}
 
 		// Ensure workspace exists.
 		$ensure = $this->ensure_exists();
-		if ( ! $ensure['success'] ) {
+		if ( is_wp_error( $ensure ) ) {
 			return $ensure;
 		}
 
@@ -244,11 +225,7 @@ class Workspace {
 		exec( $command, $output, $exit_code );
 
 		if ( 0 !== $exit_code ) {
-			return array(
-				'success' => false,
-				'name'    => $name,
-				'message' => sprintf( 'Git clone failed (exit %d): %s', $exit_code, implode( "\n", $output ) ),
-			);
+			return new \WP_Error( 'clone_failed', sprintf( 'Git clone failed (exit %d): %s', $exit_code, implode( "\n", $output ) ), array( 'status' => 500 ) );
 		}
 
 		return array(
@@ -263,26 +240,20 @@ class Workspace {
 	 * Remove a repository from the workspace.
 	 *
 	 * @param string $name Repository directory name.
-	 * @return array{success: bool, message: string}
+	 * @return array{success: bool, message: string}|\WP_Error
 	 */
-	public function remove_repo( string $name ): array {
+	public function remove_repo( string $name ): array|\WP_Error {
 		$name      = $this->sanitize_name( $name );
 		$repo_path = $this->workspace_path . '/' . $name;
 
 		if ( ! is_dir( $repo_path ) ) {
-			return array(
-				'success' => false,
-				'message' => sprintf( 'Repository "%s" not found in workspace.', $name ),
-			);
+			return new \WP_Error( 'repo_not_found', sprintf( 'Repository "%s" not found in workspace.', $name ), array( 'status' => 404 ) );
 		}
 
 		// Safety: ensure path is within workspace.
 		$validation = $this->validate_containment( $repo_path, $this->workspace_path );
 		if ( ! $validation['valid'] ) {
-			return array(
-				'success' => false,
-				'message' => $validation['message'],
-			);
+			return new \WP_Error( 'path_traversal', $validation['message'], array( 'status' => 403 ) );
 		}
 
 		// Remove recursively.
@@ -291,10 +262,7 @@ class Workspace {
 		exec( sprintf( 'rm -rf %s 2>&1', $escaped ), $output, $exit_code );
 
 		if ( 0 !== $exit_code ) {
-			return array(
-				'success' => false,
-				'message' => sprintf( 'Failed to remove (exit %d): %s', $exit_code, implode( "\n", $output ) ),
-			);
+			return new \WP_Error( 'remove_failed', sprintf( 'Failed to remove (exit %d): %s', $exit_code, implode( "\n", $output ) ), array( 'status' => 500 ) );
 		}
 
 		return array(
@@ -307,17 +275,14 @@ class Workspace {
 	 * Show detailed info about a workspace repo.
 	 *
 	 * @param string $name Repository directory name.
-	 * @return array{success: bool, name?: string, path?: string, branch?: string, remote?: string, commit?: string, dirty?: int, message?: string}
+	 * @return array{success: bool, name?: string, path?: string, branch?: string, remote?: string, commit?: string, dirty?: int}|\WP_Error
 	 */
-	public function show_repo( string $name ): array {
+	public function show_repo( string $name ): array|\WP_Error {
 		$name      = $this->sanitize_name( $name );
 		$repo_path = $this->workspace_path . '/' . $name;
 
 		if ( ! is_dir( $repo_path ) ) {
-			return array(
-				'success' => false,
-				'message' => sprintf( 'Repository "%s" not found in workspace.', $name ),
-			);
+			return new \WP_Error( 'repo_not_found', sprintf( 'Repository "%s" not found in workspace.', $name ), array( 'status' => 404 ) );
 		}
 
 		$escaped = escapeshellarg( $repo_path );
@@ -346,14 +311,14 @@ class Workspace {
 	 * @param string $name Repository directory name.
 	 * @return array
 	 */
-	public function git_status( string $name ): array {
+	public function git_status( string $name ): array|\WP_Error {
 		$repo_path = $this->resolve_repo_path( $name );
-		if ( is_array( $repo_path ) ) {
+		if ( is_wp_error( $repo_path ) ) {
 			return $repo_path;
 		}
 
 		$status_result = $this->run_git( $repo_path, 'status --porcelain' );
-		if ( ! $status_result['success'] ) {
+		if ( is_wp_error( $status_result ) ) {
 			return $status_result;
 		}
 
@@ -367,9 +332,9 @@ class Workspace {
 			'success' => true,
 			'name'    => $this->sanitize_name( $name ),
 			'path'    => $repo_path,
-			'branch'  => $branch_result['success'] ? trim( (string) $branch_result['output'] ) : null,
-			'remote'  => $remote_result['success'] ? trim( (string) $remote_result['output'] ) : null,
-			'commit'  => $latest_result['success'] ? trim( (string) $latest_result['output'] ) : null,
+			'branch'  => ! is_wp_error( $branch_result ) ? trim( (string) $branch_result['output'] ) : null,
+			'remote'  => ! is_wp_error( $remote_result ) ? trim( (string) $remote_result['output'] ) : null,
+			'commit'  => ! is_wp_error( $latest_result ) ? trim( (string) $latest_result['output'] ) : null,
 			'dirty'   => count( $files ),
 			'files'   => array_values( $files ),
 		);
@@ -382,32 +347,29 @@ class Workspace {
 	 * @param bool   $allow_dirty Allow pull with dirty working tree.
 	 * @return array
 	 */
-	public function git_pull( string $name, bool $allow_dirty = false ): array {
+	public function git_pull( string $name, bool $allow_dirty = false ): array|\WP_Error {
 		$repo_path = $this->resolve_repo_path( $name );
-		if ( is_array( $repo_path ) ) {
+		if ( is_wp_error( $repo_path ) ) {
 			return $repo_path;
 		}
 
 		$policy_check = $this->ensure_git_mutation_allowed( $this->sanitize_name( $name ) );
-		if ( ! $policy_check['success'] ) {
+		if ( is_wp_error( $policy_check ) ) {
 			return $policy_check;
 		}
 
 		$status = $this->git_status( $name );
-		if ( ! $status['success'] ) {
+		if ( is_wp_error( $status ) ) {
 			return $status;
 		}
 
 		if ( ! $allow_dirty && ( $status['dirty'] ?? 0 ) > 0 ) {
-			return array(
-				'success' => false,
-				'message' => 'Working tree is dirty. Commit/stash changes first or pass allow_dirty=true.',
-			);
+			return new \WP_Error( 'dirty_working_tree', 'Working tree is dirty. Commit/stash changes first or pass allow_dirty=true.', array( 'status' => 400 ) );
 		}
 
 		$result = $this->run_git( $repo_path, 'pull --ff-only' );
 
-		if ( ! $result['success'] ) {
+		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
 
@@ -425,31 +387,25 @@ class Workspace {
 	 * @param array  $paths Relative paths to stage.
 	 * @return array
 	 */
-	public function git_add( string $name, array $paths ): array {
+	public function git_add( string $name, array $paths ): array|\WP_Error {
 		$repo_name = $this->sanitize_name( $name );
 		$repo_path = $this->resolve_repo_path( $name );
-		if ( is_array( $repo_path ) ) {
+		if ( is_wp_error( $repo_path ) ) {
 			return $repo_path;
 		}
 
 		$policy_check = $this->ensure_git_mutation_allowed( $repo_name );
-		if ( ! $policy_check['success'] ) {
+		if ( is_wp_error( $policy_check ) ) {
 			return $policy_check;
 		}
 
 		if ( empty( $paths ) ) {
-			return array(
-				'success' => false,
-				'message' => 'At least one path is required for git add.',
-			);
+			return new \WP_Error( 'missing_paths', 'At least one path is required for git add.', array( 'status' => 400 ) );
 		}
 
 		$allowed_roots = $this->get_repo_allowed_paths( $repo_name );
 		if ( empty( $allowed_roots ) ) {
-			return array(
-				'success' => false,
-				'message' => sprintf( 'No allowed paths configured for repo "%s".', $repo_name ),
-			);
+			return new \WP_Error( 'no_allowed_paths', sprintf( 'No allowed paths configured for repo "%s".', $repo_name ), array( 'status' => 403 ) );
 		}
 
 		$clean_paths = array();
@@ -460,40 +416,28 @@ class Workspace {
 			}
 
 			if ( $this->has_traversal( $relative ) || str_starts_with( $relative, '/' ) ) {
-				return array(
-					'success' => false,
-					'message' => sprintf( 'Invalid path for git add: %s', $relative ),
-				);
+				return new \WP_Error( 'invalid_path', sprintf( 'Invalid path for git add: %s', $relative ), array( 'status' => 400 ) );
 			}
 
 			if ( $this->is_sensitive_path( $relative ) ) {
-				return array(
-					'success' => false,
-					'message' => sprintf( 'Refusing to stage sensitive path: %s', $relative ),
-				);
+				return new \WP_Error( 'sensitive_path', sprintf( 'Refusing to stage sensitive path: %s', $relative ), array( 'status' => 403 ) );
 			}
 
 			if ( ! $this->is_path_allowed( $relative, $allowed_roots ) ) {
-				return array(
-					'success' => false,
-					'message' => sprintf( 'Path "%s" is outside configured allowlist.', $relative ),
-				);
+				return new \WP_Error( 'path_not_allowed', sprintf( 'Path "%s" is outside configured allowlist.', $relative ), array( 'status' => 403 ) );
 			}
 
 			$clean_paths[] = $relative;
 		}
 
 		if ( empty( $clean_paths ) ) {
-			return array(
-				'success' => false,
-				'message' => 'No valid paths provided for git add.',
-			);
+			return new \WP_Error( 'no_valid_paths', 'No valid paths provided for git add.', array( 'status' => 400 ) );
 		}
 
 		$escaped_paths = array_map( 'escapeshellarg', $clean_paths );
 		$result        = $this->run_git( $repo_path, 'add -- ' . implode( ' ', $escaped_paths ) );
 
-		if ( ! $result['success'] ) {
+		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
 
@@ -512,55 +456,43 @@ class Workspace {
 	 * @param string $message Commit message.
 	 * @return array
 	 */
-	public function git_commit( string $name, string $message ): array {
+	public function git_commit( string $name, string $message ): array|\WP_Error {
 		$repo_name = $this->sanitize_name( $name );
 		$repo_path = $this->resolve_repo_path( $name );
-		if ( is_array( $repo_path ) ) {
+		if ( is_wp_error( $repo_path ) ) {
 			return $repo_path;
 		}
 
 		$policy_check = $this->ensure_git_mutation_allowed( $repo_name, true );
-		if ( ! $policy_check['success'] ) {
+		if ( is_wp_error( $policy_check ) ) {
 			return $policy_check;
 		}
 
 		$message = trim( $message );
 		if ( '' === $message ) {
-			return array(
-				'success' => false,
-				'message' => 'Commit message is required.',
-			);
+			return new \WP_Error( 'missing_message', 'Commit message is required.', array( 'status' => 400 ) );
 		}
 
 		if ( strlen( $message ) < 8 ) {
-			return array(
-				'success' => false,
-				'message' => 'Commit message must be at least 8 characters.',
-			);
+			return new \WP_Error( 'message_too_short', 'Commit message must be at least 8 characters.', array( 'status' => 400 ) );
 		}
 
 		if ( strlen( $message ) > 200 ) {
-			return array(
-				'success' => false,
-				'message' => 'Commit message must be 200 characters or fewer.',
-			);
+			return new \WP_Error( 'message_too_long', 'Commit message must be 200 characters or fewer.', array( 'status' => 400 ) );
 		}
 
 		$staged = $this->run_git( $repo_path, 'diff --cached --name-only' );
-		if ( ! $staged['success'] ) {
+		if ( is_wp_error( $staged ) ) {
 			return $staged;
 		}
 
 		$staged_files = array_filter( array_map( 'trim', explode( "\n", $staged['output'] ?? '' ) ) );
 		if ( empty( $staged_files ) ) {
-			return array(
-				'success' => false,
-				'message' => 'No staged changes to commit.',
-			);
+			return new \WP_Error( 'nothing_staged', 'No staged changes to commit.', array( 'status' => 400 ) );
 		}
 
 		$commit = $this->run_git( $repo_path, 'commit -m ' . escapeshellarg( $message ) );
-		if ( ! $commit['success'] ) {
+		if ( is_wp_error( $commit ) ) {
 			return $commit;
 		}
 
@@ -580,20 +512,20 @@ class Workspace {
 	 * @param string|null $branch Branch override.
 	 * @return array
 	 */
-	public function git_push( string $name, string $remote = 'origin', ?string $branch = null ): array {
+	public function git_push( string $name, string $remote = 'origin', ?string $branch = null ): array|\WP_Error {
 		$repo_name = $this->sanitize_name( $name );
 		$repo_path = $this->resolve_repo_path( $name );
-		if ( is_array( $repo_path ) ) {
+		if ( is_wp_error( $repo_path ) ) {
 			return $repo_path;
 		}
 
 		$policy_check = $this->ensure_git_mutation_allowed( $repo_name, true );
-		if ( ! $policy_check['success'] ) {
+		if ( is_wp_error( $policy_check ) ) {
 			return $policy_check;
 		}
 
 		$current_branch_result = $this->run_git( $repo_path, 'rev-parse --abbrev-ref HEAD' );
-		if ( ! $current_branch_result['success'] ) {
+		if ( is_wp_error( $current_branch_result ) ) {
 			return $current_branch_result;
 		}
 
@@ -602,16 +534,13 @@ class Workspace {
 
 		$fixed_branch = $this->get_repo_fixed_branch( $repo_name );
 		if ( null !== $fixed_branch && $target_branch !== $fixed_branch ) {
-			return array(
-				'success' => false,
-				'message' => sprintf( 'Push blocked: repo "%s" is restricted to branch "%s".', $repo_name, $fixed_branch ),
-			);
+			return new \WP_Error( 'branch_restricted', sprintf( 'Push blocked: repo "%s" is restricted to branch "%s".', $repo_name, $fixed_branch ), array( 'status' => 403 ) );
 		}
 
 		$cmd    = sprintf( 'push %s %s', escapeshellarg( $remote ), escapeshellarg( $target_branch ) );
 		$result = $this->run_git( $repo_path, $cmd );
 
-		if ( ! $result['success'] ) {
+		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
 
@@ -631,9 +560,9 @@ class Workspace {
 	 * @param int    $limit Number of entries.
 	 * @return array
 	 */
-	public function git_log( string $name, int $limit = 20 ): array {
+	public function git_log( string $name, int $limit = 20 ): array|\WP_Error {
 		$repo_path = $this->resolve_repo_path( $name );
-		if ( is_array( $repo_path ) ) {
+		if ( is_wp_error( $repo_path ) ) {
 			return $repo_path;
 		}
 
@@ -641,7 +570,7 @@ class Workspace {
 		$cmd   = sprintf( 'log -n %d --pretty=format:%s', $limit, escapeshellarg( '%h|%an|%ad|%s' ) );
 		$log   = $this->run_git( $repo_path, $cmd );
 
-		if ( ! $log['success'] ) {
+		if ( is_wp_error( $log ) ) {
 			return $log;
 		}
 
@@ -678,9 +607,9 @@ class Workspace {
 	 * @param string|null $path   Optional relative path filter.
 	 * @return array
 	 */
-	public function git_diff( string $name, ?string $from = null, ?string $to = null, bool $staged = false, ?string $path = null ): array {
+	public function git_diff( string $name, ?string $from = null, ?string $to = null, bool $staged = false, ?string $path = null ): array|\WP_Error {
 		$repo_path = $this->resolve_repo_path( $name );
-		if ( is_array( $repo_path ) ) {
+		if ( is_wp_error( $repo_path ) ) {
 			return $repo_path;
 		}
 
@@ -700,10 +629,7 @@ class Workspace {
 		if ( ! empty( $path ) ) {
 			$relative = trim( $path );
 			if ( $this->has_traversal( $relative ) || str_starts_with( $relative, '/' ) ) {
-				return array(
-					'success' => false,
-					'message' => sprintf( 'Invalid diff path: %s', $relative ),
-				);
+				return new \WP_Error( 'invalid_path', sprintf( 'Invalid diff path: %s', $relative ), array( 'status' => 400 ) );
 			}
 
 			$args[] = '--';
@@ -711,7 +637,7 @@ class Workspace {
 		}
 
 		$diff = $this->run_git( $repo_path, implode( ' ', $args ) );
-		if ( ! $diff['success'] ) {
+		if ( is_wp_error( $diff ) ) {
 			return $diff;
 		}
 
@@ -794,32 +720,23 @@ class Workspace {
 	 * Resolve and validate repository path by name.
 	 *
 	 * @param string $name Repository name.
-	 * @return string|array String path on success, error array on failure.
+	 * @return string|\WP_Error String path on success, WP_Error on failure.
 	 */
-	private function resolve_repo_path( string $name ): string|array {
+	private function resolve_repo_path( string $name ): string|\WP_Error {
 		$sanitized = $this->sanitize_name( $name );
 		$repo_path = $this->workspace_path . '/' . $sanitized;
 
 		if ( ! is_dir( $repo_path ) ) {
-			return array(
-				'success' => false,
-				'message' => sprintf( 'Repository "%s" not found in workspace.', $sanitized ),
-			);
+			return new \WP_Error( 'repo_not_found', sprintf( 'Repository "%s" not found in workspace.', $sanitized ), array( 'status' => 404 ) );
 		}
 
 		if ( ! is_dir( $repo_path . '/.git' ) ) {
-			return array(
-				'success' => false,
-				'message' => sprintf( 'Repository "%s" is not a git repository.', $sanitized ),
-			);
+			return new \WP_Error( 'not_git_repo', sprintf( 'Repository "%s" is not a git repository.', $sanitized ), array( 'status' => 400 ) );
 		}
 
 		$validation = $this->validate_containment( $repo_path, $this->workspace_path );
 		if ( ! $validation['valid'] ) {
-			return array(
-				'success' => false,
-				'message' => $validation['message'],
-			);
+			return new \WP_Error( 'path_traversal', $validation['message'], array( 'status' => 403 ) );
 		}
 
 		return $validation['real_path'];
@@ -832,7 +749,7 @@ class Workspace {
 	 * @param string $git_args  Git arguments (without leading "git").
 	 * @return array
 	 */
-	private function run_git( string $repo_path, string $git_args ): array {
+	private function run_git( string $repo_path, string $git_args ): array|\WP_Error {
 		$escaped_repo = escapeshellarg( $repo_path );
 		$command      = sprintf( 'git -C %s %s 2>&1', $escaped_repo, $git_args );
 
@@ -840,11 +757,7 @@ class Workspace {
 		exec( $command, $output, $exit_code );
 
 		if ( 0 !== $exit_code ) {
-			return array(
-				'success' => false,
-				'message' => sprintf( 'Git command failed (exit %d): %s', $exit_code, implode( "\n", $output ) ),
-				'output'  => implode( "\n", $output ),
-			);
+			return new \WP_Error( 'git_command_failed', sprintf( 'Git command failed (exit %d): %s', $exit_code, implode( "\n", $output ) ), array( 'status' => 500, 'output' => implode( "\n", $output ) ) );
 		}
 
 		return array(
@@ -860,25 +773,19 @@ class Workspace {
 	 * @param bool   $require_push Whether push must also be enabled.
 	 * @return array
 	 */
-	private function ensure_git_mutation_allowed( string $repo_name, bool $require_push = false ): array {
+	private function ensure_git_mutation_allowed( string $repo_name, bool $require_push = false ): true|\WP_Error {
 		$policies = $this->get_workspace_git_policies();
 		$repo     = $policies['repos'][ $repo_name ] ?? null;
 
 		if ( ! is_array( $repo ) || empty( $repo['write_enabled'] ) ) {
-			return array(
-				'success' => false,
-				'message' => sprintf( 'Git write operations are disabled for repo "%s".', $repo_name ),
-			);
+			return new \WP_Error( 'git_write_disabled', sprintf( 'Git write operations are disabled for repo "%s".', $repo_name ), array( 'status' => 403 ) );
 		}
 
 		if ( $require_push && empty( $repo['push_enabled'] ) ) {
-			return array(
-				'success' => false,
-				'message' => sprintf( 'Git push is disabled for repo "%s".', $repo_name ),
-			);
+			return new \WP_Error( 'git_push_disabled', sprintf( 'Git push is disabled for repo "%s".', $repo_name ), array( 'status' => 403 ) );
 		}
 
-		return array( 'success' => true );
+		return true;
 	}
 
 	/**

--- a/inc/Workspace/WorkspaceReader.php
+++ b/inc/Workspace/WorkspaceReader.php
@@ -35,76 +35,55 @@ class WorkspaceReader {
 	 * @param int        $max_size Maximum file size in bytes.
 	 * @param int|null   $offset   Line number to start reading from (1-indexed).
 	 * @param int|null   $limit    Maximum number of lines to return.
-	 * @return array{success: bool, content?: string, path?: string, size?: int, message?: string, lines_read?: int, offset?: int}
+	 * @return array{success: bool, content?: string, path?: string, size?: int, lines_read?: int, offset?: int}|\WP_Error
 	 */
-	public function read_file( string $name, string $path, int $max_size = Workspace::MAX_READ_SIZE, ?int $offset = null, ?int $limit = null ): array {
+	public function read_file( string $name, string $path, int $max_size = Workspace::MAX_READ_SIZE, ?int $offset = null, ?int $limit = null ): array|\WP_Error {
 		$repo_path = $this->workspace->get_repo_path( $name );
 		$path      = ltrim( $path, '/' );
 
 		if ( ! is_dir( $repo_path ) ) {
-			return array(
-				'success' => false,
-				'message' => sprintf( 'Repository "%s" not found in workspace.', $name ),
-			);
+			return new \WP_Error( 'repo_not_found', sprintf( 'Repository "%s" not found in workspace.', $name ), array( 'status' => 404 ) );
 		}
 
 		$file_path  = $repo_path . '/' . $path;
 		$validation = $this->workspace->validate_containment( $file_path, $repo_path );
 
 		if ( ! $validation['valid'] ) {
-			return array(
-				'success' => false,
-				'message' => $validation['message'],
-			);
+			return new \WP_Error( 'path_traversal', $validation['message'], array( 'status' => 403 ) );
 		}
 
 		$real_path = $validation['real_path'];
 
 		if ( ! is_file( $real_path ) ) {
-			return array(
-				'success' => false,
-				'message' => sprintf( 'File not found: %s', $path ),
-			);
+			return new \WP_Error( 'file_not_found', sprintf( 'File not found: %s', $path ), array( 'status' => 404 ) );
 		}
 
 		if ( ! is_readable( $real_path ) ) {
-			return array(
-				'success' => false,
-				'message' => sprintf( 'File not readable: %s', $path ),
-			);
+			return new \WP_Error( 'file_not_readable', sprintf( 'File not readable: %s', $path ), array( 'status' => 403 ) );
 		}
 
 		$size = filesize( $real_path );
 
 		if ( $size > $max_size ) {
-			return array(
-				'success' => false,
-				'message' => sprintf(
-					'File too large: %s (%s). Maximum: %s.',
-					$path,
-					size_format( $size ),
-					size_format( $max_size )
-				),
-			);
+			return new \WP_Error( 'file_too_large', sprintf(
+				'File too large: %s (%s). Maximum: %s.',
+				$path,
+				size_format( $size ),
+				size_format( $max_size )
+			), array( 'status' => 400 ) );
 		}
 
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		$content = file_get_contents( $real_path );
 
 		if ( false === $content ) {
-			return array(
-				'success' => false,
-				'message' => sprintf( 'Failed to read file: %s', $path ),
-			);
+			return new \WP_Error( 'read_failed', sprintf( 'Failed to read file: %s', $path ), array( 'status' => 500 ) );
 		}
 
 		// Detect binary: check for null bytes in first 8 KB.
 		$sample = substr( $content, 0, 8192 );
 		if ( false !== strpos( $sample, "\0" ) ) {
-			return array(
-				'success' => false,
-				'message' => sprintf( 'Binary file detected: %s. Only text files can be read.', $path ),
-			);
+			return new \WP_Error( 'binary_file', sprintf( 'Binary file detected: %s. Only text files can be read.', $path ), array( 'status' => 400 ) );
 		}
 
 		// Apply line offset and limit if specified.
@@ -147,16 +126,13 @@ class WorkspaceReader {
 	 *
 	 * @param string      $name Repository directory name.
 	 * @param string|null $path Relative directory path within the repo (null for root).
-	 * @return array{success: bool, repo?: string, path?: string, entries?: array, message?: string}
+	 * @return array{success: bool, repo?: string, path?: string, entries?: array}|\WP_Error
 	 */
-	public function list_directory( string $name, ?string $path = null ): array {
+	public function list_directory( string $name, ?string $path = null ): array|\WP_Error {
 		$repo_path = $this->workspace->get_repo_path( $name );
 
 		if ( ! is_dir( $repo_path ) ) {
-			return array(
-				'success' => false,
-				'message' => sprintf( 'Repository "%s" not found in workspace.', $name ),
-			);
+			return new \WP_Error( 'repo_not_found', sprintf( 'Repository "%s" not found in workspace.', $name ), array( 'status' => 404 ) );
 		}
 
 		$target_path = $repo_path;
@@ -168,20 +144,14 @@ class WorkspaceReader {
 			$validation = $this->workspace->validate_containment( $target_path, $repo_path );
 
 			if ( ! $validation['valid'] ) {
-				return array(
-					'success' => false,
-					'message' => $validation['message'],
-				);
+				return new \WP_Error( 'path_traversal', $validation['message'], array( 'status' => 403 ) );
 			}
 
 			$target_path = $validation['real_path'];
 		}
 
 		if ( ! is_dir( $target_path ) ) {
-			return array(
-				'success' => false,
-				'message' => sprintf( 'Directory not found: %s', $path ?? '/' ),
-			);
+			return new \WP_Error( 'directory_not_found', sprintf( 'Directory not found: %s', $path ?? '/' ), array( 'status' => 404 ) );
 		}
 
 		$entries = scandir( $target_path );

--- a/inc/Workspace/WorkspaceWriter.php
+++ b/inc/Workspace/WorkspaceWriter.php
@@ -43,32 +43,23 @@ class WorkspaceWriter {
 	 * @param string $name    Repository directory name.
 	 * @param string $path    Relative file path within the repo.
 	 * @param string $content File content to write.
-	 * @return array{success: bool, path?: string, size?: int, created?: bool, message?: string}
+	 * @return array{success: bool, path?: string, size?: int, created?: bool}|\WP_Error
 	 */
-	public function write_file( string $name, string $path, string $content ): array {
+	public function write_file( string $name, string $path, string $content ): array|\WP_Error {
 		$repo_path = $this->workspace->get_repo_path( $name );
 		$path      = ltrim( $path, '/' );
 
 		if ( ! is_dir( $repo_path ) ) {
-			return array(
-				'success' => false,
-				'message' => sprintf( 'Repository "%s" not found in workspace.', $name ),
-			);
+			return new \WP_Error( 'repo_not_found', sprintf( 'Repository "%s" not found in workspace.', $name ), array( 'status' => 404 ) );
 		}
 
 		if ( '' === $path ) {
-			return array(
-				'success' => false,
-				'message' => 'File path is required.',
-			);
+			return new \WP_Error( 'missing_path', 'File path is required.', array( 'status' => 400 ) );
 		}
 
 		// Reject path traversal components.
 		if ( $this->has_traversal( $path ) ) {
-			return array(
-				'success' => false,
-				'message' => 'Path traversal detected. Access denied.',
-			);
+			return new \WP_Error( 'path_traversal', 'Path traversal detected. Access denied.', array( 'status' => 403 ) );
 		}
 
 		$file_path = $repo_path . '/' . $path;
@@ -80,10 +71,7 @@ class WorkspaceWriter {
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir
 			$created = mkdir( $parent, 0755, true );
 			if ( ! $created ) {
-				return array(
-					'success' => false,
-					'message' => sprintf( 'Failed to create directory: %s', dirname( $path ) ),
-				);
+				return new \WP_Error( 'mkdir_failed', sprintf( 'Failed to create directory: %s', dirname( $path ) ), array( 'status' => 500 ) );
 			}
 		}
 
@@ -92,10 +80,7 @@ class WorkspaceWriter {
 		$bytes = file_put_contents( $file_path, $content );
 
 		if ( false === $bytes ) {
-			return array(
-				'success' => false,
-				'message' => sprintf( 'Failed to write file: %s', $path ),
-			);
+			return new \WP_Error( 'write_failed', sprintf( 'Failed to write file: %s', $path ), array( 'status' => 500 ) );
 		}
 
 		// Belt-and-suspenders: verify the written file actually landed inside
@@ -108,10 +93,7 @@ class WorkspaceWriter {
 				// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
 				unlink( $file_path );
 			}
-			return array(
-				'success' => false,
-				'message' => 'Path traversal detected. Written file removed.',
-			);
+			return new \WP_Error( 'path_traversal', 'Path traversal detected. Written file removed.', array( 'status' => 403 ) );
 		}
 
 		return array(
@@ -134,81 +116,57 @@ class WorkspaceWriter {
 	 * @param string $old_string  Text to find.
 	 * @param string $new_string  Replacement text.
 	 * @param bool   $replace_all Replace all occurrences (default false).
-	 * @return array{success: bool, path?: string, replacements?: int, message?: string}
+	 * @return array{success: bool, path?: string, replacements?: int}|\WP_Error
 	 */
-	public function edit_file( string $name, string $path, string $old_string, string $new_string, bool $replace_all = false ): array {
+	public function edit_file( string $name, string $path, string $old_string, string $new_string, bool $replace_all = false ): array|\WP_Error {
 		$fs        = FilesystemHelper::get();
 		$repo_path = $this->workspace->get_repo_path( $name );
 		$path      = ltrim( $path, '/' );
 
 		if ( ! is_dir( $repo_path ) ) {
-			return array(
-				'success' => false,
-				'message' => sprintf( 'Repository "%s" not found in workspace.', $name ),
-			);
+			return new \WP_Error( 'repo_not_found', sprintf( 'Repository "%s" not found in workspace.', $name ), array( 'status' => 404 ) );
 		}
 
 		$file_path  = $repo_path . '/' . $path;
 		$validation = $this->workspace->validate_containment( $file_path, $repo_path );
 
 		if ( ! $validation['valid'] ) {
-			return array(
-				'success' => false,
-				'message' => $validation['message'],
-			);
+			return new \WP_Error( 'path_traversal', $validation['message'], array( 'status' => 403 ) );
 		}
 
 		$real_path = $validation['real_path'];
 
 		if ( ! is_file( $real_path ) ) {
-			return array(
-				'success' => false,
-				'message' => sprintf( 'File not found: %s', $path ),
-			);
+			return new \WP_Error( 'file_not_found', sprintf( 'File not found: %s', $path ), array( 'status' => 404 ) );
 		}
 
 		if ( ! is_readable( $real_path ) || ! $fs->is_writable( $real_path ) ) {
-			return array(
-				'success' => false,
-				'message' => sprintf( 'File not readable/writable: %s', $path ),
-			);
+			return new \WP_Error( 'file_not_writable', sprintf( 'File not readable/writable: %s', $path ), array( 'status' => 403 ) );
 		}
 
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		$content = file_get_contents( $real_path );
 
 		if ( false === $content ) {
-			return array(
-				'success' => false,
-				'message' => sprintf( 'Failed to read file: %s', $path ),
-			);
+			return new \WP_Error( 'read_failed', sprintf( 'Failed to read file: %s', $path ), array( 'status' => 500 ) );
 		}
 
 		if ( $old_string === $new_string ) {
-			return array(
-				'success' => false,
-				'message' => 'old_string and new_string are identical.',
-			);
+			return new \WP_Error( 'identical_strings', 'old_string and new_string are identical.', array( 'status' => 400 ) );
 		}
 
 		// Count occurrences.
 		$count = substr_count( $content, $old_string );
 
 		if ( 0 === $count ) {
-			return array(
-				'success' => false,
-				'message' => 'old_string not found in file content.',
-			);
+			return new \WP_Error( 'string_not_found', 'old_string not found in file content.', array( 'status' => 400 ) );
 		}
 
 		if ( $count > 1 && ! $replace_all ) {
-			return array(
-				'success' => false,
-				'message' => sprintf(
-					'Found %d matches for old_string. Use replace_all to replace all, or provide more context to make the match unique.',
-					$count
-				),
-			);
+			return new \WP_Error( 'multiple_matches', sprintf(
+				'Found %d matches for old_string. Use replace_all to replace all, or provide more context to make the match unique.',
+				$count
+			), array( 'status' => 400 ) );
 		}
 
 		// Perform replacement.
@@ -223,10 +181,7 @@ class WorkspaceWriter {
 		$bytes = file_put_contents( $real_path, $new_content );
 
 		if ( false === $bytes ) {
-			return array(
-				'success' => false,
-				'message' => sprintf( 'Failed to write file: %s', $path ),
-			);
+			return new \WP_Error( 'write_failed', sprintf( 'Failed to write file: %s', $path ), array( 'status' => 500 ) );
 		}
 
 		return array(


### PR DESCRIPTION
## Summary

Migrates all 23 ability callbacks in data-machine-code from `['success' => false, ...]` to `WP_Error` returns, per the unified ability contract from data-machine#999.

### Provider-side (5 files, 67 error returns converted)

| File | Instances | Notes |
|------|-----------|-------|
| **GitHubAbilities** | 12 | Direct callbacks + shared `patError()`/`parseResponse()` helpers |
| **Workspace** | 28 | Git ops, repo management, `resolve_repo_path()`, `run_git()`, `ensure_git_mutation_allowed()` |
| **WorkspaceReader** | 10 | `read_file()`, `list_directory()` |
| **WorkspaceWriter** | 15 | `write_file()`, `edit_file()` |
| **data-machine-code.php** | 2 | Inline `create-github-issue` callback |

### Consumer-side (7 files updated)

| File | Changes |
|------|---------|
| **WorkspaceTools** | Removed `function_exists` guard + 5 redundant `isAbilitySuccess()` checks |
| **GitHubIssueTool** | Removed `function_exists` guard |
| **GitHubTools** | 5 `empty($result['success'])` → `is_wp_error()` |
| **WorkspaceCommand** | 8 `!$result['success']` → `is_wp_error()` |
| **GitHubCommand** | 6 `empty($result['success'])` → `is_wp_error()` |
| **GitHubIssueTask** | 1 `!$result['success']` → `is_wp_error()` |
| **GitHub handler** | 1 `!$result['success']` → `is_wp_error()` |

**12 files changed, -208 lines net.**

Refs Extra-Chill/data-machine#999
Closes #9