### PR TITLE
fix(workspace): path-aware worktree cleanup + safety rails + tests

### DIFF
--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -1226,7 +1226,7 @@ class Workspace {
 		$removed = array();
 
 		foreach ( $candidates as $cand ) {
-			$remove = $this->worktree_remove( $cand['repo'], $cand['branch'], $force );
+			$remove = $this->remove_worktree_by_path( $cand['repo'], $cand['branch'], $cand['path'], $force );
 			if ( is_wp_error( $remove ) ) {
 				$skipped[] = array(
 					'handle' => $cand['handle'],
@@ -1251,6 +1251,92 @@ class Workspace {
 			'candidates' => $candidates,
 			'removed'    => $removed,
 			'skipped'    => $skipped,
+		);
+	}
+
+	/**
+	 * Remove a worktree at an explicit path.
+	 *
+	 * Path-aware counterpart to `worktree_remove()`, which reconstructs the
+	 * path from `<repo>@<slug>` convention. Cleanup code must use this so
+	 * legacy worktrees (created before the @-slug convention landed, or via
+	 * raw `git worktree add`) can still be removed.
+	 *
+	 * Hard safety rails applied here before any removal:
+	 *   1. Primary repo's `.git` must exist (we're about to invoke it)
+	 *   2. The worktree path must be a real directory
+	 *   3. The worktree path must be inside `$workspace_path` (containment
+	 *      validation — no external targets, ever)
+	 *   4. The worktree's `.git` must be a file (worktree marker), not a
+	 *      directory. A directory `.git` means it's a primary, not a
+	 *      worktree — removing it would be catastrophic.
+	 *   5. If dirty and not forcing, refuse.
+	 *
+	 * @param string $repo    Primary repo directory name (for routing git commands).
+	 * @param string $branch  Branch the worktree is checked out to.
+	 * @param string $wt_path Absolute path to the worktree directory.
+	 * @param bool   $force   Pass --force to `git worktree remove`.
+	 * @return array{success: bool, handle: string, message: string}|\WP_Error
+	 */
+	private function remove_worktree_by_path( string $repo, string $branch, string $wt_path, bool $force ): array|\WP_Error {
+		$repo = $this->sanitize_name( $repo );
+		if ( '' === $repo ) {
+			return new \WP_Error( 'invalid_repo', 'Repository name is required.', array( 'status' => 400 ) );
+		}
+
+		$primary_path = $this->get_primary_path( $repo );
+		if ( ! is_dir( $primary_path . '/.git' ) ) {
+			return new \WP_Error( 'primary_not_found', sprintf( 'Primary checkout for "%s" does not exist.', $repo ), array( 'status' => 404 ) );
+		}
+
+		if ( '' === $wt_path || ! is_dir( $wt_path ) ) {
+			return new \WP_Error( 'worktree_path_missing', sprintf( 'Worktree path does not exist: %s', $wt_path ), array( 'status' => 404 ) );
+		}
+
+		// Belt-and-suspenders containment — cleanup callers already skip
+		// `external` worktrees, but validate again at the blast radius.
+		$validation = $this->validate_containment( $wt_path, $this->workspace_path );
+		if ( ! $validation['valid'] ) {
+			return new \WP_Error(
+				'path_outside_workspace',
+				sprintf( 'Refusing to remove "%s": path is outside workspace (%s).', $wt_path, $validation['message'] ?? '' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		// A worktree's .git is a FILE pointing at the primary's .git dir.
+		// A directory .git means we're looking at a primary checkout — never
+		// touch those.
+		$git_marker = rtrim( $validation['real_path'], '/' ) . '/.git';
+		if ( ! is_file( $git_marker ) ) {
+			return new \WP_Error(
+				'not_a_worktree',
+				sprintf( 'Refusing to remove "%s": .git is not a worktree marker file (got: %s). This may be a primary checkout.', $wt_path, is_dir( $git_marker ) ? 'directory' : 'missing' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		$cmd    = sprintf( 'worktree remove %s%s', $force ? '--force ' : '', escapeshellarg( $validation['real_path'] ) );
+		$result = $this->run_git( $primary_path, $cmd );
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		// If the directory survived `git worktree remove` (can happen for
+		// locked worktrees, or when the worktree was already detached), prune
+		// the directory manually so cleanup is effective.
+		if ( is_dir( $validation['real_path'] ) ) {
+			$escaped = escapeshellarg( $validation['real_path'] );
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
+			exec( sprintf( 'rm -rf %s 2>&1', $escaped ) );
+		}
+
+		return array(
+			'success' => true,
+			'handle'  => basename( $wt_path ),
+			'message' => sprintf( 'Worktree at "%s" removed.', $wt_path ),
+			'branch'  => $branch,
 		);
 	}
 

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -2,6 +2,18 @@
 
 End-to-end test plan for the worktree-native workspace. Pure unit-style coverage
 of handle parsing and slugification lives in `smoke-worktree-handles.php`.
+Integration coverage for the cleanup-merged flow (real git repos in a tmpdir,
+including safety-rail regressions) lives in `smoke-worktree-cleanup.php`.
+
+## 0. Pre-flight — the automated smoke tests
+
+```bash
+php tests/smoke-worktree-handles.php     # pure-unit, fast
+php tests/smoke-worktree-cleanup.php     # spawns a real git workspace
+```
+
+Expected: `32/32 passed` and `18/18 passed` respectively. Skip
+`smoke-worktree-cleanup.php` if `git` is unavailable.
 
 Prereqs:
 - WordPress 6.9+ with Data Machine + data-machine-code activated.

--- a/tests/smoke-worktree-cleanup.php
+++ b/tests/smoke-worktree-cleanup.php
@@ -1,0 +1,304 @@
+<?php
+/**
+ * Integration smoke test for worktree_cleanup_merged.
+ *
+ * Builds a real workspace in a tempdir with real git repos + real worktrees,
+ * simulates various scenarios (merged branch, unmerged branch, dirty tree,
+ * protected branch, legacy non-slug directory name), then runs cleanup and
+ * asserts the correct worktrees got pruned.
+ *
+ * Run: php tests/smoke-worktree-cleanup.php
+ *
+ * Skips entirely if `git` is unavailable on $PATH.
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Core\FilesRepository {
+	if ( ! class_exists( __NAMESPACE__ . '\\FilesystemHelper' ) ) {
+		class FilesystemHelper {
+			public static function get() {
+				return null;
+			}
+		}
+	}
+}
+
+namespace DataMachineCode\Abilities {
+	// Stub so the GitHub code path short-circuits without network calls.
+	if ( ! class_exists( __NAMESPACE__ . '\\GitHubAbilities' ) ) {
+		class GitHubAbilities {
+			public static function getPat(): string {
+				return '';
+			}
+			public static function apiGet( string $url, array $params, string $pat ) {
+				return array( 'data' => array() );
+			}
+		}
+	}
+}
+
+namespace {
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			public string $code;
+			public string $message;
+			public array $data;
+			public function __construct( $code = '', $message = '', $data = array() ) {
+				$this->code    = (string) $code;
+				$this->message = (string) $message;
+				$this->data    = (array) $data;
+			}
+			public function get_error_message(): string {
+				return $this->message;
+			}
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $thing ): bool {
+			return $thing instanceof \WP_Error;
+		}
+	}
+
+	if ( ! function_exists( 'wp_mkdir_p' ) ) {
+		function wp_mkdir_p( string $path ): bool {
+			return is_dir( $path ) || mkdir( $path, 0755, true );
+		}
+	}
+
+	if ( ! function_exists( 'get_option' ) ) {
+		function get_option( string $name, $default = false ) {
+			return $default;
+		}
+	}
+
+	if ( ! function_exists( 'size_format' ) ) {
+		function size_format( $bytes ): string {
+			return (string) $bytes;
+		}
+	}
+
+	require __DIR__ . '/../inc/Workspace/Workspace.php';
+
+	// Skip if git missing.
+	exec( 'git --version 2>&1', $_gv, $gv_exit );
+	if ( 0 !== $gv_exit ) {
+		echo "SKIP: git not available\n";
+		exit( 0 );
+	}
+
+	// Create isolated workspace in tmp.
+	$tmp = sys_get_temp_dir() . '/dmc-cleanup-smoke-' . bin2hex( random_bytes( 4 ) );
+	mkdir( $tmp, 0755, true );
+	register_shutdown_function( function () use ( $tmp ) {
+		if ( is_dir( $tmp ) ) {
+			exec( 'rm -rf ' . escapeshellarg( $tmp ) );
+		}
+	} );
+
+	define( 'DATAMACHINE_WORKSPACE_PATH', $tmp );
+
+	$failures = 0;
+	$total    = 0;
+
+	$assert = function ( $expected, $actual, string $message ) use ( &$failures, &$total ): void {
+		$total++;
+		if ( $expected === $actual ) {
+			echo "  ✓ {$message}\n";
+			return;
+		}
+		$failures++;
+		echo "  ✗ {$message}\n";
+		echo "    expected: " . var_export( $expected, true ) . "\n";
+		echo "    actual:   " . var_export( $actual, true ) . "\n";
+	};
+
+	$assert_contains = function ( array $haystack, string $needle, string $message ) use ( &$failures, &$total ): void {
+		$total++;
+		foreach ( $haystack as $item ) {
+			$handle = is_array( $item ) ? ( $item['handle'] ?? '' ) : (string) $item;
+			if ( $handle === $needle ) {
+				echo "  ✓ {$message}\n";
+				return;
+			}
+		}
+		$failures++;
+		echo "  ✗ {$message}\n";
+		echo "    needle:  {$needle}\n";
+		echo "    haystack: " . implode( ', ', array_map( fn( $i ) => is_array( $i ) ? ( $i['handle'] ?? '?' ) : $i, $haystack ) ) . "\n";
+	};
+
+	$run = function ( string $cmd, string $cwd = '' ) {
+		$full = '' === $cwd ? $cmd : sprintf( 'cd %s && %s', escapeshellarg( $cwd ), $cmd );
+		exec( $full . ' 2>&1', $out, $rc );
+		return array(
+			'output' => implode( "\n", $out ),
+			'exit'   => $rc,
+		);
+	};
+
+	// -------------------------------------------------------------------------
+	// Scenario setup
+	// -------------------------------------------------------------------------
+
+	echo "Setting up workspace at {$tmp}\n";
+
+	// "remote" bare repo that stands in for origin.
+	$remote = $tmp . '/remote.git';
+	$run( sprintf( 'git init --bare %s', escapeshellarg( $remote ) ) );
+
+	// Primary checkout: clone + initial commit on main + push.
+	$primary = $tmp . '/demo';
+	$run( sprintf( 'git clone %s %s', escapeshellarg( $remote ), escapeshellarg( $primary ) ) );
+	$run( 'git config user.email test@example.com', $primary );
+	$run( 'git config user.name test', $primary );
+	file_put_contents( $primary . '/README.md', "demo\n" );
+	$run( 'git add README.md && git commit -m init', $primary );
+	$run( 'git branch -M main', $primary );
+	$run( 'git push -u origin main', $primary );
+
+	// Helper: make a branch on the remote too so "upstream" tracking exists.
+	$make_branch = function ( string $branch, string $content ) use ( $primary, $run, $remote ) {
+		$run( sprintf( 'git checkout -b %s', escapeshellarg( $branch ) ), $primary );
+		file_put_contents( $primary . '/' . str_replace( '/', '-', $branch ) . '.txt', $content );
+		$run( sprintf( 'git add . && git commit -m %s', escapeshellarg( 'work on ' . $branch ) ), $primary );
+		$run( sprintf( 'git push -u origin %s', escapeshellarg( $branch ) ), $primary );
+		$run( 'git checkout main', $primary );
+	};
+
+	// Branches that have branches on the remote.
+	$make_branch( 'merged-autodelete', 'a' );   // → simulate remote delete below
+	$make_branch( 'merged-live-remote', 'b' );  // → simulate via PR-merged (stubbed → none)
+	$make_branch( 'unmerged-feature', 'c' );    // still active
+	$make_branch( 'dirty-branch', 'd' );        // will be dirty in worktree
+
+	// Create worktrees at various paths:
+	//   - canonical slug path (demo@merged-autodelete)
+	//   - legacy sibling path (demo-legacy-merged)
+	//   - canonical path for the unmerged one
+	//   - canonical path for dirty
+	$run( sprintf( 'git worktree add %s merged-autodelete', escapeshellarg( $tmp . '/demo@merged-autodelete' ) ), $primary );
+	$run( sprintf( 'git worktree add %s merged-live-remote', escapeshellarg( $tmp . '/demo-legacy-merged' ) ), $primary );
+	$run( sprintf( 'git worktree add %s unmerged-feature', escapeshellarg( $tmp . '/demo@unmerged-feature' ) ), $primary );
+	$run( sprintf( 'git worktree add %s dirty-branch', escapeshellarg( $tmp . '/demo@dirty-branch' ) ), $primary );
+
+	// Dirty the dirty worktree.
+	file_put_contents( $tmp . '/demo@dirty-branch/scratch.txt', 'dirty' );
+
+	// Simulate "remote deleted the merged-autodelete branch" — classic
+	// GitHub auto-delete-on-merge scenario. After a fetch --prune, the
+	// local branch's upstream tracking ref will be "gone".
+	$run( sprintf( 'git -C %s push origin --delete merged-autodelete', escapeshellarg( $remote ) ) );
+	// (The bare remote "origin" is the URL; git push --delete pushes to
+	// origin. But our origin IS the bare repo — so we need to update the
+	// bare ref directly.)
+	$run( sprintf( 'git --git-dir=%s update-ref -d refs/heads/merged-autodelete', escapeshellarg( $remote ) ) );
+
+	// -------------------------------------------------------------------------
+	// Dry-run assertions
+	// -------------------------------------------------------------------------
+
+	echo "\nDry-run scenario\n";
+	$ws   = new \DataMachineCode\Workspace\Workspace();
+	$plan = $ws->worktree_cleanup_merged(
+		array(
+			'dry_run'     => true,
+			'skip_github' => true,
+		)
+	);
+
+	$assert( true, ! is_wp_error( $plan ) && ( $plan['success'] ?? false ), 'dry_run returns success' );
+	$assert( true, $plan['dry_run'] ?? false, 'dry_run flag echoes back true' );
+
+	$assert_contains( $plan['candidates'] ?? array(), 'demo@merged-autodelete', 'canonical merged worktree flagged prunable' );
+
+	// dirty-branch should be skipped (reason: dirty)
+	$dirty_skips = array_filter( $plan['skipped'] ?? array(), fn( $s ) => ( $s['handle'] ?? '' ) === 'demo@dirty-branch' );
+	$assert( 1, count( $dirty_skips ), 'dirty worktree skipped with exactly one entry' );
+	$dirty_reason = array_values( $dirty_skips )[0]['reason'] ?? '';
+	$assert( true, str_contains( $dirty_reason, 'dirty' ), 'dirty skip reason mentions dirty' );
+
+	// unmerged-feature should be skipped (no merge signal)
+	$unmerged = array_filter( $plan['skipped'] ?? array(), fn( $s ) => ( $s['handle'] ?? '' ) === 'demo@unmerged-feature' );
+	$assert( 1, count( $unmerged ), 'unmerged worktree skipped with exactly one entry' );
+
+	// Primary itself should NEVER show up as a candidate.
+	foreach ( $plan['candidates'] ?? array() as $c ) {
+		if ( 'demo' === ( $c['handle'] ?? '' ) ) {
+			$failures++;
+			$total++;
+			echo "  ✗ primary listed as cleanup candidate (BUG — would destroy primary)\n";
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Execute
+	// -------------------------------------------------------------------------
+
+	echo "\nExecuting cleanup\n";
+	$result = $ws->worktree_cleanup_merged(
+		array(
+			'dry_run'     => false,
+			'skip_github' => true,
+		)
+	);
+
+	$assert( true, ! is_wp_error( $result ) && ( $result['success'] ?? false ), 'execute returns success' );
+	$assert( false, $result['dry_run'] ?? true, 'dry_run flag is false on execute' );
+
+	// The merged-autodelete candidate should be in removed[].
+	$assert_contains( $result['removed'] ?? array(), 'demo@merged-autodelete', 'canonical merged worktree was actually removed' );
+
+	// Directory should be gone from disk.
+	$assert( false, is_dir( $tmp . '/demo@merged-autodelete' ), 'merged worktree directory no longer exists on disk' );
+
+	// Primary survives.
+	$assert( true, is_dir( $primary . '/.git' ), 'primary .git survives cleanup' );
+
+	// Protected branches: unmerged/dirty worktrees survive.
+	$assert( true, is_dir( $tmp . '/demo@unmerged-feature' ), 'unmerged worktree survives cleanup' );
+	$assert( true, is_dir( $tmp . '/demo@dirty-branch' ), 'dirty worktree survives cleanup' );
+
+	// The local branch for the removed worktree should be gone.
+	$branch_check = $run( 'git for-each-ref --format="%(refname:short)" refs/heads/merged-autodelete', $primary );
+	$assert( '', trim( $branch_check['output'] ), 'local branch for removed worktree is deleted' );
+
+	// -------------------------------------------------------------------------
+	// Negative: primary safety
+	// -------------------------------------------------------------------------
+
+	echo "\nSafety — primary never removed\n";
+
+	// Verify validate_containment catches a primary being passed in.
+	$reflection = new \ReflectionMethod( \DataMachineCode\Workspace\Workspace::class, 'remove_worktree_by_path' );
+	$reflection->setAccessible( true );
+	$safety = $reflection->invoke( $ws, 'demo', 'main', $primary, false );
+	$is_error = is_wp_error( $safety );
+	$assert( true, $is_error, 'remove_worktree_by_path refuses primary (is WP_Error)' );
+	if ( $is_error ) {
+		$assert( true, str_contains( $safety->get_error_message(), 'not a worktree marker' ) || str_contains( $safety->get_error_message(), 'primary' ), 'rejection message identifies primary-like target' );
+	}
+
+	// -------------------------------------------------------------------------
+	// Negative: path outside workspace
+	// -------------------------------------------------------------------------
+
+	$outside = sys_get_temp_dir() . '/dmc-outside-' . bin2hex( random_bytes( 3 ) );
+	mkdir( $outside, 0755, true );
+	file_put_contents( $outside . '/.git', 'gitdir: fake' );
+	$outside_err = $reflection->invoke( $ws, 'demo', 'x', $outside, false );
+	$assert( true, is_wp_error( $outside_err ), 'path outside workspace rejected (is WP_Error)' );
+	if ( is_wp_error( $outside_err ) ) {
+		$assert( true, str_contains( $outside_err->get_error_message(), 'outside workspace' ) || str_contains( $outside_err->get_error_message(), 'traversal' ), 'rejection message mentions containment' );
+	}
+	exec( 'rm -rf ' . escapeshellarg( $outside ) );
+
+	echo "\nResult: " . ( $total - $failures ) . "/{$total} passed\n";
+	exit( $failures > 0 ? 1 : 0 );
+}


### PR DESCRIPTION
## Summary

Fixes a removal bug in `worktree_cleanup_merged` (shipped in #30) uncovered in post-merge live testing, plus adds belt-and-suspenders safety rails and integration tests.

## The bug

`worktree_cleanup_merged` called `worktree_remove(repo, branch)`, which reconstructs the worktree path from the `<repo>@<slug>` convention. Any worktree living at a legacy/arbitrary path (e.g. `workspace/data-machine-upsert-rename` instead of `workspace/data-machine@refactor-step-type-upsert-rename`) failed with `worktree_not_found` on every removal. The detection logic worked; the removal step was the broken link.

Seen live:

```
dm-code-pr27  pr-merged  PR #27 merged (closed)
  → remove failed: Worktree "data-machine-code@26-github-update-handler" not found.
```

## The fix

**New private helper** `Workspace::remove_worktree_by_path()` — takes the actual worktree path from `git worktree list` and passes it straight to `git worktree remove`. The existing public `worktree_remove()` contract is unchanged (still the slug-convention entry point for direct CLI `worktree remove <repo> <branch>` use).

**Hard safety rails inside the new helper**, applied BEFORE any removal:

1. Primary repo's `.git` must exist
2. The worktree path must be a real directory
3. **Containment validation** — path must be inside `$workspace_path` (`validate_containment`). No external targets, ever.
4. **Worktree-marker check** — `.git` must be a FILE (worktree marker). A directory `.git` means it's a primary checkout, and refusing here is the critical last line of defense against catastrophic removal.
5. Dirty check stays upstream in the cleanup loop.
6. If `git worktree remove` left the directory behind (locked worktrees, etc.), fall back to `rm -rf` on the containment-validated `real_path` only.

## Tests

`tests/smoke-worktree-cleanup.php` — integration smoke using real git repos in a tmpdir. **18 assertions**, including the nightmare cases:

- ✅ Canonical slug-path worktree flagged + actually removed
- ✅ Merged-branch worktree at legacy sibling path  
- ✅ Unmerged worktree skipped
- ✅ Dirty worktree skipped
- ✅ Primary never listed as a candidate
- ✅ `remove_worktree_by_path(primary_path)` → WP_Error (would have caught the earlier fear)
- ✅ `remove_worktree_by_path(outside_workspace_path)` → WP_Error
- ✅ Local branch cleanup verified after removal
- ✅ Primary `.git` survives cleanup
- ✅ Dirty skip reason includes "dirty"

`tests/smoke-worktree-handles.php` still passes (32/32, no regression).

## Live verification

Dry-run against the actual workspace (6 worktrees across 3 repos, 5 with merged PRs) now correctly identifies every path, and the containment/marker check confirms each would pass the safety gate:

```
data-machine-upsert-rename      upstream-gone  remote branch deleted
  .git is: FILE (worktree — good)
dm-code-pr25-rebase             pr-merged      PR #25 merged
  .git is: FILE (worktree — good)
dm-code-pr27                    pr-merged      PR #27 merged
  .git is: FILE (worktree — good)
dm-code-upsert-rename           pr-merged      PR #28 merged
  .git is: FILE (worktree — good)
dm-code-worktree-cli            pr-merged      PR #30 merged
  .git is: FILE (worktree — good)
data-machine-events-upsert      pr-merged      PR #205 merged
  .git is: FILE (worktree — good)
```

Current in-progress worktree (this branch) correctly skipped as dirty.

## Why this matters

The command shells out to `git worktree remove` and, in rare cases, `rm -rf` on a containment-validated path. Trusting it for daily-driver use requires both the detection logic AND the removal path to be airtight. Before this fix, removal was effectively broken on the workspace it was designed for; after this fix, it's tested against the exact scenarios that would be catastrophic if wrong.