### PR TITLE
refactor: rename executeUpdate() → executeUpsert()

### DIFF
--- a/inc/Handlers/GitHub/GitHubUpsert.php
+++ b/inc/Handlers/GitHub/GitHubUpsert.php
@@ -92,7 +92,7 @@ class GitHubUpsert extends UpsertHandler {
 	 * @param array $handler_config Handler configuration from settings.
 	 * @return array Success/failure response.
 	 */
-	protected function executeUpdate( array $parameters, array $handler_config ): array {
+	protected function executeUpsert( array $parameters, array $handler_config ): array {
 		$job_id = $parameters['job_id'] ?? null;
 
 		// Resolve repo: AI param > handler config > default repo setting.


### PR DESCRIPTION
Companion to [data-machine#1105](https://github.com/Extra-Chill/data-machine/pull/1105).

Renames `GitHubUpsert::executeUpdate()` → `executeUpsert()` to match the renamed abstract method in `UpsertHandler`.

Must be merged and released after data-machine#1105.