### PR TITLE
Fix: Ability category registration — correct hook and slug format

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -51,10 +51,37 @@ function datamachine_code_bootstrap() {
 	// Load Handlers (they self-register).
 	new \DataMachineCode\Handlers\GitHub\GitHub();
 
+	// Register ability categories on the correct hook (must happen during wp_abilities_api_categories_init).
+	add_action( 'wp_abilities_api_categories_init', 'datamachine_code_register_ability_categories' );
+
 	// Register GitHub issue creation ability via SystemAbilities hook.
 	add_action( 'wp_abilities_api_init', 'datamachine_code_register_system_abilities' );
 }
 add_action( 'plugins_loaded', 'datamachine_code_bootstrap', 20 );
+
+/**
+ * Register ability categories for data-machine-code.
+ *
+ * Must be called on `wp_abilities_api_categories_init` — WordPress core
+ * enforces that categories are only registered during this action.
+ */
+function datamachine_code_register_ability_categories() {
+	wp_register_ability_category(
+		'datamachine-code-workspace',
+		array(
+			'label'       => __( 'Code Workspace', 'data-machine-code' ),
+			'description' => __( 'Git workspace management — clone, read, write, edit, and git operations.', 'data-machine-code' ),
+		)
+	);
+
+	wp_register_ability_category(
+		'datamachine-code-github',
+		array(
+			'label'       => __( 'GitHub', 'data-machine-code' ),
+			'description' => __( 'GitHub issue, pull request, and repository operations.', 'data-machine-code' ),
+		)
+	);
+}
 
 /**
  * Register system-level abilities (GitHub issue creation).
@@ -64,28 +91,12 @@ function datamachine_code_register_system_abilities() {
 		return;
 	}
 
-	wp_register_ability_category(
-		'datamachine-code/workspace',
-		array(
-			'label'       => __( 'Code Workspace', 'data-machine-code' ),
-			'description' => __( 'Git workspace management — clone, read, write, edit, and git operations.', 'data-machine-code' ),
-		)
-	);
-
-	wp_register_ability_category(
-		'datamachine-code/github',
-		array(
-			'label'       => __( 'GitHub', 'data-machine-code' ),
-			'description' => __( 'GitHub issue, pull request, and repository operations.', 'data-machine-code' ),
-		)
-	);
-
 	wp_register_ability(
 		'datamachine/create-github-issue',
 		array(
 			'label'               => 'Create GitHub Issue',
 			'description'         => 'Create a new GitHub issue in a repository.',
-			'category'            => 'datamachine-code/github',
+			'category'            => 'datamachine-code-github',
 			'input_schema'        => array(
 				'type'       => 'object',
 				'required'   => array( 'title' ),

--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -56,7 +56,7 @@ class GitHubAbilities {
 				array(
 					'label'               => 'List GitHub Issues',
 					'description'         => 'List issues from a GitHub repository with optional filters',
-					'category'            => 'datamachine-code/github',
+					'category'            => 'datamachine-code-github',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'repo' ),
@@ -111,7 +111,7 @@ class GitHubAbilities {
 				array(
 					'label'               => 'Get GitHub Issue',
 					'description'         => 'Get a single GitHub issue with full details',
-					'category'            => 'datamachine-code/github',
+					'category'            => 'datamachine-code-github',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'repo', 'issue_number' ),
@@ -145,7 +145,7 @@ class GitHubAbilities {
 				array(
 					'label'               => 'Update GitHub Issue',
 					'description'         => 'Update a GitHub issue (title, body, labels, assignees, state)',
-					'category'            => 'datamachine-code/github',
+					'category'            => 'datamachine-code-github',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'repo', 'issue_number' ),
@@ -199,7 +199,7 @@ class GitHubAbilities {
 				array(
 					'label'               => 'Comment on GitHub Issue',
 					'description'         => 'Add a comment to a GitHub issue',
-					'category'            => 'datamachine-code/github',
+					'category'            => 'datamachine-code-github',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'repo', 'issue_number', 'body' ),
@@ -237,7 +237,7 @@ class GitHubAbilities {
 				array(
 					'label'               => 'List GitHub Pull Requests',
 					'description'         => 'List pull requests from a GitHub repository',
-					'category'            => 'datamachine-code/github',
+					'category'            => 'datamachine-code-github',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'repo' ),
@@ -280,7 +280,7 @@ class GitHubAbilities {
 				array(
 					'label'               => 'List GitHub Repositories',
 					'description'         => 'List repositories for a user or organization',
-					'category'            => 'datamachine-code/github',
+					'category'            => 'datamachine-code-github',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'owner' ),

--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -50,7 +50,7 @@ class WorkspaceAbilities {
 				array(
 					'label'               => 'Get Workspace Path',
 					'description'         => 'Get the agent workspace directory path. Optionally create the directory.',
-					'category'            => 'datamachine-code/workspace',
+					'category'            => 'datamachine-code-workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -80,7 +80,7 @@ class WorkspaceAbilities {
 				array(
 					'label'               => 'List Workspace Repos',
 					'description'         => 'List repositories in the agent workspace.',
-					'category'            => 'datamachine-code/workspace',
+					'category'            => 'datamachine-code-workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(),
@@ -116,7 +116,7 @@ class WorkspaceAbilities {
 				array(
 					'label'               => 'Show Workspace Repo',
 					'description'         => 'Show detailed info about a workspace repository (branch, remote, latest commit, dirty status).',
-					'category'            => 'datamachine-code/workspace',
+					'category'            => 'datamachine-code-workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -154,7 +154,7 @@ class WorkspaceAbilities {
 				array(
 					'label'               => 'Read Workspace File',
 					'description'         => 'Read the contents of a text file from a workspace repository.',
-					'category'            => 'datamachine-code/workspace',
+					'category'            => 'datamachine-code-workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -203,7 +203,7 @@ class WorkspaceAbilities {
 				array(
 					'label'               => 'List Workspace Directory',
 					'description'         => 'List directory contents within a workspace repository.',
-					'category'            => 'datamachine-code/workspace',
+					'category'            => 'datamachine-code-workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -252,7 +252,7 @@ class WorkspaceAbilities {
 				array(
 					'label'               => 'Clone Workspace Repo',
 					'description'         => 'Clone a git repository into the workspace.',
-					'category'            => 'datamachine-code/workspace',
+					'category'            => 'datamachine-code-workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -287,7 +287,7 @@ class WorkspaceAbilities {
 				array(
 					'label'               => 'Remove Workspace Repo',
 					'description'         => 'Remove a repository from the workspace.',
-					'category'            => 'datamachine-code/workspace',
+					'category'            => 'datamachine-code-workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -316,7 +316,7 @@ class WorkspaceAbilities {
 				array(
 					'label'               => 'Write Workspace File',
 					'description'         => 'Create or overwrite a file in a workspace repository.',
-					'category'            => 'datamachine-code/workspace',
+					'category'            => 'datamachine-code-workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -355,7 +355,7 @@ class WorkspaceAbilities {
 				array(
 					'label'               => 'Edit Workspace File',
 					'description'         => 'Find-and-replace text in a workspace repository file.',
-					'category'            => 'datamachine-code/workspace',
+					'category'            => 'datamachine-code-workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -401,7 +401,7 @@ class WorkspaceAbilities {
 				array(
 					'label'               => 'Workspace Git Status',
 					'description'         => 'Get git status information for a workspace repository.',
-					'category'            => 'datamachine-code/workspace',
+					'category'            => 'datamachine-code-workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -439,7 +439,7 @@ class WorkspaceAbilities {
 				array(
 					'label'               => 'Workspace Git Log',
 					'description'         => 'Read git log entries for a workspace repository.',
-					'category'            => 'datamachine-code/workspace',
+					'category'            => 'datamachine-code-workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -484,7 +484,7 @@ class WorkspaceAbilities {
 				array(
 					'label'               => 'Workspace Git Diff',
 					'description'         => 'Read git diff output for a workspace repository.',
-					'category'            => 'datamachine-code/workspace',
+					'category'            => 'datamachine-code-workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -530,7 +530,7 @@ class WorkspaceAbilities {
 				array(
 					'label'               => 'Workspace Git Pull',
 					'description'         => 'Run git pull --ff-only for a workspace repository.',
-					'category'            => 'datamachine-code/workspace',
+					'category'            => 'datamachine-code-workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -564,7 +564,7 @@ class WorkspaceAbilities {
 				array(
 					'label'               => 'Workspace Git Add',
 					'description'         => 'Stage repository paths with git add.',
-					'category'            => 'datamachine-code/workspace',
+					'category'            => 'datamachine-code-workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -603,7 +603,7 @@ class WorkspaceAbilities {
 				array(
 					'label'               => 'Workspace Git Commit',
 					'description'         => 'Commit staged changes in a workspace repository.',
-					'category'            => 'datamachine-code/workspace',
+					'category'            => 'datamachine-code-workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -638,7 +638,7 @@ class WorkspaceAbilities {
 				array(
 					'label'               => 'Workspace Git Push',
 					'description'         => 'Push commits for a workspace repository.',
-					'category'            => 'datamachine-code/workspace',
+					'category'            => 'datamachine-code-workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(


### PR DESCRIPTION
## Summary

- **Two issues fixed**:
  1. Category registration was on `wp_abilities_api_init` (wrong hook) — must be on `wp_abilities_api_categories_init`
  2. Category slugs used slashes (`datamachine-code/workspace`) which fail WordPress core's `^[a-z0-9]+(?:-[a-z0-9]+)*$` validation — changed to dashes (`datamachine-code-workspace`, `datamachine-code-github`)
- Split category registration into dedicated `datamachine_code_register_ability_categories()` function hooked to `wp_abilities_api_categories_init`

## Verification

Workspace commands now work again (previously broken due to unregistered categories):

```bash
studio wp datamachine-code workspace list
# Works without errors
```

## Related

Companion PR for data-machine core: Extra-Chill/data-machine (same slug format fix for all 18 categories)