### PR TITLE
fix(abilities): allow nullable branch/remote/commit in workspace output schemas

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -98,8 +98,9 @@ class WorkspaceAbilities {
 										'name'   => array( 'type' => 'string' ),
 										'path'   => array( 'type' => 'string' ),
 										'git'    => array( 'type' => 'boolean' ),
-										'remote' => array( 'type' => 'string' ),
-										'branch' => array( 'type' => 'string' ),
+										// Local-only repos have no remote; detached HEAD has no branch.
+										'remote' => array( 'type' => array( 'string', 'null' ) ),
+										'branch' => array( 'type' => array( 'string', 'null' ) ),
 									),
 								),
 							),
@@ -135,9 +136,11 @@ class WorkspaceAbilities {
 							'repo'        => array( 'type' => 'string' ),
 							'is_worktree' => array( 'type' => 'boolean' ),
 							'path'        => array( 'type' => 'string' ),
-							'branch'      => array( 'type' => 'string' ),
-							'remote'      => array( 'type' => 'string' ),
-							'commit'      => array( 'type' => 'string' ),
+							// Nullable: detached HEAD has no branch; local-only repos
+							// have no remote; freshly-init'd repos have no commit yet.
+							'branch'      => array( 'type' => array( 'string', 'null' ) ),
+							'remote'      => array( 'type' => array( 'string', 'null' ) ),
+							'commit'      => array( 'type' => array( 'string', 'null' ) ),
 							'dirty'       => array( 'type' => 'integer' ),
 						),
 					),
@@ -422,9 +425,11 @@ class WorkspaceAbilities {
 							'repo'        => array( 'type' => 'string' ),
 							'is_worktree' => array( 'type' => 'boolean' ),
 							'path'        => array( 'type' => 'string' ),
-							'branch'      => array( 'type' => 'string' ),
-							'remote'      => array( 'type' => 'string' ),
-							'commit'      => array( 'type' => 'string' ),
+							// Nullable: detached HEAD has no branch; local-only repos
+							// have no remote; freshly-init'd repos have no commit yet.
+							'branch'      => array( 'type' => array( 'string', 'null' ) ),
+							'remote'      => array( 'type' => array( 'string', 'null' ) ),
+							'commit'      => array( 'type' => array( 'string', 'null' ) ),
 							'dirty'       => array( 'type' => 'integer' ),
 							'files'       => array(
 								'type'  => 'array',


### PR DESCRIPTION
Closes #21.

## Summary

\`workspace-show\`, \`workspace-git-status\`, and \`workspace-list\` declared \`branch\`/\`remote\`/\`commit\` as plain \`string\` in their output schemas. Those fields legitimately return \`null\` in normal repo states:

- **Local-only repos** have no remote → \`null\`
- **Detached HEAD** has no branch name → \`null\`
- **Freshly-init'd repos** have no commit yet → \`null\`

The Abilities API validates output against the declared schema and rejected null values, making these abilities effectively unusable for any repo that wasn't freshly cloned on a tracked branch.

## Reproduction before fix

\`\`\`
wp datamachine-code workspace show <local-only-repo>
→ Error: Ability "datamachine/workspace-show" has invalid output.
  Reason: output[remote] is not of type string.
\`\`\`

## Fix

Widen the three fields to \`['string', 'null']\` in all three output schemas. The underlying \`Workspace::show_repo()\` and \`Workspace::git_status()\` methods already return \`null\` explicitly — only the schema was lying.

## Bug 1 note

The issue also reported Bug 1: \`gitStatus\` callback throwing \`TypeError\` because it was typed \`: array\` while \`Workspace::git_status()\` returns \`array|\WP_Error\`. This is **already resolved on main** — every ability callback in the file now declares \`: array|\WP_Error\`, so \`WP_Error\` returns propagate cleanly. Verified by triggering a git failure:

\`\`\`
$ wp datamachine-code workspace git status <corrupted-repo>
Error: Git command failed (exit 128): fatal: not a git repository...
\`\`\`

No TypeError — clean rendering.

## Verification

Tested four repo states against \`show\` and \`git status\` abilities:

| State | Before fix | After fix |
|-------|-----------|-----------|
| Local-only repo (no remote) | ❌ schema rejection | ✅ renders with \`Remote: -\` |
| Freshly-init'd repo (no commits) | ❌ schema rejection | ✅ renders with \`Latest: -\` |
| Detached HEAD | ⚠️ works (branch reported as "HEAD") | ✅ unchanged |
| Normal tracked repo | ✅ | ✅ unchanged |

## Scope

Three schema blocks touched (lines 101-102 \`workspace-list\` item, 138-141 \`workspace-show\`, 425-430 \`workspace-git-status\`). One file changed, +13/-8 lines.