### PR TITLE
feat: migrate GitHubIssueTask + WorktreeCleanupTask to executeTask() contract

### DIFF
--- a/inc/Tasks/GitHubIssueTask.php
+++ b/inc/Tasks/GitHubIssueTask.php
@@ -27,7 +27,7 @@ class GitHubIssueTask extends SystemTask {
 	 * @param int   $jobId  Job ID from DM Jobs table.
 	 * @param array $params Task parameters from engine_data.
 	 */
-	public function execute( int $jobId, array $params ): void {
+	public function executeTask( int $jobId, array $params ): void {
 		$result = GitHubAbilities::createIssue( $params );
 
 		if ( is_wp_error( $result ) ) {

--- a/inc/Tasks/WorktreeCleanupTask.php
+++ b/inc/Tasks/WorktreeCleanupTask.php
@@ -117,7 +117,7 @@ class WorktreeCleanupTask extends SystemTask {
 	 * @param int   $jobId  Job ID from DM Jobs table.
 	 * @param array $params Task parameters from engine_data.
 	 */
-	public function execute( int $jobId, array $params ): void {
+	public function executeTask( int $jobId, array $params ): void {
 		// Gate on the same PluginSetting the React UI toggles and the
 		// recurring schedule reads. Defensive — scheduled runs already
 		// wouldn't fire when the setting is off, but manual runs via


### PR DESCRIPTION
## Summary

- Renames `execute()` → `executeTask()` in `GitHubIssueTask` and `WorktreeCleanupTask` to match the new `SystemTask` base class contract introduced in data-machine 0.72.0.
- No logic changes — method bodies are identical, only the method name changes.

## Dependency

**This PR depends on [data-machine#1153](https://github.com/Extra-Chill/data-machine/pull/1153)** which introduces the `executeTask()` abstract method on `SystemTask`.

These two PRs must be **merged together** (big-bang deploy):
1. `data-machine#1153` — adds `executeTask()` to `SystemTask` base class
2. This PR — migrates concrete task implementations to the new contract

Merging this PR without #1153 will cause a fatal (abstract method not implemented via old `execute()` name).
Merging #1153 without this PR will cause a fatal (concrete classes still override `execute()` instead of `executeTask()`).

## BREAKING CHANGE

Requires data-machine 0.72.0+ (`SystemTask.executeTask`).