### PR TITLE
feat(gitsync): Phase 2 — write path + sticky proposal branch submit (#38)

### DIFF
--- a/docs/gitsync.md
+++ b/docs/gitsync.md
@@ -130,13 +130,91 @@ Containment is enforced at every mutation point:
 
 Shared with the Workspace system via `DataMachineCode\Support\PathSecurity` — the block list and traversal detection have one canonical source of truth.
 
-## What's next (follow-up PRs)
+## Write path (Phase 2)
 
-**Phase 2 — write path:**
+Five more abilities/CLI commands let a binding propose changes upstream.
 
-- `datamachine/gitsync-push` + `gitsync push` CLI.
-- `datamachine/gitsync-policy-update` for toggling `write_enabled`, `push_enabled`, `allowed_paths`, `conflict`.
-- Stage/commit containment using `allowed_paths` (same shape Workspace already uses).
+| Ability | CLI | Purpose |
+|---|---|---|
+| `datamachine/gitsync-add` | `gitsync add <slug> <paths>…` | Stage paths. Enforces `allowed_paths` + sensitive-file filter. |
+| `datamachine/gitsync-commit` | `gitsync commit <slug> --message=…` | Commit staged changes. 8–200 char message. |
+| `datamachine/gitsync-push` | `gitsync push <slug> [--force]` | Direct push to pinned branch. Two-key auth. |
+| `datamachine/gitsync-submit` | `gitsync submit <slug> --message=…` | Blessed PR flow on the sticky proposal branch. |
+| `datamachine/gitsync-policy-update` | `gitsync policy <slug> --flag=…` | Modify policy fields on an existing binding. |
+
+All mutating, all CLI-only (`show_in_rest = false`), all gated by `PermissionHelper::can_manage()`.
+
+### Policy gates
+
+Every write passes through policy checkpoints:
+
+| Policy | Gates |
+|---|---|
+| `write_enabled` (default: false) | `add` + `commit` |
+| `push_enabled` (default: false) | `push` + `submit` |
+| `safe_direct_push` (default: false) | `push` (direct push to pinned branch). Second key — `push_enabled` alone isn't enough. |
+| `allowed_paths` (default: `[]`) | Every staged path must sit under one of these roots. Empty allowlist = nothing stageable. |
+
+`safe_direct_push=true` requires `push_enabled=true` — the policy-update validator refuses the orphan combination.
+
+Typical progression for a wiki-content binding:
+
+```bash
+# 1. Bind read-only (Phase 1 default)
+wp datamachine-code gitsync bind wiki \
+  --local=/wp-content/uploads/markdown/wiki/ \
+  --remote=https://github.com/Automattic/a8c-wiki-woocommerce
+
+# 2. Open writes + submit, restricted to the articles subtree
+wp datamachine-code gitsync policy wiki \
+  --write-enabled=true --push-enabled=true \
+  --allowed-paths=articles/,images/
+
+# 3. Stage + commit + propose via PR
+wp datamachine-code gitsync submit wiki \
+  --message="Add CIAB kickoff article"
+```
+
+Personal-wiki (single-owner) bindings can flip the third key for direct push:
+
+```bash
+wp datamachine-code gitsync policy personal-wiki \
+  --push-enabled=true --safe-direct-push=true \
+  --allowed-paths=notes/,daily/
+```
+
+### `submit` — the sticky proposal branch
+
+Each binding gets exactly one feature branch on the remote: `gitsync/<slug>`. Every submit rewrites it from upstream + user's edits and opens (or updates) a single PR.
+
+Algorithm:
+
+1. `git fetch origin --prune` — refresh upstream refs.
+2. Stash any dirty/untracked files on the pinned branch.
+3. `git reset --hard origin/<pinned>` — align local pinned branch with upstream.
+4. `git checkout -B gitsync/<slug>` — create/reset the feature branch.
+5. `git stash pop` — restore edits on the feature branch.
+6. Stage (explicit `--paths=` list, or every dirty file under `allowed_paths`).
+7. `git commit`.
+8. `git push --force origin gitsync/<slug>` — we own this branch exclusively.
+9. Open/update PR via GitHubAbilities (using existing PAT).
+10. `git checkout <pinned>` — leave the working tree clean.
+
+Any step can fail and the `finally`-shaped cleanup always tries to return you to the pinned branch. A failed `stash pop` leaves the stash in place and logs a warning so your edits are recoverable via `git stash list`.
+
+Phase 2 supports `github.com` remotes only for `submit` — the PR backend is DMC's `GitHubAbilities`. Non-GitHub remotes error with `unsupported_remote`; pluggable backends (GitLab MR, Gitea) are Phase 3+.
+
+### Direct push — why two keys?
+
+`push_enabled` alone doesn't authorize direct push to the pinned branch. `safe_direct_push` must also be true. Rationale: bindings model a *read-synchronized mirror that tracks upstream*. The default posture says "changes go upstream via PR review" (`submit`), and anyone wanting to bypass that flow has to flip two explicit keys. Half-opting-in (write_enabled + push_enabled + push to feature branch via submit) stays safe by default; full direct-push to the tracked branch requires deliberate intent.
+
+### Auth
+
+- **github.com remotes:** the existing GitHubAbilities PAT is injected into the push URL as `https://<token>@github.com/...`. Standard pattern, matches DMC's other git-writing code.
+- **Other https remotes:** fall back to the system's `credential.helper`. Works out of the box on macOS/Linux; may need config in Studio WASM.
+- **SSH / non-GitHub PRs:** Phase 3+.
+
+## What's next
 
 **Phase 3 — scheduled sync:**
 

--- a/inc/Abilities/GitSyncAbilities.php
+++ b/inc/Abilities/GitSyncAbilities.php
@@ -251,6 +251,174 @@ class GitSyncAbilities {
 					'meta'                => array( 'show_in_rest' => false ),
 				)
 			);
