### PR TITLE
feat(workspace): bootstrap worktrees by default (closes #50)

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -706,7 +706,7 @@ class WorkspaceAbilities {
 				'datamachine/workspace-worktree-add',
 				array(
 					'label'               => 'Add Workspace Worktree',
-					'description'         => 'Create a git worktree for a branch under `<repo>@<branch-slug>`. Branches are created off the supplied `from` ref (default `origin/HEAD`) when they do not yet exist locally. When `inject_context` is true (default), the originating site\'s agent memory is snapshotted into `.claude/CLAUDE.local.md` and `.opencode/AGENTS.local.md` and added to the worktree\'s per-checkout `info/exclude`.',
+					'description'         => 'Create a git worktree for a branch under `<repo>@<branch-slug>`. Branches are created off the supplied `from` ref (default `origin/HEAD`) when they do not yet exist locally. When `inject_context` is true (default), the originating site\'s agent memory is snapshotted into `.claude/CLAUDE.local.md` and `.opencode/AGENTS.local.md` and added to the worktree\'s per-checkout `info/exclude`. When `bootstrap` is true (default), submodule init + package-manager install + composer install run after creation so the worktree is immediately test/build-ready; set false to create a bare checkout.',
 					'category'            => 'datamachine-code-workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
@@ -726,6 +726,10 @@ class WorkspaceAbilities {
 							'inject_context' => array(
 								'type'        => 'boolean',
 								'description' => 'Inject the originating site\'s agent context (MEMORY.md, USER.md, RULES.md) into the new worktree. Default true. Set false to create a bare worktree.',
+							),
+							'bootstrap'      => array(
+								'type'        => 'boolean',
+								'description' => 'Run detected bootstrap steps (submodule init, package-manager install, composer install) after creating the worktree. Default true. Steps are skipped gracefully when their trigger file or tool is missing. Set false for a bare checkout (e.g. when only reading code).',
 							),
 						),
 						'required'   => array( 'repo', 'branch' ),
@@ -747,6 +751,10 @@ class WorkspaceAbilities {
 							),
 							'context_exclude_path' => array( 'type' => 'string' ),
 							'context_skip_reason' => array( 'type' => 'string' ),
+							'bootstrap'           => array(
+								'type'        => 'object',
+								'description' => 'Present only when bootstrap=true. Contains success/ran_any booleans and a steps array.',
+							),
 						),
 					),
 					'execute_callback'    => array( self::class, 'worktreeAdd' ),
@@ -1181,11 +1189,14 @@ class WorkspaceAbilities {
 		$workspace = new Workspace();
 		// Default inject_context=true; only false when explicitly provided.
 		$inject_context = array_key_exists( 'inject_context', $input ) ? (bool) $input['inject_context'] : true;
+		// Default bootstrap=true; only false when explicitly provided.
+		$bootstrap = array_key_exists( 'bootstrap', $input ) ? (bool) $input['bootstrap'] : true;
 		return $workspace->worktree_add(
 			$input['repo'] ?? '',
 			$input['branch'] ?? '',
 			$input['from'] ?? null,
-			$inject_context
+			$inject_context,
+			$bootstrap
 		);
 	}
 

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -907,6 +907,19 @@ class WorkspaceCommand extends BaseCommand {
 	 *   paths to the repository's `info/exclude`. The ability-level input
 	 *   is `inject_context=false`; this flag is the CLI shorthand.
 	 *
+	 * [--skip-bootstrap]
+	 * : Skip the default bootstrap pass (applies to `add` only). By default,
+	 *   `worktree add` runs detected setup so the checkout is immediately
+	 *   test/build-ready:
+	 *     - git submodule update --init --recursive (if .gitmodules)
+	 *     - pnpm/bun/yarn/npm install (based on lockfile)
+	 *     - composer install --no-interaction (if composer.lock)
+	 *   Each step is skipped gracefully when its trigger file or tool is
+	 *   missing. Pass `--skip-bootstrap` to create a bare checkout for pure
+	 *   read use (faster, no deps installed). The ability-level input is
+	 *   `bootstrap=false`; this flag is the CLI shorthand (matches the
+	 *   existing `--skip-context-injection` convention).
+	 *
 	 * [--force]
 	 * : Force-remove a worktree even if it is dirty (applies to `remove` and
 	 *   `cleanup`). Does NOT override the unpushed-commits safety in cleanup.
@@ -960,6 +973,9 @@ class WorkspaceCommand extends BaseCommand {
 	 *     # Create a worktree without injecting site-agent context
 	 *     wp datamachine workspace worktree add data-machine fix/foo --skip-context-injection
 	 *
+	 *     # Create a bare worktree (skip the default bootstrap pass)
+	 *     wp datamachine workspace worktree add data-machine fix/foo --skip-bootstrap
+	 *
 	 *     # Re-read the originating site's agent memory into an existing worktree
 	 *     wp datamachine workspace worktree refresh-context data-machine@fix-foo
 	 *
@@ -999,7 +1015,7 @@ class WorkspaceCommand extends BaseCommand {
 		switch ( $operation ) {
 			case 'add':
 				if ( empty( $args[1] ) || empty( $args[2] ) ) {
-					WP_CLI::error( 'Usage: worktree add <repo> <branch> [--from=<ref>] [--skip-context-injection]' );
+					WP_CLI::error( 'Usage: worktree add <repo> <branch> [--from=<ref>] [--skip-context-injection] [--skip-bootstrap]' );
 					return;
 				}
 				$input['repo']   = $args[1];
@@ -1009,6 +1025,8 @@ class WorkspaceCommand extends BaseCommand {
 				}
 				// --skip-context-injection disables the default-on injection step.
 				$input['inject_context'] = empty( $assoc_args['skip-context-injection'] );
+				// --skip-bootstrap disables the default-on bootstrap step.
+				$input['bootstrap'] = empty( $assoc_args['skip-bootstrap'] );
 				break;
 
 			case 'refresh-context':
@@ -1157,6 +1175,17 @@ class WorkspaceCommand extends BaseCommand {
 					} else {
 						$reason = $result['context_skip_reason'] ?? 'unknown';
 						WP_CLI::log( sprintf( 'Context: not injected (%s)', $reason ) );
+					}
+				}
+				if ( isset( $result['bootstrap'] ) && is_array( $result['bootstrap'] ) ) {
+					$bs      = $result['bootstrap'];
+					$ok      = ! empty( $bs['success'] );
+					$ran_any = ! empty( $bs['ran_any'] );
+					$label   = $ok ? ( $ran_any ? 'Bootstrap: ok' : 'Bootstrap: nothing to do' ) : 'Bootstrap: one or more steps FAILED';
+					WP_CLI::log( $label );
+					WP_CLI::log( \DataMachineCode\Workspace\WorktreeBootstrapper::format( $bs ) );
+					if ( ! $ok ) {
+						WP_CLI::warning( 'Worktree was created but bootstrap had failures. Re-run the failing step manually, or remove and retry.' );
 					}
 				}
 				return;

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -861,13 +861,24 @@ class Workspace {
 	 * absent the worktree is still created successfully; injection silently
 	 * skips.
 	 *
+	 * When `$bootstrap` is true (default), a bootstrap pass runs after the
+	 * worktree is created: `git submodule update --init --recursive` if
+	 * `.gitmodules` is present, a package-manager install if a lockfile is
+	 * present (pnpm/bun/yarn/npm), and `composer install` if `composer.lock`
+	 * is present. Steps are independent and each one is skipped gracefully
+	 * when its tool is unavailable. A failing step is surfaced in the result
+	 * but does not roll back the worktree — the checkout exists either way.
+	 * Pass `$bootstrap = false` (or `--no-bootstrap` on the CLI) for a bare
+	 * checkout when you only need to read code on that branch.
+	 *
 	 * @param string      $repo           Primary repo name (no @-suffix).
 	 * @param string      $branch         Branch to check out (e.g. "fix/foo-bar").
 	 * @param string|null $from           Base ref when creating the branch.
 	 * @param bool        $inject_context Whether to inject site-agent context (default true).
-	 * @return array{success: bool, handle: string, path: string, branch: string, slug: string, created_branch: bool, message: string, context_injected?: bool, context_files?: string[], context_skip_reason?: string}|\WP_Error
+	 * @param bool        $bootstrap      Whether to run submodule/package/composer install after creation (default true).
+	 * @return array{success: bool, handle: string, path: string, branch: string, slug: string, created_branch: bool, message: string, context_injected?: bool, context_files?: string[], context_skip_reason?: string, bootstrap?: array}|\WP_Error
 	 */
-	public function worktree_add( string $repo, string $branch, ?string $from = null, bool $inject_context = true ): array|\WP_Error {
+	public function worktree_add( string $repo, string $branch, ?string $from = null, bool $inject_context = true, bool $bootstrap = true ): array|\WP_Error {
 		$repo   = $this->sanitize_name( $repo );
 		$branch = trim( $branch );
 
@@ -929,29 +940,29 @@ class Workspace {
 		if ( ! $inject_context ) {
 			$response['context_injected']    = false;
 			$response['context_skip_reason'] = 'inject_context flag disabled';
-			return $response;
+		} else {
+			$payload = WorktreeContextInjector::build_payload();
+			if ( null === $payload ) {
+				$response['context_injected']    = false;
+				$response['context_skip_reason'] = 'agent memory layer unavailable';
+			} else {
+				$injection = WorktreeContextInjector::inject( $wt_path, $payload );
+				if ( is_wp_error( $injection ) ) {
+					$response['context_injected']    = false;
+					$response['context_skip_reason'] = 'inject failed: ' . $injection->get_error_message();
+				} else {
+					WorktreeContextInjector::store_metadata( $wt_handle, $payload );
+					$response['context_injected'] = true;
+					$response['context_files']    = $injection['written'];
+					if ( ! empty( $injection['exclude_path'] ) ) {
+						$response['context_exclude_path'] = $injection['exclude_path'];
+					}
+				}
+			}
 		}
 
-		$payload = WorktreeContextInjector::build_payload();
-		if ( null === $payload ) {
-			$response['context_injected']    = false;
-			$response['context_skip_reason'] = 'agent memory layer unavailable';
-			return $response;
-		}
-
-		$injection = WorktreeContextInjector::inject( $wt_path, $payload );
-		if ( is_wp_error( $injection ) ) {
-			$response['context_injected']    = false;
-			$response['context_skip_reason'] = 'inject failed: ' . $injection->get_error_message();
-			return $response;
-		}
-
-		WorktreeContextInjector::store_metadata( $wt_handle, $payload );
-
-		$response['context_injected'] = true;
-		$response['context_files']    = $injection['written'];
-		if ( ! empty( $injection['exclude_path'] ) ) {
-			$response['context_exclude_path'] = $injection['exclude_path'];
+		if ( $bootstrap ) {
+			$response['bootstrap'] = WorktreeBootstrapper::bootstrap( $wt_path );
 		}
 
 		return $response;

--- a/inc/Workspace/WorktreeBootstrapper.php
+++ b/inc/Workspace/WorktreeBootstrapper.php
@@ -1,0 +1,334 @@
+<?php
+/**
+ * Worktree Bootstrapper
+ *
+ * `git worktree add` intentionally only replays git-tracked state. That leaves
+ * a new checkout missing anything non-tracked the repo needs before tests or
+ * builds can run — submodules (tracked but not auto-init'd), `node_modules`,
+ * Composer vendor dir, etc. Users hit silent failure modes like "vitest can't
+ * load spec" or "sh: nx: command not found".
+ *
+ * This class implements the opt-in `--bootstrap` step: detect what the repo
+ * declares it needs (via standard lockfiles + `.gitmodules`), run each step,
+ * and report structured results so callers can surface a clear status line.
+ *
+ * Detection is convention-based, not configurable (yet — issue #50 proposes a
+ * `.datamachine/worktree.yml` follow-up for repo-declared custom steps). Steps
+ * run in a fixed order:
+ *
+ *   1. `git submodule update --init --recursive` if `.gitmodules` exists
+ *   2. Package-manager install, based on lockfile presence:
+ *        pnpm-lock.yaml   → pnpm install --frozen-lockfile
+ *        bun.lockb/.lock  → bun install --frozen-lockfile
+ *        yarn.lock        → yarn install --immutable
+ *        package-lock.json → npm ci
+ *   3. `composer install --no-interaction --prefer-dist` if `composer.lock` exists
+ *
+ * Each step is optional. Missing binaries (no `pnpm` on PATH, etc.) downgrade
+ * to a `skipped` result rather than failing. Command failures are returned as
+ * structured step results — the worktree itself stays created even if bootstrap
+ * partially fails, and the CLI surfaces the failing step so the user can
+ * decide whether to retry manually.
+ *
+ * No WordPress dependency so this class is unit-testable via pure PHP smokes.
+ *
+ * @package DataMachineCode\Workspace
+ * @since   0.8.0
+ */
+
+namespace DataMachineCode\Workspace;
+
+defined( 'ABSPATH' ) || exit;
+
+final class WorktreeBootstrapper {
+
+	/**
+	 * Step kinds in the order they are executed.
+	 */
+	public const STEP_SUBMODULES = 'submodules';
+	public const STEP_PACKAGES   = 'packages';
+	public const STEP_COMPOSER   = 'composer';
+
+	/**
+	 * Status values reported per step.
+	 */
+	public const STATUS_RAN     = 'ran';      // Command executed and exited 0.
+	public const STATUS_SKIPPED = 'skipped';  // No trigger file, or tool unavailable.
+	public const STATUS_FAILED  = 'failed';   // Command executed but exited non-zero.
+
+	/**
+	 * Output size cap (bytes) retained per step. Bootstrap installs can emit
+	 * tens of megabytes of log noise; we keep the tail for diagnostics only.
+	 */
+	private const OUTPUT_CAP_BYTES = 4096;
+
+	/**
+	 * Run all applicable bootstrap steps inside the given worktree.
+	 *
+	 * @param string $worktree_path Absolute path to the worktree root.
+	 * @return array{
+	 *     success: bool,
+	 *     ran_any: bool,
+	 *     steps: array<int, array{
+	 *         step: string,
+	 *         status: string,
+	 *         reason?: string,
+	 *         command?: string,
+	 *         exit_code?: int,
+	 *         output_tail?: string,
+	 *     }>,
+	 * }
+	 */
+	public static function bootstrap( string $worktree_path ): array {
+		$steps = array();
+
+		$steps[] = self::run_submodules( $worktree_path );
+		$steps[] = self::run_packages( $worktree_path );
+		$steps[] = self::run_composer( $worktree_path );
+
+		$failed  = array_filter( $steps, fn( $s ) => self::STATUS_FAILED === ( $s['status'] ?? '' ) );
+		$ran_any = (bool) array_filter( $steps, fn( $s ) => self::STATUS_RAN === ( $s['status'] ?? '' ) );
+
+		return array(
+			'success' => empty( $failed ),
+			'ran_any' => $ran_any,
+			'steps'   => $steps,
+		);
+	}
+
+	/**
+	 * Detect which bootstrap steps WOULD run for a given worktree path, without
+	 * executing anything. Useful for diagnostics and for the smoke test.
+	 *
+	 * @param string $worktree_path Absolute path to the worktree root.
+	 * @return array{
+	 *     submodules: bool,
+	 *     packages: ?string,  // Package manager slug ("pnpm", "bun", "yarn", "npm") or null.
+	 *     composer: bool,
+	 * }
+	 */
+	public static function detect( string $worktree_path ): array {
+		return array(
+			'submodules' => is_file( rtrim( $worktree_path, '/' ) . '/.gitmodules' ),
+			'packages'   => self::detect_package_manager( $worktree_path ),
+			'composer'   => is_file( rtrim( $worktree_path, '/' ) . '/composer.lock' ),
+		);
+	}
+
+	/**
+	 * Pretty-print a bootstrap result as a multi-line human-readable block.
+	 *
+	 * @param array $result Result from {@see self::bootstrap()}.
+	 * @return string
+	 */
+	public static function format( array $result ): string {
+		$steps = is_array( $result['steps'] ?? null ) ? $result['steps'] : array();
+		if ( empty( $steps ) ) {
+			return 'Bootstrap: no steps attempted.';
+		}
+
+		$lines = array();
+		foreach ( $steps as $step ) {
+			$kind   = (string) ( $step['step'] ?? '?' );
+			$status = (string) ( $step['status'] ?? '?' );
+			$reason = (string) ( $step['reason'] ?? '' );
+			$cmd    = (string) ( $step['command'] ?? '' );
+
+			switch ( $status ) {
+				case self::STATUS_RAN:
+					$lines[] = sprintf( '  ✓ %-10s ran: %s', $kind, $cmd );
+					break;
+				case self::STATUS_SKIPPED:
+					$lines[] = sprintf( '  - %-10s skipped (%s)', $kind, '' !== $reason ? $reason : 'no trigger' );
+					break;
+				case self::STATUS_FAILED:
+					$exit    = isset( $step['exit_code'] ) ? (int) $step['exit_code'] : -1;
+					$lines[] = sprintf( '  ✗ %-10s FAILED (exit %d): %s', $kind, $exit, $cmd );
+					if ( ! empty( $step['output_tail'] ) ) {
+						foreach ( explode( "\n", (string) $step['output_tail'] ) as $out_line ) {
+							$lines[] = '      ' . $out_line;
+						}
+					}
+					break;
+				default:
+					$lines[] = sprintf( '  ? %-10s %s', $kind, $status );
+			}
+		}
+
+		return implode( "\n", $lines );
+	}
+
+	/**
+	 * Run `git submodule update --init --recursive` if `.gitmodules` is present.
+	 */
+	private static function run_submodules( string $worktree_path ): array {
+		if ( ! is_file( rtrim( $worktree_path, '/' ) . '/.gitmodules' ) ) {
+			return array(
+				'step'   => self::STEP_SUBMODULES,
+				'status' => self::STATUS_SKIPPED,
+				'reason' => 'no .gitmodules',
+			);
+		}
+
+		if ( ! self::binary_available( 'git' ) ) {
+			return array(
+				'step'   => self::STEP_SUBMODULES,
+				'status' => self::STATUS_SKIPPED,
+				'reason' => 'git not on PATH',
+			);
+		}
+
+		return self::run_command(
+			self::STEP_SUBMODULES,
+			$worktree_path,
+			'git submodule update --init --recursive'
+		);
+	}
+
+	/**
+	 * Run the detected package manager's install command, if any.
+	 */
+	private static function run_packages( string $worktree_path ): array {
+		$pm = self::detect_package_manager( $worktree_path );
+		if ( null === $pm ) {
+			return array(
+				'step'   => self::STEP_PACKAGES,
+				'status' => self::STATUS_SKIPPED,
+				'reason' => 'no lockfile',
+			);
+		}
+
+		if ( ! self::binary_available( $pm ) ) {
+			return array(
+				'step'   => self::STEP_PACKAGES,
+				'status' => self::STATUS_SKIPPED,
+				'reason' => sprintf( '%s not on PATH (lockfile present)', $pm ),
+			);
+		}
+
+		$command = match ( $pm ) {
+			'pnpm'  => 'pnpm install --frozen-lockfile',
+			'bun'   => 'bun install --frozen-lockfile',
+			'yarn'  => 'yarn install --immutable',
+			'npm'   => 'npm ci',
+			default => '',
+		};
+
+		if ( '' === $command ) {
+			return array(
+				'step'   => self::STEP_PACKAGES,
+				'status' => self::STATUS_SKIPPED,
+				'reason' => sprintf( 'unsupported package manager %s', $pm ),
+			);
+		}
+
+		return self::run_command( self::STEP_PACKAGES, $worktree_path, $command );
+	}
+
+	/**
+	 * Run `composer install` if `composer.lock` is present.
+	 */
+	private static function run_composer( string $worktree_path ): array {
+		if ( ! is_file( rtrim( $worktree_path, '/' ) . '/composer.lock' ) ) {
+			return array(
+				'step'   => self::STEP_COMPOSER,
+				'status' => self::STATUS_SKIPPED,
+				'reason' => 'no composer.lock',
+			);
+		}
+
+		if ( ! self::binary_available( 'composer' ) ) {
+			return array(
+				'step'   => self::STEP_COMPOSER,
+				'status' => self::STATUS_SKIPPED,
+				'reason' => 'composer not on PATH',
+			);
+		}
+
+		return self::run_command(
+			self::STEP_COMPOSER,
+			$worktree_path,
+			'composer install --no-interaction --prefer-dist'
+		);
+	}
+
+	/**
+	 * Detect the active package manager for a checkout based on lockfile
+	 * presence. Order: pnpm > bun > yarn > npm. A repo with multiple lockfiles
+	 * picks whichever is highest-priority — this matches the convention most
+	 * tooling (corepack, package-manager-detector) uses.
+	 *
+	 * Returns null if no supported lockfile is present, including when
+	 * `package.json` exists alone (no lockfile → we can't run a reproducible
+	 * install, so we skip rather than guess).
+	 *
+	 * @return string|null One of: "pnpm", "bun", "yarn", "npm", or null.
+	 */
+	private static function detect_package_manager( string $worktree_path ): ?string {
+		$root = rtrim( $worktree_path, '/' );
+		if ( is_file( $root . '/pnpm-lock.yaml' ) ) {
+			return 'pnpm';
+		}
+		// Bun supports both the binary lockb and the text lock file.
+		if ( is_file( $root . '/bun.lockb' ) || is_file( $root . '/bun.lock' ) ) {
+			return 'bun';
+		}
+		if ( is_file( $root . '/yarn.lock' ) ) {
+			return 'yarn';
+		}
+		if ( is_file( $root . '/package-lock.json' ) ) {
+			return 'npm';
+		}
+		return null;
+	}
+
+	/**
+	 * Is a binary available on PATH? Uses `command -v` which is portable across
+	 * bash/zsh/dash — `which` is not POSIX.
+	 */
+	private static function binary_available( string $binary ): bool {
+		if ( '' === $binary || ! preg_match( '/^[a-zA-Z0-9_.\-]+$/', $binary ) ) {
+			return false;
+		}
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
+		exec( sprintf( 'command -v %s 2>/dev/null', escapeshellarg( $binary ) ), $_unused, $exit );
+		return 0 === $exit;
+	}
+
+	/**
+	 * Execute a command inside the worktree and capture a result envelope.
+	 *
+	 * Note: we do not shell-escape the command itself — these are hard-coded
+	 * invocations, not user input. The `cd` target is escaped.
+	 */
+	private static function run_command( string $step, string $worktree_path, string $command ): array {
+		$cd = escapeshellarg( $worktree_path );
+		$shell_cmd = sprintf( 'cd %s && %s 2>&1', $cd, $command );
+
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
+		exec( $shell_cmd, $output, $exit_code );
+
+		$joined = implode( "\n", $output );
+		if ( strlen( $joined ) > self::OUTPUT_CAP_BYTES ) {
+			$joined = '...' . substr( $joined, -1 * self::OUTPUT_CAP_BYTES );
+		}
+
+		if ( 0 !== $exit_code ) {
+			return array(
+				'step'        => $step,
+				'status'      => self::STATUS_FAILED,
+				'command'     => $command,
+				'exit_code'   => $exit_code,
+				'output_tail' => $joined,
+			);
+		}
+
+		return array(
+			'step'        => $step,
+			'status'      => self::STATUS_RAN,
+			'command'     => $command,
+			'exit_code'   => 0,
+			'output_tail' => $joined,
+		);
+	}
+}

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -10,10 +10,12 @@ including safety-rail regressions) lives in `smoke-worktree-cleanup.php`.
 ```bash
 php tests/smoke-worktree-handles.php     # pure-unit, fast
 php tests/smoke-worktree-cleanup.php     # spawns a real git workspace
+php tests/smoke-worktree-bootstrap.php   # fixture + real git, no WP required
 ```
 
-Expected: `32/32 passed` and `18/18 passed` respectively. Skip
-`smoke-worktree-cleanup.php` if `git` is unavailable.
+Expected: `32/32 passed`, `18/18 passed`, and `30/30 passed` respectively.
+Skip `smoke-worktree-cleanup.php` and `smoke-worktree-bootstrap.php` if `git`
+is unavailable.
 
 Prereqs:
 - WordPress 6.9+ with Data Machine + data-machine-code activated.
@@ -65,6 +67,41 @@ wp datamachine-code workspace worktree add data-machine-code feat/test-worktree
 ```
 
 Expected: `worktree_exists` error.
+
+### 3a. Bootstrap-on-by-default and the `--skip-bootstrap` escape hatch
+
+`worktree add` runs the bootstrap pass by default:
+
+```bash
+wp datamachine-code workspace worktree add data-machine-code feat/bootstrap-smoke
+ls ~/.datamachine/workspace/data-machine-code@feat-bootstrap-smoke/vendor/composer/
+```
+
+Expected:
+- Output includes a `Bootstrap: ok` block listing each step (submodules
+  skipped, packages skipped or ran depending on lockfile presence,
+  composer ran).
+- `vendor/composer/` exists inside the worktree (composer install ran).
+- For a repo with `package-lock.json` the bootstrap block shows `packages
+  ran: npm ci` (pnpm/bun/yarn equivalents for their lockfiles) and
+  `node_modules/` is populated.
+- Re-running `worktree add` still errors with `worktree_exists` before
+  bootstrap runs — a failed bootstrap never half-creates worktrees.
+
+Escape hatch — skip the bootstrap pass when you only need to read code:
+
+```bash
+wp datamachine-code workspace worktree add data-machine-code feat/readonly-smoke --skip-bootstrap
+ls ~/.datamachine/workspace/data-machine-code@feat-readonly-smoke/vendor 2>&1
+```
+
+Expected:
+- No `Bootstrap: …` block in the output.
+- `vendor/` and `node_modules/` do not exist in the worktree.
+
+Negative case — a step with a missing tool downgrades to skipped rather
+than failing (simulate by temporarily moving `composer` off PATH; skip the
+submodule step by adding a repo without `.gitmodules`).
 
 ## 4. Operate on the worktree handle
 

--- a/tests/smoke-worktree-bootstrap.php
+++ b/tests/smoke-worktree-bootstrap.php
@@ -1,0 +1,223 @@
+<?php
+/**
+ * Pure-PHP smoke test for WorktreeBootstrapper detection + execution.
+ *
+ * Run: php tests/smoke-worktree-bootstrap.php
+ *
+ * Covers:
+ *   - detect() returns the expected booleans / package-manager slug for
+ *     synthetic worktree fixtures with various lockfile combinations
+ *   - bootstrap() skips gracefully when nothing is present (all STATUS_SKIPPED)
+ *   - bootstrap() runs `git submodule update` successfully against a real
+ *     on-disk repo with an empty `.gitmodules`
+ *   - format() produces a human-readable summary
+ */
+
+declare( strict_types=1 );
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+require __DIR__ . '/../inc/Workspace/WorktreeBootstrapper.php';
+
+use DataMachineCode\Workspace\WorktreeBootstrapper;
+
+$failures = 0;
+$total    = 0;
+
+$assert = function ( $expected, $actual, string $message ) use ( &$failures, &$total ): void {
+	$total++;
+	if ( $expected === $actual ) {
+		echo "  ✓ {$message}\n";
+		return;
+	}
+	$failures++;
+	echo "  ✗ {$message}\n";
+	echo "    expected: " . var_export( $expected, true ) . "\n";
+	echo "    actual:   " . var_export( $actual, true ) . "\n";
+};
+
+$assert_true = function ( $condition, string $message ) use ( &$failures, &$total ): void {
+	$total++;
+	if ( $condition ) {
+		echo "  ✓ {$message}\n";
+		return;
+	}
+	$failures++;
+	echo "  ✗ {$message}\n";
+};
+
+// -----------------------------------------------------------------------------
+// Fixture helpers
+// -----------------------------------------------------------------------------
+
+$make_fixture = function ( array $files ): string {
+	$root = sys_get_temp_dir() . '/dmc-bootstrap-smoke-' . bin2hex( random_bytes( 4 ) );
+	mkdir( $root, 0755, true );
+	foreach ( $files as $relative => $body ) {
+		$abs = $root . '/' . $relative;
+		$dir = dirname( $abs );
+		if ( ! is_dir( $dir ) ) {
+			mkdir( $dir, 0755, true );
+		}
+		file_put_contents( $abs, $body );
+	}
+	return $root;
+};
+
+$cleanup = function ( string $path ): void {
+	if ( ! is_dir( $path ) ) {
+		return;
+	}
+	$it = new RecursiveIteratorIterator(
+		new RecursiveDirectoryIterator( $path, FilesystemIterator::SKIP_DOTS ),
+		RecursiveIteratorIterator::CHILD_FIRST
+	);
+	foreach ( $it as $entry ) {
+		$entry->isDir() ? rmdir( $entry->getPathname() ) : unlink( $entry->getPathname() );
+	}
+	rmdir( $path );
+};
+
+// -----------------------------------------------------------------------------
+// detect()
+// -----------------------------------------------------------------------------
+
+echo "detect()\n";
+
+$empty = $make_fixture( array() );
+$d     = WorktreeBootstrapper::detect( $empty );
+$assert( false, $d['submodules'], 'empty dir: submodules=false' );
+$assert( null, $d['packages'], 'empty dir: packages=null' );
+$assert( false, $d['composer'], 'empty dir: composer=false' );
+$cleanup( $empty );
+
+$pnpm = $make_fixture(
+	array(
+		'package.json'    => '{"name":"x"}',
+		'pnpm-lock.yaml'  => "lockfileVersion: '6.0'\n",
+		'.gitmodules'     => "[submodule \"vendor/foo\"]\n\tpath = vendor/foo\n\turl = https://example.com/foo.git\n",
+		'composer.lock'   => '{"packages":[]}',
+	)
+);
+$d = WorktreeBootstrapper::detect( $pnpm );
+$assert( true, $d['submodules'], 'pnpm fixture: submodules detected' );
+$assert( 'pnpm', $d['packages'], 'pnpm fixture: packages=pnpm' );
+$assert( true, $d['composer'], 'pnpm fixture: composer detected' );
+$cleanup( $pnpm );
+
+// Priority: pnpm beats bun beats yarn beats npm when multiple are present.
+$multi = $make_fixture(
+	array(
+		'pnpm-lock.yaml'    => '',
+		'bun.lockb'         => '',
+		'yarn.lock'         => '',
+		'package-lock.json' => '{}',
+	)
+);
+$assert( 'pnpm', WorktreeBootstrapper::detect( $multi )['packages'], 'pnpm wins over bun/yarn/npm' );
+$cleanup( $multi );
+
+$bun = $make_fixture( array( 'bun.lockb' => '', 'yarn.lock' => '', 'package-lock.json' => '{}' ) );
+$assert( 'bun', WorktreeBootstrapper::detect( $bun )['packages'], 'bun wins over yarn/npm' );
+$cleanup( $bun );
+
+$bun_text = $make_fixture( array( 'bun.lock' => '', 'package-lock.json' => '{}' ) );
+$assert( 'bun', WorktreeBootstrapper::detect( $bun_text )['packages'], 'bun.lock (text) detected' );
+$cleanup( $bun_text );
+
+$yarn = $make_fixture( array( 'yarn.lock' => '', 'package-lock.json' => '{}' ) );
+$assert( 'yarn', WorktreeBootstrapper::detect( $yarn )['packages'], 'yarn wins over npm' );
+$cleanup( $yarn );
+
+$npm = $make_fixture( array( 'package-lock.json' => '{}' ) );
+$assert( 'npm', WorktreeBootstrapper::detect( $npm )['packages'], 'npm when only package-lock.json' );
+$cleanup( $npm );
+
+// No lockfile → null even with package.json present.
+$pkg_only = $make_fixture( array( 'package.json' => '{}' ) );
+$assert( null, WorktreeBootstrapper::detect( $pkg_only )['packages'], 'package.json alone → null (no lockfile)' );
+$cleanup( $pkg_only );
+
+// -----------------------------------------------------------------------------
+// bootstrap() skip behavior
+// -----------------------------------------------------------------------------
+
+echo "\nbootstrap() on empty dir → all skipped\n";
+
+$empty = $make_fixture( array() );
+$r     = WorktreeBootstrapper::bootstrap( $empty );
+$assert( true, $r['success'], 'empty dir: success=true' );
+$assert( false, $r['ran_any'], 'empty dir: ran_any=false' );
+$assert( 3, count( $r['steps'] ), 'empty dir: 3 step results' );
+foreach ( $r['steps'] as $step ) {
+	$assert( WorktreeBootstrapper::STATUS_SKIPPED, $step['status'], sprintf( 'step %s skipped', $step['step'] ) );
+}
+$cleanup( $empty );
+
+// -----------------------------------------------------------------------------
+// bootstrap() submodule path (real git repo)
+// -----------------------------------------------------------------------------
+
+echo "\nbootstrap() runs submodule update on a real repo\n";
+
+// Build a real git repo with an empty `.gitmodules` so `git submodule update`
+// has something to run against (empty but valid). We deliberately skip
+// packages/composer steps by omitting lockfiles.
+$repo = sys_get_temp_dir() . '/dmc-bootstrap-git-' . bin2hex( random_bytes( 4 ) );
+mkdir( $repo, 0755, true );
+exec( sprintf( 'cd %s && git init -q --initial-branch=main 2>&1', escapeshellarg( $repo ) ), $_u, $init_exit );
+if ( 0 !== $init_exit ) {
+	echo "  - skipped: git init failed (git unavailable?)\n";
+} else {
+	file_put_contents( $repo . '/.gitmodules', "" );
+	file_put_contents( $repo . '/README.md', "x\n" );
+	exec( sprintf( 'cd %s && git -c user.email=t@t -c user.name=t add -A && git -c user.email=t@t -c user.name=t commit -q -m init 2>&1', escapeshellarg( $repo ) ), $_u, $commit_exit );
+	$assert( 0, $commit_exit, 'seed commit created' );
+
+	$r = WorktreeBootstrapper::bootstrap( $repo );
+	$assert( true, $r['success'], 'submodule repo: success' );
+	$assert( true, $r['ran_any'], 'submodule repo: ran_any=true' );
+
+	$by_step = array();
+	foreach ( $r['steps'] as $step ) {
+		$by_step[ $step['step'] ] = $step;
+	}
+
+	$assert( WorktreeBootstrapper::STATUS_RAN, $by_step['submodules']['status'], 'submodules: ran' );
+	$assert_true( str_contains( $by_step['submodules']['command'] ?? '', 'submodule update --init --recursive' ), 'submodules: correct command' );
+	$assert( WorktreeBootstrapper::STATUS_SKIPPED, $by_step['packages']['status'], 'packages: skipped (no lockfile)' );
+	$assert( WorktreeBootstrapper::STATUS_SKIPPED, $by_step['composer']['status'], 'composer: skipped (no composer.lock)' );
+}
+$cleanup( $repo );
+
+// -----------------------------------------------------------------------------
+// format() output shape
+// -----------------------------------------------------------------------------
+
+echo "\nformat() output\n";
+
+$result = array(
+	'success' => false,
+	'ran_any' => true,
+	'steps'   => array(
+		array( 'step' => 'submodules', 'status' => WorktreeBootstrapper::STATUS_RAN, 'command' => 'git submodule update --init --recursive' ),
+		array( 'step' => 'packages', 'status' => WorktreeBootstrapper::STATUS_FAILED, 'command' => 'npm ci', 'exit_code' => 1, 'output_tail' => 'npm ERR! missing:  foo@1' ),
+		array( 'step' => 'composer', 'status' => WorktreeBootstrapper::STATUS_SKIPPED, 'reason' => 'no composer.lock' ),
+	),
+);
+$out = WorktreeBootstrapper::format( $result );
+$assert_true( str_contains( $out, '✓' ), 'format: contains ran marker' );
+$assert_true( str_contains( $out, '✗' ), 'format: contains failed marker' );
+$assert_true( str_contains( $out, 'skipped (no composer.lock)' ), 'format: contains skip reason' );
+$assert_true( str_contains( $out, 'npm ERR! missing' ), 'format: contains failure output tail' );
+
+// Empty-steps case.
+$empty_fmt = WorktreeBootstrapper::format( array( 'success' => true, 'ran_any' => false, 'steps' => array() ) );
+$assert_true( str_contains( $empty_fmt, 'no steps attempted' ), 'format: empty steps message' );
+
+// -----------------------------------------------------------------------------
+echo "\n{$total} total, ";
+echo ( 0 === $failures ) ? "{$total}/{$total} passed\n" : "{$failures} failed\n";
+exit( $failures > 0 ? 1 : 0 );


### PR DESCRIPTION
## Summary

`worktree add` now runs detected setup steps **by default** so the new checkout is immediately test/build-ready. Pass `--skip-bootstrap` to opt out for pure-read use. Closes #50.

```bash
# Default: bootstrapped, ready to test/build
wp datamachine-code workspace worktree add <repo> <branch>

# Opt out for a bare checkout
wp datamachine-code workspace worktree add <repo> <branch> --skip-bootstrap
```

## Why on by default

The earlier draft of this PR shipped `--bootstrap` as opt-in (matching the wording in the issue). Reconsidered after discussion: worktrees are overwhelmingly created to do **branch work** (run tests, build, commit, push), not to read code. Read-only consumers can use the **primary checkout**, which is already read-only by default. Making bootstrap opt-in forces every new agent to know about the flag or they silently hit the exact trap the issue describes (`vitest can't load spec`, `sh: nx: command not found`).

Making it on-by-default with a `--skip-bootstrap` escape hatch mirrors the existing `inject_context=true` + `--skip-context-injection` convention for agent-memory injection from #45. Consistent mental model across worktree setup surfaces.

## What bootstrap does

Three independent steps, in order, each skipped gracefully when trigger file or tool is missing:

1. `git submodule update --init --recursive` — if `.gitmodules` exists
2. Package-manager install — based on lockfile priority (**pnpm > bun > yarn > npm**):
   - `pnpm-lock.yaml` → `pnpm install --frozen-lockfile`
   - `bun.lockb` / `bun.lock` → `bun install --frozen-lockfile`
   - `yarn.lock` → `yarn install --immutable`
   - `package-lock.json` → `npm ci`
3. `composer install --no-interaction --prefer-dist` — if `composer.lock` exists

A repo with `package.json` but no lockfile is treated as "no package-manager step" — we never guess which manager to use.

## Safety model

- **Graceful degradation.** Missing tool on `$PATH` reports `skipped` with a reason, not an error. Missing trigger file = skipped.
- **No rollback on failure.** A failed step is surfaced as `FAILED` in the result and shown as a CLI warning, but the worktree itself stays created so the user can retry manually. Matches the existing `context_injected=false + context_skip_reason=…` precedent from #45.
- **No WordPress coupling.** `WorktreeBootstrapper` is a pure class so `tests/smoke-worktree-bootstrap.php` exercises it without a WP bootstrap.

## Output

```
Success: Worktree "data-machine@feat-foo" added at … (branch feat-foo).
Handle: data-machine@feat-foo
Path:   /Users/…/data-machine@feat-foo
Branch: feat-foo (created)
Context: injected (2 files)
  - …/.claude/CLAUDE.local.md
  - …/.opencode/AGENTS.local.md
Bootstrap: ok
  - submodules skipped (no .gitmodules)
  ✓ packages   ran: npm ci
  ✓ composer   ran: composer install --no-interaction --prefer-dist
```

## Files

- **New:** `inc/Workspace/WorktreeBootstrapper.php` — detect + bootstrap + format helpers
- **New:** `tests/smoke-worktree-bootstrap.php` — 30 assertions covering detection priority, skip behavior, real-repo submodule run, failure formatting
- **Modified:** `inc/Workspace/Workspace.php` — new `$bootstrap` param on `worktree_add()` (default `true`)
- **Modified:** `inc/Abilities/WorkspaceAbilities.php` — `bootstrap` input on `datamachine/workspace-worktree-add` (default `true`) + output schema
- **Modified:** `inc/Cli/Commands/WorkspaceCommand.php` — `--skip-bootstrap` flag, help block, result rendering
- **Modified:** `tests/TESTING.md` — new section 3a for the CLI smoke

## Testing

**Pure smokes (62/62 passing):**

```
$ php tests/smoke-worktree-bootstrap.php
30/30 passed

$ php tests/smoke-worktree-handles.php
32/32 passed
```

Covers: detect() priority (pnpm > bun > yarn > npm), skip on empty dir, real-repo submodule run, format() output shape (ran + failed + skipped markers, failure output tail).

**Live CLI tests on `intelligence-chubes4` Studio site:**

| Scenario | Repo | Result |
| --- | --- | --- |
| Default (no flag) on Node+PHP repo | `data-machine` | ✓ submodules skipped, `npm ci` ran, `composer install` ran, `node_modules/` + `vendor/` populated |
| `--skip-bootstrap` | `data-machine-code` | ✓ no bootstrap block shown, no `vendor/` in worktree |
| Default on PHP-only repo | `data-machine-code` | ✓ submodules skipped, packages skipped (no lockfile), composer ran |
| `--skip-context-injection` default-bootstrap | `data-machine-code` | ✓ context skipped, bootstrap ran |

## Out of scope (follow-ups)

- Repo-declared manifest (`.datamachine/worktree.yml`) for custom chains like `nx build shared-types` — option 3 in #50
- Teardown on `worktree remove`
- pnpm-style content-addressed `node_modules` sharing across worktrees

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Drafted the full implementation (detector + runner + CLI wiring + smoke test + TESTING.md update). Chris challenged the initial opt-in default, which was flipped to on-by-default with a `--skip-bootstrap` escape hatch. Chris ran live worktree-add scenarios on `data-machine` and `data-machine-code` from the `intelligence-chubes4` Studio site to confirm end-to-end behavior for both defaults and the escape hatch.