### PR TITLE
fix(workspace): permissive-by-default git mutation gates

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -3,7 +3,7 @@
  * Plugin Name: Data Machine Code
  * Plugin URI: https://github.com/Extra-Chill/data-machine-code
  * Description: Developer tools extension for Data Machine. GitHub integration, workspace management, git operations, and code tools for WordPress AI agents.
- * Version: 0.6.2
+ * Version: 0.6.3
  * Requires at least: 6.9
  * Requires PHP: 8.2
  * Requires Plugins: data-machine
@@ -18,7 +18,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'DATAMACHINE_CODE_VERSION', '0.6.2' );
+define( 'DATAMACHINE_CODE_VERSION', '0.6.3' );
 define( 'DATAMACHINE_CODE_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DATAMACHINE_CODE_URL', plugin_dir_url( __FILE__ ) );
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Data Machine Code will be documented in this file.
 
+## [0.6.3] - 2026-04-21
+
+### Fixed
+- workspace git wrapper: `git pull/add/commit/push` no longer fail with `git_write_disabled` on repos that have no entry in `datamachine_workspace_git_policies`. Unconfigured repos now default to permissive (primary-vs-worktree protection remains via `--allow-primary-mutation`). Explicit `write_enabled: false` / `push_enabled: false` still deny. Error messages clarified to reference the policy option.
+- `workspace git add`: `no_allowed_paths` no longer blocks unconfigured repos. The `allowed_paths` list is now opt-in — when configured, it restricts; when absent, any relative path is accepted (sensitive-path + traversal checks still enforced).
+
+### Added
+- `datamachine_workspace_git_policies` filter for runtime-injected policy (alongside the existing option). Allows site config to declare per-repo policy without persisting to the option.
+- Documentation in `get_workspace_git_policies()` describing the policy schema and defaults.
+
 ## [0.6.2] - 2026-04-19
 
 ### Changed

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -568,10 +568,11 @@ class Workspace {
 			return new \WP_Error( 'missing_paths', 'At least one path is required for git add.', array( 'status' => 400 ) );
 		}
 
+		// Allowed paths are opt-in: when configured, they restrict which relative
+		// paths may be staged; when absent, any path within the repo is allowed.
+		// This mirrors ensure_git_mutation_allowed's permissive-by-default model.
+		// Sensitive-path + traversal checks still apply unconditionally.
 		$allowed_roots = $this->get_repo_allowed_paths( $repo_name );
