### PR TITLE
feat(gitsync): Phase 1 — bind site-owned dirs to remote git repos (#38)

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -47,6 +47,7 @@ function datamachine_code_bootstrap() {
 	// Load Abilities (they self-register).
 	new \DataMachineCode\Abilities\GitHubAbilities();
 	new \DataMachineCode\Abilities\WorkspaceAbilities();
+	new \DataMachineCode\Abilities\GitSyncAbilities();
 
 	// Load Handlers (they self-register).
 	new \DataMachineCode\Handlers\GitHub\GitHub();
@@ -80,6 +81,14 @@ function datamachine_code_register_ability_categories() {
 		array(
 			'label'       => __( 'GitHub', 'data-machine-code' ),
 			'description' => __( 'GitHub issue, pull request, and repository operations.', 'data-machine-code' ),
+		)
+	);
+
+	wp_register_ability_category(
+		'datamachine-code-gitsync',
+		array(
+			'label'       => __( 'GitSync', 'data-machine-code' ),
+			'description' => __( 'Bind site-owned directories to remote git repositories with pull/status/list semantics.', 'data-machine-code' ),
 		)
 	);
 }
@@ -164,6 +173,7 @@ function datamachine_code_register_cli_commands() {
 
 	\WP_CLI::add_command( 'datamachine-code github', \DataMachineCode\Cli\Commands\GitHubCommand::class );
 	\WP_CLI::add_command( 'datamachine-code workspace', \DataMachineCode\Cli\Commands\WorkspaceCommand::class );
+	\WP_CLI::add_command( 'datamachine-code gitsync', \DataMachineCode\Cli\Commands\GitSyncCommand::class );
 }
 add_action( 'plugins_loaded', 'datamachine_code_register_cli_commands', 21 );
 

--- a/docs/gitsync.md
+++ b/docs/gitsync.md
@@ -1,0 +1,148 @@
+# GitSync
+
+GitSync binds a **site-owned local directory** under `ABSPATH` to a **remote git repository**, then keeps the two in lockstep via pull (Phase 1), push (Phase 2), and scheduled sync (Phase 3).
+
+It is the layer *above* the existing [`Workspace`](../inc/Workspace/Workspace.php) system:
+
+| System       | Owns                                 | Lives under                           | Typical user                  |
+|--------------|--------------------------------------|---------------------------------------|-------------------------------|
+| `Workspace`  | Agent-owned code checkouts           | `~/.datamachine/workspace/<repo>`     | The coding agent itself       |
+| `GitSync`    | Site-owned subtrees (content, data)  | `ABSPATH/<path>` of the site's choice | Plugins (Intelligence, etc.)  |
+
+The two systems share low-level primitives — `Support\GitRunner` for shelling out to git, `Support\PathSecurity` for containment and sensitive-file checks — but their scopes stay separate. Workspace knows about `<repo>@<branch-slug>` handles and worktrees; GitSync knows about user-named bindings pinned to a single branch.
+
+First consumers (filed, not yet wired):
+
+- [Automattic/intelligence#31](https://github.com/Automattic/intelligence/issues/31) — Git-synced wiki content subtrees (WooCommerce wiki, Jetpack wiki, etc.).
+- [Automattic/intelligence#125](https://github.com/Automattic/intelligence/issues/125) — Git-tracked wiki-generator agent definitions.
+
+Both map cleanly to one GitSync binding per synced subtree.
+
+## Binding shape
+
+Bindings are stored as an associative array in the `datamachine_gitsync_bindings` WordPress option:
+
+```php
+array(
+    'slug'        => 'intelligence-wiki',                       // unique identifier
+    'local_path'  => '/wp-content/uploads/markdown/wiki/',       // ABSPATH-relative, leading slash
+    'remote_url'  => 'https://github.com/Automattic/a8c-wiki-woocommerce',
+    'branch'      => 'main',                                     // pinned branch
+    'policy'      => array(
+        'auto_pull'     => false,                                // Phase 3 honors this
+        'pull_interval' => 'hourly',                             // reuses DM SchedulerIntervals
+        'write_enabled' => false,                                // Phase 2 honors this
+        'push_enabled'  => false,                                // Phase 2 honors this
+        'allowed_paths' => array(),                              // Phase 2 write containment
+        'conflict'      => 'fail',                               // fail | upstream_wins | manual
+    ),
+    'created_at'  => '2026-04-20T12:00:00+00:00',
+    'last_pulled' => '2026-04-20T12:15:00+00:00',
+    'last_commit' => 'abc1234',
+)
+```
+
+Defaults are deliberately conservative: no writes, no push, no auto-pull, `conflict = fail`. Every destructive behavior must be explicitly enabled per binding.
+
+## CLI (Phase 1)
+
+```bash
+# List bindings
+wp datamachine-code gitsync list
+
+# Bind + clone (or adopt an existing matching checkout)
+wp datamachine-code gitsync bind intelligence-wiki \
+  --local=/wp-content/uploads/markdown/wiki/ \
+  --remote=https://github.com/Automattic/a8c-wiki-woocommerce \
+  --branch=main
+
+# Status for a single binding
+wp datamachine-code gitsync status intelligence-wiki
+wp datamachine-code gitsync status intelligence-wiki --format=json
+
+# Pull latest (fast-forward, conflict policy applies)
+wp datamachine-code gitsync pull intelligence-wiki
+wp datamachine-code gitsync pull intelligence-wiki --allow-dirty
+
+# Unbind (keeps the directory by default)
+wp datamachine-code gitsync unbind intelligence-wiki
+wp datamachine-code gitsync unbind intelligence-wiki --purge --yes
+```
+
+## Abilities
+
+Every CLI subcommand is a thin shell over the matching WordPress ability. Consumers should call the ability, not the service class.
+
+| Ability                           | Category                    | REST? | Purpose                                                     |
+|-----------------------------------|-----------------------------|-------|-------------------------------------------------------------|
+| `datamachine/gitsync-list`        | `datamachine-code-gitsync`  | yes   | List all bindings + lightweight status.                    |
+| `datamachine/gitsync-status`      | `datamachine-code-gitsync`  | yes   | Detailed status for one binding (branch/HEAD/dirty/ahead/behind). |
+| `datamachine/gitsync-bind`        | `datamachine-code-gitsync`  | no    | Register a binding and clone or adopt the working tree.    |
+| `datamachine/gitsync-unbind`      | `datamachine-code-gitsync`  | no    | Remove a binding; optional `--purge` deletes the dir.      |
+| `datamachine/gitsync-pull`        | `datamachine-code-gitsync`  | no    | Fast-forward pull, honoring conflict policy.               |
+
+Mutating abilities are CLI-only (`show_in_rest = false`) in Phase 1 — they change filesystem state and should stay behind explicit operator action.
+
+```php
+$ability = wp_get_ability( 'datamachine/gitsync-pull' );
+$result  = $ability->execute( array(
+    'slug'        => 'intelligence-wiki',
+    'allow_dirty' => false,
+) );
+```
+
+## `bind` semantics
+
+When you call `bind`, GitSync inspects the target path and chooses one of four paths:
+
+| Path state                             | Action                                                        |
+|----------------------------------------|---------------------------------------------------------------|
+| Doesn't exist                          | `git clone --branch <branch> <remote> <path>`                |
+| Exists, empty                          | `git clone` into it                                          |
+| Exists, has `.git/` with matching origin | **Adopt** — register the binding, no clone                  |
+| Exists, has `.git/` but origin mismatch | Error (`origin_mismatch`, HTTP 409)                          |
+| Exists, non-empty, no `.git/`          | Error (`dirty_target`, HTTP 409) — refuses to overlay        |
+
+Adopt semantics mean `bind` is **idempotent**: running it twice against the same path with the same remote is safe. This is important when bindings are provisioned declaratively (e.g. by a plugin on activation).
+
+## `pull` semantics
+
+- Pull is **fast-forward only** (`git pull --ff-only origin <branch>`).
+- If the working tree's current branch drifted from the binding's pinned branch, pull **refuses** rather than silently switching.
+- The binding's `conflict` policy drives dirty-tree behavior:
+
+| Policy          | Dirty tree behavior                                                        |
+|-----------------|----------------------------------------------------------------------------|
+| `fail` (default) | Refuse pull with `dirty_working_tree` (HTTP 400).                         |
+| `upstream_wins` | `git reset --hard HEAD` before pull, discarding local changes.            |
+| `manual`        | Attempt the pull; git surfaces the conflict and the admin resolves it.    |
+
+`--allow-dirty` on the CLI overrides `fail` for a single invocation without changing the policy.
+
+## Security posture
+
+Containment is enforced at every mutation point:
+
+- `local_path` must be ABSPATH-relative (leading slash, no `..`, no `.`).
+- Sensitive filename fragments (`.env`, `id_rsa`, `.pem`, `.key`, `credentials.json`, `secrets`) are refused outright.
+- `purge` re-validates containment via `realpath()` immediately before `rm -rf`, defending against symlink escapes.
+- All abilities require `PermissionHelper::can_manage()`.
+
+Shared with the Workspace system via `DataMachineCode\Support\PathSecurity` — the block list and traversal detection have one canonical source of truth.
+
+## What's next (follow-up PRs)
+
+**Phase 2 — write path:**
+
+- `datamachine/gitsync-push` + `gitsync push` CLI.
+- `datamachine/gitsync-policy-update` for toggling `write_enabled`, `push_enabled`, `allowed_paths`, `conflict`.
+- Stage/commit containment using `allowed_paths` (same shape Workspace already uses).
+
+**Phase 3 — scheduled sync:**
+
+- `GitSyncPullTask extends SystemTask` (mirror of `WorktreeCleanupTask`).
+- Registered via `datamachine_tasks` + `datamachine_recurring_schedules` filters.
+- Honors each binding's `auto_pull` + `pull_interval` policy.
+- Opt-in via a PluginSetting gate.
+
+See [data-machine-code#38](https://github.com/Extra-Chill/data-machine-code/issues/38) for the full design + acceptance checklist.

--- a/inc/Abilities/GitSyncAbilities.php
+++ b/inc/Abilities/GitSyncAbilities.php
@@ -1,0 +1,295 @@
+<?php
+/**
+ * GitSync Abilities
+ *
+ * WordPress Abilities API surface for the Phase 1 GitSync primitive:
+ * bind, unbind, pull, status, list. Push, policy-update, and the
+ * scheduled pull task land in later phases (see DMC#38).
+ *
+ * Read-only abilities (status, list) are exposed via REST; mutating
+ * abilities (bind, unbind, pull) are CLI-only (`show_in_rest = false`)
+ * since they change filesystem state and should be gated behind
+ * manual review.
+ *
+ * @package DataMachineCode\Abilities
+ * @since   0.7.0
+ */
+
+namespace DataMachineCode\Abilities;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachineCode\GitSync\GitSync;
+
+defined( 'ABSPATH' ) || exit;
+
+class GitSyncAbilities {
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->registerAbilities();
+		self::$registered = true;
+	}
+
+	private function registerAbilities(): void {
+		$register_callback = function () {
+
+			// -----------------------------------------------------------------
+			// Read-only abilities (show_in_rest = true).
+			// -----------------------------------------------------------------
+
+			wp_register_ability(
+				'datamachine/gitsync-list',
+				array(
+					'label'               => 'List GitSync Bindings',
+					'description'         => 'List every registered GitSync binding and its on-disk status snapshot.',
+					'category'            => 'datamachine-code-gitsync',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'  => array( 'type' => 'boolean' ),
+							'bindings' => array(
+								'type'  => 'array',
+								'items' => array(
+									'type'       => 'object',
+									'properties' => array(
+										'slug'          => array( 'type' => 'string' ),
+										'local_path'    => array( 'type' => 'string' ),
+										'absolute_path' => array( 'type' => 'string' ),
+										'remote_url'    => array( 'type' => 'string' ),
+										'branch'        => array( 'type' => 'string' ),
+										'exists'        => array( 'type' => 'boolean' ),
+										'is_repo'       => array( 'type' => 'boolean' ),
+										'auto_pull'     => array( 'type' => 'boolean' ),
+										'pull_interval' => array( 'type' => 'string' ),
+										'last_pulled'   => array( 'type' => array( 'string', 'null' ) ),
+										'last_commit'   => array( 'type' => array( 'string', 'null' ) ),
+									),
+								),
+							),
+						),
+					),
+					'execute_callback'    => array( self::class, 'listBindings' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/gitsync-status',
+				array(
+					'label'               => 'GitSync Binding Status',
+					'description'         => 'Report on-disk status for a single GitSync binding: branch, HEAD, dirty count, ahead/behind vs upstream.',
+					'category'            => 'datamachine-code-gitsync',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'slug' ),
+						'properties' => array(
+							'slug' => array(
+								'type'        => 'string',
+								'description' => 'Binding slug.',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'        => array( 'type' => 'boolean' ),
+							'slug'           => array( 'type' => 'string' ),
+							'local_path'     => array( 'type' => 'string' ),
+							'remote_url'     => array( 'type' => 'string' ),
+							'tracked_branch' => array( 'type' => 'string' ),
+							'exists'         => array( 'type' => 'boolean' ),
+							'is_repo'        => array( 'type' => 'boolean' ),
+							'branch'         => array( 'type' => array( 'string', 'null' ) ),
+							'head'           => array( 'type' => array( 'string', 'null' ) ),
+							'dirty'          => array( 'type' => 'integer' ),
+							'ahead'          => array( 'type' => array( 'integer', 'null' ) ),
+							'behind'         => array( 'type' => array( 'integer', 'null' ) ),
+							'last_pulled'    => array( 'type' => array( 'string', 'null' ) ),
+							'policy'         => array( 'type' => 'object' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'status' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			// -----------------------------------------------------------------
+			// Mutating abilities (show_in_rest = false).
+			// -----------------------------------------------------------------
+
+			wp_register_ability(
+				'datamachine/gitsync-bind',
+				array(
+					'label'               => 'Bind GitSync Path',
+					'description'         => 'Bind a site-owned directory (relative to ABSPATH) to a remote git repository. Clones the remote or adopts an existing matching checkout.',
+					'category'            => 'datamachine-code-gitsync',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'slug', 'local_path', 'remote_url' ),
+						'properties' => array(
+							'slug'       => array(
+								'type'        => 'string',
+								'description' => 'Unique binding slug. Lowercase letters, digits, hyphen, underscore.',
+							),
+							'local_path' => array(
+								'type'        => 'string',
+								'description' => 'Path relative to ABSPATH, e.g. "/wp-content/uploads/markdown/wiki/".',
+							),
+							'remote_url' => array(
+								'type'        => 'string',
+								'description' => 'Git remote URL (https:// or git@).',
+							),
+							'branch'     => array(
+								'type'        => 'string',
+								'description' => 'Branch to track. Defaults to "main".',
+							),
+							'policy'     => array(
+								'type'        => 'object',
+								'description' => 'Policy overrides (auto_pull, pull_interval, conflict, write_enabled, push_enabled, allowed_paths).',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'    => array( 'type' => 'boolean' ),
+							'binding'    => array( 'type' => 'object' ),
+							'cloned'     => array( 'type' => 'boolean' ),
+							'adopted'    => array( 'type' => 'boolean' ),
+							'local_path' => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'bind' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/gitsync-unbind',
+				array(
+					'label'               => 'Unbind GitSync Path',
+					'description'         => 'Remove a GitSync binding. By default the on-disk directory is preserved; pass purge=true to delete it.',
+					'category'            => 'datamachine-code-gitsync',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'slug' ),
+						'properties' => array(
+							'slug'  => array(
+								'type'        => 'string',
+								'description' => 'Binding slug.',
+							),
+							'purge' => array(
+								'type'        => 'boolean',
+								'description' => 'Also remove the on-disk directory. Default: false.',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'    => array( 'type' => 'boolean' ),
+							'slug'       => array( 'type' => 'string' ),
+							'purged'     => array( 'type' => 'boolean' ),
+							'local_path' => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'unbind' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/gitsync-pull',
+				array(
+					'label'               => 'Pull GitSync Binding',
+					'description'         => 'Fast-forward pull the remote into a bound directory, honoring the binding\'s conflict policy.',
+					'category'            => 'datamachine-code-gitsync',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'slug' ),
+						'properties' => array(
+							'slug'        => array(
+								'type'        => 'string',
+								'description' => 'Binding slug.',
+							),
+							'allow_dirty' => array(
+								'type'        => 'boolean',
+								'description' => 'Bypass dirty-working-tree safety for this pull. Default: false.',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'       => array( 'type' => 'boolean' ),
+							'slug'          => array( 'type' => 'string' ),
+							'branch'        => array( 'type' => 'string' ),
+							'previous_head' => array( 'type' => array( 'string', 'null' ) ),
+							'head'          => array( 'type' => array( 'string', 'null' ) ),
+							'message'       => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'pull' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+		};
+
+		// Matches the WorkspaceAbilities lifecycle: register now if we're
+		// inside the init action, defer if it hasn't fired yet, skip if it
+		// already fired without us (registration missed the window).
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	// =========================================================================
+	// Execute callbacks
+	// =========================================================================
+
+	public static function listBindings( array $input ): array|\WP_Error { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+		return ( new GitSync() )->list_bindings();
+	}
+
+	public static function status( array $input ): array|\WP_Error {
+		return ( new GitSync() )->status( (string) ( $input['slug'] ?? '' ) );
+	}
+
+	public static function bind( array $input ): array|\WP_Error {
+		return ( new GitSync() )->bind( $input );
+	}
+
+	public static function unbind( array $input ): array|\WP_Error {
+		return ( new GitSync() )->unbind(
+			(string) ( $input['slug'] ?? '' ),
+			! empty( $input['purge'] )
+		);
+	}
+
+	public static function pull( array $input ): array|\WP_Error {
+		return ( new GitSync() )->pull(
+			(string) ( $input['slug'] ?? '' ),
+			! empty( $input['allow_dirty'] )
+		);
+	}
+}

--- a/inc/Cli/Commands/GitSyncCommand.php
+++ b/inc/Cli/Commands/GitSyncCommand.php
@@ -1,0 +1,375 @@
+<?php
+/**
+ * WP-CLI GitSync Command
+ *
+ * Thin CLI shell over the `datamachine/gitsync-*` abilities. Every
+ * subcommand resolves the corresponding ability via `wp_get_ability()`,
+ * maps CLI args into the ability's input schema, and formats the output
+ * — no business logic lives here.
+ *
+ * @package DataMachineCode\Cli\Commands
+ * @since   0.7.0
+ */
+
+namespace DataMachineCode\Cli\Commands;
+
+use WP_CLI;
+use DataMachine\Cli\BaseCommand;
+
+defined( 'ABSPATH' ) || exit;
+
+class GitSyncCommand extends BaseCommand {
+
+	/**
+	 * List all GitSync bindings.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-code gitsync list
+	 *     wp datamachine-code gitsync list --format=json
+	 *
+	 * @subcommand list
+	 */
+	public function list_bindings( array $args, array $assoc_args ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+		$result = $this->execute_ability( 'datamachine/gitsync-list', array() );
+
+		if ( empty( $result['bindings'] ) ) {
+			WP_CLI::log( 'No GitSync bindings registered.' );
+			WP_CLI::log( 'Create one with: wp datamachine-code gitsync bind <slug> --local=<path> --remote=<url>' );
+			return;
+		}
+
+		$items = array_map(
+			function ( array $b ): array {
+				return array(
+					'slug'          => $b['slug'],
+					'local_path'    => $b['local_path'],
+					'remote_url'    => $b['remote_url'],
+					'branch'        => $b['branch'],
+					'is_repo'       => ! empty( $b['is_repo'] ) ? 'yes' : 'no',
+					'auto_pull'     => ! empty( $b['auto_pull'] ) ? 'yes' : 'no',
+					'interval'      => (string) ( $b['pull_interval'] ?? '-' ),
+					'last_pulled'   => (string) ( $b['last_pulled'] ?? '-' ),
+					'last_commit'   => (string) ( $b['last_commit'] ?? '-' ),
+				);
+			},
+			$result['bindings']
+		);
+
+		$this->format_items(
+			$items,
+			array( 'slug', 'local_path', 'remote_url', 'branch', 'is_repo', 'auto_pull', 'interval', 'last_pulled', 'last_commit' ),
+			$assoc_args,
+			'slug'
+		);
+	}
+
+	/**
+	 * Bind a site-owned directory to a remote git repository.
+	 *
+	 * Clones the remote into the target path, or adopts an existing
+	 * checkout whose origin matches `--remote`.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <slug>
+	 * : Unique binding identifier. Lowercase letters, digits, hyphen, underscore.
+	 *
+	 * --local=<path>
+	 * : Path relative to ABSPATH (leading slash). e.g. /wp-content/uploads/markdown/wiki/
+	 *
+	 * --remote=<url>
+	 * : Git remote URL (https:// or git@).
+	 *
+	 * [--branch=<branch>]
+	 * : Branch to track. Default: main.
+	 *
+	 * [--conflict=<strategy>]
+	 * : Conflict policy.
+	 * ---
+	 * default: fail
+	 * options:
+	 *   - fail
+	 *   - upstream_wins
+	 *   - manual
+	 * ---
+	 *
+	 * [--auto-pull]
+	 * : Opt the binding into scheduled sync (Phase 3 honors this flag).
+	 *
+	 * [--pull-interval=<interval>]
+	 * : Scheduled pull cadence. Default: hourly.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Bind the wiki content directory
+	 *     wp datamachine-code gitsync bind intelligence-wiki \
+	 *       --local=/wp-content/uploads/markdown/wiki/ \
+	 *       --remote=https://github.com/Automattic/a8c-wiki-woocommerce
+	 *
+	 *     # Bind + auto-pull hourly
+	 *     wp datamachine-code gitsync bind wg-agent-def \
+	 *       --local=/wp-content/uploads/datamachine-files/agents/wiki-generator/ \
+	 *       --remote=https://github.com/Automattic/a8c-wiki-generator \
+	 *       --auto-pull --pull-interval=hourly
+	 *
+	 * @subcommand bind
+	 */
+	public function bind( array $args, array $assoc_args ): void {
+		$slug = $args[0] ?? '';
+		if ( '' === $slug ) {
+			WP_CLI::error( 'Binding slug is required (first positional argument).' );
+			return;
+		}
+
+		$local  = (string) ( $assoc_args['local'] ?? '' );
+		$remote = (string) ( $assoc_args['remote'] ?? '' );
+		if ( '' === $local || '' === $remote ) {
+			WP_CLI::error( 'Both --local and --remote are required.' );
+			return;
+		}
+
+		$policy = array();
+		if ( isset( $assoc_args['conflict'] ) ) {
+			$policy['conflict'] = (string) $assoc_args['conflict'];
+		}
+		if ( ! empty( $assoc_args['auto-pull'] ) ) {
+			$policy['auto_pull'] = true;
+		}
+		if ( isset( $assoc_args['pull-interval'] ) ) {
+			$policy['pull_interval'] = (string) $assoc_args['pull-interval'];
+		}
+
+		$input = array(
+			'slug'       => $slug,
+			'local_path' => $local,
+			'remote_url' => $remote,
+		);
+		if ( ! empty( $assoc_args['branch'] ) ) {
+			$input['branch'] = (string) $assoc_args['branch'];
+		}
+		if ( ! empty( $policy ) ) {
+			$input['policy'] = $policy;
+		}
+
+		$result = $this->execute_ability( 'datamachine/gitsync-bind', $input );
+
+		$verb = ! empty( $result['adopted'] ) ? 'Adopted existing' : 'Cloned and bound';
+		WP_CLI::success( sprintf( '%s: %s → %s', $verb, $slug, $result['local_path'] ?? '' ) );
+		WP_CLI::log( sprintf( '  remote: %s', $result['binding']['remote_url'] ?? '' ) );
+		WP_CLI::log( sprintf( '  branch: %s', $result['binding']['branch'] ?? '' ) );
+		if ( ! empty( $result['binding']['last_commit'] ) ) {
+			WP_CLI::log( sprintf( '  head:   %s', $result['binding']['last_commit'] ) );
+		}
+	}
+
+	/**
+	 * Unbind a GitSync binding.
+	 *
+	 * By default the on-disk directory is preserved — the binding is
+	 * metadata, not ownership of the filesystem. Pass `--purge` to also
+	 * delete the working tree.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <slug>
+	 * : Binding slug.
+	 *
+	 * [--purge]
+	 * : Also delete the on-disk directory.
+	 *
+	 * [--yes]
+	 * : Skip the purge confirmation prompt.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-code gitsync unbind intelligence-wiki
+	 *     wp datamachine-code gitsync unbind intelligence-wiki --purge
+	 *
+	 * @subcommand unbind
+	 */
+	public function unbind( array $args, array $assoc_args ): void {
+		$slug = $args[0] ?? '';
+		if ( '' === $slug ) {
+			WP_CLI::error( 'Binding slug is required.' );
+			return;
+		}
+
+		$purge = ! empty( $assoc_args['purge'] );
+
+		if ( $purge && empty( $assoc_args['yes'] ) ) {
+			WP_CLI::confirm( sprintf( 'Purge the on-disk directory for binding "%s"? This permanently deletes files.', $slug ) );
+		}
+
+		$result = $this->execute_ability(
+			'datamachine/gitsync-unbind',
+			array(
+				'slug'  => $slug,
+				'purge' => $purge,
+			)
+		);
+
+		if ( $result['purged'] ?? false ) {
+			WP_CLI::success( sprintf( 'Unbound "%s" and purged %s', $slug, $result['local_path'] ?? '' ) );
+		} else {
+			WP_CLI::success( sprintf( 'Unbound "%s" (directory preserved: %s)', $slug, $result['local_path'] ?? '' ) );
+		}
+	}
+
+	/**
+	 * Pull the remote into a bound directory.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <slug>
+	 * : Binding slug.
+	 *
+	 * [--allow-dirty]
+	 * : Bypass dirty-working-tree safety for this pull only.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-code gitsync pull intelligence-wiki
+	 *     wp datamachine-code gitsync pull intelligence-wiki --allow-dirty
+	 *
+	 * @subcommand pull
+	 */
+	public function pull( array $args, array $assoc_args ): void {
+		$slug = $args[0] ?? '';
+		if ( '' === $slug ) {
+			WP_CLI::error( 'Binding slug is required.' );
+			return;
+		}
+
+		$result = $this->execute_ability(
+			'datamachine/gitsync-pull',
+			array(
+				'slug'        => $slug,
+				'allow_dirty' => ! empty( $assoc_args['allow-dirty'] ),
+			)
+		);
+
+		$previous = $result['previous_head'] ?? '-';
+		$head     = $result['head'] ?? '-';
+
+		if ( $previous === $head ) {
+			WP_CLI::success( sprintf( 'Already up to date: %s @ %s', $slug, (string) $head ) );
+		} else {
+			WP_CLI::success( sprintf( 'Pulled %s: %s → %s', $slug, (string) $previous, (string) $head ) );
+		}
+
+		$message = trim( (string) ( $result['message'] ?? '' ) );
+		if ( '' !== $message ) {
+			WP_CLI::log( $message );
+		}
+	}
+
+	/**
+	 * Show status for a GitSync binding.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <slug>
+	 * : Binding slug.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-code gitsync status intelligence-wiki
+	 *     wp datamachine-code gitsync status intelligence-wiki --format=json
+	 *
+	 * @subcommand status
+	 */
+	public function status( array $args, array $assoc_args ): void {
+		$slug = $args[0] ?? '';
+		if ( '' === $slug ) {
+			WP_CLI::error( 'Binding slug is required.' );
+			return;
+		}
+
+		$result = $this->execute_ability( 'datamachine/gitsync-status', array( 'slug' => $slug ) );
+
+		$format = $assoc_args['format'] ?? 'table';
+		if ( 'json' === $format ) {
+			WP_CLI::log( wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+		if ( 'yaml' === $format ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+			WP_CLI::log( (string) print_r( $result, true ) );
+			return;
+		}
+
+		// Default table-like summary — a single record flattened into key/value rows.
+		$rows = array(
+			array( 'field' => 'slug',           'value' => (string) ( $result['slug'] ?? '' ) ),
+			array( 'field' => 'local_path',     'value' => (string) ( $result['local_path'] ?? '' ) ),
+			array( 'field' => 'remote_url',     'value' => (string) ( $result['remote_url'] ?? '' ) ),
+			array( 'field' => 'tracked_branch', 'value' => (string) ( $result['tracked_branch'] ?? '' ) ),
+			array( 'field' => 'exists',         'value' => ! empty( $result['exists'] ) ? 'yes' : 'no' ),
+			array( 'field' => 'is_repo',        'value' => ! empty( $result['is_repo'] ) ? 'yes' : 'no' ),
+			array( 'field' => 'branch',         'value' => (string) ( $result['branch'] ?? '-' ) ),
+			array( 'field' => 'head',           'value' => (string) ( $result['head'] ?? '-' ) ),
+			array( 'field' => 'dirty',          'value' => (string) ( (int) ( $result['dirty'] ?? 0 ) ) ),
+			array( 'field' => 'ahead',          'value' => null === ( $result['ahead'] ?? null ) ? '-' : (string) $result['ahead'] ),
+			array( 'field' => 'behind',         'value' => null === ( $result['behind'] ?? null ) ? '-' : (string) $result['behind'] ),
+			array( 'field' => 'last_pulled',    'value' => (string) ( $result['last_pulled'] ?? '-' ) ),
+		);
+
+		$this->format_items( $rows, array( 'field', 'value' ), $assoc_args, 'field' );
+	}
+
+	// =========================================================================
+	// Helpers
+	// =========================================================================
+
+	/**
+	 * Resolve + execute an ability, erroring out on missing or failed calls.
+	 *
+	 * Centralized so every subcommand gets the same "ability missing → CLI
+	 * error" and "WP_Error result → CLI error" behavior without boilerplate.
+	 *
+	 * @param string               $ability_name Fully qualified ability name.
+	 * @param array<string, mixed> $input        Ability input payload.
+	 * @return array<string, mixed> On success. Exits via WP_CLI::error otherwise.
+	 */
+	private function execute_ability( string $ability_name, array $input ): array {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			WP_CLI::error( 'WordPress Abilities API unavailable — requires WP 6.9+ or the Abilities API plugin.' );
+		}
+
+		$ability = wp_get_ability( $ability_name );
+		if ( ! $ability ) {
+			WP_CLI::error( sprintf( 'Ability "%s" is not registered.', $ability_name ) );
+		}
+
+		$result = $ability->execute( $input );
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+		}
+
+		return is_array( $result ) ? $result : array();
+	}
+}

--- a/inc/GitSync/GitSync.php
+++ b/inc/GitSync/GitSync.php
@@ -1,0 +1,517 @@
+<?php
+/**
+ * GitSync
+ *
+ * Binds site-owned local directories under ABSPATH to remote git
+ * repositories, keeping them in lockstep via pull (and, in later phases,
+ * push + scheduled sync). Parallel to `Workspace\Workspace` — Workspace
+ * manages agent-owned checkouts under `~/.datamachine/workspace/`;
+ * GitSync manages site-owned subtrees (wiki content, synced agent
+ * definitions, etc.) where the site chooses the path.
+ *
+ * Phase 1 surface (this file):
+ *   - bind()    — register a binding and either clone or adopt an
+ *                 existing git checkout at the target path.
+ *   - unbind()  — remove binding metadata; directory is preserved by
+ *                 default (pass `$purge = true` to wipe it).
+ *   - pull()    — fast-forward pull, honoring conflict policy.
+ *   - status()  — dirty count, branch, HEAD, upstream gap.
+ *   - list_bindings() — every registered binding.
+ *
+ * Push, policy-update, and the scheduled pull task land in follow-up
+ * PRs (DMC#38 phases 2 and 3).
+ *
+ * @package DataMachineCode\GitSync
+ * @since   0.7.0
+ * @see     https://github.com/Extra-Chill/data-machine-code/issues/38
+ */
+
+namespace DataMachineCode\GitSync;
+
+use DataMachineCode\Support\GitRunner;
+use DataMachineCode\Support\PathSecurity;
+
+defined( 'ABSPATH' ) || exit;
+
+final class GitSync {
+
+	private GitSyncRegistry $registry;
+
+	public function __construct( ?GitSyncRegistry $registry = null ) {
+		$this->registry = $registry ?? new GitSyncRegistry();
+	}
+
+	// =========================================================================
+	// Public API
+	// =========================================================================
+
+	/**
+	 * Register a new binding and materialize it on disk.
+	 *
+	 * On disk behavior:
+	 *   - Path missing            → git clone into it.
+	 *   - Path exists, empty      → git clone into it.
+	 *   - Path exists, has `.git` → adopt if origin matches the binding's
+	 *                               remote_url; error otherwise.
+	 *   - Path exists, non-empty, no `.git` → refuse. Safer to make the
+	 *                               user decide than to overlay a clone
+	 *                               on whatever's already there.
+	 *
+	 * @param array<string, mixed> $input {
+	 *     @type string $slug       Unique binding identifier.
+	 *     @type string $local_path ABSPATH-relative path (leading slash).
+	 *     @type string $remote_url Git remote URL (https:// or git@).
+	 *     @type string $branch     Branch to track. Default 'main'.
+	 *     @type array  $policy     Policy overrides (see GitSyncBinding::DEFAULT_POLICY).
+	 * }
+	 * @return array{success: true, binding: array<string, mixed>, cloned: bool, adopted: bool, local_path: string}|\WP_Error
+	 */
+	public function bind( array $input ): array|\WP_Error {
+		$binding = GitSyncBinding::create( $input );
+		if ( is_wp_error( $binding ) ) {
+			return $binding;
+		}
+
+		if ( $this->registry->exists( $binding->slug ) ) {
+			return new \WP_Error(
+				'binding_exists',
+				sprintf( 'A binding with slug "%s" already exists. Unbind it first.', $binding->slug ),
+				array( 'status' => 409 )
+			);
+		}
+
+		$containment = $this->validateBindingPath( $binding );
+		if ( is_wp_error( $containment ) ) {
+			return $containment;
+		}
+		$absolute = $containment;
+
+		$materialize = $this->materializeClone( $binding, $absolute );
+		if ( is_wp_error( $materialize ) ) {
+			return $materialize;
+		}
+
+		$binding->last_commit = $this->readHead( $absolute );
+		$binding->last_pulled = gmdate( 'c' );
+		$this->registry->save( $binding );
+
+		return array(
+			'success'    => true,
+			'binding'    => $binding->toArray(),
+			'cloned'     => ! $materialize['adopted'],
+			'adopted'    => $materialize['adopted'],
+			'local_path' => $absolute,
+		);
+	}
+
+	/**
+	 * Remove a binding.
+	 *
+	 * By default the on-disk working tree is preserved — the binding is
+	 * metadata, not ownership of the directory. `$purge = true` opts in
+	 * to deleting the directory (with strict containment re-validation
+	 * at the blast radius).
+	 *
+	 * @param string $slug  Binding slug.
+	 * @param bool   $purge If true, remove the on-disk directory too.
+	 * @return array{success: true, slug: string, purged: bool, local_path: string}|\WP_Error
+	 */
+	public function unbind( string $slug, bool $purge = false ): array|\WP_Error {
+		$binding = $this->registry->get( $slug );
+		if ( null === $binding ) {
+			return $this->notFound( $slug );
+		}
+
+		$absolute = $binding->resolveAbsolutePath();
+		$purged   = false;
+
+		if ( $purge && is_dir( $absolute ) ) {
+			// Belt-and-suspenders: re-validate containment right before rm.
+			$abspath    = rtrim( ABSPATH, '/' );
+			$validation = PathSecurity::validateContainment( $absolute, $abspath );
+			if ( ! $validation['valid'] ) {
+				return new \WP_Error(
+					'path_outside_abspath',
+					sprintf( 'Refusing to purge "%s": %s', $absolute, $validation['message'] ?? 'containment failed' ),
+					array( 'status' => 403 )
+				);
+			}
+
+			$escaped = escapeshellarg( $validation['real_path'] );
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
+			exec( sprintf( 'rm -rf %s 2>&1', $escaped ), $_unused, $exit_code );
+			if ( 0 !== $exit_code ) {
+				return new \WP_Error( 'purge_failed', sprintf( 'Failed to remove directory %s (exit %d).', $absolute, $exit_code ), array( 'status' => 500 ) );
+			}
+			$purged = true;
+		}
+
+		$this->registry->delete( $slug );
+
+		return array(
+			'success'    => true,
+			'slug'       => $slug,
+			'purged'     => $purged,
+			'local_path' => $absolute,
+		);
+	}
+
+	/**
+	 * Fast-forward pull a binding.
+	 *
+	 * Conflict handling:
+	 *   - `fail`          (default): refuse pull when working tree is dirty.
+	 *   - `upstream_wins`: reset hard to the remote tip, discarding local
+	 *                      changes. Non-reversible; opt-in per binding.
+	 *   - `manual`:        allow the dirty pull to run and surface the
+	 *                      failure for admin review.
+	 *
+	 * `$allow_dirty` can override a `fail` policy one-off (CLI convenience).
+	 *
+	 * @param string $slug        Binding slug.
+	 * @param bool   $allow_dirty Bypass dirty-tree safety for this pull.
+	 * @return array{success: true, slug: string, branch: string, previous_head: ?string, head: ?string, message: string}|\WP_Error
+	 */
+	public function pull( string $slug, bool $allow_dirty = false ): array|\WP_Error {
+		$binding = $this->registry->get( $slug );
+		if ( null === $binding ) {
+			return $this->notFound( $slug );
+		}
+
+		$absolute = $binding->resolveAbsolutePath();
+		$repo_err = $this->assertRepo( $absolute, $slug );
+		if ( is_wp_error( $repo_err ) ) {
+			return $repo_err;
+		}
+
+		$previous_head = $this->readHead( $absolute );
+		$dirty_count   = $this->countDirty( $absolute );
+		$conflict      = (string) ( $binding->policy['conflict'] ?? 'fail' );
+
+		if ( $dirty_count > 0 && ! $allow_dirty ) {
+			if ( 'fail' === $conflict ) {
+				return new \WP_Error(
+					'dirty_working_tree',
+					sprintf( 'Working tree for "%s" is dirty (%d file(s)). Pass allow_dirty=true or change conflict policy.', $slug, $dirty_count ),
+					array( 'status' => 400, 'dirty' => $dirty_count )
+				);
+			}
+			if ( 'upstream_wins' === $conflict ) {
+				// Reset hard before fetching to ensure a clean fast-forward.
+				$reset = GitRunner::run( $absolute, 'reset --hard HEAD' );
+				if ( is_wp_error( $reset ) ) {
+					return $reset;
+				}
+			}
+			// 'manual' — fall through and let the pull attempt happen; git
+			// will refuse on conflict and the error surfaces to the caller.
+		}
+
+		// Refuse any pull that would change branches.
+		$current_branch = $this->readBranch( $absolute );
+		if ( null !== $current_branch && $current_branch !== $binding->branch ) {
+			return new \WP_Error(
+				'branch_mismatch',
+				sprintf(
+					'Binding "%s" is pinned to branch "%s" but the working tree is on "%s". Refusing to pull.',
+					$slug,
+					$binding->branch,
+					$current_branch
+				),
+				array( 'status' => 409 )
+			);
+		}
+
+		$pull = GitRunner::run( $absolute, 'pull --ff-only origin ' . escapeshellarg( $binding->branch ) );
+		if ( is_wp_error( $pull ) ) {
+			return $pull;
+		}
+
+		$new_head             = $this->readHead( $absolute );
+		$binding->last_pulled = gmdate( 'c' );
+		$binding->last_commit = $new_head;
+		$this->registry->save( $binding );
+
+		return array(
+			'success'       => true,
+			'slug'          => $slug,
+			'branch'        => $binding->branch,
+			'previous_head' => $previous_head,
+			'head'          => $new_head,
+			'message'       => trim( (string) ( $pull['output'] ?? '' ) ),
+		);
+	}
+
+	/**
+	 * Status snapshot for a binding.
+	 *
+	 * Reports the working-tree state (branch, HEAD, dirty files) and any
+	 * drift between local HEAD and the tracked upstream ref. Drift is
+	 * computed against `origin/<binding->branch>` via `rev-list --count`,
+	 * so a stale local ref produces a conservative number rather than
+	 * failing the call.
+	 *
+	 * @param string $slug Binding slug.
+	 * @return array<string, mixed>|\WP_Error
+	 */
+	public function status( string $slug ): array|\WP_Error {
+		$binding = $this->registry->get( $slug );
+		if ( null === $binding ) {
+			return $this->notFound( $slug );
+		}
+
+		$absolute = $binding->resolveAbsolutePath();
+		$exists   = is_dir( $absolute );
+		$is_repo  = $exists && ( is_dir( $absolute . '/.git' ) || is_file( $absolute . '/.git' ) );
+
+		$data = array(
+			'success'     => true,
+			'slug'        => $slug,
+			'local_path'  => $absolute,
+			'remote_url'  => $binding->remote_url,
+			'tracked_branch' => $binding->branch,
+			'exists'      => $exists,
+			'is_repo'     => $is_repo,
+			'branch'      => null,
+			'head'        => null,
+			'dirty'       => 0,
+			'ahead'       => null,
+			'behind'      => null,
+			'last_pulled' => $binding->last_pulled,
+			'policy'      => $binding->policy,
+		);
+
+		if ( ! $is_repo ) {
+			return $data;
+		}
+
+		$data['branch'] = $this->readBranch( $absolute );
+		$data['head']   = $this->readHead( $absolute );
+		$data['dirty']  = $this->countDirty( $absolute );
+
+		$upstream = 'origin/' . $binding->branch;
+		$ahead    = GitRunner::run( $absolute, 'rev-list --count ' . escapeshellarg( $upstream ) . '..HEAD' );
+		$behind   = GitRunner::run( $absolute, 'rev-list --count HEAD..' . escapeshellarg( $upstream ) );
+		$data['ahead']  = is_wp_error( $ahead ) ? null : (int) trim( (string) $ahead['output'] );
+		$data['behind'] = is_wp_error( $behind ) ? null : (int) trim( (string) $behind['output'] );
+
+		return $data;
+	}
+
+	/**
+	 * List every registered binding with a lightweight status snapshot.
+	 *
+	 * @return array{success: true, bindings: array<int, array<string, mixed>>}
+	 */
+	public function list_bindings(): array {
+		$bindings = $this->registry->all();
+		$out      = array();
+		foreach ( $bindings as $binding ) {
+			$absolute = $binding->resolveAbsolutePath();
+			$is_repo  = is_dir( $absolute ) && ( is_dir( $absolute . '/.git' ) || is_file( $absolute . '/.git' ) );
+			$out[]    = array(
+				'slug'           => $binding->slug,
+				'local_path'     => $binding->local_path,
+				'absolute_path'  => $absolute,
+				'remote_url'     => $binding->remote_url,
+				'branch'         => $binding->branch,
+				'exists'         => is_dir( $absolute ),
+				'is_repo'        => $is_repo,
+				'auto_pull'      => (bool) ( $binding->policy['auto_pull'] ?? false ),
+				'pull_interval'  => (string) ( $binding->policy['pull_interval'] ?? 'hourly' ),
+				'last_pulled'    => $binding->last_pulled,
+				'last_commit'    => $binding->last_commit,
+			);
+		}
+
+		return array(
+			'success'  => true,
+			'bindings' => $out,
+		);
+	}
+
+	// =========================================================================
+	// Internal helpers
+	// =========================================================================
+
+	/**
+	 * Validate the binding's `local_path` against ABSPATH containment rules.
+	 *
+	 * Pre-write validation — the target may not exist yet, so we check the
+	 * relative segments first (no `..`, no absolute prefix after stripping
+	 * the leading slash) and then compute the absolute path without calling
+	 * `realpath()` on a non-existent target. Existing targets get an extra
+	 * `realpath`-based containment check as a belt-and-suspenders.
+	 *
+	 * @return string|\WP_Error Absolute path on success.
+	 */
+	private function validateBindingPath( GitSyncBinding $binding ): string|\WP_Error {
+		$relative = ltrim( str_replace( '\\', '/', $binding->local_path ), '/' );
+
+		if ( '' === $relative ) {
+			return new \WP_Error( 'invalid_local_path', 'local_path cannot resolve to ABSPATH itself.', array( 'status' => 400 ) );
+		}
+
+		if ( PathSecurity::hasTraversal( $relative ) ) {
+			return new \WP_Error( 'path_traversal', 'local_path contains traversal segments (`.`, `..`).', array( 'status' => 400 ) );
+		}
+
+		if ( PathSecurity::isSensitivePath( $relative ) ) {
+			return new \WP_Error( 'sensitive_path', sprintf( 'Refusing to bind sensitive path: %s', $relative ), array( 'status' => 403 ) );
+		}
+
+		$abspath  = rtrim( ABSPATH, '/' );
+		$absolute = $abspath . '/' . rtrim( $relative, '/' );
+
+		// If it already exists, confirm it really resolves under ABSPATH via
+		// realpath (defends against symlink escapes).
+		if ( is_dir( $absolute ) ) {
+			$validation = PathSecurity::validateContainment( $absolute, $abspath );
+			if ( ! $validation['valid'] ) {
+				return new \WP_Error(
+					'path_outside_abspath',
+					sprintf( 'local_path resolves outside ABSPATH: %s', $validation['message'] ?? '' ),
+					array( 'status' => 403 )
+				);
+			}
+			$absolute = $validation['real_path'];
+		}
+
+		return $absolute;
+	}
+
+	/**
+	 * Either clone the remote into `$absolute` or adopt an existing checkout.
+	 *
+	 * Returns `['adopted' => bool]` on success so the caller can report
+	 * whether the working tree was materialized fresh or already present.
+	 *
+	 * @return array{adopted: bool}|\WP_Error
+	 */
+	private function materializeClone( GitSyncBinding $binding, string $absolute ): array|\WP_Error {
+		$git_path = $absolute . '/.git';
+		$exists   = is_dir( $absolute );
+
+		if ( $exists && ( is_dir( $git_path ) || is_file( $git_path ) ) ) {
+			$remote = GitRunner::run( $absolute, 'config --get remote.origin.url' );
+			if ( is_wp_error( $remote ) ) {
+				return $remote;
+			}
+			$current_origin = trim( (string) $remote['output'] );
+			if ( $current_origin !== $binding->remote_url ) {
+				return new \WP_Error(
+					'origin_mismatch',
+					sprintf(
+						'Existing checkout at "%s" has origin "%s", but binding expects "%s". Refusing to adopt.',
+						$absolute,
+						$current_origin,
+						$binding->remote_url
+					),
+					array( 'status' => 409 )
+				);
+			}
+
+			// Optional: verify branch alignment. Not fatal (caller can pull/fetch
+			// to re-align), but we warn by returning success so the CLI can report.
+			return array( 'adopted' => true );
+		}
+
+		if ( $exists && ! $this->isDirEmpty( $absolute ) ) {
+			return new \WP_Error(
+				'dirty_target',
+				sprintf(
+					'Target "%s" exists and is non-empty without a .git directory. Refusing to clone over it.',
+					$absolute
+				),
+				array( 'status' => 409 )
+			);
+		}
+
+		// Create parent directory if missing.
+		$parent = dirname( $absolute );
+		if ( ! is_dir( $parent ) && ! wp_mkdir_p( $parent ) ) {
+			return new \WP_Error( 'parent_mkdir_failed', sprintf( 'Failed to create parent directory: %s', $parent ), array( 'status' => 500 ) );
+		}
+
+		$cmd = sprintf(
+			'git clone --branch %s %s %s 2>&1',
+			escapeshellarg( $binding->branch ),
+			escapeshellarg( $binding->remote_url ),
+			escapeshellarg( $absolute )
+		);
+
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
+		exec( $cmd, $output, $exit_code );
+
+		if ( 0 !== $exit_code ) {
+			return new \WP_Error(
+				'clone_failed',
+				sprintf( 'Git clone failed (exit %d): %s', $exit_code, implode( "\n", $output ) ),
+				array( 'status' => 500 )
+			);
+		}
+
+		return array( 'adopted' => false );
+	}
+
+	private function isDirEmpty( string $path ): bool {
+		$handle = @opendir( $path );
+		if ( false === $handle ) {
+			return false;
+		}
+		while ( false !== ( $entry = readdir( $handle ) ) ) {
+			if ( '.' !== $entry && '..' !== $entry ) {
+				closedir( $handle );
+				return false;
+			}
+		}
+		closedir( $handle );
+		return true;
+	}
+
+	private function assertRepo( string $absolute, string $slug ): ?\WP_Error {
+		if ( ! is_dir( $absolute ) ) {
+			return new \WP_Error( 'missing_working_tree', sprintf( 'Binding "%s" has no working tree on disk at %s.', $slug, $absolute ), array( 'status' => 404 ) );
+		}
+		$git_path = $absolute . '/.git';
+		if ( ! is_dir( $git_path ) && ! is_file( $git_path ) ) {
+			return new \WP_Error( 'not_a_repo', sprintf( 'Binding "%s" is not a git repository (no .git at %s).', $slug, $absolute ), array( 'status' => 409 ) );
+		}
+		return null;
+	}
+
+	private function readHead( string $absolute ): ?string {
+		$result = GitRunner::run( $absolute, 'rev-parse --short HEAD' );
+		if ( is_wp_error( $result ) ) {
+			return null;
+		}
+		$head = trim( (string) $result['output'] );
+		return '' === $head ? null : $head;
+	}
+
+	private function readBranch( string $absolute ): ?string {
+		$result = GitRunner::run( $absolute, 'rev-parse --abbrev-ref HEAD' );
+		if ( is_wp_error( $result ) ) {
+			return null;
+		}
+		$branch = trim( (string) $result['output'] );
+		return '' === $branch ? null : $branch;
+	}
+
+	private function countDirty( string $absolute ): int {
+		$result = GitRunner::run( $absolute, 'status --porcelain' );
+		if ( is_wp_error( $result ) ) {
+			return 0;
+		}
+		$lines = array_filter( array_map( 'trim', explode( "\n", (string) $result['output'] ) ) );
+		return count( $lines );
+	}
+
+	private function notFound( string $slug ): \WP_Error {
+		return new \WP_Error(
+			'binding_not_found',
+			sprintf( 'No GitSync binding with slug "%s".', $slug ),
+			array( 'status' => 404 )
+		);
+	}
+}

--- a/inc/GitSync/GitSyncBinding.php
+++ b/inc/GitSync/GitSyncBinding.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * GitSync Binding
+ *
+ * Value object representing a single binding between a site-owned local
+ * directory (relative to ABSPATH) and a remote git repository.
+ *
+ * Bindings are stored serialized inside the `datamachine_gitsync_bindings`
+ * option by `GitSyncRegistry`. This class exists so the serialization
+ * shape has one canonical source of truth and validation lives alongside
+ * the data it validates.
+ *
+ * @package DataMachineCode\GitSync
+ * @since   0.7.0
+ */
+
+namespace DataMachineCode\GitSync;
+
+defined( 'ABSPATH' ) || exit;
+
+final class GitSyncBinding {
+
+	/**
+	 * Default policy shape applied to freshly created bindings.
+	 *
+	 * Deliberately conservative: no writes, no push, no auto-pull. The
+	 * caller has to explicitly opt each of those in. `conflict = fail`
+	 * means a dirty pull aborts instead of destroying local state.
+	 *
+	 * @var array<string, mixed>
+	 */
+	public const DEFAULT_POLICY = array(
+		'auto_pull'     => false,
+		'pull_interval' => 'hourly',
+		'write_enabled' => false,
+		'push_enabled'  => false,
+		'allowed_paths' => array(),
+		'conflict'      => 'fail',
+	);
+
+	/**
+	 * Allowed conflict-resolution strategies.
+	 *
+	 * @var string[]
+	 */
+	public const CONFLICT_STRATEGIES = array( 'fail', 'upstream_wins', 'manual' );
+
+	public string $slug;
+	public string $local_path;
+	public string $remote_url;
+	public string $branch;
+
+	/**
+	 * @var array<string, mixed>
+	 */
+	public array $policy;
+
+	public string $created_at;
+	public ?string $last_pulled;
+	public ?string $last_commit;
+
+	/**
+	 * @param array<string, mixed> $data
+	 */
+	private function __construct( array $data ) {
+		$this->slug        = (string) $data['slug'];
+		$this->local_path  = (string) $data['local_path'];
+		$this->remote_url  = (string) $data['remote_url'];
+		$this->branch      = (string) ( $data['branch'] ?? 'main' );
+		$this->policy      = is_array( $data['policy'] ?? null ) ? $data['policy'] : array();
+		$this->policy      = array_merge( self::DEFAULT_POLICY, $this->policy );
+		$this->created_at  = (string) ( $data['created_at'] ?? gmdate( 'c' ) );
+		$this->last_pulled = isset( $data['last_pulled'] ) ? (string) $data['last_pulled'] : null;
+		$this->last_commit = isset( $data['last_commit'] ) ? (string) $data['last_commit'] : null;
+	}
+
+	/**
+	 * Build a binding from a raw input array, validating each field.
+	 *
+	 * @param array<string, mixed> $input Raw user input.
+	 * @return self|\WP_Error
+	 */
+	public static function create( array $input ): self|\WP_Error {
+		$slug = strtolower( trim( (string) ( $input['slug'] ?? '' ) ) );
+		if ( ! preg_match( '/^[a-z0-9][a-z0-9_-]*$/', $slug ) ) {
+			return new \WP_Error(
+				'invalid_slug',
+				'Slug must start with a letter/digit and contain only lowercase letters, digits, underscore, and hyphen.',
+				array( 'status' => 400 )
+			);
+		}
+
+		$local = trim( (string) ( $input['local_path'] ?? '' ) );
+		if ( '' === $local ) {
+			return new \WP_Error( 'missing_local_path', 'local_path is required.', array( 'status' => 400 ) );
+		}
+
+		$remote = trim( (string) ( $input['remote_url'] ?? '' ) );
+		if ( '' === $remote ) {
+			return new \WP_Error( 'missing_remote_url', 'remote_url is required.', array( 'status' => 400 ) );
+		}
+
+		if ( ! preg_match( '#^(https?://|git@)#', $remote ) ) {
+			return new \WP_Error(
+				'invalid_remote_url',
+				'remote_url must be an https:// or git@ URL.',
+				array( 'status' => 400 )
+			);
+		}
+
+		$branch = trim( (string) ( $input['branch'] ?? 'main' ) );
+		if ( '' === $branch || ! preg_match( '#^[A-Za-z0-9._/\-]+$#', $branch ) ) {
+			return new \WP_Error( 'invalid_branch', 'Branch name is invalid.', array( 'status' => 400 ) );
+		}
+
+		$policy_in = is_array( $input['policy'] ?? null ) ? $input['policy'] : array();
+		$policy    = array_merge( self::DEFAULT_POLICY, $policy_in );
+
+		if ( ! in_array( $policy['conflict'] ?? 'fail', self::CONFLICT_STRATEGIES, true ) ) {
+			return new \WP_Error(
+				'invalid_conflict_strategy',
+				sprintf( 'conflict must be one of: %s.', implode( ', ', self::CONFLICT_STRATEGIES ) ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( ! is_array( $policy['allowed_paths'] ?? null ) ) {
+			$policy['allowed_paths'] = array();
+		}
+
+		return new self(
+			array(
+				'slug'       => $slug,
+				'local_path' => $local,
+				'remote_url' => $remote,
+				'branch'     => $branch,
+				'policy'     => $policy,
+				'created_at' => gmdate( 'c' ),
+			)
+		);
+	}
+
+	/**
+	 * Restore a binding from its stored array form.
+	 *
+	 * Unlike `create()` this does NOT re-validate — callers trust the
+	 * option store. If storage is ever migrated to a stricter format,
+	 * add validation here.
+	 *
+	 * @param array<string, mixed> $data
+	 * @return self
+	 */
+	public static function fromArray( array $data ): self {
+		return new self( $data );
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function toArray(): array {
+		return array(
+			'slug'        => $this->slug,
+			'local_path'  => $this->local_path,
+			'remote_url'  => $this->remote_url,
+			'branch'      => $this->branch,
+			'policy'      => $this->policy,
+			'created_at'  => $this->created_at,
+			'last_pulled' => $this->last_pulled,
+			'last_commit' => $this->last_commit,
+		);
+	}
+
+	/**
+	 * Resolve `local_path` to an absolute filesystem path under ABSPATH.
+	 *
+	 * `local_path` convention: leading-slash string, interpreted relative
+	 * to ABSPATH (e.g. `/wp-content/uploads/markdown/wiki/` →
+	 * `ABSPATH/wp-content/uploads/markdown/wiki/`). This matches the shape
+	 * documented in Extra-Chill/data-machine-code#38 and keeps bindings
+	 * portable across installs with different ABSPATHs.
+	 *
+	 * @return string Absolute path with no trailing slash.
+	 */
+	public function resolveAbsolutePath(): string {
+		$relative = ltrim( str_replace( '\\', '/', $this->local_path ), '/' );
+		$abspath  = rtrim( ABSPATH, '/' );
+		return $abspath . '/' . rtrim( $relative, '/' );
+	}
+}

--- a/inc/GitSync/GitSyncRegistry.php
+++ b/inc/GitSync/GitSyncRegistry.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * GitSync Registry
+ *
+ * Option-backed persistence for GitSync bindings.
+ *
+ * Storage shape:
+ *
+ *   datamachine_gitsync_bindings = array(
+ *       '<slug>' => array(  // GitSyncBinding::toArray()
+ *           'slug'        => 'intelligence-wiki',
+ *           'local_path'  => '/wp-content/uploads/markdown/wiki/',
+ *           'remote_url'  => 'https://github.com/...',
+ *           'branch'      => 'main',
+ *           'policy'      => array( ... ),
+ *           'created_at'  => '2026-04-20T12:00:00+00:00',
+ *           'last_pulled' => null|'2026-04-20T12:15:00+00:00',
+ *           'last_commit' => null|'abc1234',
+ *       ),
+ *       ...
+ *   )
+ *
+ * v1 sticks to an option; if usage grows past ~50 bindings the whole
+ * registry can move to a custom table without changing the public API.
+ *
+ * @package DataMachineCode\GitSync
+ * @since   0.7.0
+ */
+
+namespace DataMachineCode\GitSync;
+
+defined( 'ABSPATH' ) || exit;
+
+final class GitSyncRegistry {
+
+	public const OPTION_KEY = 'datamachine_gitsync_bindings';
+
+	/**
+	 * Load all bindings keyed by slug.
+	 *
+	 * @return array<string, GitSyncBinding>
+	 */
+	public function all(): array {
+		$raw = get_option( self::OPTION_KEY, array() );
+		if ( ! is_array( $raw ) ) {
+			return array();
+		}
+
+		$out = array();
+		foreach ( $raw as $slug => $data ) {
+			if ( ! is_array( $data ) ) {
+				continue;
+			}
+			// Tolerate missing slug key by falling back to the array key.
+			if ( empty( $data['slug'] ) ) {
+				$data['slug'] = (string) $slug;
+			}
+			$out[ (string) $slug ] = GitSyncBinding::fromArray( $data );
+		}
+
+		return $out;
+	}
+
+	public function get( string $slug ): ?GitSyncBinding {
+		$all = $this->all();
+		return $all[ $slug ] ?? null;
+	}
+
+	public function exists( string $slug ): bool {
+		return null !== $this->get( $slug );
+	}
+
+	/**
+	 * Persist a binding (insert or update).
+	 */
+	public function save( GitSyncBinding $binding ): void {
+		$all                     = $this->loadRawArray();
+		$all[ $binding->slug ]   = $binding->toArray();
+		update_option( self::OPTION_KEY, $all, false );
+	}
+
+	public function delete( string $slug ): bool {
+		$all = $this->loadRawArray();
+		if ( ! array_key_exists( $slug, $all ) ) {
+			return false;
+		}
+		unset( $all[ $slug ] );
+		update_option( self::OPTION_KEY, $all, false );
+		return true;
+	}
+
+	/**
+	 * @return array<string, array<string, mixed>>
+	 */
+	private function loadRawArray(): array {
+		$raw = get_option( self::OPTION_KEY, array() );
+		return is_array( $raw ) ? $raw : array();
+	}
+}

--- a/inc/Support/GitRunner.php
+++ b/inc/Support/GitRunner.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Git Runner
+ *
+ * Thin shared wrapper around `exec()` for running git commands in a target
+ * directory. Used by both `Workspace\Workspace` (for agent-owned checkouts
+ * under the workspace root) and `GitSync\GitSync` (for site-owned subtrees
+ * under ABSPATH).
+ *
+ * Keeps the shell invocation pattern in one place so containment checks,
+ * stderr merging, and error shape stay consistent across callers.
+ *
+ * @package DataMachineCode\Support
+ * @since   0.7.0
+ */
+
+namespace DataMachineCode\Support;
+
+defined( 'ABSPATH' ) || exit;
+
+final class GitRunner {
+
+	/**
+	 * Run a git command inside a repository working tree.
+	 *
+	 * `$path` is assumed to have already been validated for containment by the
+	 * caller — this class does not re-check. It only shell-escapes and routes
+	 * stderr into the output stream for a single source of truth on errors.
+	 *
+	 * @param string $path Absolute working-tree path (passed to `git -C`).
+	 * @param string $args Git arguments (without leading `git`).
+	 * @return array{success: true, output: string}|\WP_Error
+	 */
+	public static function run( string $path, string $args ): array|\WP_Error {
+		$escaped = escapeshellarg( $path );
+		$command = sprintf( 'git -C %s %s 2>&1', $escaped, $args );
+
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
+		exec( $command, $output, $exit_code );
+
+		if ( 0 !== $exit_code ) {
+			return new \WP_Error(
+				'git_command_failed',
+				sprintf( 'Git command failed (exit %d): %s', $exit_code, implode( "\n", $output ) ),
+				array(
+					'status' => 500,
+					'output' => implode( "\n", $output ),
+				)
+			);
+		}
+
+		return array(
+			'success' => true,
+			'output'  => implode( "\n", $output ),
+		);
+	}
+}

--- a/inc/Support/PathSecurity.php
+++ b/inc/Support/PathSecurity.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Path Security
+ *
+ * Shared containment + sensitive-file primitives used by both
+ * `Workspace\Workspace` and `GitSync\GitSync`. Kept in one place so the
+ * block list, traversal detection, and realpath-based containment stay
+ * consistent across every code path that touches the filesystem.
+ *
+ * @package DataMachineCode\Support
+ * @since   0.7.0
+ */
+
+namespace DataMachineCode\Support;
+
+defined( 'ABSPATH' ) || exit;
+
+final class PathSecurity {
+
+	/**
+	 * Sensitive filename fragments — any path containing one is refused
+	 * for mutations (staging, writing). Matched against the lower-cased
+	 * normalized path so case variants (e.g. `.ENV`) can't sneak through.
+	 *
+	 * @var string[]
+	 */
+	private const SENSITIVE_PATTERNS = array(
+		'.env',
+		'credentials.json',
+		'id_rsa',
+		'id_ed25519',
+		'.pem',
+		'.key',
+		'secrets',
+	);
+
+	/**
+	 * Validate that a target path is contained within a parent directory.
+	 *
+	 * Uses `realpath()` so symlinks cannot escape the container. Both paths
+	 * must exist on disk — use `hasTraversal()` for pre-existence checks on
+	 * relative paths before writing.
+	 *
+	 * @param string $target    Path to validate.
+	 * @param string $container Parent directory that must contain the target.
+	 * @return array{valid: bool, real_path?: string, message?: string}
+	 */
+	public static function validateContainment( string $target, string $container ): array {
+		$real_container = realpath( $container );
+		$real_target    = realpath( $target );
+
+		if ( false === $real_container || false === $real_target ) {
+			return array(
+				'valid'   => false,
+				'message' => 'Path does not exist.',
+			);
+		}
+
+		if ( 0 !== strpos( $real_target, $real_container . '/' ) && $real_target !== $real_container ) {
+			return array(
+				'valid'   => false,
+				'message' => 'Path traversal detected. Access denied.',
+			);
+		}
+
+		return array(
+			'valid'     => true,
+			'real_path' => $real_target,
+		);
+	}
+
+	/**
+	 * Detect `.` or `..` components in a relative path.
+	 *
+	 * Pre-write companion to `validateContainment()` — use this to reject
+	 * relative paths *before* resolving them, so we never write to an
+	 * escaping location even transiently.
+	 *
+	 * @param string $path Relative path.
+	 * @return bool True if any segment is `.` or `..`.
+	 */
+	public static function hasTraversal( string $path ): bool {
+		$parts = explode( '/', str_replace( '\\', '/', $path ) );
+		foreach ( $parts as $part ) {
+			if ( '..' === $part || '.' === $part ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Check whether a path looks sensitive (env files, credentials, keys).
+	 *
+	 * @param string $path Relative path.
+	 * @return bool
+	 */
+	public static function isSensitivePath( string $path ): bool {
+		$normalized = strtolower( ltrim( str_replace( '\\', '/', $path ), '/' ) );
+
+		foreach ( self::SENSITIVE_PATTERNS as $pattern ) {
+			if ( str_contains( $normalized, $pattern ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -13,6 +13,8 @@
 namespace DataMachineCode\Workspace;
 
 use DataMachine\Core\FilesRepository\FilesystemHelper;
+use DataMachineCode\Support\GitRunner;
+use DataMachineCode\Support\PathSecurity;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -1550,27 +1552,7 @@ class Workspace {
 	 * @return array{valid: bool, real_path?: string, message?: string}
 	 */
 	public function validate_containment( string $target, string $container ): array {
-		$real_container = realpath( $container );
-		$real_target    = realpath( $target );
-
-		if ( false === $real_container || false === $real_target ) {
-			return array(
-				'valid'   => false,
-				'message' => 'Path does not exist.',
-			);
-		}
-
-		if ( 0 !== strpos( $real_target, $real_container . '/' ) && $real_target !== $real_container ) {
-			return array(
-				'valid'   => false,
-				'message' => 'Path traversal detected. Access denied.',
-			);
-		}
-
-		return array(
-			'valid'     => true,
-			'real_path' => $real_target,
-		);
+		return PathSecurity::validateContainment( $target, $container );
 	}
 
 	/**
@@ -1639,27 +1621,7 @@ class Workspace {
 	 * @return array
 	 */
 	private function run_git( string $repo_path, string $git_args ): array|\WP_Error {
-		$escaped_repo = escapeshellarg( $repo_path );
-		$command      = sprintf( 'git -C %s %s 2>&1', $escaped_repo, $git_args );
-
-		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
-		exec( $command, $output, $exit_code );
-
-		if ( 0 !== $exit_code ) {
-			return new \WP_Error(
-				'git_command_failed',
-				sprintf( 'Git command failed (exit %d): %s', $exit_code, implode( "\n", $output ) ),
-				array(
-					'status' => 500,
-					'output' => implode( "\n", $output ),
-				)
-			);
-		}
-
-		return array(
-			'success' => true,
-			'output'  => implode( "\n", $output ),
-		);
+		return GitRunner::run( $repo_path, $git_args );
 	}
 
 	/**
@@ -1788,25 +1750,7 @@ class Workspace {
 	 * @return bool
 	 */
 	private function is_sensitive_path( string $path ): bool {
-		$normalized = strtolower( ltrim( str_replace( '\\', '/', $path ), '/' ) );
-
-		$sensitive_patterns = array(
-			'.env',
-			'credentials.json',
-			'id_rsa',
-			'id_ed25519',
-			'.pem',
-			'.key',
-			'secrets',
-		);
-
-		foreach ( $sensitive_patterns as $pattern ) {
-			if ( str_contains( $normalized, $pattern ) ) {
-				return true;
-			}
-		}
-
-		return false;
+		return PathSecurity::isSensitivePath( $path );
 	}
 
 	/**
@@ -1816,14 +1760,7 @@ class Workspace {
 	 * @return bool
 	 */
 	private function has_traversal( string $path ): bool {
-		$parts = explode( '/', str_replace( '\\', '/', $path ) );
-		foreach ( $parts as $part ) {
-			if ( '..' === $part || '.' === $part ) {
-				return true;
-			}
-		}
-
-		return false;
+		return PathSecurity::hasTraversal( $path );
 	}
 
 	/**

--- a/tests/smoke-gitsync.php
+++ b/tests/smoke-gitsync.php
@@ -1,0 +1,261 @@
+<?php
+/**
+ * Pure-PHP end-to-end smoke test for GitSync Phase 1.
+ *
+ * Exercises bind (clone) → status → pull → unbind against a real public
+ * remote. Runs on native macOS/Linux PHP + git — does not require a full
+ * WordPress bootstrap. Needed because Studio WASM can't spawn git clone
+ * into its mounted /wordpress filesystem (Studio#3082), so the CLI smoke
+ * lives here instead.
+ *
+ * Run: php tests/smoke-gitsync.php
+ *
+ * The test uses `mcp-context-wporg` as a small, stable public remote. If
+ * you don't have network, skip this smoke and rely on the handle/binding
+ * unit checks plus manual in-Studio verification for the non-git surface.
+ */
+
+declare( strict_types=1 );
+
+namespace {
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		// Point ABSPATH at a scratch directory we control so bindings
+		// actually land in real writable space during the smoke run.
+		$scratch = sys_get_temp_dir() . '/dmc-gitsync-smoke-' . getmypid();
+		@mkdir( $scratch, 0755, true );
+		define( 'ABSPATH', $scratch . '/' );
+	}
+
+	// Minimal WordPress polyfills. Options are held in-memory for the run.
+	$GLOBALS['__dmc_options'] = array();
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			public string $code;
+			public string $message;
+			public array $data;
+			public function __construct( string $code = '', string $message = '', array $data = array() ) {
+				$this->code    = $code;
+				$this->message = $message;
+				$this->data    = $data;
+			}
+			public function get_error_code(): string { return $this->code; }
+			public function get_error_message(): string { return $this->message; }
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $thing ): bool { return $thing instanceof \WP_Error; }
+	}
+
+	if ( ! function_exists( 'wp_mkdir_p' ) ) {
+		function wp_mkdir_p( string $path ): bool { return is_dir( $path ) || mkdir( $path, 0755, true ); }
+	}
+
+	if ( ! function_exists( 'get_option' ) ) {
+		function get_option( string $name, $default = false ) {
+			return $GLOBALS['__dmc_options'][ $name ] ?? $default;
+		}
+	}
+
+	if ( ! function_exists( 'update_option' ) ) {
+		function update_option( string $name, $value, $autoload = null ): bool {
+			$GLOBALS['__dmc_options'][ $name ] = $value;
+			return true;
+		}
+	}
+
+	require __DIR__ . '/../inc/Support/GitRunner.php';
+	require __DIR__ . '/../inc/Support/PathSecurity.php';
+	require __DIR__ . '/../inc/GitSync/GitSyncBinding.php';
+	require __DIR__ . '/../inc/GitSync/GitSyncRegistry.php';
+	require __DIR__ . '/../inc/GitSync/GitSync.php';
+
+	$failures = 0;
+	$total    = 0;
+
+	$assert = function ( $cond, string $message ) use ( &$failures, &$total ): void {
+		$total++;
+		if ( $cond ) {
+			echo "  ✓ {$message}\n";
+			return;
+		}
+		$failures++;
+		echo "  ✗ {$message}\n";
+	};
+
+	$cleanup = function () use ( $scratch ): void {
+		if ( is_dir( $scratch ) ) {
+			exec( 'rm -rf ' . escapeshellarg( $scratch ) );
+		}
+	};
+
+	register_shutdown_function( $cleanup );
+
+	echo "GitSync Phase 1 — end-to-end smoke\n";
+	echo "Scratch ABSPATH: " . ABSPATH . "\n\n";
+
+	$gs = new \DataMachineCode\GitSync\GitSync();
+
+	// ---------------------------------------------------------------------
+	// 1. Input validation rejects bad inputs.
+	// ---------------------------------------------------------------------
+	echo "Input validation\n";
+
+	$bad_slug = $gs->bind( array(
+		'slug'       => 'Bad Slug!',
+		'local_path' => '/scratch/repo/',
+		'remote_url' => 'https://github.com/example/repo',
+	) );
+	$assert( is_wp_error( $bad_slug ) && 'invalid_slug' === $bad_slug->get_error_code(), 'rejects invalid slug' );
+
+	$bad_url = $gs->bind( array(
+		'slug'       => 'repo',
+		'local_path' => '/scratch/repo/',
+		'remote_url' => 'not-a-url',
+	) );
+	$assert( is_wp_error( $bad_url ) && 'invalid_remote_url' === $bad_url->get_error_code(), 'rejects invalid remote URL' );
+
+	$traversal = $gs->bind( array(
+		'slug'       => 'repo',
+		'local_path' => '/../../etc/',
+		'remote_url' => 'https://github.com/example/repo',
+	) );
+	$assert( is_wp_error( $traversal ) && 'path_traversal' === $traversal->get_error_code(), 'rejects traversal in local_path' );
+
+	$sensitive = $gs->bind( array(
+		'slug'       => 'repo',
+		'local_path' => '/.env/',
+		'remote_url' => 'https://github.com/example/repo',
+	) );
+	$assert( is_wp_error( $sensitive ) && 'sensitive_path' === $sensitive->get_error_code(), 'rejects sensitive local_path' );
+
+	// ---------------------------------------------------------------------
+	// 2. Real clone against a public repo.
+	// ---------------------------------------------------------------------
+	echo "\nBind + clone (public repo)\n";
+
+	$remote = 'https://github.com/Automattic/mcp-context-wporg';
+	$result = $gs->bind( array(
+		'slug'       => 'smoke',
+		'local_path' => '/sync/mcp-context-wporg/',
+		'remote_url' => $remote,
+	) );
+
+	if ( is_wp_error( $result ) ) {
+		echo "  ! clone failed: " . $result->get_error_message() . "\n";
+		echo "  ! skipping remaining smoke (network or git unavailable)\n";
+		exit( $failures > 0 ? 1 : 0 );
+	}
+
+	$assert( true === ( $result['success'] ?? false ), 'bind returned success' );
+	$assert( true === ( $result['cloned'] ?? false ), 'bind marked path as newly cloned' );
+	$assert( false === ( $result['adopted'] ?? true ), 'bind did not mark path as adopted' );
+	$assert( is_dir( $result['local_path'] . '/.git' ), '.git/ present after clone' );
+
+	// ---------------------------------------------------------------------
+	// 3. Duplicate bind is rejected.
+	// ---------------------------------------------------------------------
+	echo "\nDuplicate bind\n";
+	$dup = $gs->bind( array(
+		'slug'       => 'smoke',
+		'local_path' => '/sync/mcp-context-wporg/',
+		'remote_url' => $remote,
+	) );
+	$assert( is_wp_error( $dup ) && 'binding_exists' === $dup->get_error_code(), 'refuses duplicate slug' );
+
+	// ---------------------------------------------------------------------
+	// 4. Adopt: new binding slug against already-cloned path + matching origin.
+	// ---------------------------------------------------------------------
+	echo "\nAdopt existing checkout\n";
+	$adopt = $gs->bind( array(
+		'slug'       => 'smoke-adopt',
+		'local_path' => '/sync/mcp-context-wporg/',
+		'remote_url' => $remote,
+	) );
+	$assert( ! is_wp_error( $adopt ), 'adopt bind succeeded' );
+	$assert( true === ( $adopt['adopted'] ?? false ), 'adopt flagged as adopted' );
+	$assert( false === ( $adopt['cloned'] ?? true ), 'adopt did not re-clone' );
+
+	// Cleanup adopt entry so status/list results stay readable.
+	$gs->unbind( 'smoke-adopt' );
+
+	// ---------------------------------------------------------------------
+	// 5. Adopt rejection: mismatched origin.
+	// ---------------------------------------------------------------------
+	echo "\nReject adopt on origin mismatch\n";
+	$mismatch = $gs->bind( array(
+		'slug'       => 'smoke-mismatch',
+		'local_path' => '/sync/mcp-context-wporg/',
+		'remote_url' => 'https://github.com/example/other-repo',
+	) );
+	$assert( is_wp_error( $mismatch ) && 'origin_mismatch' === $mismatch->get_error_code(), 'rejects adopt on origin mismatch' );
+
+	// ---------------------------------------------------------------------
+	// 6. Status reports repo + branch + head.
+	// ---------------------------------------------------------------------
+	echo "\nStatus\n";
+	$status = $gs->status( 'smoke' );
+	$assert( ! is_wp_error( $status ), 'status succeeded' );
+	$assert( true === ( $status['exists'] ?? false ), 'status reports exists' );
+	$assert( true === ( $status['is_repo'] ?? false ), 'status reports is_repo' );
+	$assert( is_string( $status['head'] ?? null ) && '' !== $status['head'], 'status has HEAD hash' );
+	$assert( 0 === ( $status['ahead'] ?? -1 ), 'status ahead=0 on fresh clone' );
+
+	// ---------------------------------------------------------------------
+	// 7. Pull on an already-up-to-date tree is idempotent and succeeds.
+	// ---------------------------------------------------------------------
+	echo "\nPull (idempotent on clean tree)\n";
+	$pull = $gs->pull( 'smoke' );
+	$assert( ! is_wp_error( $pull ), 'pull succeeded' );
+	$assert( ( $pull['previous_head'] ?? null ) === ( $pull['head'] ?? null ), 'pull did not advance HEAD on clean tree' );
+
+	// ---------------------------------------------------------------------
+	// 8. Dirty-tree pull fails under default policy.
+	// ---------------------------------------------------------------------
+	echo "\nDirty-tree pull refusal\n";
+	file_put_contents( $result['local_path'] . '/SMOKE_DIRTY_FILE', 'dirty' );
+	$dirty = $gs->pull( 'smoke' );
+	$assert( is_wp_error( $dirty ) && 'dirty_working_tree' === $dirty->get_error_code(), 'pull refuses on dirty tree with fail policy' );
+
+	$allow = $gs->pull( 'smoke', true );
+	$assert( ! is_wp_error( $allow ), 'pull succeeds with allow_dirty=true' );
+
+	unlink( $result['local_path'] . '/SMOKE_DIRTY_FILE' );
+
+	// ---------------------------------------------------------------------
+	// 9. List reports both bindings before + only remaining after unbind.
+	// ---------------------------------------------------------------------
+	echo "\nList + unbind\n";
+	$list = $gs->list_bindings();
+	$assert( 1 === count( $list['bindings'] ?? array() ), 'list reports 1 binding' );
+
+	$unbind = $gs->unbind( 'smoke' );
+	$assert( ! is_wp_error( $unbind ), 'unbind succeeded' );
+	$assert( false === ( $unbind['purged'] ?? true ), 'unbind preserved directory by default' );
+	$assert( is_dir( $result['local_path'] . '/.git' ), 'working tree preserved after unbind' );
+
+	$list_after = $gs->list_bindings();
+	$assert( 0 === count( $list_after['bindings'] ?? array() ), 'list empty after unbind' );
+
+	// ---------------------------------------------------------------------
+	// 10. Re-bind + purge wipes the directory.
+	// ---------------------------------------------------------------------
+	echo "\nRebind + purge\n";
+	$rebind = $gs->bind( array(
+		'slug'       => 'smoke',
+		'local_path' => '/sync/mcp-context-wporg/',
+		'remote_url' => $remote,
+	) );
+	$assert( ! is_wp_error( $rebind ), 'rebind adopted existing tree' );
+	$assert( true === ( $rebind['adopted'] ?? false ), 'rebind flagged as adopted' );
+
+	$purge = $gs->unbind( 'smoke', true );
+	$assert( ! is_wp_error( $purge ), 'purge unbind succeeded' );
+	$assert( true === ( $purge['purged'] ?? false ), 'purge flag set' );
+	$assert( ! is_dir( $result['local_path'] ), 'working tree removed by purge' );
+
+	echo "\nResult: " . ( $total - $failures ) . "/{$total} passed\n";
+	exit( $failures > 0 ? 1 : 0 );
+}


### PR DESCRIPTION
## Summary

Ships Phase 1 of the GitSync primitive outlined in #38 — binding arbitrary **site-owned directories** under `ABSPATH` to remote git repositories, parallel to the existing `Workspace` (which manages agent-owned checkouts under `~/.datamachine/workspace/`).

Phase 1 is the **read path** only: `bind`, `unbind`, `pull`, `status`, `list`. Push + policy updates ship in Phase 2; scheduled sync in Phase 3.

Unblocks:

- Automattic/intelligence#31 — git-synced wiki content subtrees
- Automattic/intelligence#125 — git-tracked wiki-generator agent definitions

Both consume this primitive rather than reinventing git plumbing in Intelligence.

## What's in the box

### Shared substrate refactor
- `inc/Support/GitRunner.php` — one place for the `git -C <path> <args>` shell idiom.
- `inc/Support/PathSecurity.php` — one place for containment (`validateContainment`), traversal detection (`hasTraversal`), and the sensitive-filename block list (`isSensitivePath`).
- `Workspace\Workspace` refactored to delegate its private helpers to these — pure internal change, zero public surface impact. Existing `tests/smoke-worktree-handles.php` still 32/32 green.

### GitSync module
- `GitSync\GitSync` — `bind()`, `unbind()`, `pull()`, `status()`, `list_bindings()`.
- `GitSync\GitSyncBinding` — value object with validation + policy defaults (`conflict=fail`, `auto_pull=false`, `write_enabled=false`, `push_enabled=false`).
- `GitSync\GitSyncRegistry` — option-backed storage (`datamachine_gitsync_bindings`), separate from `datamachine_workspace_git_policies` per spec.

### Semantics worth calling out
- **`bind` is idempotent via adopt.** A path that already has `.git/` with a matching `origin` is registered without re-cloning. Mismatched origin → `origin_mismatch` (409). Non-empty non-repo target → `dirty_target` (409). Doesn't exist or empty → clone.
- **`pull` is fast-forward only** and refuses cross-branch drift (branch on disk ≠ binding's pinned branch returns `branch_mismatch`).
- **Conflict policy** drives dirty-tree behavior: `fail` (default, refuse), `upstream_wins` (`reset --hard` then pull), `manual` (let git surface the conflict).
- **`unbind` preserves the directory by default** — the binding is metadata, not ownership of the filesystem. `--purge` opts into `rm -rf` with re-validated containment at the blast radius.

### Abilities (5 new)

| Ability | Category | REST? |
|---|---|---|
| `datamachine/gitsync-list` | `datamachine-code-gitsync` | ✅ |
| `datamachine/gitsync-status` | `datamachine-code-gitsync` | ✅ |
| `datamachine/gitsync-bind` | `datamachine-code-gitsync` | ❌ (CLI-only) |
| `datamachine/gitsync-unbind` | `datamachine-code-gitsync` | ❌ (CLI-only) |
| `datamachine/gitsync-pull` | `datamachine-code-gitsync` | ❌ (CLI-only) |

All gated by `PermissionHelper::can_manage()`.

### CLI

`wp datamachine-code gitsync <bind|unbind|pull|status|list>` — thin wrapper over the abilities (every subcommand resolves the matching ability via `wp_get_ability()` and formats the result; no business logic in the CLI layer).

## Testing

`tests/smoke-gitsync.php` — pure-PHP end-to-end smoke that:

1. Validates input rejection (bad slug, bad URL, traversal, sensitive path)
2. Clones a real public repo (`Automattic/mcp-context-wporg`)
3. Refuses duplicate bind
4. Adopts an existing matching checkout without re-cloning
5. Refuses adopt on origin mismatch
6. Reports full status (branch/HEAD/ahead/behind)
7. Pulls idempotently on clean tree
8. Refuses dirty-tree pull under `fail` policy; allows via `allow_dirty=true`
9. Preserves directory on `unbind` without `purge`
10. Wipes directory on `unbind --purge`

**Result: 32/32 passed.**

Runs on native PHP + git — needed because Studio WASM can't spawn `git clone` into its mounted `/wordpress` tree (Studio#3082). CLI registration verified in Studio:

```
$ studio wp datamachine-code gitsync list
No GitSync bindings registered.
Create one with: wp datamachine-code gitsync bind <slug> --local=<path> --remote=<url>
```

All 5 abilities confirmed registered via `wp_get_abilities()`.

## Version

`0.6.2` → `0.7.0` (new public surface).

## What's next (follow-up PRs, per #38)

- **Phase 2** — `push` + `policy-update` abilities/CLI; write containment via `allowed_paths`.
- **Phase 3** — `GitSyncPullTask extends SystemTask` + `datamachine_gitsync_tick` recurring schedule (hourly, opt-in PluginSetting), honoring per-binding `auto_pull` + `pull_interval`.

## Files

- New: 8 (3 GitSync classes, 2 Support helpers, 1 abilities class, 1 CLI command, 1 smoke, 1 doc)
- Modified: 2 (`data-machine-code.php` bootstrap wiring + version bump; `Workspace\Workspace` refactor to delegate helpers)

Closes nothing — #38 stays open until Phase 3 ships. This PR's merge checks off the Phase 1 acceptance items.