### PR TITLE
Add GitHub update handler for committing files back to repos

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -50,6 +50,7 @@ function datamachine_code_bootstrap() {
 
 	// Load Handlers (they self-register).
 	new \DataMachineCode\Handlers\GitHub\GitHub();
+	new \DataMachineCode\Handlers\GitHub\GitHubUpdate();
 
 	// Register ability categories on the correct hook (must happen during wp_abilities_api_categories_init).
 	add_action( 'wp_abilities_api_categories_init', 'datamachine_code_register_ability_categories' );

--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -276,6 +276,53 @@ class GitHubAbilities {
 			);
 
 			wp_register_ability(
+				'datamachine/create-or-update-github-file',
+				array(
+					'label'               => 'Create or Update GitHub File',
+					'description'         => 'Create or update a file in a GitHub repository via the Contents API (upsert). If the file exists, it is updated; if not, it is created.',
+					'category'            => 'datamachine-code-github',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'repo', 'file_path', 'content', 'commit_message' ),
+						'properties' => array(
+							'repo'           => array(
+								'type'        => 'string',
+								'description' => 'Repository in owner/repo format.',
+							),
+							'file_path'      => array(
+								'type'        => 'string',
+								'description' => 'Path within the repository (e.g., docs/getting-started.md).',
+							),
+							'content'        => array(
+								'type'        => 'string',
+								'description' => 'File content (will be base64-encoded automatically).',
+							),
+							'commit_message' => array(
+								'type'        => 'string',
+								'description' => 'Commit message for the change.',
+							),
+							'branch'         => array(
+								'type'        => 'string',
+								'description' => 'Target branch. Defaults to the repository\'s default branch.',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'      => array( 'type' => 'boolean' ),
+							'commit'       => array( 'type' => 'object' ),
+							'content'      => array( 'type' => 'object' ),
+							'error'        => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'createOrUpdateFile' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
 				'datamachine/list-github-repos',
 				array(
 					'label'               => 'List GitHub Repositories',
@@ -605,6 +652,85 @@ class GitHubAbilities {
 			'success' => true,
 			'repos'   => $normalized,
 			'count'   => count( $normalized ),
+		);
+	}
+
+	public static function createOrUpdateFile( array $input ): array|\WP_Error {
+		$repo = self::resolveRepo( sanitize_text_field( $input['repo'] ?? '' ) );
+		if ( empty( $repo ) ) {
+			return new \WP_Error( 'missing_repo', 'Repository (owner/repo) is required or configure a default repo.', array( 'status' => 400 ) );
+		}
+
+		$file_path = sanitize_text_field( $input['file_path'] ?? '' );
+		if ( empty( $file_path ) ) {
+			return new \WP_Error( 'missing_file_path', 'File path is required.', array( 'status' => 400 ) );
+		}
+
+		$content = $input['content'] ?? '';
+		if ( '' === $content ) {
+			return new \WP_Error( 'missing_content', 'File content is required.', array( 'status' => 400 ) );
+		}
+
+		$commit_message = sanitize_text_field( $input['commit_message'] ?? '' );
+		if ( empty( $commit_message ) ) {
+			return new \WP_Error( 'missing_commit_message', 'Commit message is required.', array( 'status' => 400 ) );
+		}
+
+		$pat = self::getPat();
+		if ( empty( $pat ) ) {
+			return self::patError();
+		}
+
+		$branch = sanitize_text_field( $input['branch'] ?? '' );
+
+		// Check if the file already exists to get its SHA for update.
+		$get_url    = sprintf( '%s/repos/%s/contents/%s', self::API_BASE, $repo, $file_path );
+		$get_params = array();
+		if ( ! empty( $branch ) ) {
+			$get_params['ref'] = $branch;
+		}
+
+		$existing = self::apiGet( $get_url, $get_params, $pat );
+
+		$body = array(
+			'message' => $commit_message,
+			'content' => base64_encode( $content ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Required by GitHub API.
+		);
+
+		// If the file exists, include its SHA for the update.
+		if ( ! is_wp_error( $existing ) && ! empty( $existing['data']['sha'] ) ) {
+			$body['sha'] = $existing['data']['sha'];
+		}
+
+		if ( ! empty( $branch ) ) {
+			$body['branch'] = $branch;
+		}
+
+		$put_url  = sprintf( '%s/repos/%s/contents/%s', self::API_BASE, $repo, $file_path );
+		$response = self::apiRequest( 'PUT', $put_url, $body, $pat );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$data = $response['data'];
+
+		return array(
+			'success' => true,
+			'commit'  => array(
+				'sha'       => $data['commit']['sha'] ?? '',
+				'html_url'  => $data['commit']['html_url'] ?? '',
+				'message'   => $data['commit']['message'] ?? '',
+			),
+			'content' => array(
+				'path'      => $data['content']['path'] ?? $file_path,
+				'html_url'  => $data['content']['html_url'] ?? '',
+			),
+			'message' => sprintf(
+				'File %s in %s.',
+				isset( $data['content'] ) ? 'updated' : 'created',
+				$repo
+			),
 		);
 	}
 

--- a/inc/Handlers/GitHub/GitHubUpdate.php
+++ b/inc/Handlers/GitHub/GitHubUpdate.php
@@ -89,7 +89,7 @@ class GitHubUpdate extends UpsertHandler {
 	 * @param array $handler_config Handler configuration from settings.
 	 * @return array Success/failure response.
 	 */
-	protected function executeUpdate( array $parameters, array $handler_config ): array {
+	protected function executeUpsert( array $parameters, array $handler_config ): array {
 		$job_id = $parameters['job_id'] ?? null;
 
 		// Resolve repo: AI param > handler config > default repo setting.

--- a/inc/Handlers/GitHub/GitHubUpdate.php
+++ b/inc/Handlers/GitHub/GitHubUpdate.php
@@ -14,20 +14,20 @@ namespace DataMachineCode\Handlers\GitHub;
 
 use DataMachineCode\Abilities\GitHubAbilities;
 use DataMachine\Core\Steps\HandlerRegistrationTrait;
-use DataMachine\Core\Steps\Update\Handlers\UpdateHandler;
+use DataMachine\Core\Steps\Upsert\Handlers\UpsertHandler;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-class GitHubUpdate extends UpdateHandler {
+class GitHubUpdate extends UpsertHandler {
 
 	use HandlerRegistrationTrait;
 
 	public function __construct() {
 		self::registerHandler(
 			'github_update',
-			'update',
+			'upsert',
 			self::class,
 			'GitHub Update',
 			'Commit files to GitHub repositories via the Contents API',

--- a/inc/Handlers/GitHub/GitHubUpdate.php
+++ b/inc/Handlers/GitHub/GitHubUpdate.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * GitHub Update Handler
+ *
+ * Commits files back to GitHub repositories via the Contents API.
+ * Used as the final step in automated documentation pipelines:
+ * fetch source → AI translate → publish to WordPress → commit docs back to repo.
+ *
+ * @package DataMachineCode\Handlers\GitHub
+ * @since 0.6.0
+ */
+
+namespace DataMachineCode\Handlers\GitHub;
+
+use DataMachineCode\Abilities\GitHubAbilities;
+use DataMachine\Core\Steps\HandlerRegistrationTrait;
+use DataMachine\Core\Steps\Update\Handlers\UpdateHandler;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class GitHubUpdate extends UpdateHandler {
+
+	use HandlerRegistrationTrait;
+
+	public function __construct() {
+		self::registerHandler(
+			'github_update',
+			'update',
+			self::class,
+			'GitHub Update',
+			'Commit files to GitHub repositories via the Contents API',
+			false,
+			null,
+			GitHubUpdateSettings::class,
+			array( self::class, 'registerTools' )
+		);
+	}
+
+	/**
+	 * Register the AI tool for the update step.
+	 *
+	 * The AI step in the pipeline calls this tool with the generated content.
+	 * Parameters from the AI override handler config defaults.
+	 *
+	 * @param array  $tools          Registered tools.
+	 * @param string $handler_slug   Current handler slug.
+	 * @param array  $handler_config Handler configuration from settings.
+	 * @return array Tools with GitHub update tool added.
+	 */
+	public static function registerTools( $tools, $handler_slug, $handler_config ) {
+		if ( 'github_update' === $handler_slug ) {
+			$tools['github_update'] = array(
+				'class'       => self::class,
+				'method'      => 'handle_tool_call',
+				'handler'     => 'github_update',
+				'description' => 'Commit a file to a GitHub repository. Creates the file if it does not exist, or updates it if it does.',
+				'parameters'  => array(
+					'type'       => 'object',
+					'required'   => array( 'content' ),
+					'properties' => array(
+						'content'        => array(
+							'type'        => 'string',
+							'description' => 'The file content to commit (markdown, code, etc.).',
+						),
+						'file_path'      => array(
+							'type'        => 'string',
+							'description' => 'Path within the repository (e.g., docs/getting-started.md). Overrides handler config if provided.',
+						),
+						'commit_message' => array(
+							'type'        => 'string',
+							'description' => 'Commit message. Overrides handler config if provided.',
+						),
+					),
+				),
+			);
+		}
+		return $tools;
+	}
+
+	/**
+	 * Execute the GitHub file update.
+	 *
+	 * Merges AI-provided parameters with handler config defaults,
+	 * then delegates to GitHubAbilities::createOrUpdateFile().
+	 *
+	 * @param array $parameters    Tool parameters (job_id, engine, plus AI-provided fields).
+	 * @param array $handler_config Handler configuration from settings.
+	 * @return array Success/failure response.
+	 */
+	protected function executeUpdate( array $parameters, array $handler_config ): array {
+		$job_id = $parameters['job_id'] ?? null;
+
+		// Resolve repo: AI param > handler config > default repo setting.
+		$repo = ! empty( $parameters['repo'] )
+			? sanitize_text_field( $parameters['repo'] )
+			: ( $handler_config['repo'] ?? '' );
+
+		if ( empty( $repo ) ) {
+			$repo = GitHubAbilities::getDefaultRepo();
+		}
+
+		if ( empty( $repo ) ) {
+			return $this->errorResponse( 'GitHub Update: No repository configured and no default repo set.', array( 'job_id' => $job_id ) );
+		}
+
+		if ( ! GitHubAbilities::isConfigured() ) {
+			return $this->errorResponse( 'GitHub Update: Personal Access Token not configured.', array( 'job_id' => $job_id ) );
+		}
+
+		// Resolve file path: AI param > handler config.
+		$file_path = ! empty( $parameters['file_path'] )
+			? sanitize_text_field( $parameters['file_path'] )
+			: ( $handler_config['file_path'] ?? '' );
+
+		if ( empty( $file_path ) ) {
+			return $this->errorResponse( 'GitHub Update: file_path is required (provide via AI tool call or handler config).', array( 'job_id' => $job_id ) );
+		}
+
+		// Resolve commit message: AI param > handler config > default.
+		$commit_message = ! empty( $parameters['commit_message'] )
+			? sanitize_text_field( $parameters['commit_message'] )
+			: ( $handler_config['commit_message'] ?? 'docs: update generated content' );
+
+		// Resolve branch: AI param > handler config (empty = repo default).
+		$branch = ! empty( $parameters['branch'] )
+			? sanitize_text_field( $parameters['branch'] )
+			: ( $handler_config['branch'] ?? '' );
+
+		$content = $parameters['content'] ?? '';
+		if ( '' === $content ) {
+			return $this->errorResponse( 'GitHub Update: content is required.', array( 'job_id' => $job_id ) );
+		}
+
+		$input = array(
+			'repo'           => $repo,
+			'file_path'      => $file_path,
+			'content'        => $content,
+			'commit_message' => $commit_message,
+		);
+
+		if ( ! empty( $branch ) ) {
+			$input['branch'] = $branch;
+		}
+
+		$result = GitHubAbilities::createOrUpdateFile( $input );
+
+		if ( is_wp_error( $result ) ) {
+			return $this->errorResponse(
+				'GitHub Update: ' . $result->get_error_message(),
+				array(
+					'job_id'    => $job_id,
+					'repo'      => $repo,
+					'file_path' => $file_path,
+				)
+			);
+		}
+
+		return array(
+			'success'   => true,
+			'data'      => array(
+				'repo'        => $repo,
+				'file_path'   => $file_path,
+				'commit_sha'  => $result['commit']['sha'] ?? '',
+				'commit_url'  => $result['commit']['html_url'] ?? '',
+				'file_url'    => $result['content']['html_url'] ?? '',
+			),
+			'tool_name' => 'github_update',
+		);
+	}
+
+	/**
+	 * Get the handler label.
+	 *
+	 * @return string
+	 */
+	public static function get_label(): string {
+		return __( 'GitHub Update', 'data-machine-code' );
+	}
+}

--- a/inc/Handlers/GitHub/GitHubUpdateSettings.php
+++ b/inc/Handlers/GitHub/GitHubUpdateSettings.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * GitHub Update Handler Settings
+ *
+ * Defines settings fields for the GitHub update handler UI.
+ * Configures repository, branch, file path, and commit message
+ * for committing generated content back to GitHub repositories.
+ *
+ * @package DataMachineCode\Handlers\GitHub
+ * @since 0.6.0
+ */
+
+namespace DataMachineCode\Handlers\GitHub;
+
+use DataMachine\Core\Steps\Settings\SettingsHandler;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class GitHubUpdateSettings extends SettingsHandler {
+
+	/**
+	 * Get settings fields for GitHub update handler.
+	 *
+	 * @return array
+	 */
+	public static function get_fields(): array {
+		return array(
+			'repo'           => array(
+				'type'        => 'text',
+				'label'       => __( 'Repository', 'data-machine-code' ),
+				'description' => __( 'GitHub repository in owner/repo format (e.g., Extra-Chill/data-machine). Falls back to default repo in settings.', 'data-machine-code' ),
+				'required'    => false,
+			),
+			'branch'         => array(
+				'type'        => 'text',
+				'label'       => __( 'Branch', 'data-machine-code' ),
+				'description' => __( 'Target branch for the commit. Defaults to the repository\'s default branch.', 'data-machine-code' ),
+				'required'    => false,
+			),
+			'file_path'      => array(
+				'type'        => 'text',
+				'label'       => __( 'File Path', 'data-machine-code' ),
+				'description' => __( 'Path within the repository (e.g., docs/getting-started.md). Can be overridden by the AI step.', 'data-machine-code' ),
+				'required'    => false,
+			),
+			'commit_message' => array(
+				'type'        => 'text',
+				'label'       => __( 'Commit Message', 'data-machine-code' ),
+				'description' => __( 'Default commit message template. Can be overridden by the AI step.', 'data-machine-code' ),
+				'required'    => false,
+				'default'     => 'docs: update generated content',
+			),
+		);
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `GitHubUpdate` handler extending `UpdateHandler` — registered as `github_update` update step type
- Adds `GitHubUpdateSettings` with repo, branch, file_path, and commit_message fields
- Adds `GitHubAbilities::createOrUpdateFile()` — performs GitHub Contents API upsert (GET for SHA → PUT with base64 content)
- Registers the new ability `datamachine/create-or-update-github-file` and tool in the pipeline
- Instantiates `GitHubUpdate` in the plugin bootstrap

## Pipeline Flow

This closes the loop on the automated documentation pipeline described in the issue:

```
Fetch (github, files)    → read plugin source
AI step                  → translate code to user-facing docs
Publish (wordpress)      → create/update ec_doc on docs site
Update (github)          → commit generated markdown back to repo  ← this PR
```

## Files Changed

| File | Change |
|------|--------|
| `inc/Handlers/GitHub/GitHubUpdate.php` | **NEW** — Update handler with `registerTools()` and `executeUpdate()` |
| `inc/Handlers/GitHub/GitHubUpdateSettings.php` | **NEW** — Settings (repo, branch, file_path, commit_message) |
| `inc/Abilities/GitHubAbilities.php` | Added `createOrUpdateFile()` method + ability registration |
| `data-machine-code.php` | Bootstrap `new GitHubUpdate()` |

Closes #26