### PR TITLE
Add 'files' data source to GitHub fetch handler

### DIFF
--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -3,8 +3,9 @@
  * GitHub Abilities
  *
  * Core business logic for GitHub API interactions: listing issues, PRs,
- * repos, and managing issues (update, close, comment). All GitHub
- * operations — CLI, REST, chat tools, fetch handler — route through here.
+ * repos, reading repo source files, and managing issues (update, close,
+ * comment). All GitHub operations — CLI, REST, chat tools, fetch handler —
+ * route through here.
  *
  * Auth: Uses the github_pat stored in Data Machine PluginSettings.
  *
@@ -655,6 +656,18 @@ class GitHubAbilities {
 		);
 	}
 
+	/**
+	 * Create or update a file in a repository via the Contents API.
+	 *
+	 * GET for SHA (if exists) → PUT with base64 content. Genuinely upsert:
+	 * creates the file if it doesn't exist, updates it if it does.
+	 *
+	 * @param array $input {
+	 *     Required: repo, file_path, content, commit_message.
+	 *     Optional: branch.
+	 * }
+	 * @return array|\WP_Error Success payload or error.
+	 */
 	public static function createOrUpdateFile( array $input ): array|\WP_Error {
 		$repo = self::resolveRepo( sanitize_text_field( $input['repo'] ?? '' ) );
 		if ( empty( $repo ) ) {
@@ -731,6 +744,111 @@ class GitHubAbilities {
 				isset( $data['content'] ) ? 'updated' : 'created',
 				$repo
 			),
+		);
+	}
+
+	/**
+	 * Get the recursive file tree for a repository branch.
+	 *
+	 * Calls `GET /repos/{owner}/{repo}/git/trees/{sha}?recursive=1`.
+	 * Returns all files and directories in a single response.
+	 *
+	 * @param array $input {
+	 *     Required: repo. Optional: branch (default: default branch).
+	 * }
+	 * @return array|\WP_Error { files: normalized[], count: int } or error.
+	 */
+	public static function getRepoTree( array $input ): array|\WP_Error {
+		$repo = sanitize_text_field( $input['repo'] ?? '' );
+		if ( empty( $repo ) ) {
+			return new \WP_Error( 'missing_repo', 'Repository is required (owner/repo format).', array( 'status' => 400 ) );
+		}
+
+		$pat = self::getPat();
+		if ( empty( $pat ) ) {
+			return self::patError();
+		}
+
+		$branch = sanitize_text_field( $input['branch'] ?? '' );
+		$ref    = ! empty( $branch ) ? $branch : 'HEAD';
+
+		$url      = sprintf( '%s/repos/%s/git/trees/%s', self::API_BASE, $repo, $ref );
+		$response = self::apiGet( $url, array( 'recursive' => '1' ), $pat );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$tree = $response['data']['tree'] ?? array();
+
+		// Filter to blobs (files) only — skip trees (directories).
+		$files = array_filter( $tree, fn( $entry ) => 'blob' === ( $entry['type'] ?? '' ) );
+		$files = array_values( array_map( array( self::class, 'normalizeTreeEntry' ), $files ) );
+
+		return array(
+			'success' => true,
+			'files'   => $files,
+			'count'   => count( $files ),
+		);
+	}
+
+	/**
+	 * Get the decoded content of a single file from a repository.
+	 *
+	 * Calls `GET /repos/{owner}/{repo}/contents/{path}`.
+	 * GitHub returns base64-encoded content for files ≤ 1 MB.
+	 *
+	 * @param array $input {
+	 *     Required: repo, path. Optional: branch.
+	 * }
+	 * @return array|\WP_Error { success: bool, file: normalized } or error.
+	 */
+	public static function getFileContents( array $input ): array|\WP_Error {
+		$repo = sanitize_text_field( $input['repo'] ?? '' );
+		$path = sanitize_text_field( $input['path'] ?? '' );
+
+		if ( empty( $repo ) || empty( $path ) ) {
+			return new \WP_Error( 'missing_params', 'Repository (owner/repo) and file path are required.', array( 'status' => 400 ) );
+		}
+
+		$pat = self::getPat();
+		if ( empty( $pat ) ) {
+			return self::patError();
+		}
+
+		$query_params = array();
+		$branch       = sanitize_text_field( $input['branch'] ?? '' );
+		if ( ! empty( $branch ) ) {
+			$query_params['ref'] = $branch;
+		}
+
+		$url      = sprintf( '%s/repos/%s/contents/%s', self::API_BASE, $repo, ltrim( $path, '/' ) );
+		$response = self::apiGet( $url, $query_params, $pat );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$data = $response['data'];
+
+		// GitHub returns a directory listing if path is a directory.
+		if ( isset( $data[0] ) && is_array( $data[0] ) ) {
+			return new \WP_Error( 'is_directory', 'Path is a directory, not a file.', array( 'status' => 400 ) );
+		}
+
+		// Reject large files (> 1 MB returns HTML URL instead of content).
+		if ( empty( $data['content'] ) ) {
+			return new \WP_Error( 'file_too_large', 'File content not available (may exceed 1 MB GitHub API limit).', array( 'status' => 400 ) );
+		}
+
+		$decoded = base64_decode( $data['content'], true );
+		if ( false === $decoded ) {
+			return new \WP_Error( 'decode_failed', 'Failed to decode file content.', array( 'status' => 500 ) );
+		}
+
+		return array(
+			'success' => true,
+			'file'    => self::normalizeFileContent( $data, $decoded ),
 		);
 	}
 
