### PR TITLE
chore(agents): declare AGENTS.md header via MemoryFileRegistry arg

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -293,6 +293,7 @@ add_action( 'plugins_loaded', function () {
 		'convention_path' => 'AGENTS.md',
 		'label'           => 'Agent Instructions',
 		'description'     => 'Auto-generated from registered sections. Regenerate via: wp datamachine agent compose AGENTS.md',
+		'header'          => '# AI Instructions',
 	) );
 
 	if ( ! class_exists( '\DataMachine\Engine\AI\SectionRegistry' ) ) {


### PR DESCRIPTION
## Summary

Paired change for [Extra-Chill/data-machine#1126](https://github.com/Extra-Chill/data-machine/pull/1126), which moves header ownership for composable files from the core generator to the file's registrar.

`data-machine-code` is the owner of `AGENTS.md` (it is the only thing that registers a composable file in the whole ecosystem), so it is the right place to declare the file's top-level title. This PR passes the new `header` arg on the existing `MemoryFileRegistry::register()` call.

## Change

One line in `data-machine-code.php` inside the AGENTS.md registration block:

```php
'header' => '# AI Instructions',
```

After both PRs land, regenerated `AGENTS.md` keeps its `# AI Instructions` heading at the top, and the old auto-generated "Do not edit directly" HTML warning is gone.

## Depends on

- [Extra-Chill/data-machine#1126](https://github.com/Extra-Chill/data-machine/pull/1126) — exposes the \`header\` arg on \`MemoryFileRegistry::register()\`

Until the core PR lands, the new \`header\` arg is simply ignored by the older core, so this PR is safe to merge in either order (forward-compatible). However, to avoid a cosmetic regression (missing top-level heading for a few hours between merges), land the core PR first or release them together.