-		if ( empty( $allowed_roots ) ) {
-			return new \WP_Error( 'no_allowed_paths', sprintf( 'No allowed paths configured for repo "%s".', $repo_name ), array( 'status' => 403 ) );
-		}
 
 		$clean_paths = array();
 		foreach ( $paths as $path ) {
@@ -588,7 +589,8 @@ class Workspace {
 				return new \WP_Error( 'sensitive_path', sprintf( 'Refusing to stage sensitive path: %s', $relative ), array( 'status' => 403 ) );
 			}
 
-			if ( ! $this->is_path_allowed( $relative, $allowed_roots ) ) {
+			// Only enforce the allowlist when one has been configured.
+			if ( ! empty( $allowed_roots ) && ! $this->is_path_allowed( $relative, $allowed_roots ) ) {
 				return new \WP_Error( 'path_not_allowed', sprintf( 'Path "%s" is outside configured allowlist.', $relative ), array( 'status' => 403 ) );
 			}
 
@@ -1650,6 +1652,19 @@ class Workspace {
 	/**
 	 * Check if repo has git mutation permissions enabled.
 	 *
+	 * Unconfigured repos are permissive by default: `datamachine_workspace_git_policies`
+	 * is an opt-in restriction layer. When no entry exists for $repo_name, both
+	 * write and push are allowed. When an entry exists, its flags (`write_enabled`,
+	 * `push_enabled`) are honored; missing flags default to `true` so a partial
+	 * config doesn't accidentally lock out ops that weren't explicitly restricted.
+	 *
+	 * The primary-vs-worktree gate (see ensure_primary_mutation_allowed) remains
+	 * the documented default safety mechanism for protecting tracked branches.
+	 *
+	 * To explicitly deny a repo, add an entry with `write_enabled: false` and/or
+	 * `push_enabled: false`. The `datamachine_workspace_git_policies` filter also
+	 * lets plugins inject policy at runtime.
+	 *
 	 * @param string $repo_name    Repository name.
 	 * @param bool   $require_push Whether push must also be enabled.
 	 * @return true|\WP_Error
@@ -1658,12 +1673,43 @@ class Workspace {
 		$policies = $this->get_workspace_git_policies();
 		$repo     = $policies['repos'][ $repo_name ] ?? null;
 
-		if ( ! is_array( $repo ) || empty( $repo['write_enabled'] ) ) {
-			return new \WP_Error( 'git_write_disabled', sprintf( 'Git write operations are disabled for repo "%s".', $repo_name ), array( 'status' => 403 ) );
+		// No entry = permissive default. Callers should still respect
+		// primary-vs-worktree separation via ensure_primary_mutation_allowed.
+		if ( null === $repo ) {
+			return true;
 		}
 
-		if ( $require_push && empty( $repo['push_enabled'] ) ) {
-			return new \WP_Error( 'git_push_disabled', sprintf( 'Git push is disabled for repo "%s".', $repo_name ), array( 'status' => 403 ) );
+		if ( ! is_array( $repo ) ) {
+			return true;
+		}
+
+		// Entry exists — honor explicit flags. Missing flags default to true
+		// so a partial config (e.g. only setting allowed_paths) doesn't
+		// accidentally disable write/push.
+		$write_enabled = array_key_exists( 'write_enabled', $repo ) ? (bool) $repo['write_enabled'] : true;
+		if ( ! $write_enabled ) {
+			return new \WP_Error(
+				'git_write_disabled',
+				sprintf(
+					'Git write operations are explicitly disabled for repo "%s" via datamachine_workspace_git_policies.',
+					$repo_name
+				),
+				array( 'status' => 403 )
+			);
+		}
+
+		if ( $require_push ) {
+			$push_enabled = array_key_exists( 'push_enabled', $repo ) ? (bool) $repo['push_enabled'] : true;
+			if ( ! $push_enabled ) {
+				return new \WP_Error(
+					'git_push_disabled',
+					sprintf(
+						'Git push is explicitly disabled for repo "%s" via datamachine_workspace_git_policies.',
+						$repo_name
+					),
+					array( 'status' => 403 )
+				);
+			}
 		}
 
 		return true;
@@ -1760,7 +1806,21 @@ class Workspace {
 	/**
 	 * Read workspace git policy settings.
 	 *
-	 * @return array
+	 * The option defaults to an empty array, which is treated as "no
+	 * restrictions" by the mutation gates (see ensure_git_mutation_allowed
+	 * and git_add's allowed_paths check). To restrict a repo, configure an
+	 * entry under `repos[<repo_name>]` with any combination of:
+	 *
+	 *   - write_enabled (bool, default true)
+	 *   - push_enabled  (bool, default true)
+	 *   - allowed_paths (string[], optional — if set, restricts git_add)
+	 *   - fixed_branch  (string, optional — constrains push on primary)
+	 *
+	 * The `datamachine_workspace_git_policies` filter allows plugins and
+	 * site configuration to inject or override policy at runtime without
+	 * touching the stored option.
+	 *
+	 * @return array{repos: array<string, array<string, mixed>>}
 	 */
 	private function get_workspace_git_policies(): array {
 		$defaults = array(
@@ -1769,11 +1829,29 @@ class Workspace {
 
 		$settings = get_option( 'datamachine_workspace_git_policies', $defaults );
 		if ( ! is_array( $settings ) ) {
-			return $defaults;
+			$settings = $defaults;
 		}
 
 		if ( ! isset( $settings['repos'] ) || ! is_array( $settings['repos'] ) ) {
 			$settings['repos'] = array();
+		}
+
+		/**
+		 * Filter the workspace git policy map.
+		 *
+		 * Allows plugins to inject or override per-repo git mutation policy
+		 * without persisting changes to the `datamachine_workspace_git_policies`
+		 * option. Useful for environment-specific policy (dev vs prod) or for
+		 * tying policy to site configuration managed elsewhere.
+		 *
+		 * @since 0.x.0
+		 *
+		 * @param array $settings Current policy array, shape { repos: { <name>: {...} } }.
+		 */
+		$settings = apply_filters( 'datamachine_workspace_git_policies', $settings );
+
+		if ( ! is_array( $settings ) || ! isset( $settings['repos'] ) || ! is_array( $settings['repos'] ) ) {
+			return $defaults;
 		}
 
 		return $settings;


### PR DESCRIPTION
## Summary

The `datamachine_workspace_git_policies` WordPress option gates git mutation ops (`pull` / `add` / `commit` / `push`) and `git_add`'s path allowlist in the workspace wrapper. Before this change, **every unconfigured repo** failed every git mutation with `git_write_disabled` or `no_allowed_paths`, making the wrapper's git-family subcommands unusable out of the box.

## Repro

On a fresh install (no `datamachine_workspace_git_policies` option set):

```bash
$ wp datamachine-code workspace git pull data-machine --allow-primary-mutation
Error: Git write operations are disabled for repo "data-machine".
```

The `--allow-primary-mutation` flag (the override documented in AGENTS.md) never gets evaluated because an earlier, undocumented gate fires first. The error message doesn't reference the option key or suggest a fix.

Workaround before this PR: `git -C /var/lib/datamachine/workspace/<repo> pull` — bypassing the wrapper entirely.

## Root cause

`ensure_git_mutation_allowed()` treated "no entry in policy array" identically to "explicitly disabled":

```php
// Before:
$repo = $policies['repos'][ $repo_name ] ?? null;
if ( ! is_array( $repo ) || empty( $repo['write_enabled'] ) ) {
    return new WP_Error( 'git_write_disabled', ... );
}
```

Combined with:
- No CLI to populate the option (`workspace --help` has no policy subcommands)
- No admin UI
- No filter (until this PR)
- No docs describing the option

…this was a hidden hard gate with no configuration surface.

A second, analogous gate lived in `git_add()`: the `allowed_paths` check returned `no_allowed_paths` when the list was empty, which it always is by default.

## Fix

**Permissive-by-default.** The policy option becomes an **opt-in restriction layer** instead of a hidden requirement:

1. **`ensure_git_mutation_allowed()`** — `null` entry → allow. Entry present → honor explicit flags. `write_enabled` / `push_enabled` default to `true` when the flag itself is missing, so a partial config (e.g. only setting `allowed_paths`) doesn't accidentally disable writes.

2. **`git_add()`** — empty `allowed_paths` → no restriction. When configured, the allowlist still gates. Sensitive-path + traversal checks are always enforced regardless of policy.

3. **Error messages** now reference the policy option by name, so if someone does hit a deny, they know what to look at.

4. **New filter `datamachine_workspace_git_policies`** for runtime injection of policy (e.g. env-specific, or driven by site config managed elsewhere) without writing to the option.

5. **`get_workspace_git_policies()` docblock** documents the schema (`write_enabled`, `push_enabled`, `allowed_paths`, `fixed_branch`) and the permissive defaults.

## What doesn't change

The **primary-vs-worktree gate** (`ensure_primary_mutation_allowed` + `--allow-primary-mutation` override) is the documented default safety mechanism per AGENTS.md:

> *"Primary is read-only by default: mutating ops on bare `<repo>` handles require `--allow-primary-mutation`."*

That gate is untouched. It's the intended protection layer — the one users read about and expect.

## To explicitly deny a repo

Set an option entry:

```php
update_option( 'datamachine_workspace_git_policies', array(
    'repos' => array(
        'sensitive-repo' => array(
            'write_enabled' => false,
            'push_enabled'  => false,
        ),
    ),
) );
```

Or via the filter:

```php
add_filter( 'datamachine_workspace_git_policies', function( $policies ) {
    $policies['repos']['sensitive-repo'] = array( 'write_enabled' => false );
    return $policies;
} );
```

## Files

- `inc/Workspace/Workspace.php` — gate logic + filter + docblock
- `data-machine-code.php` — version bump 0.6.2 → 0.6.3
- `docs/CHANGELOG.md` — entry added

## Testing

No existing unit tests cover the workspace git mutation gates (only `tests/smoke-gitsync.php` covers the separate GitSync subsystem, which uses its own policy storage via `GitSync::updatePolicy()` and is unaffected by this change).

Manual verification: with this PR applied, `workspace git pull <repo> --allow-primary-mutation` and `workspace git commit/push <repo>@<branch>` succeed on an unconfigured workspace, matching AGENTS.md's documented contract.

## Related

Not blocking but discovered during a data-machine release cascade that involves pulling `main` via the workspace wrapper. With this fix, the wrapper becomes usable for its intended workflows without requiring manual option configuration first.