@@ -845,6 +963,33 @@ class GitHubAbilities {
 			'default_branch'   => $repo['default_branch'] ?? 'main',
 			'pushed_at'        => $repo['pushed_at'] ?? '',
 			'updated_at'       => $repo['updated_at'] ?? '',
+		);
+	}
+
+	/**
+	 * Normalize a git tree entry (file listing from getRepoTree).
+	 */
+	public static function normalizeTreeEntry( array $entry ): array {
+		return array(
+			'path' => $entry['path'] ?? '',
+			'size' => (int) ( $entry['size'] ?? 0 ),
+			'sha'  => $entry['sha'] ?? '',
+		);
+	}
+
+	/**
+	 * Normalize a file content response from getFileContents.
+	 *
+	 * @param array  $data     Raw GitHub API response data.
+	 * @param string $decoded  Base64-decoded file content.
+	 */
+	public static function normalizeFileContent( array $data, string $decoded ): array {
+		return array(
+			'path'    => $data['path'] ?? '',
+			'size'    => (int) ( $data['size'] ?? 0 ),
+			'sha'     => $data['sha'] ?? '',
+			'content' => $decoded,
+			'html_url' => $data['html_url'] ?? '',
 		);
 	}
 

--- a/inc/Handlers/GitHub/GitHub.php
+++ b/inc/Handlers/GitHub/GitHub.php
@@ -2,9 +2,10 @@
 /**
  * GitHub Fetch Handler
  *
- * Fetches issues or pull requests from a GitHub repository and returns
- * them as DataPackets for pipeline processing. Supports deduplication
- * via processed items, timeframe filtering, and keyword search.
+ * Fetches issues, pull requests, or source file contents from a GitHub
+ * repository and returns them as DataPackets for pipeline processing.
+ * Supports deduplication via processed items, timeframe filtering, and
+ * keyword search.
  *
  * @package DataMachineCode\Handlers\GitHub
  * @since 0.1.0
@@ -33,7 +34,7 @@ class GitHub extends FetchHandler {
 			'fetch',
 			self::class,
 			'GitHub',
-			'Fetch issues and pull requests from GitHub repositories',
+			'Fetch issues, pull requests, or source file contents from GitHub repositories',
 			false,
 			null,
 			GitHubSettings::class,
@@ -51,8 +52,6 @@ class GitHub extends FetchHandler {
 	protected function executeFetch( array $config, ExecutionContext $context ): array {
 		$repo        = $config['repo'] ?? '';
 		$data_source = $config['data_source'] ?? 'issues';
-		$state       = $config['state'] ?? 'open';
-		$labels      = $config['labels'] ?? '';
 
 		if ( empty( $repo ) ) {
 			$repo = GitHubAbilities::getDefaultRepo();
@@ -71,8 +70,131 @@ class GitHub extends FetchHandler {
 		$context->log( 'debug', 'GitHub: Fetching data', array(
 			'repo'        => $repo,
 			'data_source' => $data_source,
-			'state'       => $state,
 		) );
+
+		if ( 'files' === $data_source ) {
+			return $this->fetchFiles( $config, $context, $repo );
+		}
+
+		return $this->fetchIssuesOrPulls( $config, $context, $repo, $data_source );
+	}
+
+	/**
+	 * Fetch source file contents from a GitHub repository.
+	 *
+	 * Uses the Git Trees API to list files, applies path/pattern filters,
+	 * then fetches content for each matching file via the Contents API.
+	 *
+	 * @param array            $config  Handler configuration.
+	 * @param ExecutionContext $context Execution context.
+	 * @param string           $repo    Repository in owner/repo format.
+	 * @return array DataPacket-compatible array or empty on no data.
+	 */
+	private function fetchFiles( array $config, ExecutionContext $context, string $repo ): array {
+		$branch       = $config['branch'] ?? '';
+		$file_path    = $config['file_path'] ?? '';
+		$file_pattern = $config['file_pattern'] ?? '';
+
+		$context->log( 'info', sprintf( 'GitHub: Fetching file tree for %s', $repo ) );
+
+		$result = GitHubAbilities::getRepoTree( array(
+			'repo'   => $repo,
+			'branch' => $branch,
+		) );
+
+		if ( is_wp_error( $result ) ) {
+			$context->log( 'error', 'GitHub: Tree API error — ' . $result->get_error_message() );
+			return array();
+		}
+
+		$files = $result['files'] ?? array();
+
+		if ( empty( $files ) ) {
+			$context->log( 'info', 'GitHub: No files found in repository.' );
+			return array();
+		}
+
+		// Apply path prefix filter.
+		if ( ! empty( $file_path ) ) {
+			$prefix = rtrim( $file_path, '/' ) . '/';
+			$files  = array_filter( $files, fn( $f ) => str_starts_with( $f['path'], $prefix ) || $f['path'] === trim( $file_path, '/' ) );
+			$files  = array_values( $files );
+		}
+
+		// Apply file pattern filter (simple glob: *.php, *.md, etc.).
+		if ( ! empty( $file_pattern ) ) {
+			$files = $this->filterByPattern( $files, $file_pattern );
+		}
+
+		// Filter out binary/large files (> 500 KB, likely not source).
+		$max_file_size = (int) ( $config['max_file_size'] ?? 512000 );
+		$files = array_filter( $files, fn( $f ) => $f['size'] > 0 && $f['size'] <= $max_file_size );
+		$files = array_values( $files );
+
+		if ( empty( $files ) ) {
+			$context->log( 'info', 'GitHub: No files matched filters.' );
+			return array();
+		}
+
+		$context->log( 'info', sprintf( 'GitHub: Found %d matching files.', count( $files ) ) );
+
+		$eligible_items = array();
+
+		foreach ( $files as $file ) {
+			$file_result = GitHubAbilities::getFileContents( array(
+				'repo'   => $repo,
+				'path'   => $file['path'],
+				'branch' => $branch,
+			) );
+
+			if ( is_wp_error( $file_result ) ) {
+				$context->log( 'debug', sprintf( 'GitHub: Skipped %s — %s', $file['path'], $file_result->get_error_message() ) );
+				continue;
+			}
+
+			$file_data   = $file_result['file'];
+			$guid        = sprintf( 'github_%s_files_%s', $repo, $file['sha'] );
+
+			$eligible_items[] = array(
+				'title'    => $file_data['path'],
+				'content'  => $file_data['content'],
+				'metadata' => array(
+					'source_type'       => 'github',
+					'original_id'       => $guid,
+					'dedup_key'         => $guid,
+					'original_title'    => $file_data['path'],
+					'github_repo'       => $repo,
+					'github_type'       => 'files',
+					'github_file_path'  => $file_data['path'],
+					'github_file_size'  => $file_data['size'],
+					'github_file_sha'   => $file_data['sha'],
+					'github_url'        => $file_data['html_url'],
+					'source_url'        => $file_data['html_url'],
+				),
+			);
+		}
+
+		if ( empty( $eligible_items ) ) {
+			$context->log( 'info', 'GitHub: No file contents could be retrieved.' );
+			return array();
+		}
+
+		$context->log( 'info', sprintf( 'GitHub: Retrieved %d file contents.', count( $eligible_items ) ) );
+		return array( 'items' => $eligible_items );
+	}
+
+	/**
+	 * Fetch issues or pull requests from a GitHub repository.
+	 *
+	 * @param array            $config      Handler configuration.
+	 * @param ExecutionContext $context     Execution context.
+	 * @param string           $repo        Repository in owner/repo format.
+	 * @param string           $data_source 'issues' or 'pulls'.
+	 * @return array DataPacket-compatible array or empty on no data.
+	 */
+	private function fetchIssuesOrPulls( array $config, ExecutionContext $context, string $repo, string $data_source ): array {
+		$state  = $config['state'] ?? 'open';
+		$labels = $config['labels'] ?? '';
 
 		$input = array(
 			'repo'     => $repo,
@@ -167,6 +289,35 @@ class GitHub extends FetchHandler {
 
 		$context->log( 'info', sprintf( 'GitHub: Found %d eligible items.', count( $eligible_items ) ) );
 		return array( 'items' => $eligible_items );
+	}
+
+	/**
+	 * Filter files by a glob-like pattern.
+	 *
+	 * Supports simple patterns like `*.php`, `*.md`, `*.css`.
+	 * Multiple patterns can be comma-separated: `*.php,*.json`.
+	 *
+	 * @param array  $files   Normalized file entries from getRepoTree.
+	 * @param string $pattern Glob pattern(s).
+	 * @return array Filtered files.
+	 */
+	private function filterByPattern( array $files, string $pattern ): array {
+		$patterns = array_map( 'trim', explode( ',', $pattern ) );
+		$patterns = array_filter( $patterns );
+
+		if ( empty( $patterns ) ) {
+			return $files;
+		}
+
+		return array_values( array_filter( $files, function ( $file ) use ( $patterns ) {
+			$filename = basename( $file['path'] );
+			foreach ( $patterns as $p ) {
+				if ( fnmatch( $p, $filename ) ) {
+					return true;
+				}
+			}
+			return false;
+		} ) );
 	}
 
 	private function buildIssueContent( array $issue ): string {

--- a/inc/Handlers/GitHub/GitHubSettings.php
+++ b/inc/Handlers/GitHub/GitHubSettings.php
@@ -40,6 +40,7 @@ class GitHubSettings extends FetchHandlerSettings {
 				'options'     => array(
 					'issues' => __( 'Issues', 'data-machine-code' ),
 					'pulls'  => __( 'Pull Requests', 'data-machine-code' ),
+					'files'  => __( 'Source Files', 'data-machine-code' ),
 				),
 			),
 			'state'       => array(
@@ -59,6 +60,31 @@ class GitHubSettings extends FetchHandlerSettings {
 				'label'       => __( 'Label Filter', 'data-machine-code' ),
 				'description' => __( 'Comma-separated label names to filter by (issues only).', 'data-machine-code' ),
 				'required'    => false,
+			),
+			'branch'       => array(
+				'type'        => 'text',
+				'label'       => __( 'Branch', 'data-machine-code' ),
+				'description' => __( 'Git branch or ref to read from (files data source). Defaults to the repository default branch.', 'data-machine-code' ),
+				'required'    => false,
+			),
+			'file_path'    => array(
+				'type'        => 'text',
+				'label'       => __( 'File Path', 'data-machine-code' ),
+				'description' => __( 'Directory or file path prefix to filter (files data source). E.g., "inc/" or "src/Commands/". Leave empty for all files.', 'data-machine-code' ),
+				'required'    => false,
+			),
+			'file_pattern' => array(
+				'type'        => 'text',
+				'label'       => __( 'File Pattern', 'data-machine-code' ),
+				'description' => __( 'Glob pattern to filter filenames (files data source). E.g., "*.php" or "*.php,*.json". Leave empty for all file types.', 'data-machine-code' ),
+				'required'    => false,
+			),
+			'max_file_size' => array(
+				'type'        => 'number',
+				'label'       => __( 'Max File Size (bytes)', 'data-machine-code' ),
+				'description' => __( 'Skip files larger than this size in bytes (files data source). Default: 512000 (500 KB).', 'data-machine-code' ),
+				'required'    => false,
+				'default'     => 512000,
 			),
 		);
 


### PR DESCRIPTION
Closes #24

## Summary

Extends the existing GitHub fetch handler with a new \`files\` data source that reads **source file contents** from a GitHub repository, enabling pipelines that process code — automated documentation, code review, changelog generation, etc.

## Changes

### \`GitHubAbilities\` — 2 new methods + 2 normalizers

- **\`getRepoTree()\`** — calls \`GET /repos/{owner}/{repo}/git/trees/{sha}?recursive=1\` to get the full file listing in one call
- **\`getFileContents()\`** — calls \`GET /repos/{owner}/{repo}/contents/{path}\` to read individual file content (base64 decode)
- **\`normalizeTreeEntry()\`** — normalizes tree entries to \`{path, size, sha}\`
- **\`normalizeFileContent()\`** — normalizes file responses with decoded content

Both reuse existing \`apiGet()\`, PAT auth, error handling.

### \`GitHub\` handler — refactored into focused methods

- **\`executeFetch()\`** now routes to \`fetchFiles()\` or \`fetchIssuesOrPulls()\` based on \`data_source\`
- **\`fetchFiles()\`** — gets tree, applies filters, fetches content per file, returns DataPackets with \`github_file_path\`, \`github_file_sha\` for dedup
- **\`filterByPattern()\`** — glob-style filename filtering supporting comma-separated patterns (\`*.php,*.json\`)
- File size cap (default 500 KB) to skip large binaries
- Path prefix filtering (\`inc/\`, \`src/Commands/\`)

### \`GitHubSettings\` — 4 new fields for files mode

| Field | Type | Description |
|-------|------|-------------|
| \`branch\` | text | Git ref to read from |
| \`file_path\` | text | Directory prefix filter |
| \`file_pattern\` | text | Glob pattern (\`*.php\`, \`*.md\`) |
| \`max_file_size\` | number | Skip files larger than this (default 500 KB) |

## How It Works

\`\`\`
Pipeline config:
  handler: github
  data_source: files
  repo: Extra-Chill/extrachill-community
  file_path: inc/
  file_pattern: *.php

↓

1. getRepoTree() → full file listing
2. Filter by path prefix + glob pattern + file size
3. getFileContents() per matching file
4. Return DataPackets with source content + file metadata
5. Dedup via git SHA (content change = new SHA = re-process)

↓

AI step receives source code → generates user-facing docs
\`\`\`

## Testing

- All three files pass \`php -l\` syntax check
- Backward compatible — existing \`issues\` and \`pulls\` data sources unchanged
- New fields only apply when \`data_source = files\`

## Use Case

This is the foundation for **automated documentation** at docs.extrachill.com — a Data Machine pipeline that reads plugin source from GitHub, feeds it through an AI step that translates code into plain-English user docs, and publishes to the docs site.