### PR TITLE
feat: ability categories and tool-ability linkage

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -64,12 +64,28 @@ function datamachine_code_register_system_abilities() {
 		return;
 	}
 
+	wp_register_ability_category(
+		'datamachine-code/workspace',
+		array(
+			'label'       => __( 'Code Workspace', 'data-machine-code' ),
+			'description' => __( 'Git workspace management — clone, read, write, edit, and git operations.', 'data-machine-code' ),
+		)
+	);
+
+	wp_register_ability_category(
+		'datamachine-code/github',
+		array(
+			'label'       => __( 'GitHub', 'data-machine-code' ),
+			'description' => __( 'GitHub issue, pull request, and repository operations.', 'data-machine-code' ),
+		)
+	);
+
 	wp_register_ability(
 		'datamachine/create-github-issue',
 		array(
 			'label'               => 'Create GitHub Issue',
 			'description'         => 'Create a new GitHub issue in a repository.',
-			'category'            => 'datamachine',
+			'category'            => 'datamachine-code/github',
 			'input_schema'        => array(
 				'type'       => 'object',
 				'required'   => array( 'title' ),

--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -56,7 +56,7 @@ class GitHubAbilities {
 				array(
 					'label'               => 'List GitHub Issues',
 					'description'         => 'List issues from a GitHub repository with optional filters',
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-code/github',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'repo' ),
@@ -111,7 +111,7 @@ class GitHubAbilities {
 				array(
 					'label'               => 'Get GitHub Issue',
 					'description'         => 'Get a single GitHub issue with full details',
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-code/github',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'repo', 'issue_number' ),
@@ -145,7 +145,7 @@ class GitHubAbilities {
 				array(
 					'label'               => 'Update GitHub Issue',
 					'description'         => 'Update a GitHub issue (title, body, labels, assignees, state)',
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-code/github',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'repo', 'issue_number' ),
@@ -199,7 +199,7 @@ class GitHubAbilities {
 				array(
 					'label'               => 'Comment on GitHub Issue',
 					'description'         => 'Add a comment to a GitHub issue',
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-code/github',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'repo', 'issue_number', 'body' ),
@@ -237,7 +237,7 @@ class GitHubAbilities {
 				array(
 					'label'               => 'List GitHub Pull Requests',
 					'description'         => 'List pull requests from a GitHub repository',
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-code/github',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'repo' ),
@@ -280,7 +280,7 @@ class GitHubAbilities {
 				array(
 					'label'               => 'List GitHub Repositories',
 					'description'         => 'List repositories for a user or organization',
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-code/github',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'owner' ),

--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -50,7 +50,7 @@ class WorkspaceAbilities {
 				array(
 					'label'               => 'Get Workspace Path',
 					'description'         => 'Get the agent workspace directory path. Optionally create the directory.',
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-code/workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -80,7 +80,7 @@ class WorkspaceAbilities {
 				array(
 					'label'               => 'List Workspace Repos',
 					'description'         => 'List repositories in the agent workspace.',
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-code/workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(),
@@ -116,7 +116,7 @@ class WorkspaceAbilities {
 				array(
 					'label'               => 'Show Workspace Repo',
 					'description'         => 'Show detailed info about a workspace repository (branch, remote, latest commit, dirty status).',
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-code/workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -154,7 +154,7 @@ class WorkspaceAbilities {
 				array(
 					'label'               => 'Read Workspace File',
 					'description'         => 'Read the contents of a text file from a workspace repository.',
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-code/workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -203,7 +203,7 @@ class WorkspaceAbilities {
 				array(
 					'label'               => 'List Workspace Directory',
 					'description'         => 'List directory contents within a workspace repository.',
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-code/workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -252,7 +252,7 @@ class WorkspaceAbilities {
 				array(
 					'label'               => 'Clone Workspace Repo',
 					'description'         => 'Clone a git repository into the workspace.',
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-code/workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -287,7 +287,7 @@ class WorkspaceAbilities {
 				array(
 					'label'               => 'Remove Workspace Repo',
 					'description'         => 'Remove a repository from the workspace.',
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-code/workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -316,7 +316,7 @@ class WorkspaceAbilities {
 				array(
 					'label'               => 'Write Workspace File',
 					'description'         => 'Create or overwrite a file in a workspace repository.',
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-code/workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -355,7 +355,7 @@ class WorkspaceAbilities {
 				array(
 					'label'               => 'Edit Workspace File',
 					'description'         => 'Find-and-replace text in a workspace repository file.',
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-code/workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -401,7 +401,7 @@ class WorkspaceAbilities {
 				array(
 					'label'               => 'Workspace Git Status',
 					'description'         => 'Get git status information for a workspace repository.',
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-code/workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -439,7 +439,7 @@ class WorkspaceAbilities {
 				array(
 					'label'               => 'Workspace Git Log',
 					'description'         => 'Read git log entries for a workspace repository.',
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-code/workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -484,7 +484,7 @@ class WorkspaceAbilities {
 				array(
 					'label'               => 'Workspace Git Diff',
 					'description'         => 'Read git diff output for a workspace repository.',
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-code/workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -530,7 +530,7 @@ class WorkspaceAbilities {
 				array(
 					'label'               => 'Workspace Git Pull',
 					'description'         => 'Run git pull --ff-only for a workspace repository.',
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-code/workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -564,7 +564,7 @@ class WorkspaceAbilities {
 				array(
 					'label'               => 'Workspace Git Add',
 					'description'         => 'Stage repository paths with git add.',
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-code/workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -603,7 +603,7 @@ class WorkspaceAbilities {
 				array(
 					'label'               => 'Workspace Git Commit',
 					'description'         => 'Commit staged changes in a workspace repository.',
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-code/workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -638,7 +638,7 @@ class WorkspaceAbilities {
 				array(
 					'label'               => 'Workspace Git Push',
 					'description'         => 'Push commits for a workspace repository.',
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-code/workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Tools/GitHubIssueTool.php
+++ b/inc/Tools/GitHubIssueTool.php
@@ -28,7 +28,7 @@ class GitHubIssueTool extends BaseTool {
 	 * Constructor.
 	 */
 	public function __construct() {
-		$this->registerTool( 'create_github_issue', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline' ) );
+		$this->registerTool( 'create_github_issue', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline' ), array( 'ability' => 'datamachine/create-github-issue' ) );
 	}
 
 	/**

--- a/inc/Tools/GitHubTools.php
+++ b/inc/Tools/GitHubTools.php
@@ -24,11 +24,11 @@ class GitHubTools extends BaseTool {
 	 */
 	public function __construct() {
 		$contexts = array( 'chat', 'pipeline' );
-		$this->registerTool( 'list_github_issues', array( $this, 'getListIssuesDefinition' ), $contexts );
-		$this->registerTool( 'get_github_issue', array( $this, 'getGetIssueDefinition' ), $contexts );
-		$this->registerTool( 'manage_github_issue', array( $this, 'getManageIssueDefinition' ), $contexts );
-		$this->registerTool( 'list_github_pulls', array( $this, 'getListPullsDefinition' ), $contexts );
-		$this->registerTool( 'list_github_repos', array( $this, 'getListReposDefinition' ), $contexts );
+		$this->registerTool( 'list_github_issues', array( $this, 'getListIssuesDefinition' ), $contexts, array( 'access_level' => 'editor' ) );
+		$this->registerTool( 'get_github_issue', array( $this, 'getGetIssueDefinition' ), $contexts, array( 'access_level' => 'editor' ) );
+		$this->registerTool( 'manage_github_issue', array( $this, 'getManageIssueDefinition' ), $contexts, array( 'access_level' => 'editor' ) );
+		$this->registerTool( 'list_github_pulls', array( $this, 'getListPullsDefinition' ), $contexts, array( 'access_level' => 'editor' ) );
+		$this->registerTool( 'list_github_repos', array( $this, 'getListReposDefinition' ), $contexts, array( 'access_level' => 'editor' ) );
 	}
 
 	/**

--- a/inc/Tools/WorkspaceTools.php
+++ b/inc/Tools/WorkspaceTools.php
@@ -54,11 +54,11 @@ class WorkspaceTools extends BaseTool {
 	 */
 	public function __construct() {
 		$contexts = array( 'chat', 'pipeline' );
-		$this->registerTool( 'workspace_path', array( $this, 'getPathDefinition' ), $contexts );
-		$this->registerTool( 'workspace_list', array( $this, 'getListDefinition' ), $contexts );
-		$this->registerTool( 'workspace_show', array( $this, 'getShowDefinition' ), $contexts );
-		$this->registerTool( 'workspace_ls', array( $this, 'getLsDefinition' ), $contexts );
-		$this->registerTool( 'workspace_read', array( $this, 'getReadDefinition' ), $contexts );
+		$this->registerTool( 'workspace_path', array( $this, 'getPathDefinition' ), $contexts, array( 'ability' => 'datamachine/workspace-path' ) );
+		$this->registerTool( 'workspace_list', array( $this, 'getListDefinition' ), $contexts, array( 'ability' => 'datamachine/workspace-list' ) );
+		$this->registerTool( 'workspace_show', array( $this, 'getShowDefinition' ), $contexts, array( 'ability' => 'datamachine/workspace-show' ) );
+		$this->registerTool( 'workspace_ls', array( $this, 'getLsDefinition' ), $contexts, array( 'ability' => 'datamachine/workspace-ls' ) );
+		$this->registerTool( 'workspace_read', array( $this, 'getReadDefinition' ), $contexts, array( 'ability' => 'datamachine/workspace-read' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Register **2 ability categories**: `datamachine-code/workspace` and `datamachine-code/github`
- Update all **23 ability registrations** from flat `datamachine` to proper subcategories
- Add `ability` metadata to all **11 tool `registerTool()` calls** (workspace tools → ability linkage, GitHub tools → access_level)

## Context

Companion PR to Extra-Chill/data-machine#1052 which introduces ability categories in core. Extensions register their own categories — this extension registers `datamachine-code/workspace` and `datamachine-code/github`.

With these categories, pipeline AI steps can scope their tools by category. A pipeline that only needs workspace operations can declare `tool_categories: ['datamachine-code/workspace']` and won't get GitHub tools (or vice versa).

## Changes

| File | Change |
|------|--------|
| `data-machine-code.php` | Register 2 categories, update `create-github-issue` ability category |
| `inc/Abilities/WorkspaceAbilities.php` | 16 abilities → `datamachine-code/workspace` |
| `inc/Abilities/GitHubAbilities.php` | 6 abilities → `datamachine-code/github` |
| `inc/Tools/WorkspaceTools.php` | 5 tools get `ability` meta |
| `inc/Tools/GitHubTools.php` | 5 tools get `access_level` meta |
| `inc/Tools/GitHubIssueTool.php` | 1 tool gets `ability` meta |