### PR TITLE
Fix PHPCS and PHPStan lint issues

### DIFF
--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -373,7 +373,11 @@ class GitHubAbilities {
 
 		$normalized = array_map( array( self::class, 'normalizeIssue' ), $issues );
 
-		return array( 'success' => true, 'issues' => $normalized, 'count' => count( $normalized ) );
+		return array(
+			'success' => true,
+			'issues'  => $normalized,
+			'count'   => count( $normalized ),
+		);
 	}
 
 	public static function getIssue( array $input ): array|\WP_Error {
@@ -396,7 +400,10 @@ class GitHubAbilities {
 			return $response;
 		}
 
-		return array( 'success' => true, 'issue' => self::normalizeIssue( $response['data'] ) );
+		return array(
+			'success' => true,
+			'issue'   => self::normalizeIssue( $response['data'] ),
+		);
 	}
 
 	public static function updateIssue( array $input ): array|\WP_Error {
@@ -552,7 +559,11 @@ class GitHubAbilities {
 
 		$normalized = array_map( array( self::class, 'normalizePull' ), $response['data'] );
 
-		return array( 'success' => true, 'pulls' => $normalized, 'count' => count( $normalized ) );
+		return array(
+			'success' => true,
+			'pulls'   => $normalized,
+			'count'   => count( $normalized ),
+		);
 	}
 
 	public static function listRepos( array $input ): array|\WP_Error {
@@ -590,7 +601,11 @@ class GitHubAbilities {
 
 		$normalized = array_map( array( self::class, 'normalizeRepo' ), $response['data'] );
 
-		return array( 'success' => true, 'repos' => $normalized, 'count' => count( $normalized ) );
+		return array(
+			'success' => true,
+			'repos'   => $normalized,
+			'count'   => count( $normalized ),
+		);
 	}
 
 	// -------------------------------------------------------------------------
@@ -635,7 +650,10 @@ class GitHubAbilities {
 			return new \WP_Error( $code, sprintf( 'GitHub API error (%d): %s', $status_code, $message ), array( 'status' => $status_code ) );
 		}
 
-		return array( 'success' => true, 'data' => $body );
+		return array(
+			'success' => true,
+			'data'    => $body,
+		);
 	}
 
 	private static function getHeaders( string $pat ): array {

--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -718,8 +718,7 @@ class WorkspaceAbilities {
 	 * @param array $input Input parameters.
 	 * @return array Result.
 	 */
-	public static function listRepos( array $input ): array {
-		$input;
+	public static function listRepos( array $input ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 		$workspace = new Workspace();
 		return $workspace->list_repos();
 	}

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -184,11 +184,6 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 
-		if ( is_wp_error( $result ) ) {
-			WP_CLI::error( $result->get_error_message() );
-			return;
-		}
-
 		WP_CLI::success( $result['message'] );
 		WP_CLI::log( sprintf( 'Path: %s', $result['path'] ) );
 	}
@@ -242,11 +237,6 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 
-		if ( is_wp_error( $result ) ) {
-			WP_CLI::error( $result->get_error_message() );
-			return;
-		}
-
 		WP_CLI::success( $result['message'] );
 	}
 
@@ -278,11 +268,6 @@ class WorkspaceCommand extends BaseCommand {
 		}
 
 		$result = $ability->execute( array( 'name' => $args[0] ) );
-
-		if ( is_wp_error( $result ) ) {
-			WP_CLI::error( $result->get_error_message() );
-			return;
-		}
 
 		if ( is_wp_error( $result ) ) {
 			WP_CLI::error( $result->get_error_message() );
@@ -376,11 +361,6 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 
-		if ( is_wp_error( $result ) ) {
-			WP_CLI::error( $result->get_error_message() );
-			return;
-		}
-
 		// Output raw content — suitable for piping.
 		WP_CLI::log( $result['content'] );
 	}
@@ -442,11 +422,6 @@ class WorkspaceCommand extends BaseCommand {
 		}
 
 		$result = $ability->execute( $input );
-
-		if ( is_wp_error( $result ) ) {
-			WP_CLI::error( $result->get_error_message() );
-			return;
-		}
 
 		if ( is_wp_error( $result ) ) {
 			WP_CLI::error( $result->get_error_message() );
@@ -552,11 +527,6 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 
-		if ( is_wp_error( $result ) ) {
-			WP_CLI::error( $result->get_error_message() );
-			return;
-		}
-
 		$action = ! empty( $result['created'] ) ? 'Created' : 'Updated';
 		WP_CLI::success( sprintf( '%s %s (%s)', $action, $result['path'], size_format( $result['size'] ) ) );
 	}
@@ -626,11 +596,6 @@ class WorkspaceCommand extends BaseCommand {
 		}
 
 		$result = $ability->execute( $input );
-
-		if ( is_wp_error( $result ) ) {
-			WP_CLI::error( $result->get_error_message() );
-			return;
-		}
 
 		if ( is_wp_error( $result ) ) {
 			WP_CLI::error( $result->get_error_message() );
@@ -836,11 +801,6 @@ class WorkspaceCommand extends BaseCommand {
 		}
 
 		$result = $ability->execute( $input );
-
-		if ( is_wp_error( $result ) ) {
-			WP_CLI::error( $result->get_error_message() );
-			return;
-		}
 
 		if ( is_wp_error( $result ) ) {
 			WP_CLI::error( $result->get_error_message() );

--- a/inc/Handlers/GitHub/GitHub.php
+++ b/inc/Handlers/GitHub/GitHub.php
@@ -170,7 +170,7 @@ class GitHub extends FetchHandler {
 	}
 
 	private function buildIssueContent( array $issue ): string {
-		$parts = array();
+		$parts   = array();
 		$parts[] = sprintf( '**State:** %s', $issue['state'] ?? 'unknown' );
 		$parts[] = sprintf( '**Author:** %s', $issue['user'] ?? 'unknown' );
 		if ( ! empty( $issue['labels'] ) ) {
@@ -190,7 +190,7 @@ class GitHub extends FetchHandler {
 	}
 
 	private function buildPrContent( array $pr ): string {
-		$parts = array();
+		$parts   = array();
 		$parts[] = sprintf( '**State:** %s', $pr['state'] ?? 'unknown' );
 		$parts[] = sprintf( '**Author:** %s', $pr['user'] ?? 'unknown' );
 		$parts[] = sprintf( '**Branch:** %s → %s', $pr['head'] ?? '?', $pr['base'] ?? '?' );

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -780,7 +780,14 @@ class Workspace {
 		exec( $command, $output, $exit_code );
 
 		if ( 0 !== $exit_code ) {
-			return new \WP_Error( 'git_command_failed', sprintf( 'Git command failed (exit %d): %s', $exit_code, implode( "\n", $output ) ), array( 'status' => 500, 'output' => implode( "\n", $output ) ) );
+			return new \WP_Error(
+				'git_command_failed',
+				sprintf( 'Git command failed (exit %d): %s', $exit_code, implode( "\n", $output ) ),
+				array(
+					'status' => 500,
+					'output' => implode( "\n", $output ),
+				)
+			);
 		}
 
 		return array(
@@ -794,7 +801,7 @@ class Workspace {
 	 *
 	 * @param string $repo_name    Repository name.
 	 * @param bool   $require_push Whether push must also be enabled.
-	 * @return array
+	 * @return true|\WP_Error
 	 */
 	private function ensure_git_mutation_allowed( string $repo_name, bool $require_push = false ): true|\WP_Error {
 		$policies = $this->get_workspace_git_policies();


### PR DESCRIPTION
## Summary

- Remove 8 duplicate `is_wp_error()` checks in `WorkspaceCommand` (each ability result was checked twice — second check always evaluated to false)
- Expand 5 single-line associative arrays to multi-line in `GitHubAbilities` (PHPCS `AssociativeArrayFound`)
- Align equals signs in `GitHub` handler (PHPCS `MultipleStatementAlignment`)
- Expand long `WP_Error` constructor in `Workspace::run_git()` (PHPCS `AssociativeArrayFound`)
- Fix `@return` docblock on `ensure_git_mutation_allowed` — was `array`, should be `true|\WP_Error` (PHPStan `return.phpDocType`)
- Remove unused `$input;` expression in `WorkspaceAbilities::listRepos()` (PHPStan `expr.resultUnused`)

## Test plan

- [ ] `homeboy release` passes PHPCS with 0 errors, 0 warnings
- [ ] `homeboy release` passes PHPStan with 0 errors