+
+			// -----------------------------------------------------------------
+			// Phase 2 — write path (all CLI-only).
+			// -----------------------------------------------------------------
+
+			wp_register_ability(
+				'datamachine/gitsync-add',
+				array(
+					'label'               => 'Stage Paths in GitSync Binding',
+					'description'         => 'Stage one or more relative paths in a binding\'s working tree. Paths must sit under policy.allowed_paths.',
+					'category'            => 'datamachine-code-gitsync',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'slug', 'paths' ),
+						'properties' => array(
+							'slug'  => array( 'type' => 'string' ),
+							'paths' => array(
+								'type'  => 'array',
+								'items' => array( 'type' => 'string' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'slug'    => array( 'type' => 'string' ),
+							'paths'   => array( 'type' => 'array' ),
+							'message' => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'add' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/gitsync-commit',
+				array(
+					'label'               => 'Commit Staged Changes in GitSync Binding',
+					'description'         => 'Commit the currently-staged changes on a binding\'s working tree. Requires policy.write_enabled=true.',
+					'category'            => 'datamachine-code-gitsync',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'slug', 'message' ),
+						'properties' => array(
+							'slug'    => array( 'type' => 'string' ),
+							'message' => array( 'type' => 'string' ),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'slug'    => array( 'type' => 'string' ),
+							'commit'  => array( 'type' => array( 'string', 'null' ) ),
+							'message' => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'commit' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/gitsync-push',
+				array(
+					'label'               => 'Push GitSync Binding to Pinned Branch',
+					'description'         => 'Direct push to the pinned branch on origin. Requires policy.push_enabled=true AND policy.safe_direct_push=true (two-key authorization). Use submit() for PR-based flow.',
+					'category'            => 'datamachine-code-gitsync',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'slug' ),
+						'properties' => array(
+							'slug'  => array( 'type' => 'string' ),
+							'force' => array(
+								'type'        => 'boolean',
+								'description' => 'Use --force-with-lease for the push. Default: false.',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'slug'    => array( 'type' => 'string' ),
+							'branch'  => array( 'type' => 'string' ),
+							'head'    => array( 'type' => array( 'string', 'null' ) ),
+							'message' => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'push' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/gitsync-submit',
+				array(
+					'label'               => 'Submit GitSync Binding as Pull Request',
+					'description'         => 'Stage + commit + push the sticky proposal branch (gitsync/<slug>) and open or update a PR upstream. Phase 2 requires a github.com remote.',
+					'category'            => 'datamachine-code-gitsync',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'slug', 'message' ),
+						'properties' => array(
+							'slug'    => array( 'type' => 'string' ),
+							'message' => array( 'type' => 'string' ),
+							'paths'   => array(
+								'type'        => 'array',
+								'items'       => array( 'type' => 'string' ),
+								'description' => 'Optional explicit list of relative paths to stage. If omitted, every dirty file under allowed_paths is staged.',
+							),
+							'title'   => array( 'type' => 'string' ),
+							'body'    => array( 'type' => 'string' ),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'slug'    => array( 'type' => 'string' ),
+							'branch'  => array( 'type' => 'string' ),
+							'commit'  => array( 'type' => array( 'string', 'null' ) ),
+							'staged'  => array( 'type' => 'array' ),
+							'pr'      => array( 'type' => 'object' ),
+							'message' => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'submit' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/gitsync-policy-update',
+				array(
+					'label'               => 'Update GitSync Binding Policy',
+					'description'         => 'Update one or more policy fields on an existing binding (write_enabled, push_enabled, safe_direct_push, allowed_paths, conflict, auto_pull, pull_interval).',
+					'category'            => 'datamachine-code-gitsync',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'slug', 'policy' ),
+						'properties' => array(
+							'slug'   => array( 'type' => 'string' ),
+							'policy' => array(
+								'type'        => 'object',
+								'description' => 'Subset of policy keys to update.',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'slug'    => array( 'type' => 'string' ),
+							'policy'  => array( 'type' => 'object' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'policyUpdate' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
 		};
 
 		// Matches the WorkspaceAbilities lifecycle: register now if we're
@@ -291,5 +459,42 @@ class GitSyncAbilities {
 			(string) ( $input['slug'] ?? '' ),
 			! empty( $input['allow_dirty'] )
 		);
+	}
+
+	public static function add( array $input ): array|\WP_Error {
+		$paths = $input['paths'] ?? array();
+		if ( ! is_array( $paths ) ) {
+			$paths = array();
+		}
+		return ( new GitSync() )->add( (string) ( $input['slug'] ?? '' ), $paths );
+	}
+
+	public static function commit( array $input ): array|\WP_Error {
+		return ( new GitSync() )->commit(
+			(string) ( $input['slug'] ?? '' ),
+			(string) ( $input['message'] ?? '' )
+		);
+	}
+
+	public static function push( array $input ): array|\WP_Error {
+		return ( new GitSync() )->push(
+			(string) ( $input['slug'] ?? '' ),
+			! empty( $input['force'] )
+		);
+	}
+
+	public static function submit( array $input ): array|\WP_Error {
+		$slug = (string) ( $input['slug'] ?? '' );
+		$args = $input;
+		unset( $args['slug'] );
+		return ( new GitSync() )->submit( $slug, $args );
+	}
+
+	public static function policyUpdate( array $input ): array|\WP_Error {
+		$patch = $input['policy'] ?? array();
+		if ( ! is_array( $patch ) ) {
+			$patch = array();
+		}
+		return ( new GitSync() )->updatePolicy( (string) ( $input['slug'] ?? '' ), $patch );
 	}
 }

--- a/inc/Cli/Commands/GitSyncCommand.php
+++ b/inc/Cli/Commands/GitSyncCommand.php
@@ -341,9 +341,315 @@ class GitSyncCommand extends BaseCommand {
 		$this->format_items( $rows, array( 'field', 'value' ), $assoc_args, 'field' );
 	}
 
+	/**
+	 * Stage paths for commit in a binding's working tree.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <slug>
+	 * : Binding slug.
+	 *
+	 * <paths>...
+	 * : Relative paths inside the binding to stage. Must live under
+	 *   policy.allowed_paths; sensitive-file patterns are always refused.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-code gitsync add intelligence-wiki articles/new-article.md
+	 *     wp datamachine-code gitsync add intelligence-wiki articles/a.md articles/b.md
+	 *
+	 * @subcommand add
+	 */
+	public function add( array $args, array $assoc_args ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+		$slug = $args[0] ?? '';
+		if ( '' === $slug ) {
+			WP_CLI::error( 'Binding slug is required.' );
+		}
+		$paths = array_slice( $args, 1 );
+		if ( empty( $paths ) ) {
+			WP_CLI::error( 'At least one path is required.' );
+		}
+
+		$result = $this->execute_ability(
+			'datamachine/gitsync-add',
+			array(
+				'slug'  => $slug,
+				'paths' => $paths,
+			)
+		);
+
+		WP_CLI::success( (string) ( $result['message'] ?? 'Staged.' ) );
+	}
+
+	/**
+	 * Commit staged changes in a binding's working tree.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <slug>
+	 * : Binding slug.
+	 *
+	 * --message=<message>
+	 * : Commit message (8–200 characters).
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-code gitsync commit intelligence-wiki \
+	 *       --message="Add new CIAB article"
+	 *
+	 * @subcommand commit
+	 */
+	public function commit( array $args, array $assoc_args ): void {
+		$slug = $args[0] ?? '';
+		if ( '' === $slug ) {
+			WP_CLI::error( 'Binding slug is required.' );
+		}
+		$message = (string) ( $assoc_args['message'] ?? '' );
+		if ( '' === $message ) {
+			WP_CLI::error( '--message is required.' );
+		}
+
+		$result = $this->execute_ability(
+			'datamachine/gitsync-commit',
+			array(
+				'slug'    => $slug,
+				'message' => $message,
+			)
+		);
+
+		WP_CLI::success( (string) ( $result['message'] ?? 'Committed.' ) );
+		if ( ! empty( $result['commit'] ) ) {
+			WP_CLI::log( sprintf( '  head: %s', $result['commit'] ) );
+		}
+	}
+
+	/**
+	 * Direct-push a binding to its pinned branch on origin.
+	 *
+	 * Requires policy.push_enabled=true AND policy.safe_direct_push=true.
+	 * For most workflows you want `submit` instead, which pushes to a
+	 * feature branch and opens a PR.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <slug>
+	 * : Binding slug.
+	 *
+	 * [--force]
+	 * : Use git push --force-with-lease. Default: false.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-code gitsync push personal-wiki
+	 *     wp datamachine-code gitsync push personal-wiki --force
+	 *
+	 * @subcommand push
+	 */
+	public function push( array $args, array $assoc_args ): void {
+		$slug = $args[0] ?? '';
+		if ( '' === $slug ) {
+			WP_CLI::error( 'Binding slug is required.' );
+		}
+
+		$result = $this->execute_ability(
+			'datamachine/gitsync-push',
+			array(
+				'slug'  => $slug,
+				'force' => ! empty( $assoc_args['force'] ),
+			)
+		);
+
+		WP_CLI::success( sprintf( 'Pushed %s → %s @ %s', $slug, (string) ( $result['branch'] ?? '' ), (string) ( $result['head'] ?? '-' ) ) );
+		$output = trim( (string) ( $result['message'] ?? '' ) );
+		if ( '' !== $output ) {
+			WP_CLI::log( $output );
+		}
+	}
+
+	/**
+	 * Submit local edits as a pull request.
+	 *
+	 * Orchestrates the sticky proposal branch flow: align with upstream,
+	 * push gitsync/<slug> with --force-with-lease, open or update a PR.
+	 * Phase 2 supports github.com remotes only.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <slug>
+	 * : Binding slug.
+	 *
+	 * --message=<message>
+	 * : Commit message (8–200 characters).
+	 *
+	 * [--paths=<paths>]
+	 * : Comma-separated list of relative paths to stage. If omitted,
+	 *   every dirty file under policy.allowed_paths is staged.
+	 *
+	 * [--title=<title>]
+	 * : PR title. Defaults to the commit message.
+	 *
+	 * [--body=<body>]
+	 * : PR body. Defaults to a generated summary.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-code gitsync submit intelligence-wiki \
+	 *       --message="Add CIAB kickoff article"
+	 *
+	 *     wp datamachine-code gitsync submit intelligence-wiki \
+	 *       --message="Update two articles" \
+	 *       --paths=articles/a.md,articles/b.md \
+	 *       --title="docs: update a + b"
+	 *
+	 * @subcommand submit
+	 */
+	public function submit( array $args, array $assoc_args ): void {
+		$slug = $args[0] ?? '';
+		if ( '' === $slug ) {
+			WP_CLI::error( 'Binding slug is required.' );
+		}
+		$message = (string) ( $assoc_args['message'] ?? '' );
+		if ( '' === $message ) {
+			WP_CLI::error( '--message is required.' );
+		}
+
+		$input = array(
+			'slug'    => $slug,
+			'message' => $message,
+		);
+		if ( isset( $assoc_args['paths'] ) && '' !== $assoc_args['paths'] ) {
+			$input['paths'] = array_values( array_filter( array_map( 'trim', explode( ',', (string) $assoc_args['paths'] ) ) ) );
+		}
+		if ( isset( $assoc_args['title'] ) ) {
+			$input['title'] = (string) $assoc_args['title'];
+		}
+		if ( isset( $assoc_args['body'] ) ) {
+			$input['body'] = (string) $assoc_args['body'];
+		}
+
+		$result = $this->execute_ability( 'datamachine/gitsync-submit', $input );
+
+		$pr = $result['pr'] ?? array();
+		WP_CLI::success( sprintf(
+			'%s PR #%d on %s: %s',
+			'updated' === ( $pr['action'] ?? '' ) ? 'Updated' : 'Opened',
+			(int) ( $pr['number'] ?? 0 ),
+			(string) ( $result['branch'] ?? '' ),
+			(string) ( $pr['html_url'] ?? '' )
+		) );
+		WP_CLI::log( sprintf( '  commit: %s', (string) ( $result['commit'] ?? '-' ) ) );
+		WP_CLI::log( sprintf( '  files:  %d staged', count( (array) ( $result['staged'] ?? array() ) ) ) );
+	}
+
+	/**
+	 * Update policy fields on an existing binding.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <slug>
+	 * : Binding slug.
+	 *
+	 * [--write-enabled=<bool>]
+	 * : Gate add + commit.
+	 *
+	 * [--push-enabled=<bool>]
+	 * : Gate push + submit.
+	 *
+	 * [--safe-direct-push=<bool>]
+	 * : Second key required for direct push to the pinned branch.
+	 *
+	 * [--allowed-paths=<list>]
+	 * : Comma-separated list of relative path prefixes that may be staged.
+	 *   Use "clear" to reset to an empty allowlist.
+	 *
+	 * [--conflict=<strategy>]
+	 * : Conflict strategy for pull.
+	 * ---
+	 * options:
+	 *   - fail
+	 *   - upstream_wins
+	 *   - manual
+	 * ---
+	 *
+	 * [--auto-pull=<bool>]
+	 * : Enroll in scheduled sync (Phase 3).
+	 *
+	 * [--pull-interval=<interval>]
+	 * : Scheduled pull cadence.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Open up writes + submit for a wiki binding
+	 *     wp datamachine-code gitsync policy intelligence-wiki \
+	 *       --write-enabled=true --push-enabled=true \
+	 *       --allowed-paths=articles/,images/
+	 *
+	 *     # Allow direct push for a personal (single-owner) binding
+	 *     wp datamachine-code gitsync policy personal-wiki \
+	 *       --push-enabled=true --safe-direct-push=true
+	 *
+	 * @subcommand policy
+	 */
+	public function policy( array $args, array $assoc_args ): void {
+		$slug = $args[0] ?? '';
+		if ( '' === $slug ) {
+			WP_CLI::error( 'Binding slug is required.' );
+		}
+
+		$patch = array();
+		$bool_keys = array(
+			'write-enabled'    => 'write_enabled',
+			'push-enabled'     => 'push_enabled',
+			'safe-direct-push' => 'safe_direct_push',
+			'auto-pull'        => 'auto_pull',
+		);
+		foreach ( $bool_keys as $cli_key => $policy_key ) {
+			if ( array_key_exists( $cli_key, $assoc_args ) ) {
+				$patch[ $policy_key ] = $this->coerce_bool( (string) $assoc_args[ $cli_key ] );
+			}
+		}
+		if ( isset( $assoc_args['conflict'] ) ) {
+			$patch['conflict'] = (string) $assoc_args['conflict'];
+		}
+		if ( isset( $assoc_args['pull-interval'] ) ) {
+			$patch['pull_interval'] = (string) $assoc_args['pull-interval'];
+		}
+		if ( isset( $assoc_args['allowed-paths'] ) ) {
+			$raw = (string) $assoc_args['allowed-paths'];
+			if ( 'clear' === trim( strtolower( $raw ) ) ) {
+				$patch['allowed_paths'] = array();
+			} else {
+				$patch['allowed_paths'] = array_values( array_filter( array_map( 'trim', explode( ',', $raw ) ) ) );
+			}
+		}
+
+		if ( empty( $patch ) ) {
+			WP_CLI::error( 'No policy flags provided.' );
+		}
+
+		$result = $this->execute_ability(
+			'datamachine/gitsync-policy-update',
+			array(
+				'slug'   => $slug,
+				'policy' => $patch,
+			)
+		);
+
+		WP_CLI::success( sprintf( 'Policy updated for "%s".', $slug ) );
+		WP_CLI::log( wp_json_encode( $result['policy'] ?? array(), JSON_PRETTY_PRINT ) );
+	}
+
 	// =========================================================================
 	// Helpers
 	// =========================================================================
+
+	/**
+	 * Coerce a CLI-provided string into a boolean. Treats common truthy
+	 * strings (`true`, `1`, `yes`, `on`) as true; everything else as false.
+	 */
+	private function coerce_bool( string $value ): bool {
+		return in_array( strtolower( trim( $value ) ), array( '1', 'true', 'yes', 'on' ), true );
+	}
 
 	/**
 	 * Resolve + execute an ability, erroring out on missing or failed calls.

--- a/inc/GitSync/GitRepo.php
+++ b/inc/GitSync/GitRepo.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Git Repo
+ *
+ * Read-only helpers for inspecting a local working tree — HEAD, branch,
+ * dirty count. Shared by GitSync + GitSyncSubmitter so these three
+ * operations have one canonical shell invocation.
+ *
+ * Parallel to Support/GitRunner (which wraps `git -C <path> <args>`):
+ * this class builds on GitRunner for the narrow set of queries GitSync
+ * needs repeatedly, returning plain scalars instead of the runner's
+ * `{success, output}` envelope.
+ *
+ * @package DataMachineCode\GitSync
+ * @since   0.7.0
+ */
+
+namespace DataMachineCode\GitSync;
+
+use DataMachineCode\Support\GitRunner;
+
+defined( 'ABSPATH' ) || exit;
+
+final class GitRepo {
+
+	/**
+	 * Short HEAD SHA, or null on any failure.
+	 *
+	 * Explicitly tolerates errors — callers use this to annotate
+	 * bindings with their current commit for the registry, and a null
+	 * value there just means "we couldn't read it this time."
+	 */
+	public static function head( string $path ): ?string {
+		$result = GitRunner::run( $path, 'rev-parse --short HEAD' );
+		if ( is_wp_error( $result ) ) {
+			return null;
+		}
+		$head = trim( (string) $result['output'] );
+		return '' === $head ? null : $head;
+	}
+
+	/**
+	 * Current branch name, or null on failure/detached HEAD.
+	 *
+	 * `git rev-parse --abbrev-ref HEAD` returns `HEAD` for detached
+	 * checkouts; callers treat that as null here so a detached tree
+	 * doesn't silently pass branch-match checks.
+	 */
+	public static function branch( string $path ): ?string {
+		$result = GitRunner::run( $path, 'rev-parse --abbrev-ref HEAD' );
+		if ( is_wp_error( $result ) ) {
+			return null;
+		}
+		$branch = trim( (string) $result['output'] );
+		if ( '' === $branch || 'HEAD' === $branch ) {
+			return null;
+		}
+		return $branch;
+	}
+
+	/**
+	 * Count entries in `git status --porcelain`.
+	 *
+	 * Zero on any error (shell-out failed, path isn't a repo, etc.) —
+	 * the conservative default that keeps callers from treating a
+	 * readback failure as "dirty."
+	 */
+	public static function dirtyCount( string $path ): int {
+		$result = GitRunner::run( $path, 'status --porcelain' );
+		if ( is_wp_error( $result ) ) {
+			return 0;
+		}
+		return count( array_filter( array_map( 'trim', explode( "\n", (string) $result['output'] ) ) ) );
+	}
+}

--- a/inc/GitSync/GitSync.php
+++ b/inc/GitSync/GitSync.php
@@ -28,6 +28,9 @@
 
 namespace DataMachineCode\GitSync;
 
+use DataMachineCode\GitSync\GitRepo;
+use DataMachineCode\GitSync\GitSyncSubmitter;
+use DataMachineCode\Support\GitHubRemote;
 use DataMachineCode\Support\GitRunner;
 use DataMachineCode\Support\PathSecurity;
 
@@ -91,7 +94,7 @@ final class GitSync {
 			return $materialize;
 		}
 
-		$binding->last_commit = $this->readHead( $absolute );
+		$binding->last_commit = GitRepo::head( $absolute );
 		$binding->last_pulled = gmdate( 'c' );
 		$this->registry->save( $binding );
 
@@ -184,8 +187,8 @@ final class GitSync {
 			return $repo_err;
 		}
 
-		$previous_head = $this->readHead( $absolute );
-		$dirty_count   = $this->countDirty( $absolute );
+		$previous_head = GitRepo::head( $absolute );
+		$dirty_count   = GitRepo::dirtyCount( $absolute );
 		$conflict      = (string) ( $binding->policy['conflict'] ?? 'fail' );
 
 		if ( $dirty_count > 0 && ! $allow_dirty ) {
@@ -208,7 +211,7 @@ final class GitSync {
 		}
 
 		// Refuse any pull that would change branches.
-		$current_branch = $this->readBranch( $absolute );
+		$current_branch = GitRepo::branch( $absolute );
 		if ( null !== $current_branch && $current_branch !== $binding->branch ) {
 			return new \WP_Error(
 				'branch_mismatch',
@@ -227,7 +230,7 @@ final class GitSync {
 			return $pull;
 		}
 
-		$new_head             = $this->readHead( $absolute );
+		$new_head             = GitRepo::head( $absolute );
 		$binding->last_pulled = gmdate( 'c' );
 		$binding->last_commit = $new_head;
 		$this->registry->save( $binding );
@@ -285,9 +288,9 @@ final class GitSync {
 			return $data;
 		}
 
-		$data['branch'] = $this->readBranch( $absolute );
-		$data['head']   = $this->readHead( $absolute );
-		$data['dirty']  = $this->countDirty( $absolute );
+		$data['branch'] = GitRepo::branch( $absolute );
+		$data['head']   = GitRepo::head( $absolute );
+		$data['dirty']  = GitRepo::dirtyCount( $absolute );
 
 		$upstream = 'origin/' . $binding->branch;
 		$ahead    = GitRunner::run( $absolute, 'rev-list --count ' . escapeshellarg( $upstream ) . '..HEAD' );
@@ -328,6 +331,331 @@ final class GitSync {
 			'success'  => true,
 			'bindings' => $out,
 		);
+	}
+
+	// =========================================================================
+	// Phase 2 — write path
+	// =========================================================================
+
+	/**
+	 * Stage one or more relative paths for commit on a binding's working tree.
+	 *
+	 * Every path runs through the same checkpoint:
+	 *   1. Not absolute, no traversal, not sensitive.
+	 *   2. Under at least one of the binding's `allowed_paths` roots.
+	 *   3. Actually exists under the binding's working tree.
+	 *
+	 * A single rejected path fails the whole call — we never partially stage.
+	 * This keeps the outcome predictable: either all requested paths are
+	 * staged, or none are.
+	 *
+	 * @param string   $slug  Binding slug.
+	 * @param string[] $paths Relative paths inside the binding.
+	 * @return array{success: true, slug: string, paths: string[], message: string}|\WP_Error
+	 */
+	public function add( string $slug, array $paths ): array|\WP_Error {
+		$binding = $this->registry->get( $slug );
+		if ( null === $binding ) {
+			return $this->notFound( $slug );
+		}
+
+		if ( empty( $binding->policy['write_enabled'] ) ) {
+			return new \WP_Error(
+				'write_disabled',
+				sprintf( 'Writes are disabled for binding "%s" (policy.write_enabled=false).', $slug ),
+				array( 'status' => 403 )
+			);
+		}
+
+		$allowed_roots = is_array( $binding->policy['allowed_paths'] ?? null )
+			? $binding->policy['allowed_paths']
+			: array();
+		if ( empty( $allowed_roots ) ) {
+			return new \WP_Error(
+				'no_allowed_paths',
+				sprintf( 'Binding "%s" has no allowed_paths configured — nothing can be staged.', $slug ),
+				array( 'status' => 403 )
+			);
+		}
+
+		$absolute = $binding->resolveAbsolutePath();
+		$repo_err = $this->assertRepo( $absolute, $slug );
+		if ( is_wp_error( $repo_err ) ) {
+			return $repo_err;
+		}
+
+		$clean = array();
+		foreach ( $paths as $raw ) {
+			$relative = ltrim( trim( (string) $raw ), '/' );
+			if ( '' === $relative ) {
+				continue;
+			}
+
+			if ( PathSecurity::hasTraversal( $relative ) ) {
+				return new \WP_Error( 'path_traversal', sprintf( 'Invalid path (traversal): %s', $relative ), array( 'status' => 400 ) );
+			}
+			if ( PathSecurity::isSensitivePath( $relative ) ) {
+				return new \WP_Error( 'sensitive_path', sprintf( 'Refusing to stage sensitive path: %s', $relative ), array( 'status' => 403 ) );
+			}
+			if ( ! PathSecurity::isPathAllowed( $relative, $allowed_roots ) ) {
+				return new \WP_Error(
+					'path_not_allowed',
+					sprintf( 'Path "%s" is outside the binding\'s allowed_paths allowlist.', $relative ),
+					array( 'status' => 403, 'allowed_paths' => $allowed_roots )
+				);
+			}
+
+			$clean[] = $relative;
+		}
+
+		if ( empty( $clean ) ) {
+			return new \WP_Error( 'no_paths', 'At least one non-empty path is required.', array( 'status' => 400 ) );
+		}
+
+		$escaped = array_map( 'escapeshellarg', $clean );
+		$result  = GitRunner::run( $absolute, 'add -- ' . implode( ' ', $escaped ) );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return array(
+			'success' => true,
+			'slug'    => $slug,
+			'paths'   => $clean,
+			'message' => sprintf( 'Staged %d path(s) on "%s".', count( $clean ), $slug ),
+		);
+	}
+
+	/**
+	 * Commit staged changes on a binding's working tree.
+	 *
+	 * Message constraints mirror Workspace for consistency: 8–200 characters.
+	 * Refuses when nothing is staged so empty commits never sneak through.
+	 *
+	 * @param string $slug    Binding slug.
+	 * @param string $message Commit message.
+	 * @return array{success: true, slug: string, commit: ?string, message: string}|\WP_Error
+	 */
+	public function commit( string $slug, string $message ): array|\WP_Error {
+		$binding = $this->registry->get( $slug );
+		if ( null === $binding ) {
+			return $this->notFound( $slug );
+		}
+
+		if ( empty( $binding->policy['write_enabled'] ) ) {
+			return new \WP_Error( 'write_disabled', sprintf( 'Writes are disabled for binding "%s".', $slug ), array( 'status' => 403 ) );
+		}
+
+		$message = trim( $message );
+		if ( '' === $message ) {
+			return new \WP_Error( 'missing_message', 'Commit message is required.', array( 'status' => 400 ) );
+		}
+		if ( strlen( $message ) < 8 ) {
+			return new \WP_Error( 'message_too_short', 'Commit message must be at least 8 characters.', array( 'status' => 400 ) );
+		}
+		if ( strlen( $message ) > 200 ) {
+			return new \WP_Error( 'message_too_long', 'Commit message must be 200 characters or fewer.', array( 'status' => 400 ) );
+		}
+
+		$absolute = $binding->resolveAbsolutePath();
+		$repo_err = $this->assertRepo( $absolute, $slug );
+		if ( is_wp_error( $repo_err ) ) {
+			return $repo_err;
+		}
+
+		$staged = GitRunner::run( $absolute, 'diff --cached --name-only' );
+		if ( is_wp_error( $staged ) ) {
+			return $staged;
+		}
+		$staged_files = array_filter( array_map( 'trim', explode( "\n", (string) ( $staged['output'] ?? '' ) ) ) );
+		if ( empty( $staged_files ) ) {
+			return new \WP_Error( 'nothing_staged', 'No staged changes to commit.', array( 'status' => 400 ) );
+		}
+
+		$result = GitRunner::run( $absolute, 'commit -m ' . escapeshellarg( $message ) );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return array(
+			'success' => true,
+			'slug'    => $slug,
+			'commit'  => GitRepo::head( $absolute ),
+			'message' => sprintf( 'Committed %d file(s) on "%s".', count( $staged_files ), $slug ),
+		);
+	}
+
+	/**
+	 * Push the binding's pinned branch to origin.
+	 *
+	 * Direct push requires two keys: `push_enabled=true` AND
+	 * `safe_direct_push=true`. Missing either refuses — use submit() for
+	 * the PR-based flow if you don't want to flip both.
+	 *
+	 * `--force` is honored but uses `--force-with-lease` under the hood so
+	 * a concurrent upstream move isn't silently overwritten.
+	 *
+	 * @param string $slug  Binding slug.
+	 * @param bool   $force Force push (uses --force-with-lease).
+	 * @return array{success: true, slug: string, branch: string, head: ?string, message: string}|\WP_Error
+	 */
+	public function push( string $slug, bool $force = false ): array|\WP_Error {
+		$binding = $this->registry->get( $slug );
+		if ( null === $binding ) {
+			return $this->notFound( $slug );
+		}
+
+		if ( empty( $binding->policy['push_enabled'] ) ) {
+			return new \WP_Error( 'push_disabled', sprintf( 'Pushes are disabled for binding "%s" (policy.push_enabled=false).', $slug ), array( 'status' => 403 ) );
+		}
+
+		if ( empty( $binding->policy['safe_direct_push'] ) ) {
+			return new \WP_Error(
+				'direct_push_blocked',
+				sprintf(
+					'Direct push to the pinned branch is blocked for binding "%s". Set policy.safe_direct_push=true, or use submit() to open a PR instead.',
+					$slug
+				),
+				array( 'status' => 403 )
+			);
+		}
+
+		$absolute = $binding->resolveAbsolutePath();
+		$repo_err = $this->assertRepo( $absolute, $slug );
+		if ( is_wp_error( $repo_err ) ) {
+			return $repo_err;
+		}
+
+		$current = GitRepo::branch( $absolute );
+		if ( null !== $current && $current !== $binding->branch ) {
+			return new \WP_Error(
+				'branch_mismatch',
+				sprintf(
+					'Binding "%s" is pinned to "%s" but working tree is on "%s". Refusing to push.',
+					$slug, $binding->branch, $current
+				),
+				array( 'status' => 409 )
+			);
+		}
+
+		$push_url = $this->resolveAuthenticatedPushUrl( $binding );
+		$flag     = $force ? '--force-with-lease ' : '';
+		$cmd      = sprintf(
+			'push %s%s %s',
+			$flag,
+			escapeshellarg( $push_url ),
+			escapeshellarg( $binding->branch . ':' . $binding->branch )
+		);
+
+		$result = GitRunner::run( $absolute, $cmd );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		$binding->last_commit = GitRepo::head( $absolute );
+		$this->registry->save( $binding );
+
+		return array(
+			'success' => true,
+			'slug'    => $slug,
+			'branch'  => $binding->branch,
+			'head'    => $binding->last_commit,
+			'message' => trim( (string) ( $result['output'] ?? '' ) ),
+		);
+	}
+
+	/**
+	 * Submit local edits as a pull request.
+	 *
+	 * Delegates the orchestration to GitSyncSubmitter — this method is a
+	 * thin wrapper so the ability callback has a short spelling.
+	 *
+	 * @param string $slug Binding slug.
+	 * @param array<string, mixed> $args Submit args (message, paths, title, body).
+	 * @return array<string, mixed>|\WP_Error
+	 */
+	public function submit( string $slug, array $args ): array|\WP_Error {
+		$binding = $this->registry->get( $slug );
+		if ( null === $binding ) {
+			return $this->notFound( $slug );
+		}
+
+		return ( new GitSyncSubmitter( $this->registry ) )->submit( $binding, $args );
+	}
+
+	/**
+	 * Update policy fields on an existing binding.
+	 *
+	 * Accepts a subset of policy keys and merges them into the current
+	 * policy. Validates the same way `GitSyncBinding::create()` does so
+	 * bad values are refused before they hit storage.
+	 *
+	 * @param string               $slug  Binding slug.
+	 * @param array<string, mixed> $patch Policy keys to update.
+	 * @return array{success: true, slug: string, policy: array<string, mixed>}|\WP_Error
+	 */
+	public function updatePolicy( string $slug, array $patch ): array|\WP_Error {
+		$binding = $this->registry->get( $slug );
+		if ( null === $binding ) {
+			return $this->notFound( $slug );
+		}
+
+		$merged = array_merge( $binding->policy, array() );
+		foreach ( $patch as $key => $value ) {
+			if ( ! array_key_exists( $key, GitSyncBinding::DEFAULT_POLICY ) ) {
+				return new \WP_Error( 'unknown_policy_key', sprintf( 'Unknown policy key: %s', $key ), array( 'status' => 400 ) );
+			}
+			$merged[ $key ] = $value;
+		}
+
+		if ( ! in_array( $merged['conflict'] ?? 'fail', GitSyncBinding::CONFLICT_STRATEGIES, true ) ) {
+			return new \WP_Error(
+				'invalid_conflict_strategy',
+				sprintf( 'conflict must be one of: %s.', implode( ', ', GitSyncBinding::CONFLICT_STRATEGIES ) ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( ! is_array( $merged['allowed_paths'] ?? null ) ) {
+			return new \WP_Error( 'invalid_allowed_paths', 'allowed_paths must be an array.', array( 'status' => 400 ) );
+		}
+
+		// Safety coupling: safe_direct_push only meaningful with push_enabled.
+		if ( ! empty( $merged['safe_direct_push'] ) && empty( $merged['push_enabled'] ) ) {
+			return new \WP_Error(
+				'policy_conflict',
+				'safe_direct_push=true requires push_enabled=true.',
+				array( 'status' => 400 )
+			);
+		}
+
+		$binding->policy = $merged;
+		$this->registry->save( $binding );
+
+		return array(
+			'success' => true,
+			'slug'    => $slug,
+			'policy'  => $binding->policy,
+		);
+	}
+
+	/**
+	 * Resolve the push URL, injecting a GitHub PAT when the remote is
+	 * github.com and DMC has one registered. Non-GitHub remotes pass
+	 * through unchanged and rely on the system's credential.helper.
+	 *
+	 * Thin wrapper around Support\GitHubRemote — the actual rewriting
+	 * and host detection live there so every GitHub-aware caller
+	 * (GitSync, GitSyncSubmitter, future write paths) stays consistent.
+	 */
+	private function resolveAuthenticatedPushUrl( GitSyncBinding $binding ): string {
+		if ( ! GitHubRemote::isGitHubRemote( $binding->remote_url ) ) {
+			return $binding->remote_url;
+		}
+		if ( ! class_exists( '\DataMachineCode\Abilities\GitHubAbilities' ) ) {
+			return $binding->remote_url;
+		}
+		return GitHubRemote::pushUrlWithPat( $binding->remote_url, \DataMachineCode\Abilities\GitHubAbilities::getPat() );
 	}
 
 	// =========================================================================
@@ -478,33 +806,6 @@ final class GitSync {
 			return new \WP_Error( 'not_a_repo', sprintf( 'Binding "%s" is not a git repository (no .git at %s).', $slug, $absolute ), array( 'status' => 409 ) );
 		}
 		return null;
-	}
-
-	private function readHead( string $absolute ): ?string {
-		$result = GitRunner::run( $absolute, 'rev-parse --short HEAD' );
-		if ( is_wp_error( $result ) ) {
-			return null;
-		}
-		$head = trim( (string) $result['output'] );
-		return '' === $head ? null : $head;
-	}
-
-	private function readBranch( string $absolute ): ?string {
-		$result = GitRunner::run( $absolute, 'rev-parse --abbrev-ref HEAD' );
-		if ( is_wp_error( $result ) ) {
-			return null;
-		}
-		$branch = trim( (string) $result['output'] );
-		return '' === $branch ? null : $branch;
-	}
-
-	private function countDirty( string $absolute ): int {
-		$result = GitRunner::run( $absolute, 'status --porcelain' );
-		if ( is_wp_error( $result ) ) {
-			return 0;
-		}
-		$lines = array_filter( array_map( 'trim', explode( "\n", (string) $result['output'] ) ) );
-		return count( $lines );
 	}
 
 	private function notFound( string $slug ): \WP_Error {

--- a/inc/GitSync/GitSyncBinding.php
+++ b/inc/GitSync/GitSyncBinding.php
@@ -30,12 +30,18 @@ final class GitSyncBinding {
 	 * @var array<string, mixed>
 	 */
 	public const DEFAULT_POLICY = array(
-		'auto_pull'     => false,
-		'pull_interval' => 'hourly',
-		'write_enabled' => false,
-		'push_enabled'  => false,
-		'allowed_paths' => array(),
-		'conflict'      => 'fail',
+		'auto_pull'        => false,
+		'pull_interval'    => 'hourly',
+		'write_enabled'    => false,
+		'push_enabled'     => false,
+		// Second key for direct push to the pinned branch. Even with
+		// push_enabled=true, pushes straight to the tracked branch are
+		// refused unless this is also true. submit() pushes to a feature
+		// branch and does NOT require this flag — PR flow is the
+		// intended default for bindings that allow writes.
+		'safe_direct_push' => false,
+		'allowed_paths'    => array(),
+		'conflict'         => 'fail',
 	);
 
 	/**
@@ -100,10 +106,14 @@ final class GitSyncBinding {
 			return new \WP_Error( 'missing_remote_url', 'remote_url is required.', array( 'status' => 400 ) );
 		}
 
-		if ( ! preg_match( '#^(https?://|git@)#', $remote ) ) {
+		// Accept https://, http:// (for self-hosted git), git@ SSH, and
+		// file:// (useful for local bare-repo testing). Anything outside
+		// these schemes is refused — guards against accidental bindings
+		// to filesystem paths that git's URL-sniffing might still accept.
+		if ( ! preg_match( '#^(https?://|git@|file://)#', $remote ) ) {
 			return new \WP_Error(
 				'invalid_remote_url',
-				'remote_url must be an https:// or git@ URL.',
+				'remote_url must be an https://, http://, git@, or file:// URL.',
 				array( 'status' => 400 )
 			);
 		}

--- a/inc/GitSync/GitSyncSubmitter.php
+++ b/inc/GitSync/GitSyncSubmitter.php
@@ -1,0 +1,545 @@
+<?php
+/**
+ * GitSync Submitter
+ *
+ * Orchestrates the submit() flow — the blessed path for sending local
+ * edits upstream as a pull request. Keeps submit logic out of GitSync
+ * proper so GitSync stays a clean CRUD surface over bindings.
+ *
+ * Model: **sticky proposal branch.** Each binding gets exactly one
+ * feature branch on the remote (`gitsync/<slug>`). Every submit
+ * rebases that branch onto fresh upstream, applies the user's edits,
+ * force-pushes with lease, and opens or updates a single PR. The
+ * branch represents "the latest proposal from this binding" — it
+ * doesn't accumulate stale per-submit branches.
+ *
+ * Algorithm:
+ *   1. Fetch origin so upstream and gitsync/<slug> refs are current.
+ *   2. Stash any dirty/staged changes on the pinned branch.
+ *   3. Hard-reset the pinned branch to origin/<pinned> so local state
+ *      matches upstream exactly.
+ *   4. Create (or reset) local gitsync/<slug> at origin/<pinned>.
+ *   5. Check out gitsync/<slug>, pop the stash to restore edits.
+ *   6. Stage the requested paths (or the full allowed subset if none
+ *      specified) and commit.
+ *   7. Push gitsync/<slug> to origin with --force-with-lease.
+ *   8. Open or update the PR via GitHubAbilities.
+ *   9. Switch back to the pinned branch and reset it to upstream so
+ *      the working tree is clean and idempotent across runs.
+ *
+ * Errors at any step trigger best-effort cleanup — we always try to
+ * return the working tree to the pinned branch so a failed submit
+ * doesn't leave the binding in a half-migrated state.
+ *
+ * Phase 2 only supports github.com remotes for submit (PR backend is
+ * GitHubAbilities). Non-GitHub remotes error with a clear message;
+ * a pluggable PR backend is Phase 3+.
+ *
+ * @package DataMachineCode\GitSync
+ * @since   0.8.0
+ * @see     https://github.com/Extra-Chill/data-machine-code/issues/38
+ */
+
+namespace DataMachineCode\GitSync;
+
+use DataMachineCode\Support\GitHubRemote;
+use DataMachineCode\Support\GitRunner;
+use DataMachineCode\Support\PathSecurity;
+
+defined( 'ABSPATH' ) || exit;
+
+final class GitSyncSubmitter {
+
+	public const BRANCH_PREFIX = 'gitsync/';
+
+	private GitSyncRegistry $registry;
+
+	public function __construct( GitSyncRegistry $registry ) {
+		$this->registry = $registry;
+	}
+
+	/**
+	 * Submit local edits as a PR on the sticky proposal branch.
+	 *
+	 * @param GitSyncBinding      $binding Binding to submit from.
+	 * @param array<string, mixed> $args {
+	 *     @type string   $message Commit message (required).
+	 *     @type string[] $paths   Relative paths to stage. If omitted,
+	 *                             stage every dirty file that sits under
+	 *                             the binding's allowed_paths roots.
+	 *     @type string   $title   PR title. Defaults to the commit subject.
+	 *     @type string   $body    PR body. Defaults to a short note.
+	 * }
+	 * @return array{success: true, slug: string, branch: string, pr: array<string, mixed>, commit: ?string, message: string}|\WP_Error
+	 */
+	public function submit( GitSyncBinding $binding, array $args ): array|\WP_Error {
+		$gate = $this->checkGates( $binding );
+		if ( is_wp_error( $gate ) ) {
+			return $gate;
+		}
+
+		$absolute = $binding->resolveAbsolutePath();
+		if ( ! is_dir( $absolute . '/.git' ) && ! is_file( $absolute . '/.git' ) ) {
+			return new \WP_Error( 'not_a_repo', sprintf( 'Binding "%s" has no git working tree at %s.', $binding->slug, $absolute ), array( 'status' => 409 ) );
+		}
+
+		$message = trim( (string) ( $args['message'] ?? '' ) );
+		if ( strlen( $message ) < 8 ) {
+			return new \WP_Error( 'message_too_short', 'Commit message must be at least 8 characters.', array( 'status' => 400 ) );
+		}
+		if ( strlen( $message ) > 200 ) {
+			return new \WP_Error( 'message_too_long', 'Commit message must be 200 characters or fewer.', array( 'status' => 400 ) );
+		}
+
+		$feature_branch = self::BRANCH_PREFIX . $binding->slug;
+		$pinned_branch  = $binding->branch;
+
+		// Paths to stage: explicit list, or derived from the dirty set.
+		$paths = $this->resolveStagingPaths( $absolute, $binding, $args );
+		if ( is_wp_error( $paths ) ) {
+			return $paths;
+		}
+		if ( empty( $paths ) ) {
+			return new \WP_Error(
+				'nothing_to_submit',
+				sprintf( 'Binding "%s" has no changes under its allowed_paths.', $binding->slug ),
+				array( 'status' => 400 )
+			);
+		}
+
+		// --- Begin orchestration. Everything from here until the final
+		// restore runs inside a try-finally-shaped block so partial
+		// failures always attempt to leave the working tree clean.
+		$state = array(
+			'stashed'          => false,
+			'switched_to_feat' => false,
+		);
+
+		$result = $this->runOrchestration( $absolute, $binding, $feature_branch, $pinned_branch, $paths, $message, $args, $state );
+
+		// Best-effort restore: always return to the pinned branch, aligned
+		// with upstream, working tree clean.
+		$this->restorePinned( $absolute, $pinned_branch, $state );
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		$binding->last_commit = $result['commit'] ?? null;
+		$this->registry->save( $binding );
+
+		return $result;
+	}
+
+	/**
+	 * Check submit-time policy gates.
+	 *
+	 * Separate from inline checks so tests can exercise each gate cleanly.
+	 *
+	 * @return true|\WP_Error
+	 */
+	private function checkGates( GitSyncBinding $binding ): true|\WP_Error {
+		if ( empty( $binding->policy['write_enabled'] ) ) {
+			return new \WP_Error( 'write_disabled', sprintf( 'Writes are disabled for binding "%s".', $binding->slug ), array( 'status' => 403 ) );
+		}
+		if ( empty( $binding->policy['push_enabled'] ) ) {
+			return new \WP_Error( 'push_disabled', sprintf( 'Pushes are disabled for binding "%s".', $binding->slug ), array( 'status' => 403 ) );
+		}
+
+		$allowed = is_array( $binding->policy['allowed_paths'] ?? null ) ? $binding->policy['allowed_paths'] : array();
+		if ( empty( $allowed ) ) {
+			return new \WP_Error( 'no_allowed_paths', sprintf( 'Binding "%s" has no allowed_paths — nothing can be submitted.', $binding->slug ), array( 'status' => 403 ) );
+		}
+
+		if ( ! GitHubRemote::isGitHubRemote( $binding->remote_url ) ) {
+			return new \WP_Error(
+				'unsupported_remote',
+				sprintf( 'submit() requires a github.com remote (got %s). Non-GitHub backends are Phase 3+.', $binding->remote_url ),
+				array( 'status' => 400 )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * The sticky-branch orchestration, factored out so submit() can run
+	 * restorePinned() as a finally even when steps mid-flow fail.
+	 *
+	 * @param array<string, bool> $state By-ref state flags updated so the
+	 *                                    restore path knows what to undo.
+	 * @return array<string, mixed>|\WP_Error
+	 */
+	private function runOrchestration(
+		string $absolute,
+		GitSyncBinding $binding,
+		string $feature_branch,
+		string $pinned_branch,
+		array $paths,
+		string $message,
+		array $args,
+		array &$state
+	): array|\WP_Error {
+		$pat      = $this->resolvePat();
+		$push_url = GitHubRemote::pushUrlWithPat( $binding->remote_url, $pat );
+
+		// 1. Fetch so origin refs are current (pinned branch + feature branch).
+		$fetch = GitRunner::run( $absolute, 'fetch origin --prune' );
+		if ( is_wp_error( $fetch ) ) {
+			return $fetch;
+		}
+
+		// 2. Ensure we're on the pinned branch before stashing, so a later
+		// stash-pop lands the changes on the feature branch cleanly.
+		$current = GitRepo::branch( $absolute );
+		if ( null !== $current && $current !== $pinned_branch ) {
+			$checkout = GitRunner::run( $absolute, 'checkout ' . escapeshellarg( $pinned_branch ) );
+			if ( is_wp_error( $checkout ) ) {
+				return $checkout;
+			}
+		}
+
+		// 3. Stash all changes (including untracked) so reset --hard doesn't
+		// nuke them. Skip the stash when the working tree is already clean.
+		$dirty = GitRepo::dirtyCount( $absolute );
+		if ( $dirty > 0 ) {
+			$stash = GitRunner::run( $absolute, 'stash push --include-untracked -m ' . escapeshellarg( 'gitsync-submit-' . $binding->slug ) );
+			if ( is_wp_error( $stash ) ) {
+				return $stash;
+			}
+			$state['stashed'] = true;
+		}
+
+		// 4. Align local pinned branch with upstream. Fast-forward would be
+		// sufficient when clean, but reset --hard guarantees alignment even
+		// after we've stashed divergent local state.
+		$reset = GitRunner::run( $absolute, 'reset --hard ' . escapeshellarg( 'origin/' . $pinned_branch ) );
+		if ( is_wp_error( $reset ) ) {
+			return $reset;
+		}
+
+		// 5. Create (or reset) the feature branch from the freshly-aligned
+		// upstream tip. `checkout -B` replaces any stale local ref.
+		$feat = GitRunner::run( $absolute, 'checkout -B ' . escapeshellarg( $feature_branch ) );
+		if ( is_wp_error( $feat ) ) {
+			return $feat;
+		}
+		$state['switched_to_feat'] = true;
+
+		// 6. Re-apply the stashed edits onto the feature branch. If pop
+		// fails (conflict against upstream move), abort and surface.
+		if ( $state['stashed'] ) {
+			$pop = GitRunner::run( $absolute, 'stash pop' );
+			if ( is_wp_error( $pop ) ) {
+				// Leave the stash in place so the user can recover manually.
+				return new \WP_Error(
+					'stash_conflict',
+					'Upstream moved in a way that conflicts with local edits. Your changes are preserved in the stash — resolve manually and retry.',
+					array( 'status' => 409, 'detail' => $pop->get_error_message() )
+				);
+			}
+			$state['stashed'] = false;
+		}
+
+		// 7. Stage the requested paths.
+		foreach ( $paths as $rel ) {
+			$stage = GitRunner::run( $absolute, 'add -- ' . escapeshellarg( $rel ) );
+			if ( is_wp_error( $stage ) ) {
+				return $stage;
+			}
+		}
+
+		$staged = GitRunner::run( $absolute, 'diff --cached --name-only' );
+		if ( is_wp_error( $staged ) ) {
+			return $staged;
+		}
+		$staged_lines = array_filter( array_map( 'trim', explode( "\n", (string) ( $staged['output'] ?? '' ) ) ) );
+		if ( empty( $staged_lines ) ) {
+			return new \WP_Error( 'nothing_staged', 'After staging, no diff detected. Nothing to submit.', array( 'status' => 400 ) );
+		}
+
+		// 8. Commit.
+		$commit = GitRunner::run( $absolute, 'commit -m ' . escapeshellarg( $message ) );
+		if ( is_wp_error( $commit ) ) {
+			return $commit;
+		}
+		$head = GitRepo::head( $absolute );
+
+		// 9. Push the feature branch with --force. We own gitsync/<slug>
+		// exclusively (no other writer touches it by convention), so a
+		// plain force is safe and matches the sticky-proposal-branch
+		// model. --force-with-lease would be belt-and-suspenders but it
+		// can't compute a lease when pushing to a URL rather than a
+		// named remote, which produces a "stale info" refusal.
+		$push_cmd = sprintf(
+			'push --force %s %s',
+			escapeshellarg( $push_url ),
+			escapeshellarg( $feature_branch . ':' . $feature_branch )
+		);
+		$push = GitRunner::run( $absolute, $push_cmd );
+		if ( is_wp_error( $push ) ) {
+			return $push;
+		}
+
+		// 10. Open or update the PR. PR failure is surfaced but doesn't undo
+		// the push — the branch is upstream, the PR can be opened manually.
+		$pr = $this->openOrUpdatePullRequest( $binding, $feature_branch, $pinned_branch, $message, $args, $staged_lines, $pat );
+		if ( is_wp_error( $pr ) ) {
+			return new \WP_Error(
+				'pr_failed',
+				sprintf(
+					'Branch "%s" pushed, but PR open/update failed: %s',
+					$feature_branch,
+					$pr->get_error_message()
+				),
+				array(
+					'status'    => 502,
+					'branch'    => $feature_branch,
+					'head'      => $head,
+					'staged'    => array_values( $staged_lines ),
+					'pr_error'  => $pr->get_error_code(),
+				)
+			);
+		}
+
+		return array(
+			'success' => true,
+			'slug'    => $binding->slug,
+			'branch'  => $feature_branch,
+			'commit'  => $head,
+			'staged'  => array_values( $staged_lines ),
+			'pr'      => $pr,
+			'message' => sprintf( 'Submitted %d file(s) from "%s" via PR #%d.', count( $staged_lines ), $binding->slug, (int) ( $pr['number'] ?? 0 ) ),
+		);
+	}
+
+	/**
+	 * Best-effort restore to the pinned branch after submit finishes or
+	 * fails partway through.
+	 */
+	private function restorePinned( string $absolute, string $pinned_branch, array $state ): void {
+		if ( $state['switched_to_feat'] ) {
+			// Checkout the pinned branch. Ignore errors — we're already in
+			// cleanup mode and the user can recover manually if this fails.
+			GitRunner::run( $absolute, 'checkout ' . escapeshellarg( $pinned_branch ) );
+		}
+		if ( $state['stashed'] ) {
+			// We never popped the stash — leave it in place so the user can
+			// decide what to do. A noisy log keeps them from losing track.
+			do_action(
+				'datamachine_log',
+				'warning',
+				sprintf( 'GitSync submit left a stash on binding working tree (%s). Recover via `git stash list`.', $absolute ),
+				array( 'context' => 'gitsync-submit' )
+			);
+		}
+	}
+
+	/**
+	 * Resolve the stage set for a submit call.
+	 *
+	 * If the caller passed an explicit `paths` array, validate each one.
+	 * Otherwise, derive the stage set from the current dirty list filtered
+	 * by the binding's allowed_paths — the "submit everything I've touched
+	 * that the policy lets me touch" convenience.
+	 *
+	 * @param array<string, mixed> $args
+	 * @return string[]|\WP_Error
+	 */
+	private function resolveStagingPaths( string $absolute, GitSyncBinding $binding, array $args ): array|\WP_Error {
+		$allowed = is_array( $binding->policy['allowed_paths'] ?? null ) ? $binding->policy['allowed_paths'] : array();
+
+		$explicit = isset( $args['paths'] ) && is_array( $args['paths'] ) ? $args['paths'] : null;
+		if ( null !== $explicit ) {
+			$clean = array();
+			foreach ( $explicit as $raw ) {
+				$rel = ltrim( trim( (string) $raw ), '/' );
+				if ( '' === $rel ) {
+					continue;
+				}
+				if ( PathSecurity::hasTraversal( $rel ) ) {
+					return new \WP_Error( 'path_traversal', sprintf( 'Invalid path: %s', $rel ), array( 'status' => 400 ) );
+				}
+				if ( PathSecurity::isSensitivePath( $rel ) ) {
+					return new \WP_Error( 'sensitive_path', sprintf( 'Refusing to submit sensitive path: %s', $rel ), array( 'status' => 403 ) );
+				}
+				if ( ! PathSecurity::isPathAllowed( $rel, $allowed ) ) {
+					return new \WP_Error( 'path_not_allowed', sprintf( 'Path "%s" is outside allowed_paths.', $rel ), array( 'status' => 403 ) );
+				}
+				$clean[] = $rel;
+			}
+			return $clean;
+		}
+
+		// Derive from git status --porcelain on the pinned branch.
+		$status = GitRunner::run( $absolute, 'status --porcelain' );
+		if ( is_wp_error( $status ) ) {
+			return $status;
+		}
+		$lines = array_filter( array_map( 'trim', explode( "\n", (string) ( $status['output'] ?? '' ) ) ) );
+
+		$derived = array();
+		foreach ( $lines as $line ) {
+			// Porcelain lines: `XY path[ -> newpath]`. Keep it simple — take
+			// the tail after the first whitespace, ignoring rename arrows.
+			$parts = preg_split( '/\s+/', $line, 2 );
+			if ( count( $parts ) < 2 ) {
+				continue;
+			}
+			$rel = trim( $parts[1] );
+			if ( str_contains( $rel, ' -> ' ) ) {
+				$rel = trim( explode( ' -> ', $rel, 2 )[1] );
+			}
+			if ( '' === $rel ) {
+				continue;
+			}
+
+			// Silently skip files outside the policy — this is the
+			// convenience path, not a validation path.
+			if ( PathSecurity::hasTraversal( $rel ) || PathSecurity::isSensitivePath( $rel ) ) {
+				continue;
+			}
+			if ( ! PathSecurity::isPathAllowed( $rel, $allowed ) ) {
+				continue;
+			}
+			$derived[] = $rel;
+		}
+
+		return array_values( array_unique( $derived ) );
+	}
+
+	/**
+	 * Open a PR on the feature branch, or update the existing one.
+	 *
+	 * Delegates every HTTP call to `GitHubAbilities::apiGet` /
+	 * `apiRequest` so the auth headers, JSON decoding, and error
+	 * envelope stay identical to the rest of DMC's GitHub surface.
+	 *
+	 * Phase 2 only targets github.com — caller has already gated.
+	 *
+	 * @param string[] $staged Relative paths we just committed.
+	 * @return array<string, mixed>|\WP_Error
+	 */
+	private function openOrUpdatePullRequest(
+		GitSyncBinding $binding,
+		string $feature_branch,
+		string $pinned_branch,
+		string $commit_message,
+		array $args,
+		array $staged,
+		string $pat
+	): array|\WP_Error {
+		if ( '' === $pat ) {
+			return new \WP_Error( 'missing_pat', 'GitHub PAT not configured — cannot open PR. Configure via data-machine-code settings.', array( 'status' => 500 ) );
+		}
+
+		$slug = GitHubRemote::slug( $binding->remote_url );
+		if ( null === $slug ) {
+			return new \WP_Error( 'unparseable_remote', sprintf( 'Could not parse GitHub owner/repo from %s.', $binding->remote_url ), array( 'status' => 400 ) );
+		}
+
+		$owner = explode( '/', $slug )[0];
+		$head  = $owner . ':' . $feature_branch;
+		$title = trim( (string) ( $args['title'] ?? '' ) );
+		if ( '' === $title ) {
+			$title = $commit_message;
+		}
+		$body = trim( (string) ( $args['body'] ?? '' ) );
+		if ( '' === $body ) {
+			$body = $this->buildDefaultBody( $binding, $commit_message, $staged );
+		}
+
+		// Look up existing PR on this head.
+		$existing = \DataMachineCode\Abilities\GitHubAbilities::apiGet(
+			GitHubRemote::apiUrl( $slug, 'pulls' ),
+			array(
+				'head'     => $head,
+				'state'    => 'open',
+				'per_page' => 5,
+			),
+			$pat
+		);
+		if ( is_wp_error( $existing ) ) {
+			return $existing;
+		}
+		$existing_pr = is_array( $existing['data'] ?? null ) && ! empty( $existing['data'] ) ? $existing['data'][0] : null;
+
+		if ( null !== $existing_pr ) {
+			$patched = \DataMachineCode\Abilities\GitHubAbilities::apiRequest(
+				'PATCH',
+				GitHubRemote::apiUrl( $slug, 'pulls/' . (int) $existing_pr['number'] ),
+				array(
+					'title' => $title,
+					'body'  => $body,
+				),
+				$pat
+			);
+			if ( is_wp_error( $patched ) ) {
+				return $patched;
+			}
+			$patched_data = is_array( $patched['data'] ?? null ) ? $patched['data'] : array();
+			return array(
+				'number'   => (int) ( $patched_data['number'] ?? $existing_pr['number'] ),
+				'html_url' => (string) ( $patched_data['html_url'] ?? $existing_pr['html_url'] ),
+				'state'    => (string) ( $patched_data['state'] ?? 'open' ),
+				'action'   => 'updated',
+			);
+		}
+
+		$created = \DataMachineCode\Abilities\GitHubAbilities::apiRequest(
+			'POST',
+			GitHubRemote::apiUrl( $slug, 'pulls' ),
+			array(
+				'title' => $title,
+				'body'  => $body,
+				'head'  => $feature_branch,
+				'base'  => $pinned_branch,
+			),
+			$pat
+		);
+		if ( is_wp_error( $created ) ) {
+			return $created;
+		}
+		$created_data = is_array( $created['data'] ?? null ) ? $created['data'] : array();
+		return array(
+			'number'   => (int) ( $created_data['number'] ?? 0 ),
+			'html_url' => (string) ( $created_data['html_url'] ?? '' ),
+			'state'    => (string) ( $created_data['state'] ?? 'open' ),
+			'action'   => 'opened',
+		);
+	}
+
+	private function buildDefaultBody( GitSyncBinding $binding, string $commit_message, array $staged ): string {
+		$files = '';
+		foreach ( array_slice( $staged, 0, 25 ) as $rel ) {
+			$files .= "- `{$rel}`\n";
+		}
+		if ( count( $staged ) > 25 ) {
+			$files .= sprintf( "- …and %d more\n", count( $staged ) - 25 );
+		}
+		return <<<BODY
+Proposed by GitSync binding **{$binding->slug}** from local edits.
+
+## Commit
+{$commit_message}
+
+## Files
+{$files}
+---
+*Opened via `datamachine/gitsync-submit`. Re-running submit updates this PR in place.*
+BODY;
+	}
+
+	/**
+	 * Fetch the GitHub PAT from DMC's settings, or empty string if
+	 * the GitHubAbilities class isn't loaded. The caller decides how
+	 * to react to an empty PAT — push may still succeed via system
+	 * credential.helper, but PR creation requires one.
+	 */
+	private function resolvePat(): string {
+		if ( ! class_exists( '\DataMachineCode\Abilities\GitHubAbilities' ) ) {
+			return '';
+		}
+		return (string) \DataMachineCode\Abilities\GitHubAbilities::getPat();
+	}
+}

--- a/inc/Support/GitHubRemote.php
+++ b/inc/Support/GitHubRemote.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * GitHub Remote
+ *
+ * One place for GitHub-specific URL manipulation:
+ *   - "is this a GitHub remote?"
+ *   - "parse owner/repo out of the URL"
+ *   - "rewrite the URL with a PAT injected for authenticated push"
+ *
+ * Shared by GitSync (push + submit) and Workspace (merge-signal lookup)
+ * so the regex + host-detection logic has a single source of truth.
+ *
+ * @package DataMachineCode\Support
+ * @since   0.7.0
+ */
+
+namespace DataMachineCode\Support;
+
+defined( 'ABSPATH' ) || exit;
+
+final class GitHubRemote {
+
+	/**
+	 * Detect a GitHub remote. Matches https://github.com/... and
+	 * git@github.com:... Both forms count.
+	 */
+	public static function isGitHubRemote( string $url ): bool {
+		return (bool) preg_match( '#(https?://github\.com/|git@github\.com:)#', $url );
+	}
+
+	/**
+	 * Extract `owner/repo` from a GitHub URL.
+	 *
+	 * Accepts both `https://github.com/owner/repo(.git)(/)?` and
+	 * `git@github.com:owner/repo(.git)`. Returns null for any URL that
+	 * isn't recognizable as GitHub, or where owner/repo can't be cleanly
+	 * extracted — callers must defend against null.
+	 *
+	 * @return string|null `owner/repo` or null.
+	 */
+	public static function slug( string $url ): ?string {
+		if ( preg_match( '#github\.com[:/]([\w.-]+)/([\w.-]+?)(?:\.git)?/?$#', $url, $m ) ) {
+			return $m[1] . '/' . $m[2];
+		}
+		return null;
+	}
+
+	/**
+	 * Rewrite an https://github.com/... URL to include a PAT for auth.
+	 *
+	 * Non-https URLs (git@ SSH, file://, non-GitHub) pass through untouched
+	 * — SSH uses ssh-agent, file:// has no auth surface, and non-GitHub
+	 * hosts should rely on system credential.helper.
+	 *
+	 * The PAT is rawurlencoded before injection so exotic token characters
+	 * don't break URL parsing downstream.
+	 */
+	public static function pushUrlWithPat( string $url, string $pat ): string {
+		if ( '' === $pat ) {
+			return $url;
+		}
+		if ( ! str_starts_with( $url, 'https://github.com/' ) ) {
+			return $url;
+		}
+		return 'https://' . rawurlencode( $pat ) . '@' . substr( $url, strlen( 'https://' ) );
+	}
+
+	/**
+	 * Build a GitHub REST API URL for a repo.
+	 *
+	 *   apiUrl('foo/bar')                 → https://api.github.com/repos/foo/bar
+	 *   apiUrl('foo/bar', 'pulls')        → https://api.github.com/repos/foo/bar/pulls
+	 *   apiUrl('foo/bar', 'pulls/42')     → https://api.github.com/repos/foo/bar/pulls/42
+	 *
+	 * `$slug` is expected to be validated ahead of time (output of
+	 * `slug()` or a value the caller already trusts). No sanitization
+	 * is attempted here beyond string concatenation.
+	 */
+	public static function apiUrl( string $slug, string $path = '' ): string {
+		$base = 'https://api.github.com/repos/' . $slug;
+		if ( '' === $path ) {
+			return $base;
+		}
+		return $base . '/' . ltrim( $path, '/' );
+	}
+}

--- a/inc/Support/PathSecurity.php
+++ b/inc/Support/PathSecurity.php
@@ -90,6 +90,42 @@ final class PathSecurity {
 	}
 
 	/**
+	 * Check whether a relative path is under any of a set of prefix roots.
+	 *
+	 * Used to enforce `allowed_paths` policy when staging for commit —
+	 * a path must sit inside at least one of the configured roots to be
+	 * stageable. Roots are compared as directory prefixes (so root
+	 * `articles` matches `articles/foo.md` but not `articlesX/foo.md`),
+	 * and an exact-match counts.
+	 *
+	 * Empty `$allowed_paths` returns false — an empty allowlist means
+	 * nothing is allowed, matching the conservative Phase 2 default.
+	 *
+	 * @param string   $path          Normalized relative path (no leading slash).
+	 * @param string[] $allowed_paths Roots the path must sit inside.
+	 * @return bool
+	 */
+	public static function isPathAllowed( string $path, array $allowed_paths ): bool {
+		$normalized = ltrim( str_replace( '\\', '/', $path ), '/' );
+		if ( '' === $normalized ) {
+			return false;
+		}
+
+		foreach ( $allowed_paths as $allowed ) {
+			$root = trim( str_replace( '\\', '/', (string) $allowed ) );
+			$root = trim( $root, '/' );
+			if ( '' === $root ) {
+				continue;
+			}
+			if ( $normalized === $root || str_starts_with( $normalized, $root . '/' ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Check whether a path looks sensitive (env files, credentials, keys).
 	 *
 	 * @param string $path Relative path.

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -13,6 +13,7 @@
 namespace DataMachineCode\Workspace;
 
 use DataMachine\Core\FilesRepository\FilesystemHelper;
+use DataMachineCode\Support\GitHubRemote;
 use DataMachineCode\Support\GitRunner;
 use DataMachineCode\Support\PathSecurity;
 
@@ -1421,13 +1422,7 @@ class Workspace {
 		if ( null === $remote || '' === $remote ) {
 			return null;
 		}
-
-		// Match https://github.com/owner/repo(.git) and git@github.com:owner/repo(.git)
-		if ( preg_match( '#github\.com[:/]([\w.-]+)/([\w.-]+?)(?:\.git)?/?$#', $remote, $m ) ) {
-			return $m[1] . '/' . $m[2];
-		}
-
-		return null;
+		return GitHubRemote::slug( $remote );
 	}
 
 	/**
@@ -1455,9 +1450,8 @@ class Workspace {
 			return null;
 		}
 
-		$url      = sprintf( 'https://api.github.com/repos/%s/pulls', $slug );
 		$response = \DataMachineCode\Abilities\GitHubAbilities::apiGet(
-			$url,
+			GitHubRemote::apiUrl( $slug, 'pulls' ),
 			array(
 				'state'    => 'closed',
 				'head'     => $owner . ':' . $branch,

--- a/tests/smoke-gitsync-write.php
+++ b/tests/smoke-gitsync-write.php
@@ -1,0 +1,450 @@
+<?php
+/**
+ * Pure-PHP smoke test for GitSync Phase 2 — the write path.
+ *
+ * Exercises policy gates, add, commit, push, submit (sans GitHub call),
+ * and updatePolicy against a **local bare repo as the fake remote**.
+ * Zero network, zero credentials — everything runs under a temp
+ * directory that's torn down on exit.
+ *
+ * Run: php tests/smoke-gitsync-write.php
+ *
+ * The `submit` flow is exercised up to the `git push` step; the
+ * GitHubAbilities PR call is stubbed via the `pre_http_request` filter
+ * so we can assert request shape without hitting the network.
+ */
+
+declare( strict_types=1 );
+
+namespace {
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		$scratch = sys_get_temp_dir() . '/dmc-gitsync-write-' . getmypid();
+		@mkdir( $scratch, 0755, true );
+		define( 'ABSPATH', $scratch . '/' );
+	}
+
+	$GLOBALS['__dmc_options']      = array();
+	$GLOBALS['__dmc_http_mock']    = array();
+	$GLOBALS['__dmc_http_capture'] = array();
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			public string $code;
+			public string $message;
+			public array $data;
+			public function __construct( string $code = '', string $message = '', array $data = array() ) {
+				$this->code    = $code;
+				$this->message = $message;
+				$this->data    = $data;
+			}
+			public function get_error_code(): string { return $this->code; }
+			public function get_error_message(): string { return $this->message; }
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $thing ): bool { return $thing instanceof \WP_Error; }
+	}
+
+	if ( ! function_exists( 'wp_mkdir_p' ) ) {
+		function wp_mkdir_p( string $path ): bool { return is_dir( $path ) || mkdir( $path, 0755, true ); }
+	}
+
+	if ( ! function_exists( 'get_option' ) ) {
+		function get_option( string $name, $default = false ) {
+			return $GLOBALS['__dmc_options'][ $name ] ?? $default;
+		}
+	}
+
+	if ( ! function_exists( 'update_option' ) ) {
+		function update_option( string $name, $value, $autoload = null ): bool {
+			$GLOBALS['__dmc_options'][ $name ] = $value;
+			return true;
+		}
+	}
+
+	if ( ! function_exists( 'wp_json_encode' ) ) {
+		function wp_json_encode( $data, int $options = 0 ) { return json_encode( $data, $options ); }
+	}
+
+	if ( ! function_exists( 'add_query_arg' ) ) {
+		function add_query_arg( array $args, string $url ): string {
+			$qs = http_build_query( $args );
+			return $url . ( str_contains( $url, '?' ) ? '&' : '?' ) . $qs;
+		}
+	}
+
+	// wp_remote_request stub — routes through the in-memory mock table so
+	// tests can assert request shape without network access.
+	if ( ! function_exists( 'wp_remote_request' ) ) {
+		function wp_remote_request( string $url, array $args = array() ) {
+			$GLOBALS['__dmc_http_capture'][] = array(
+				'url'     => $url,
+				'method'  => $args['method'] ?? 'GET',
+				'body'    => $args['body'] ?? null,
+				'headers' => $args['headers'] ?? array(),
+			);
+			$method = strtoupper( $args['method'] ?? 'GET' );
+			$key    = $method . ' ' . strtok( $url, '?' );
+			if ( isset( $GLOBALS['__dmc_http_mock'][ $key ] ) ) {
+				return $GLOBALS['__dmc_http_mock'][ $key ];
+			}
+			return array(
+				'response' => array( 'code' => 404 ),
+				'body'     => json_encode( array( 'message' => 'Not mocked: ' . $key ) ),
+			);
+		}
+	}
+
+	if ( ! function_exists( 'wp_remote_retrieve_response_code' ) ) {
+		function wp_remote_retrieve_response_code( $response ): int {
+			return (int) ( $response['response']['code'] ?? 0 );
+		}
+	}
+
+	if ( ! function_exists( 'wp_remote_retrieve_body' ) ) {
+		function wp_remote_retrieve_body( $response ): string {
+			return (string) ( $response['body'] ?? '' );
+		}
+	}
+
+	if ( ! function_exists( 'do_action' ) ) {
+		function do_action( ...$args ): void {}
+	}
+
+	require __DIR__ . '/../inc/Support/GitRunner.php';
+	require __DIR__ . '/../inc/Support/PathSecurity.php';
+	require __DIR__ . '/../inc/Support/GitHubRemote.php';
+	require __DIR__ . '/../inc/GitSync/GitRepo.php';
+	require __DIR__ . '/../inc/GitSync/GitSyncBinding.php';
+	require __DIR__ . '/../inc/GitSync/GitSyncRegistry.php';
+	require __DIR__ . '/../inc/GitSync/GitSyncSubmitter.php';
+	require __DIR__ . '/../inc/GitSync/GitSync.php';
+
+	$failures = 0;
+	$total    = 0;
+
+	$assert = function ( $cond, string $message ) use ( &$failures, &$total ): void {
+		$total++;
+		if ( $cond ) { echo "  ✓ {$message}\n"; return; }
+		$failures++;
+		echo "  ✗ {$message}\n";
+	};
+
+	$cleanup = function () use ( $scratch ): void {
+		if ( is_dir( $scratch ) ) {
+			exec( 'rm -rf ' . escapeshellarg( $scratch ) );
+		}
+	};
+	register_shutdown_function( $cleanup );
+
+	echo "GitSync Phase 2 — write-path smoke\n";
+	echo "Scratch ABSPATH: " . ABSPATH . "\n\n";
+
+	// -------------------------------------------------------------------------
+	// Fake remote: a local bare repo seeded with an initial commit on `main`.
+	// -------------------------------------------------------------------------
+	$fake_remote_path = sys_get_temp_dir() . '/dmc-gitsync-fake-remote-' . getmypid() . '.git';
+	$fake_remote      = 'file://' . $fake_remote_path;
+	$seed_dir         = sys_get_temp_dir() . '/dmc-gitsync-fake-seed-' . getmypid();
+	exec( 'git init --bare ' . escapeshellarg( $fake_remote_path ) . ' 2>&1', $_out, $init_ok );
+	if ( 0 !== $init_ok ) { echo "  ! could not init bare repo\n"; exit( 1 ); }
+	register_shutdown_function( fn() => exec( 'rm -rf ' . escapeshellarg( $fake_remote_path ) ) );
+	register_shutdown_function( fn() => exec( 'rm -rf ' . escapeshellarg( $seed_dir ) ) );
+
+	// Seed with one commit so origin/main exists.
+	mkdir( $seed_dir, 0755, true );
+	exec( 'git -C ' . escapeshellarg( $seed_dir ) . ' init -b main 2>&1' );
+	exec( 'git -C ' . escapeshellarg( $seed_dir ) . ' -c user.email=smoke@example.com -c user.name=Smoke commit --allow-empty -m "init" 2>&1' );
+	exec( 'git -C ' . escapeshellarg( $seed_dir ) . ' remote add origin ' . escapeshellarg( $fake_remote ) . ' 2>&1' );
+	exec( 'git -C ' . escapeshellarg( $seed_dir ) . ' push -u origin main 2>&1', $_out, $seed_ok );
+	if ( 0 !== $seed_ok ) { echo "  ! could not seed bare repo\n"; exit( 1 ); }
+
+	// Configure git identity on the test binding so commits don't fail in
+	// CI-like envs where user.email isn't set globally.
+	putenv( 'GIT_AUTHOR_NAME=Smoke' );
+	putenv( 'GIT_AUTHOR_EMAIL=smoke@example.com' );
+	putenv( 'GIT_COMMITTER_NAME=Smoke' );
+	putenv( 'GIT_COMMITTER_EMAIL=smoke@example.com' );
+
+	$gs = new \DataMachineCode\GitSync\GitSync();
+
+	// -------------------------------------------------------------------------
+	// 1. Bind (reuses Phase 1 code path).
+	// -------------------------------------------------------------------------
+	echo "Bind against fake remote\n";
+	$bind = $gs->bind( array(
+		'slug'       => 'w',
+		'local_path' => '/bound/',
+		'remote_url' => $fake_remote,
+	) );
+	$assert( ! is_wp_error( $bind ), 'bind succeeded' );
+	$absolute = $bind['local_path'] ?? '';
+
+	// Configure local git identity inside the clone.
+	exec( 'git -C ' . escapeshellarg( $absolute ) . ' config user.email smoke@example.com' );
+	exec( 'git -C ' . escapeshellarg( $absolute ) . ' config user.name Smoke' );
+
+	// -------------------------------------------------------------------------
+	// 2. add/commit/push refuse when write_enabled=false (Phase 1 default).
+	// -------------------------------------------------------------------------
+	echo "\nPolicy gates (write_enabled=false)\n";
+	file_put_contents( $absolute . '/foo.md', "hello\n" );
+	$add_blocked = $gs->add( 'w', array( 'foo.md' ) );
+	$assert( is_wp_error( $add_blocked ) && 'write_disabled' === $add_blocked->get_error_code(), 'add refused without write_enabled' );
+
+	$commit_blocked = $gs->commit( 'w', 'nope nope nope' );
+	$assert( is_wp_error( $commit_blocked ) && 'write_disabled' === $commit_blocked->get_error_code(), 'commit refused without write_enabled' );
+
+	$push_blocked = $gs->push( 'w' );
+	$assert( is_wp_error( $push_blocked ) && 'push_disabled' === $push_blocked->get_error_code(), 'push refused without push_enabled' );
+
+	// -------------------------------------------------------------------------
+	// 3. updatePolicy: turn on writes but not allowed_paths yet.
+	// -------------------------------------------------------------------------
+	echo "\nupdatePolicy\n";
+	$p1 = $gs->updatePolicy( 'w', array( 'write_enabled' => true ) );
+	$assert( ! is_wp_error( $p1 ), 'policy update succeeded' );
+	$assert( true === ( $p1['policy']['write_enabled'] ?? false ), 'write_enabled now true' );
+
+	$add_noroots = $gs->add( 'w', array( 'foo.md' ) );
+	$assert( is_wp_error( $add_noroots ) && 'no_allowed_paths' === $add_noroots->get_error_code(), 'add refused without allowed_paths' );
+
+	// Policy key whitelist.
+	$unknown = $gs->updatePolicy( 'w', array( 'bogus' => true ) );
+	$assert( is_wp_error( $unknown ) && 'unknown_policy_key' === $unknown->get_error_code(), 'rejects unknown policy key' );
+
+	// safe_direct_push without push_enabled errors.
+	$sdp_orphan = $gs->updatePolicy( 'w', array( 'safe_direct_push' => true ) );
+	$assert( is_wp_error( $sdp_orphan ) && 'policy_conflict' === $sdp_orphan->get_error_code(), 'rejects safe_direct_push without push_enabled' );
+
+	// -------------------------------------------------------------------------
+	// 4. Set allowed_paths + push_enabled and exercise add/commit path restrictions.
+	// -------------------------------------------------------------------------
+	echo "\nallowed_paths enforcement\n";
+	mkdir( $absolute . '/articles', 0755, true );
+	file_put_contents( $absolute . '/articles/a.md', "aaa\n" );
+	file_put_contents( $absolute . '/secrets.env', "KEY=val\n" );
+	file_put_contents( $absolute . '/README.md', "readme\n" );
+
+	$p2 = $gs->updatePolicy( 'w', array(
+		'allowed_paths' => array( 'articles/' ),
+		'push_enabled'  => true,
+	) );
+	$assert( ! is_wp_error( $p2 ), 'allowed_paths + push_enabled set' );
+
+	$add_outside = $gs->add( 'w', array( 'README.md' ) );
+	$assert( is_wp_error( $add_outside ) && 'path_not_allowed' === $add_outside->get_error_code(), 'add refuses path outside allowed_paths' );
+
+	$add_sensitive = $gs->add( 'w', array( 'secrets.env' ) );
+	$assert( is_wp_error( $add_sensitive ) && 'sensitive_path' === $add_sensitive->get_error_code(), 'add refuses sensitive filename' );
+
+	$add_ok = $gs->add( 'w', array( 'articles/a.md' ) );
+	$assert( ! is_wp_error( $add_ok ) && array( 'articles/a.md' ) === $add_ok['paths'], 'add accepts allowed path' );
+
+	// -------------------------------------------------------------------------
+	// 5. Commit validation.
+	// -------------------------------------------------------------------------
+	echo "\nCommit\n";
+	$short = $gs->commit( 'w', 'nope' );
+	$assert( is_wp_error( $short ) && 'message_too_short' === $short->get_error_code(), 'rejects short commit message' );
+
+	$too_long = $gs->commit( 'w', str_repeat( 'x', 201 ) );
+	$assert( is_wp_error( $too_long ) && 'message_too_long' === $too_long->get_error_code(), 'rejects overlong commit message' );
+
+	$commit = $gs->commit( 'w', 'Add first article' );
+	$assert( ! is_wp_error( $commit ), 'commit succeeded' );
+	$assert( is_string( $commit['commit'] ?? null ) && '' !== $commit['commit'], 'commit returns hash' );
+
+	// Clean-tree commit refuses.
+	$empty = $gs->commit( 'w', 'another commit message' );
+	$assert( is_wp_error( $empty ) && 'nothing_staged' === $empty->get_error_code(), 'refuses commit when nothing staged' );
+
+	// -------------------------------------------------------------------------
+	// 6. Direct push: push_enabled alone still refuses.
+	// -------------------------------------------------------------------------
+	echo "\nDirect push (two-key auth)\n";
+	$dp_blocked = $gs->push( 'w' );
+	$assert( is_wp_error( $dp_blocked ) && 'direct_push_blocked' === $dp_blocked->get_error_code(), 'direct push needs safe_direct_push' );
+
+	$gs->updatePolicy( 'w', array( 'safe_direct_push' => true ) );
+	$push_ok = $gs->push( 'w' );
+	$assert( ! is_wp_error( $push_ok ), 'direct push with both keys set' );
+
+	// Verify the commit actually landed on the fake remote.
+	exec( 'git -C ' . escapeshellarg( $fake_remote_path ) . ' rev-parse HEAD', $remote_head );
+	$assert( ! empty( $remote_head[0] ), 'bare remote advanced after push' );
+
+	// -------------------------------------------------------------------------
+	// 7. Submit flow — fake GitHub remote slug via a fs path. We can't run
+	//    openOrUpdatePullRequest against an fs path, so point submit at a
+	//    pretend github.com URL that pushes to the same fs bare repo via a
+	//    separate mock. Instead: verify the pre-GitHub steps complete and
+	//    the PR call hits the mock table.
+	// -------------------------------------------------------------------------
+	echo "\nSubmit (mocked PR API)\n";
+
+	// Re-bind to a github.com-shaped URL for submit — but actually push to
+	// our fake remote by monkey-patching via environment: we rewrite the
+	// binding's remote_url after bind so it passes the github.com gate while
+	// pointing at the real bare repo for git operations.
+	$gs2 = $gs; // reuse
+	$gs->unbind( 'w', true );
+
+	$bind2 = $gs->bind( array(
+		'slug'       => 's',
+		'local_path' => '/submitbound/',
+		'remote_url' => $fake_remote,
+	) );
+	$assert( ! is_wp_error( $bind2 ), 'submit binding created' );
+	$absolute2 = $bind2['local_path'];
+	exec( 'git -C ' . escapeshellarg( $absolute2 ) . ' config user.email smoke@example.com' );
+	exec( 'git -C ' . escapeshellarg( $absolute2 ) . ' config user.name Smoke' );
+
+	// Swap remote_url to github-looking value so submit() passes the host
+	// check. The git remote stays pointed at the bare repo (origin).
+	$opts                               = $GLOBALS['__dmc_options']['datamachine_gitsync_bindings'];
+	$opts['s']['remote_url']            = 'https://github.com/example/repo';
+	$opts['s']['policy']['write_enabled'] = true;
+	$opts['s']['policy']['push_enabled']  = true;
+	$opts['s']['policy']['allowed_paths'] = array( 'articles/' );
+	$GLOBALS['__dmc_options']['datamachine_gitsync_bindings'] = $opts;
+
+	// Route the PAT-injected push URL back to the local bare repo via git's
+	// insteadOf config. Scoped to this clone only (no global pollution).
+	$injected_url = 'https://test-pat@github.com/example/repo';
+	exec( sprintf(
+		'git -C %s config url.%s.insteadOf %s',
+		escapeshellarg( $absolute2 ),
+		escapeshellarg( $fake_remote ),
+		escapeshellarg( $injected_url )
+	) );
+	// Also the un-injected URL, in case PAT resolution short-circuits.
+	exec( sprintf(
+		'git -C %s config --add url.%s.insteadOf %s',
+		escapeshellarg( $absolute2 ),
+		escapeshellarg( $fake_remote ),
+		escapeshellarg( 'https://github.com/example/repo' )
+	) );
+
+	if ( ! is_dir( $absolute2 . '/articles' ) ) {
+		mkdir( $absolute2 . '/articles', 0755, true );
+	}
+	file_put_contents( $absolute2 . '/articles/new.md', "new\n" );
+
+	// Mock GitHub API: GET existing pulls returns [], POST creates PR #42.
+	$GLOBALS['__dmc_http_mock']['GET https://api.github.com/repos/example/repo/pulls']  = array(
+		'response' => array( 'code' => 200 ),
+		'body'     => '[]',
+	);
+	$GLOBALS['__dmc_http_mock']['POST https://api.github.com/repos/example/repo/pulls'] = array(
+		'response' => array( 'code' => 201 ),
+		'body'     => json_encode( array(
+			'number'   => 42,
+			'html_url' => 'https://github.com/example/repo/pull/42',
+			'state'    => 'open',
+		) ),
+	);
+
+	// Stub GitHubAbilities so the PAT resolves and apiGet/apiRequest
+	// route through the mocked wp_remote_request. Mirrors the real class's
+	// response envelope (`['success' => true, 'data' => $decoded_body]`)
+	// so callers don't need test-specific unwrapping.
+	if ( ! class_exists( '\DataMachineCode\Abilities\GitHubAbilities' ) ) {
+		eval( 'namespace DataMachineCode\\Abilities;
+		class GitHubAbilities {
+			public static function getPat(): string { return "test-pat"; }
+			public static function apiGet( string $url, array $query, string $pat ) {
+				if ( ! empty( $query ) ) { $url = add_query_arg( $query, $url ); }
+				$resp = wp_remote_request( $url, array( "method" => "GET", "headers" => array( "Authorization" => "token " . $pat ) ) );
+				$code = (int) wp_remote_retrieve_response_code( $resp );
+				$body = json_decode( (string) wp_remote_retrieve_body( $resp ), true );
+				if ( $code >= 400 ) { return new \\WP_Error( "github_api_error", "stub error", array( "status" => $code ) ); }
+				return array( "success" => true, "data" => $body );
+			}
+			public static function apiRequest( string $method, string $url, array $body, string $pat ) {
+				$resp = wp_remote_request( $url, array( "method" => $method, "headers" => array( "Authorization" => "token " . $pat ), "body" => json_encode( $body ) ) );
+				$code = (int) wp_remote_retrieve_response_code( $resp );
+				$decoded = json_decode( (string) wp_remote_retrieve_body( $resp ), true );
+				if ( $code >= 400 ) { return new \\WP_Error( "github_api_error", "stub error", array( "status" => $code ) ); }
+				return array( "success" => true, "data" => $decoded );
+			}
+		}' );
+	}
+
+	$submit = $gs->submit( 's', array(
+		'message' => 'Propose a new article',
+	) );
+
+	$assert( ! is_wp_error( $submit ), 'submit succeeded — ' . ( is_wp_error( $submit ) ? $submit->get_error_message() : '' ) );
+	$assert( 42 === ( $submit['pr']['number'] ?? null ), 'submit returned PR #42' );
+	$assert( 'opened' === ( $submit['pr']['action'] ?? null ), 'submit reports PR as opened' );
+	$assert( 'gitsync/s' === ( $submit['branch'] ?? null ), 'feature branch is gitsync/s' );
+
+	// Verify working tree returned to pinned branch (main).
+	exec( 'git -C ' . escapeshellarg( $absolute2 ) . ' rev-parse --abbrev-ref HEAD', $br_out );
+	$assert( 'main' === trim( (string) ( $br_out[0] ?? '' ) ), 'working tree returned to pinned branch after submit' );
+
+	// Verify feature branch pushed to bare remote.
+	$feat_out = array();
+	exec( 'git -C ' . escapeshellarg( $fake_remote_path ) . ' rev-parse refs/heads/gitsync/s 2>&1', $feat_out, $feat_exit );
+	$assert( 0 === $feat_exit, 'feature branch gitsync/s exists on bare remote' );
+
+	// Verify API was called in the expected order.
+	$captured = $GLOBALS['__dmc_http_capture'];
+	$assert( count( $captured ) >= 2, 'at least 2 API calls captured' );
+	$assert( 'GET' === ( $captured[0]['method'] ?? '' ), 'first API call is GET' );
+	$assert( 'POST' === ( $captured[1]['method'] ?? '' ), 'second API call is POST' );
+	$assert( str_contains( (string) ( $captured[0]['headers']['Authorization'] ?? '' ), 'test-pat' ), 'PAT sent in Authorization header' );
+
+	// -------------------------------------------------------------------------
+	// 8. Submit is idempotent — second run updates PR in place.
+	// -------------------------------------------------------------------------
+	echo "\nSubmit update (second run)\n";
+	$GLOBALS['__dmc_http_capture'] = array();
+	$GLOBALS['__dmc_http_mock']['GET https://api.github.com/repos/example/repo/pulls']  = array(
+		'response' => array( 'code' => 200 ),
+		'body'     => json_encode( array(
+			array(
+				'number'   => 42,
+				'html_url' => 'https://github.com/example/repo/pull/42',
+				'state'    => 'open',
+			),
+		) ),
+	);
+	$GLOBALS['__dmc_http_mock']['PATCH https://api.github.com/repos/example/repo/pulls/42'] = array(
+		'response' => array( 'code' => 200 ),
+		'body'     => json_encode( array(
+			'number'   => 42,
+			'html_url' => 'https://github.com/example/repo/pull/42',
+			'state'    => 'open',
+		) ),
+	);
+
+	if ( ! is_dir( $absolute2 . '/articles' ) ) {
+		mkdir( $absolute2 . '/articles', 0755, true );
+	}
+	file_put_contents( $absolute2 . '/articles/new.md', "new v2\n" );
+	$submit2 = $gs->submit( 's', array( 'message' => 'Update the new article' ) );
+	$assert(
+		! is_wp_error( $submit2 ),
+		'second submit succeeded' . ( is_wp_error( $submit2 ) ? ' — ' . $submit2->get_error_code() . ': ' . $submit2->get_error_message() : '' )
+	);
+	if ( is_wp_error( $submit2 ) ) {
+		// Skip remaining assertions to keep the run readable.
+		echo "\nResult: " . ( $total - $failures ) . "/{$total} passed\n";
+		exit( $failures > 0 ? 1 : 0 );
+	}
+	$assert( 'updated' === ( $submit2['pr']['action'] ?? null ), 'second submit reports PR as updated' );
+
+	// -------------------------------------------------------------------------
+	// 9. Submit with no changes under allowed_paths errors cleanly.
+	// -------------------------------------------------------------------------
+	echo "\nSubmit with nothing to propose\n";
+	$clean_submit = $gs->submit( 's', array( 'message' => 'nothing changed here' ) );
+	$assert( is_wp_error( $clean_submit ) && 'nothing_to_submit' === $clean_submit->get_error_code(), 'submit refuses when nothing is staged' );
+
+	echo "\nResult: " . ( $total - $failures ) . "/{$total} passed\n";
+	exit( $failures > 0 ? 1 : 0 );
+}

--- a/tests/smoke-gitsync.php
+++ b/tests/smoke-gitsync.php
@@ -68,8 +68,11 @@ namespace {
 
 	require __DIR__ . '/../inc/Support/GitRunner.php';
 	require __DIR__ . '/../inc/Support/PathSecurity.php';
+	require __DIR__ . '/../inc/Support/GitHubRemote.php';
+	require __DIR__ . '/../inc/GitSync/GitRepo.php';
 	require __DIR__ . '/../inc/GitSync/GitSyncBinding.php';
 	require __DIR__ . '/../inc/GitSync/GitSyncRegistry.php';
+	require __DIR__ . '/../inc/GitSync/GitSyncSubmitter.php';
 	require __DIR__ . '/../inc/GitSync/GitSync.php';
 
 	$failures = 0;


### PR DESCRIPTION
Phase 2 of GitSync (DMC#38) — the write path. Originally PR #40; that PR auto-closed when its base branch was deleted after #39 merged. Same commit, retargeted to `main`.

See the original PR #40 thread for full discussion and review.

## Summary

Layers a full write path on top of Phase 1's read surface:

- **`add`** / **`commit`** / **`push`** / **`submit`** / **`policy-update`** — 5 new abilities, all CLI-only, all gated by `PermissionHelper::can_manage()`.
- **Four-flag policy surface**: `write_enabled`, `push_enabled`, `safe_direct_push` (two-key auth for direct push to pinned branch), `allowed_paths` (staging allowlist).
- **`submit` = sticky proposal branch** — each binding gets one `gitsync/<slug>` feature branch on the remote, force-pushed in place on every submit, single PR updated via GitHub API.
- **Clean layering** — shared `Support/GitHubRemote` (host detection, slug parsing, PAT injection, API URL template) used by GitSync, GitSyncSubmitter, AND refactored back into Workspace. Zero duplication across the codebase.
- **Zero new HTTP wrapping** — Submitter routes through existing `GitHubAbilities::apiGet`/`apiRequest`.

## Smokes

- `tests/smoke-gitsync-write.php` — **35/35 green** (local bare repo as fake remote, GitHub API mocked via `wp_remote_request` stub)
- `tests/smoke-gitsync.php` (Phase 1) — 32/32 green
- `tests/smoke-worktree-handles.php` — 32/32 green (Workspace refactor clean)

All 10 `datamachine/gitsync-*` abilities verified registered in Studio.

## Files

New: `inc/GitSync/GitRepo.php`, `inc/GitSync/GitSyncSubmitter.php`, `inc/Support/GitHubRemote.php`, `tests/smoke-gitsync-write.php`.
Modified: `inc/GitSync/GitSync.php`, `inc/GitSync/GitSyncBinding.php`, `inc/Abilities/GitSyncAbilities.php`, `inc/Cli/Commands/GitSyncCommand.php`, `inc/Support/PathSecurity.php`, `inc/Workspace/Workspace.php`, `tests/smoke-gitsync.php`, `docs/gitsync.md`.

Issue #38 stays open — Phase 3 (scheduled sync) is deferred until a real consumer tells us what cadence pattern they actually need.