### PR TITLE
feat(workspace): `worktree cleanup` for merged branches

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -847,6 +847,45 @@ class WorkspaceAbilities {
 					'meta'                => array( 'show_in_rest' => false ),
 				)
 			);
+
+			wp_register_ability(
+				'datamachine/workspace-worktree-cleanup',
+				array(
+					'label'               => 'Cleanup Merged Worktrees',
+					'description'         => 'Remove worktrees whose branch is merged to the remote default branch. Detects merge via `upstream: gone` (remote branch deleted, e.g. by GitHub auto-delete on PR merge) or closed+merged PR via the GitHub API. Deletes the local branch and prunes the git registry after removal. Dry-run supported.',
+					'category'            => 'datamachine-code-workspace',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'dry_run'     => array(
+								'type'        => 'boolean',
+								'description' => 'If true, return the plan without removing anything.',
+							),
+							'force'       => array(
+								'type'        => 'boolean',
+								'description' => 'If true, ignore dirty working-tree safety check.',
+							),
+							'skip_github' => array(
+								'type'        => 'boolean',
+								'description' => 'If true, rely solely on the local upstream-gone signal and skip GitHub API lookup.',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'    => array( 'type' => 'boolean' ),
+							'dry_run'    => array( 'type' => 'boolean' ),
+							'candidates' => array( 'type' => 'array' ),
+							'removed'    => array( 'type' => 'array' ),
+							'skipped'    => array( 'type' => 'array' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'worktreeCleanup' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
 		};
 
 		if ( doing_action( 'wp_abilities_api_init' ) ) {
@@ -1132,6 +1171,23 @@ class WorkspaceAbilities {
 	public static function worktreePrune( array $input ): array|\WP_Error { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 		$workspace = new Workspace();
 		return $workspace->worktree_prune();
+	}
+
+	/**
+	 * Remove merged worktrees across all primary checkouts.
+	 *
+	 * @param array $input Input parameters (dry_run, force, skip_github).
+	 * @return array
+	 */
+	public static function worktreeCleanup( array $input ): array|\WP_Error {
+		$workspace = new Workspace();
+		return $workspace->worktree_cleanup_merged(
+			array(
+				'dry_run'     => ! empty( $input['dry_run'] ),
+				'force'       => ! empty( $input['force'] ),
+				'skip_github' => ! empty( $input['skip_github'] ),
+			)
+		);
 	}
 
 	/**

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -927,22 +927,35 @@ class WorkspaceCommand extends BaseCommand {
 	 *     # Prune stale worktree registry entries across all primaries
 	 *     wp datamachine workspace worktree prune
 	 *
+	 *     # Preview worktrees that would be removed (upstream gone or PR merged)
+	 *     wp datamachine workspace worktree cleanup --dry-run
+	 *
+	 *     # Remove all merged worktrees
+	 *     wp datamachine workspace worktree cleanup
+	 *
+	 *     # Local-only detection (no GitHub API call)
+	 *     wp datamachine workspace worktree cleanup --skip-github
+	 *
+	 *     # Ignore dirty working-tree safety (caution)
+	 *     wp datamachine workspace worktree cleanup --force
+	 *
 	 * @subcommand worktree
 	 */
 	public function worktree( array $args, array $assoc_args ): void {
 		$operation = $args[0] ?? '';
 
 		if ( '' === $operation ) {
-			WP_CLI::error( 'Usage: wp datamachine workspace worktree <add|list|remove|prune> [<repo>] [<branch>] [--flags]' );
+			WP_CLI::error( 'Usage: wp datamachine workspace worktree <add|list|remove|prune|cleanup> [<repo>] [<branch>] [--flags]' );
 			return;
 		}
 
 		$ability_name = match ( $operation ) {
-			'add'    => 'datamachine/workspace-worktree-add',
-			'list'   => 'datamachine/workspace-worktree-list',
-			'remove' => 'datamachine/workspace-worktree-remove',
-			'prune'  => 'datamachine/workspace-worktree-prune',
-			default  => '',
+			'add'     => 'datamachine/workspace-worktree-add',
+			'list'    => 'datamachine/workspace-worktree-list',
+			'remove'  => 'datamachine/workspace-worktree-remove',
+			'prune'   => 'datamachine/workspace-worktree-prune',
+			'cleanup' => 'datamachine/workspace-worktree-cleanup',
+			default   => '',
 		};
 
 		if ( '' === $ability_name ) {
@@ -985,6 +998,12 @@ class WorkspaceCommand extends BaseCommand {
 				$input['repo']   = $args[1];
 				$input['branch'] = $args[2];
 				$input['force']  = ! empty( $assoc_args['force'] );
+				break;
+
+			case 'cleanup':
+				$input['dry_run']     = ! empty( $assoc_args['dry-run'] );
+				$input['force']       = ! empty( $assoc_args['force'] );
+				$input['skip_github'] = ! empty( $assoc_args['skip-github'] );
 				break;
 		}
 
@@ -1035,6 +1054,52 @@ class WorkspaceCommand extends BaseCommand {
 					return;
 				}
 				WP_CLI::success( sprintf( 'Pruned worktree registry across: %s', implode( ', ', $pruned ) ) );
+				return;
+
+			case 'cleanup':
+				$candidates = $result['candidates'] ?? array();
+				$removed    = $result['removed'] ?? array();
+				$skipped    = $result['skipped'] ?? array();
+				$dry_run    = ! empty( $result['dry_run'] );
+
+				if ( empty( $candidates ) && empty( $skipped ) ) {
+					WP_CLI::log( 'No worktrees found.' );
+					return;
+				}
+
+				if ( ! empty( $candidates ) ) {
+					WP_CLI::log( $dry_run ? 'Would remove:' : 'Removed:' );
+					$rows = array_map(
+						fn( $c ) => array(
+							'handle' => $c['handle'] ?? '',
+							'branch' => $c['branch'] ?? '',
+							'signal' => $c['signal'] ?? '',
+							'reason' => $c['reason'] ?? '',
+						),
+						$candidates
+					);
+					$this->format_items( $rows, array( 'handle', 'branch', 'signal', 'reason' ), $assoc_args, 'handle' );
+				}
+
+				if ( ! empty( $skipped ) ) {
+					WP_CLI::log( '' );
+					WP_CLI::log( 'Skipped:' );
+					$rows = array_map(
+						fn( $s ) => array(
+							'handle' => $s['handle'] ?? '',
+							'reason' => $s['reason'] ?? '',
+						),
+						$skipped
+					);
+					$this->format_items( $rows, array( 'handle', 'reason' ), $assoc_args, 'handle' );
+				}
+
+				if ( $dry_run ) {
+					WP_CLI::log( '' );
+					WP_CLI::success( sprintf( '%d worktree(s) would be removed. Re-run without --dry-run to apply.', count( $candidates ) ) );
+				} else {
+					WP_CLI::success( sprintf( 'Removed %d worktree(s); %d skipped.', count( $removed ), count( $skipped ) ) );
+				}
 				return;
 
 			case 'add':

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -1085,6 +1085,304 @@ class Workspace {
 	}
 
 	/**
+	 * Cleanup merged worktrees across all primary checkouts.
+	 *
+	 * Scans all worktrees, consults upstream tracking + GitHub PR state,
+	 * and (unless dry-run) removes worktrees whose work is already merged
+	 * to the remote default branch. Also deletes the local branch and
+	 * prunes the git registry afterwards.
+	 *
+	 * A worktree is considered prunable when ALL of:
+	 *   - It is not the primary checkout
+	 *   - Its branch is not main/master/trunk/develop/HEAD
+	 *   - It has no uncommitted changes (unless $force)
+	 *   - At least one merge signal is present:
+	 *       a) `git for-each-ref` reports upstream status "gone" (branch
+	 *          was deleted on the remote — typical after GitHub
+	 *          "auto-delete head branches" fires on PR merge), OR
+	 *       b) GitHub API reports a closed+merged PR whose head
+	 *          branch matches this worktree's branch.
+	 *
+	 * Signal (a) is local and fast; signal (b) requires a PAT + network
+	 * but catches the case where the remote branch still exists (e.g.
+	 * manual merge without branch deletion).
+	 *
+	 * @param array $opts {
+	 *     @type bool $dry_run If true, return the plan without removing anything.
+	 *     @type bool $force   If true, ignore dirty working-tree safety.
+	 *     @type bool $skip_github If true, only use upstream-gone signal (no API calls).
+	 * }
+	 * @return array{
+	 *     success: bool,
+	 *     dry_run: bool,
+	 *     candidates: array<int,array>,
+	 *     removed: array<int,array>,
+	 *     skipped: array<int,array>,
+	 * }|\WP_Error
+	 */
+	public function worktree_cleanup_merged( array $opts = array() ): array|\WP_Error {
+		$dry_run     = ! empty( $opts['dry_run'] );
+		$force       = ! empty( $opts['force'] );
+		$skip_github = ! empty( $opts['skip_github'] );
+
+		$listing = $this->worktree_list();
+		if ( is_wp_error( $listing ) ) {
+			return $listing;
+		}
+
+		$protected_branches = array( 'main', 'master', 'trunk', 'develop', 'HEAD' );
+		$candidates         = array();
+		$skipped            = array();
+
+		// Fetch + prune each primary once up-front so upstream-gone signals are fresh.
+		$fetched = array();
+
+		foreach ( $listing['worktrees'] ?? array() as $wt ) {
+			if ( ! empty( $wt['is_primary'] ) ) {
+				continue;
+			}
+			if ( ! empty( $wt['external'] ) ) {
+				$skipped[] = array(
+					'handle' => $wt['handle'] ?? '?',
+					'reason' => 'external worktree (outside workspace)',
+				);
+				continue;
+			}
+
+			$repo        = $wt['repo'] ?? '';
+			$branch      = $wt['branch'] ?? '';
+			$wt_path     = $wt['path'] ?? '';
+			$dirty_count = (int) ( $wt['dirty'] ?? 0 );
+
+			if ( '' === $repo || '' === $branch || '' === $wt_path ) {
+				$skipped[] = array(
+					'handle' => $wt['handle'] ?? '?',
+					'reason' => 'missing repo/branch/path',
+				);
+				continue;
+			}
+
+			if ( in_array( $branch, $protected_branches, true ) ) {
+				$skipped[] = array(
+					'handle' => $wt['handle'] ?? '?',
+					'reason' => sprintf( 'protected branch (%s)', $branch ),
+				);
+				continue;
+			}
+
+			if ( $dirty_count > 0 && ! $force ) {
+				$skipped[] = array(
+					'handle' => $wt['handle'] ?? '?',
+					'reason' => sprintf( 'working tree dirty (%d files) — pass force=true to override', $dirty_count ),
+				);
+				continue;
+			}
+
+			$primary_path = $this->get_primary_path( $repo );
+			if ( ! is_dir( $primary_path . '/.git' ) ) {
+				$skipped[] = array(
+					'handle' => $wt['handle'] ?? '?',
+					'reason' => 'primary checkout missing',
+				);
+				continue;
+			}
+
+			if ( empty( $fetched[ $repo ] ) ) {
+				$this->run_git( $primary_path, 'fetch --prune --quiet origin' );
+				$fetched[ $repo ] = true;
+			}
+
+			$signal = $this->detect_merge_signal( $primary_path, $repo, $branch, $skip_github );
+			if ( null === $signal ) {
+				$skipped[] = array(
+					'handle' => $wt['handle'] ?? '?',
+					'reason' => 'no merge signal — leaving in place',
+				);
+				continue;
+			}
+
+			$candidates[] = array(
+				'handle'  => $wt['handle'],
+				'repo'    => $repo,
+				'branch'  => $branch,
+				'path'    => $wt_path,
+				'dirty'   => $dirty_count,
+				'signal'  => $signal['signal'],
+				'reason'  => $signal['reason'],
+				'pr_url'  => $signal['pr_url'] ?? null,
+			);
+		}
+
+		if ( $dry_run ) {
+			return array(
+				'success'    => true,
+				'dry_run'    => true,
+				'candidates' => $candidates,
+				'removed'    => array(),
+				'skipped'    => $skipped,
+			);
+		}
+
+		$removed = array();
+
+		foreach ( $candidates as $cand ) {
+			$remove = $this->worktree_remove( $cand['repo'], $cand['branch'], $force );
+			if ( is_wp_error( $remove ) ) {
+				$skipped[] = array(
+					'handle' => $cand['handle'],
+					'reason' => 'remove failed: ' . $remove->get_error_message(),
+				);
+				continue;
+			}
+
+			// Delete the now-detached local branch.
+			$primary_path = $this->get_primary_path( $cand['repo'] );
+			$this->run_git( $primary_path, sprintf( 'branch -D %s', escapeshellarg( $cand['branch'] ) ) );
+
+			$removed[] = $cand;
+		}
+
+		// Final sweep to drop any remaining registry entries.
+		$this->worktree_prune();
+
+		return array(
+			'success'    => true,
+			'dry_run'    => false,
+			'candidates' => $candidates,
+			'removed'    => $removed,
+			'skipped'    => $skipped,
+		);
+	}
+
+	/**
+	 * Detect whether a branch looks merged into the remote default branch.
+	 *
+	 * Returns an array with `signal` and `reason`, or null if no signal is
+	 * present (leave the worktree alone).
+	 *
+	 * Signal priority:
+	 *   1. `upstream-gone` — local branch's upstream tracking ref is gone.
+	 *      Typical after GitHub auto-deletes the head branch on PR merge.
+	 *   2. `pr-merged` — GitHub API reports a closed+merged PR for this
+	 *      branch. Requires $skip_github = false and a configured PAT.
+	 *
+	 * @param string $primary_path Path to the primary git checkout.
+	 * @param string $repo         Primary repo directory name.
+	 * @param string $branch       Branch name.
+	 * @param bool   $skip_github  If true, skip GitHub API lookup.
+	 * @return array{signal: string, reason: string, pr_url?: string}|null
+	 */
+	private function detect_merge_signal( string $primary_path, string $repo, string $branch, bool $skip_github ): ?array {
+		$ref    = 'refs/heads/' . $branch;
+		$format = '%(upstream:track)';
+		$result = $this->run_git( $primary_path, sprintf( 'for-each-ref --format=%s %s', escapeshellarg( $format ), escapeshellarg( $ref ) ) );
+
+		if ( ! is_wp_error( $result ) ) {
+			$track = trim( (string) ( $result['output'] ?? '' ) );
+			if ( str_contains( $track, 'gone' ) ) {
+				return array(
+					'signal' => 'upstream-gone',
+					'reason' => 'remote branch deleted (likely merged + auto-deleted)',
+				);
+			}
+		}
+
+		if ( $skip_github ) {
+			return null;
+		}
+
+		$gh_slug = $this->resolve_github_slug( $primary_path );
+		if ( null === $gh_slug ) {
+			return null;
+		}
+
+		$pr = $this->find_merged_pr_for_branch( $gh_slug, $branch );
+		if ( null === $pr ) {
+			return null;
+		}
+
+		return array(
+			'signal' => 'pr-merged',
+			'reason' => sprintf( 'PR #%d merged (%s)', $pr['number'], $pr['state'] ),
+			'pr_url' => $pr['html_url'] ?? null,
+		);
+	}
+
+	/**
+	 * Extract owner/repo slug from a primary checkout's origin remote.
+	 *
+	 * @param string $primary_path Primary checkout path.
+	 * @return string|null `owner/repo` or null if origin is not a GitHub URL.
+	 */
+	private function resolve_github_slug( string $primary_path ): ?string {
+		$remote = $this->git_get_remote( $primary_path );
+		if ( null === $remote || '' === $remote ) {
+			return null;
+		}
+
+		// Match https://github.com/owner/repo(.git) and git@github.com:owner/repo(.git)
+		if ( preg_match( '#github\.com[:/]([\w.-]+)/([\w.-]+?)(?:\.git)?/?$#', $remote, $m ) ) {
+			return $m[1] . '/' . $m[2];
+		}
+
+		return null;
+	}
+
+	/**
+	 * Look up a merged PR for a branch via the GitHub API.
+	 *
+	 * Queries `GET /repos/{slug}/pulls?state=closed&head={owner}:{branch}`
+	 * and returns the first entry whose `merged_at` is non-null.
+	 *
+	 * @param string $slug   owner/repo.
+	 * @param string $branch Branch name.
+	 * @return array|null PR data or null.
+	 */
+	private function find_merged_pr_for_branch( string $slug, string $branch ): ?array {
+		if ( ! class_exists( '\DataMachineCode\Abilities\GitHubAbilities' ) ) {
+			return null;
+		}
+
+		$pat = \DataMachineCode\Abilities\GitHubAbilities::getPat();
+		if ( empty( $pat ) ) {
+			return null;
+		}
+
+		$owner = explode( '/', $slug )[0] ?? '';
+		if ( '' === $owner ) {
+			return null;
+		}
+
+		$url      = sprintf( 'https://api.github.com/repos/%s/pulls', $slug );
+		$response = \DataMachineCode\Abilities\GitHubAbilities::apiGet(
+			$url,
+			array(
+				'state'    => 'closed',
+				'head'     => $owner . ':' . $branch,
+				'per_page' => 5,
+			),
+			$pat
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return null;
+		}
+
+		foreach ( (array) ( $response['data'] ?? array() ) as $pr ) {
+			if ( ! empty( $pr['merged_at'] ) ) {
+				return array(
+					'number'    => (int) ( $pr['number'] ?? 0 ),
+					'state'     => (string) ( $pr['state'] ?? 'closed' ),
+					'merged_at' => (string) $pr['merged_at'],
+					'html_url'  => (string) ( $pr['html_url'] ?? '' ),
+				);
+			}
+		}
+
+		return null;
+	}
+
+	/**
 	 * Resolve a sensible default base for new branches.
 	 *
 	 * Prefers `origin/HEAD` (typically `origin/main` or `origin/trunk`); falls


### PR DESCRIPTION
Closes #29.

## Summary

Adds `wp datamachine workspace worktree cleanup` which removes worktrees whose work has been merged upstream. Makes the worktree-first workflow sustainable as a daily driver — no more manual accumulation of stale checkouts after a session of PR work.

## Detection

Two complementary signals. Either is sufficient for removal; neither means leave it alone.

### 1. upstream-gone (local, no API)

The branch's remote tracking ref is gone (`git for-each-ref --format='%(upstream:track)'` contains `gone`). Typical after GitHub's "Automatically delete head branches" repo setting fires on PR merge.

### 2. pr-merged (GitHub API)

A closed+merged PR exists for this branch. Caught via `GET /repos/{owner}/{repo}/pulls?state=closed&head={owner}:{branch}` — only runs when origin is a GitHub URL and a PAT is configured. Skippable via `--skip-github`.

## Safety rails

- Primary checkouts are never touched
- Protected branches (main/master/trunk/develop/HEAD) are never touched
- Dirty working trees are skipped unless `--force`
- External worktrees (outside `$workspace_path`) are skipped
- `--dry-run` previews the plan without executing
- After removal, the local branch is deleted and `worktree prune` runs across all primaries

## CLI usage

```bash
# Preview what would be removed
wp datamachine workspace worktree cleanup --dry-run

# Remove all merged worktrees
wp datamachine workspace worktree cleanup

# Local-only (no GitHub API)
wp datamachine workspace worktree cleanup --skip-github

# Override dirty-check
wp datamachine workspace worktree cleanup --force
```

## Real-world test

Run against a live workspace with 6 worktrees across 3 repos after a day of PR merges:

```
=== candidates ===
  data-machine-upsert-rename                upstream-gone   remote branch deleted (likely merged + auto-deleted)
  dm-code-pr25-rebase                       pr-merged       PR #25 merged (closed)
    PR: https://github.com/Extra-Chill/data-machine-code/pull/25
  dm-code-pr27                              pr-merged       PR #27 merged (closed)
    PR: https://github.com/Extra-Chill/data-machine-code/pull/27
  dm-code-upsert-rename                     pr-merged       PR #28 merged (closed)
    PR: https://github.com/Extra-Chill/data-machine-code/pull/28
  data-machine-events-upsert                pr-merged       PR #205 merged (closed)
    PR: https://github.com/Extra-Chill/data-machine-events/pull/205

=== skipped ===
  dm-code-worktree-cli                      working tree dirty (3 files) — pass force=true to override
```

All 5 merged PRs from today's session correctly detected. Current worktree (this branch) correctly skipped as dirty.

## Implementation

| Layer | File | Addition |
|-------|------|----------|
| Workspace | `inc/Workspace/Workspace.php` | `worktree_cleanup_merged()`, `detect_merge_signal()`, `resolve_github_slug()`, `find_merged_pr_for_branch()` |
| Abilities | `inc/Abilities/WorkspaceAbilities.php` | `datamachine/workspace-worktree-cleanup` + `worktreeCleanup()` callback |
| CLI | `inc/Cli/Commands/WorkspaceCommand.php` | `cleanup` subcommand under `workspace worktree` with `--dry-run`, `--force`, `--skip-github` |

Reuses the existing `GitHubAbilities::apiGet()` + `getPat()` plumbing. No new dependencies.

## Out of scope (per issue #29)

- `worktree add` convenience wrapper (current ability already suffices)
- Session/thread tracking (kimaki's domain)
- Automatic periodic pruning (explicit CLI only for v1)