### PR TITLE
feat(workspace): surface worktree staleness at create-time (refs #52)

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -755,6 +755,30 @@ class WorkspaceAbilities {
 								'type'        => 'object',
 								'description' => 'Present only when bootstrap=true. Contains success/ran_any booleans and a steps array.',
 							),
+							'fetch_failed'        => array(
+								'type'        => 'boolean',
+								'description' => 'Present only when the pre-create `git fetch origin` failed. Worktree creation continues either way; staleness fields are omitted when true.',
+							),
+							'fetch_error'         => array(
+								'type'        => 'string',
+								'description' => 'Present only when fetch_failed=true. Trimmed error output from the failing fetch.',
+							),
+							'stale_commits_behind' => array(
+								'type'        => 'integer',
+								'description' => 'For the existing-local-branch path, how many commits the worktree branch is behind its configured upstream. Omitted when no upstream is configured.',
+							),
+							'upstream'            => array(
+								'type'        => 'string',
+								'description' => 'Paired with stale_commits_behind: the upstream ref label (e.g. `origin/fix/foo`).',
+							),
+							'base_stale_commits_behind' => array(
+								'type'        => 'integer',
+								'description' => 'For the new-branch path cut from a local base ref: how many commits that local base is behind its origin counterpart at fetch time.',
+							),
+							'base_upstream'       => array(
+								'type'        => 'string',
+								'description' => 'Paired with base_stale_commits_behind: the origin ref the local base was compared against (e.g. `origin/main`).',
+							),
 						),
 					),
 					'execute_callback'    => array( self::class, 'worktreeAdd' ),

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1188,6 +1188,7 @@ class WorkspaceCommand extends BaseCommand {
 						WP_CLI::warning( 'Worktree was created but bootstrap had failures. Re-run the failing step manually, or remove and retry.' );
 					}
 				}
+				$this->render_worktree_freshness( $result );
 				return;
 
 			case 'refresh-context':
@@ -1210,5 +1211,70 @@ class WorkspaceCommand extends BaseCommand {
 				WP_CLI::success( $result['message'] ?? 'Worktree operation complete.' );
 				return;
 		}
+	}
+
+	/**
+	 * Render the freshness block for `worktree add` results.
+	 *
+	 * States, in priority order:
+	 *   - fetch_failed=true         → `⚠ fetch failed — staleness unknown` (warning)
+	 *   - stale_commits_behind>0    → `⚠ <N> commits behind <upstream>` (warning + rebase hint)
+	 *   - base_stale_commits_behind>0 → `⚠ base was <N> commits behind <base_upstream>` (warning + rebase hint)
+	 *   - otherwise                 → `Freshness: up to date` (log)
+	 *
+	 * When no staleness signal is present at all (no fetch attempt recorded,
+	 * no upstream configured, defaults used) the line is elided entirely —
+	 * silence beats an ambiguous "up to date" we can't actually vouch for.
+	 *
+	 * @param array $result Ability result payload.
+	 * @return void
+	 */
+	private function render_worktree_freshness( array $result ): void {
+		if ( ! empty( $result['fetch_failed'] ) ) {
+			$msg = 'Freshness: ⚠ fetch failed — staleness unknown';
+			if ( ! empty( $result['fetch_error'] ) ) {
+				$msg .= "\n  " . $result['fetch_error'];
+			}
+			WP_CLI::warning( $msg );
+			return;
+		}
+
+		if ( isset( $result['stale_commits_behind'] ) ) {
+			$behind   = (int) $result['stale_commits_behind'];
+			$upstream = isset( $result['upstream'] ) ? (string) $result['upstream'] : 'upstream';
+			if ( $behind > 0 ) {
+				WP_CLI::warning( sprintf(
+					"Freshness: ⚠ %d commits behind %s\n  Rebase before opening a PR:\n    git -C %s pull --rebase origin %s",
+					$behind,
+					$upstream,
+					$result['path'] ?? '<worktree>',
+					$result['branch'] ?? '<branch>'
+				) );
+				return;
+			}
+			WP_CLI::log( sprintf( 'Freshness: up to date (vs %s)', $upstream ) );
+			return;
+		}
+
+		if ( isset( $result['base_stale_commits_behind'] ) ) {
+			$behind        = (int) $result['base_stale_commits_behind'];
+			$base_upstream = isset( $result['base_upstream'] ) ? (string) $result['base_upstream'] : 'origin';
+			if ( $behind > 0 ) {
+				WP_CLI::warning( sprintf(
+					"Freshness: ⚠ base was %d commits behind %s\n  Rebase before opening a PR:\n    git -C %s pull --rebase origin %s",
+					$behind,
+					$base_upstream,
+					$result['path'] ?? '<worktree>',
+					$result['branch'] ?? '<branch>'
+				) );
+				return;
+			}
+			WP_CLI::log( sprintf( 'Freshness: up to date (base %s)', $base_upstream ) );
+			return;
+		}
+
+		// No signal available (default base was origin/HEAD, or no upstream
+		// configured for the existing branch). Elide the line rather than
+		// print a potentially-misleading "up to date".
 	}
 }

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -876,7 +876,7 @@ class Workspace {
 	 * @param string|null $from           Base ref when creating the branch.
 	 * @param bool        $inject_context Whether to inject site-agent context (default true).
 	 * @param bool        $bootstrap      Whether to run submodule/package/composer install after creation (default true).
-	 * @return array{success: bool, handle: string, path: string, branch: string, slug: string, created_branch: bool, message: string, context_injected?: bool, context_files?: string[], context_skip_reason?: string, bootstrap?: array}|\WP_Error
+	 * @return array{success: bool, handle: string, path: string, branch: string, slug: string, created_branch: bool, message: string, context_injected?: bool, context_files?: string[], context_skip_reason?: string, bootstrap?: array, fetch_failed?: bool, fetch_error?: string, stale_commits_behind?: int, upstream?: string, base_stale_commits_behind?: int, base_upstream?: string}|\WP_Error
 	 */
 	public function worktree_add( string $repo, string $branch, ?string $from = null, bool $inject_context = true, bool $bootstrap = true ): array|\WP_Error {
 		$repo   = $this->sanitize_name( $repo );
@@ -907,18 +907,25 @@ class Workspace {
 			return new \WP_Error( 'worktree_exists', sprintf( 'Worktree handle "%s" already exists.', $wt_handle ), array( 'status' => 400 ) );
 		}
 
+		// Always fetch first so staleness data (and the default base) reflects the
+		// current remote. Failure is logged but never aborts — offline work should
+		// still be possible, the agent just needs to know staleness is unknown.
+		$fetch        = WorktreeStalenessProbe::fetch( $primary_path );
+		$fetch_failed = ! $fetch['ok'];
+		$fetch_error  = $fetch['error'] ?? null;
+
 		// Does the branch already exist locally?
 		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
 		exec( sprintf( 'git -C %s show-ref --verify --quiet %s 2>&1', escapeshellarg( $primary_path ), escapeshellarg( 'refs/heads/' . $branch ) ), $_unused, $exists_local );
 		$created_branch = false;
+		$resolved_base  = null;
 
 		if ( 0 === $exists_local ) {
 			$cmd = sprintf( 'worktree add %s %s', escapeshellarg( $wt_path ), escapeshellarg( $branch ) );
 		} else {
-			$base = $from && '' !== trim( $from ) ? trim( $from ) : $this->resolve_default_base( $primary_path );
-			// Fetch first to make sure remote refs are current.
-			$this->run_git( $primary_path, 'fetch --quiet origin' );
-			$cmd = sprintf( 'worktree add -b %s %s %s', escapeshellarg( $branch ), escapeshellarg( $wt_path ), escapeshellarg( $base ) );
+			$base          = $from && '' !== trim( $from ) ? trim( $from ) : $this->resolve_default_base( $primary_path );
+			$resolved_base = $base;
+			$cmd           = sprintf( 'worktree add -b %s %s %s', escapeshellarg( $branch ), escapeshellarg( $wt_path ), escapeshellarg( $base ) );
 			$created_branch = true;
 		}
 
@@ -936,6 +943,49 @@ class Workspace {
 			'created_branch' => $created_branch,
 			'message'        => sprintf( 'Worktree "%s" added at %s (branch %s).', $wt_handle, $wt_path, $branch ),
 		);
+
+		if ( $fetch_failed ) {
+			$response['fetch_failed'] = true;
+			if ( null !== $fetch_error && '' !== $fetch_error ) {
+				$response['fetch_error'] = $fetch_error;
+			}
+		}
+
+		// Compute staleness. Only meaningful when fetch succeeded — otherwise the
+		// upstream refs are potentially stale themselves and any behind-count we
+		// produce would be misleading.
+		if ( ! $fetch_failed ) {
+			if ( ! $created_branch ) {
+				// Existing local branch: compare against its configured upstream.
+				$behind = WorktreeStalenessProbe::behind_count( $wt_path, $branch, '@{upstream}' );
+				if ( is_int( $behind ) ) {
+					$response['stale_commits_behind'] = $behind;
+					// Derive a human-readable upstream label. Best-effort; silently
+					// skipped when git's plumbing doesn't cooperate.
+					$upstream_name = $this->run_git(
+						$wt_path,
+						sprintf( 'rev-parse --abbrev-ref --symbolic-full-name %s', escapeshellarg( $branch . '@{upstream}' ) )
+					);
+					if ( ! is_wp_error( $upstream_name ) ) {
+						$label = trim( (string) ( $upstream_name['output'] ?? '' ) );
+						if ( '' !== $label ) {
+							$response['upstream'] = $label;
+						}
+					}
+				}
+				// null → no upstream configured; WP_Error → unexpected failure.
+				// Both cases: silently omit staleness fields.
+			} elseif ( null !== $resolved_base && ! $this->is_remote_tracking_ref( $resolved_base ) && 'HEAD' !== $resolved_base ) {
+				// New branch cut from a local ref: compare that ref to its origin
+				// counterpart so the agent sees when the base itself was stale.
+				$base_upstream = 'origin/' . $resolved_base;
+				$behind        = WorktreeStalenessProbe::behind_count( $primary_path, $resolved_base, $base_upstream );
+				if ( is_int( $behind ) ) {
+					$response['base_stale_commits_behind'] = $behind;
+					$response['base_upstream']             = $base_upstream;
+				}
+			}
+		}
 
 		if ( ! $inject_context ) {
 			$response['context_injected']    = false;
@@ -1611,6 +1661,21 @@ class Workspace {
 			}
 		}
 		return 'HEAD';
+	}
+
+	/**
+	 * Does a ref look like a remote-tracking ref?
+	 *
+	 * `resolve_default_base()` returns fully-qualified paths
+	 * (`refs/remotes/origin/main`), but callers may pass short forms like
+	 * `origin/main`. Both are "already at-tip post-fetch" and staleness
+	 * comparisons against them would be nonsensical.
+	 *
+	 * @param string $ref Ref name to classify.
+	 * @return bool
+	 */
+	private function is_remote_tracking_ref( string $ref ): bool {
+		return str_starts_with( $ref, 'refs/remotes/' ) || str_starts_with( $ref, 'origin/' );
 	}
 
 	/**

--- a/inc/Workspace/WorktreeStalenessProbe.php
+++ b/inc/Workspace/WorktreeStalenessProbe.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Worktree Staleness Probe
+ *
+ * Helper for `Workspace::worktree_add()` to always fetch remote refs first
+ * and compute how far behind upstream the new worktree's branch (or the
+ * local base it was cut from) is. The result is surfaced verbatim in the
+ * ability response and CLI output so agents can decide whether to rebase
+ * before cooking more changes on a stale base.
+ *
+ * Design choices:
+ *
+ * - `fetch()` never aborts the caller. Network failures, missing `origin`
+ *   remote, or transient DNS hiccups are logged into the result so the
+ *   agent knows staleness data is untrustworthy, but the worktree is still
+ *   created.
+ * - `behind_count()` returns null when no upstream is configured (fresh
+ *   local branch with no tracking). Callers MUST distinguish null from 0 —
+ *   0 means "up to date", null means "cannot tell".
+ * - All git invocations route through `GitRunner` so stderr handling and
+ *   exit-code semantics stay consistent with the rest of the plugin.
+ *
+ * @package DataMachineCode\Workspace
+ * @since   0.7.x
+ */
+
+namespace DataMachineCode\Workspace;
+
+use DataMachineCode\Support\GitRunner;
+
+defined( 'ABSPATH' ) || exit;
+
+final class WorktreeStalenessProbe {
+
+	/**
+	 * Fetch `origin` in a repository. Returns structured result instead of
+	 * throwing so the caller can decide whether to continue on failure.
+	 *
+	 * @param string $repo_path Primary repo path (passed to `git -C`).
+	 * @return array{ok: bool, error?: string}
+	 */
+	public static function fetch( string $repo_path ): array {
+		$result = GitRunner::run( $repo_path, 'fetch --quiet origin' );
+		if ( is_wp_error( $result ) ) {
+			$data  = $result->get_error_data();
+			$tail  = is_array( $data ) && isset( $data['output'] ) ? trim( (string) $data['output'] ) : '';
+			$error = '' !== $tail ? $tail : $result->get_error_message();
+			return array(
+				'ok'    => false,
+				'error' => $error,
+			);
+		}
+		return array( 'ok' => true );
+	}
+
+	/**
+	 * Count commits `$ref` is behind `$upstream` via `git rev-list --count`.
+	 *
+	 * Returns an integer ≥ 0 on success, null when `$upstream` is not
+	 * configured / does not exist, and a WP_Error on any other git failure
+	 * so the caller can surface it without conflating "no upstream" with
+	 * "command errored".
+	 *
+	 * @param string $repo_path Repository path (worktree path or primary).
+	 * @param string $ref       Left-hand revision (e.g. current branch name).
+	 * @param string $upstream  Right-hand revision (e.g. `@{upstream}` or `origin/main`).
+	 * @return int|null|\WP_Error
+	 */
+	public static function behind_count( string $repo_path, string $ref, string $upstream ): int|null|\WP_Error {
+		$args   = sprintf( 'rev-list --count %s..%s', escapeshellarg( $ref ), escapeshellarg( $upstream ) );
+		$result = GitRunner::run( $repo_path, $args );
+		if ( is_wp_error( $result ) ) {
+			$data = $result->get_error_data();
+			$out  = is_array( $data ) && isset( $data['output'] ) ? (string) $data['output'] : '';
+
+			// Missing upstream configuration. Treated as "unknown", not an error.
+			if ( self::is_missing_upstream( $out ) ) {
+				return null;
+			}
+			return $result;
+		}
+
+		$count = self::parse_count( (string) ( $result['output'] ?? '' ) );
+		return $count;
+	}
+
+	/**
+	 * Parse a `rev-list --count` stdout payload into an int. Tolerant of
+	 * trailing whitespace / empty output (returns 0 for empty, matching git).
+	 *
+	 * @param string $output Raw stdout.
+	 * @return int
+	 */
+	public static function parse_count( string $output ): int {
+		$trimmed = trim( $output );
+		if ( '' === $trimmed ) {
+			return 0;
+		}
+		if ( ! preg_match( '/^\d+$/', $trimmed ) ) {
+			return 0;
+		}
+		return (int) $trimmed;
+	}
+
+	/**
+	 * Heuristic: does a git error blob signal "no upstream configured" rather
+	 * than a real failure? Matches the common phrasings git uses across
+	 * versions.
+	 *
+	 * @param string $output Git stderr/stdout.
+	 * @return bool
+	 */
+	public static function is_missing_upstream( string $output ): bool {
+		$needles = array(
+			'no upstream configured',
+			'unknown revision',
+			'bad revision',
+			'ambiguous argument',
+			'No such ref',
+			'Needed a single revision',
+		);
+		foreach ( $needles as $needle ) {
+			if ( false !== stripos( $output, $needle ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/tests/smoke-worktree-staleness.php
+++ b/tests/smoke-worktree-staleness.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Pure-PHP smoke test for WorktreeStalenessProbe.
+ *
+ * Run: php tests/smoke-worktree-staleness.php
+ *
+ * Covers:
+ *   - fetch() success returns ok=true and no error field
+ *   - fetch() failure populates ok=false + trimmed error message
+ *     (synthetic repo with no `origin` remote configured)
+ *   - behind_count() parses the rev-list output to an int on success
+ *   - behind_count() returns null when upstream is not configured
+ *   - parse_count() handles empty / whitespace / non-numeric output
+ *   - is_missing_upstream() matches common git phrasings
+ */
+
+declare( strict_types=1 );
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+// The probe depends on GitRunner and WP_Error. Stub WP_Error minimally so the
+// probe can run without a WP bootstrap, mirroring smoke-worktree-bootstrap.php.
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public string $code;
+		public string $message;
+		public $data;
+		public function __construct( string $code = '', string $message = '', $data = null ) {
+			$this->code    = $code;
+			$this->message = $message;
+			$this->data    = $data;
+		}
+		public function get_error_code() { return $this->code; }
+		public function get_error_message() { return $this->message; }
+		public function get_error_data() { return $this->data; }
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $thing ): bool {
+		return $thing instanceof WP_Error;
+	}
+}
+
+require __DIR__ . '/../inc/Support/GitRunner.php';
+require __DIR__ . '/../inc/Workspace/WorktreeStalenessProbe.php';
+
+use DataMachineCode\Workspace\WorktreeStalenessProbe;
+
+$failures = 0;
+$total    = 0;
+
+$assert = function ( $expected, $actual, string $message ) use ( &$failures, &$total ): void {
+	$total++;
+	if ( $expected === $actual ) {
+		echo "  ✓ {$message}\n";
+		return;
+	}
+	$failures++;
+	echo "  ✗ {$message}\n";
+	echo "    expected: " . var_export( $expected, true ) . "\n";
+	echo "    actual:   " . var_export( $actual, true ) . "\n";
+};
+
+$assert_true = function ( $condition, string $message ) use ( &$failures, &$total ): void {
+	$total++;
+	if ( $condition ) {
+		echo "  ✓ {$message}\n";
+		return;
+	}
+	$failures++;
+	echo "  ✗ {$message}\n";
+};
+
+$cleanup = function ( string $path ): void {
+	if ( ! is_dir( $path ) && ! is_file( $path ) ) {
+		return;
+	}
+	if ( is_file( $path ) ) {
+		unlink( $path );
+		return;
+	}
+	$it = new RecursiveIteratorIterator(
+		new RecursiveDirectoryIterator( $path, FilesystemIterator::SKIP_DOTS ),
+		RecursiveIteratorIterator::CHILD_FIRST
+	);
+	foreach ( $it as $entry ) {
+		$entry->isDir() ? rmdir( $entry->getPathname() ) : unlink( $entry->getPathname() );
+	}
+	rmdir( $path );
+};
+
+// -----------------------------------------------------------------------------
+// parse_count()
+// -----------------------------------------------------------------------------
+
+echo "parse_count()\n";
+$assert( 0, WorktreeStalenessProbe::parse_count( '' ), 'empty string → 0' );
+$assert( 0, WorktreeStalenessProbe::parse_count( "\n" ), 'newline only → 0' );
+$assert( 0, WorktreeStalenessProbe::parse_count( "  \t\n" ), 'whitespace only → 0' );
+$assert( 3, WorktreeStalenessProbe::parse_count( '3' ), 'plain "3"' );
+$assert( 42, WorktreeStalenessProbe::parse_count( "42\n" ), 'trailing newline' );
+$assert( 7, WorktreeStalenessProbe::parse_count( "  7  " ), 'surrounding whitespace' );
+$assert( 0, WorktreeStalenessProbe::parse_count( 'abc' ), 'non-numeric → 0' );
+$assert( 0, WorktreeStalenessProbe::parse_count( '3 extra' ), 'mixed tokens → 0' );
+
+// -----------------------------------------------------------------------------
+// is_missing_upstream()
+// -----------------------------------------------------------------------------
+
+echo "\nis_missing_upstream()\n";
+$assert( true, WorktreeStalenessProbe::is_missing_upstream( "fatal: no upstream configured for branch 'foo'" ), 'no upstream configured' );
+$assert( true, WorktreeStalenessProbe::is_missing_upstream( "fatal: ambiguous argument '@{upstream}': unknown revision" ), 'unknown revision' );
+$assert( true, WorktreeStalenessProbe::is_missing_upstream( "fatal: bad revision 'main..@{u}'" ), 'bad revision' );
+$assert( true, WorktreeStalenessProbe::is_missing_upstream( "fatal: Needed a single revision" ), 'needed a single revision' );
+$assert( false, WorktreeStalenessProbe::is_missing_upstream( "fatal: not a git repository" ), 'generic failure → false' );
+$assert( false, WorktreeStalenessProbe::is_missing_upstream( '' ), 'empty string → false' );
+
+// -----------------------------------------------------------------------------
+// fetch() + behind_count() against real git fixtures
+// -----------------------------------------------------------------------------
+
+echo "\nfetch() + behind_count() against real git fixtures\n";
+
+$which_git = trim( (string) shell_exec( 'command -v git 2>/dev/null' ) );
+if ( '' === $which_git ) {
+	echo "  - skipped: git binary not available on PATH\n";
+} else {
+	// Build a tiny upstream repo with 3 commits on main.
+	$upstream_repo = sys_get_temp_dir() . '/dmc-stale-upstream-' . bin2hex( random_bytes( 4 ) );
+	mkdir( $upstream_repo, 0755, true );
+	exec( sprintf( 'cd %s && git init -q --initial-branch=main', escapeshellarg( $upstream_repo ) ) );
+	for ( $i = 1; $i <= 3; $i++ ) {
+		file_put_contents( $upstream_repo . '/f.txt', "v{$i}\n" );
+		exec( sprintf(
+			'cd %s && git -c user.email=t@t -c user.name=t add -A && git -c user.email=t@t -c user.name=t commit -q -m "c%d"',
+			escapeshellarg( $upstream_repo ),
+			$i
+		) );
+	}
+
+	// Clone into a consumer repo, then reset it back 2 commits so it is
+	// demonstrably "behind" origin/main.
+	$consumer = sys_get_temp_dir() . '/dmc-stale-consumer-' . bin2hex( random_bytes( 4 ) );
+	exec( sprintf( 'git clone -q %s %s', escapeshellarg( $upstream_repo ), escapeshellarg( $consumer ) ) );
+	exec( sprintf( 'cd %s && git reset -q --hard HEAD~2', escapeshellarg( $consumer ) ) );
+
+	// fetch() against a working `origin` → ok.
+	$ok = WorktreeStalenessProbe::fetch( $consumer );
+	$assert( true, $ok['ok'], 'fetch() ok against real origin' );
+	$assert_true( ! isset( $ok['error'] ), 'fetch() ok: no error field set' );
+
+	// behind_count() with upstream configured → 2.
+	$behind = WorktreeStalenessProbe::behind_count( $consumer, 'main', '@{upstream}' );
+	$assert( 2, $behind, 'behind_count main..@{upstream} = 2 (reset back 2)' );
+
+	// behind_count() on a fresh local branch with no tracking → null.
+	exec( sprintf( 'cd %s && git checkout -q -b orphan', escapeshellarg( $consumer ) ) );
+	$no_upstream = WorktreeStalenessProbe::behind_count( $consumer, 'orphan', '@{upstream}' );
+	$assert( null, $no_upstream, 'behind_count() with no @{upstream} → null (not 0, not WP_Error)' );
+
+	// behind_count() against a non-existent ref → null (matches is_missing_upstream heuristic).
+	$bogus = WorktreeStalenessProbe::behind_count( $consumer, 'main', 'origin/does-not-exist' );
+	$assert( null, $bogus, 'behind_count() with unknown upstream ref → null' );
+
+	// behind_count() where ref is up to date with upstream → 0, not null.
+	exec( sprintf( 'cd %s && git checkout -q main && git reset -q --hard origin/main', escapeshellarg( $consumer ) ) );
+	$tip = WorktreeStalenessProbe::behind_count( $consumer, 'main', '@{upstream}' );
+	$assert( 0, $tip, 'behind_count() at tip → 0 (distinct from null)' );
+
+	$cleanup( $consumer );
+	$cleanup( $upstream_repo );
+
+	// fetch() against a repo with NO `origin` remote → ok=false + error populated.
+	$no_origin = sys_get_temp_dir() . '/dmc-stale-no-origin-' . bin2hex( random_bytes( 4 ) );
+	mkdir( $no_origin, 0755, true );
+	exec( sprintf( 'cd %s && git init -q --initial-branch=main', escapeshellarg( $no_origin ) ) );
+	file_put_contents( $no_origin . '/x.txt', "x\n" );
+	exec( sprintf(
+		'cd %s && git -c user.email=t@t -c user.name=t add -A && git -c user.email=t@t -c user.name=t commit -q -m init',
+		escapeshellarg( $no_origin )
+	) );
+
+	$failed = WorktreeStalenessProbe::fetch( $no_origin );
+	$assert( false, $failed['ok'], 'fetch() ok=false when no origin remote' );
+	$assert_true( isset( $failed['error'] ) && '' !== $failed['error'], 'fetch() failure: error field populated' );
+	// The error message should mention origin or remote or repository.
+	$assert_true(
+		isset( $failed['error'] ) && (
+			false !== stripos( $failed['error'], 'origin' )
+			|| false !== stripos( $failed['error'], 'remote' )
+			|| false !== stripos( $failed['error'], 'repository' )
+		),
+		'fetch() failure: error mentions origin/remote/repository'
+	);
+	$cleanup( $no_origin );
+}
+
+// -----------------------------------------------------------------------------
+echo "\n{$total} total, ";
+echo ( 0 === $failures ) ? "{$total}/{$total} passed\n" : "{$failures} failed\n";
+exit( $failures > 0 ? 1 : 0 );


### PR DESCRIPTION
## Summary

`worktree add` now unconditionally fetches `origin` before creating the new checkout, then compares the materialized branch (or the local base it was cut from) against its origin counterpart and surfaces the behind-count in the ability response + CLI output. Agents see **at creation time** that they're about to cook on top of a 47-commit-stale base, instead of discovering it at PR-review time.

Refs #52 (does not close — this is PR 1 of 2; the `--allow-stale` gate + `--rebase-base` opt-in live in a follow-up).

## What changed

Non-breaking and purely additive. No gating, no auto-rebase, no new required inputs. Default invocations behave identically except for a freshness line in CLI output when the probe has something meaningful to say.

### New: `WorktreeStalenessProbe`

Pure helper under `inc/Workspace/`. Two public static methods plus parse utilities:

- `fetch( $repo_path )` — wraps `git fetch --quiet origin`, returns `['ok' => bool, 'error' => string?]`. Never throws. Offline work stays possible; the caller just learns staleness data is untrustworthy.
- `behind_count( $repo_path, $ref, $upstream )` — returns `int` on success, `null` when no upstream is configured, `WP_Error` on unexpected git failure. Callers MUST distinguish `null` from `0` — 0 means "up to date", null means "cannot tell".
- `parse_count()` + `is_missing_upstream()` — tolerant parsing of rev-list output and a heuristic for git's many ways of saying "no upstream configured" (unknown revision / ambiguous argument / bad revision / etc.).

### Modified: `Workspace::worktree_add()`

Three tweaks:

1. **Unconditional fetch** at the top (right after input validation, before `show-ref`). Moved out of the new-branch arm where it used to live. Cheap — shared object store. Fetch failure is recorded in the response as `fetch_failed: true` + `fetch_error: <tail>` but does not abort worktree creation.

2. **Post-creation staleness computation** in two forms:
   - **Existing-local-branch path:** `rev-list --count <branch>..@{upstream}` from the new worktree. Surfaces `stale_commits_behind` + `upstream` (best-effort derived via `rev-parse --abbrev-ref --symbolic-full-name`). When no `@{upstream}` is configured, fields are silently omitted.
   - **New-branch-off-local-base path:** when the resolved base is NOT a remote-tracking ref, compare it against `origin/<base>`. Surfaces `base_stale_commits_behind` + `base_upstream`. When the origin counterpart doesn't exist, silently omitted.

3. **`is_remote_tracking_ref()` helper** — recognizes both `refs/remotes/origin/*` (what `resolve_default_base()` returns for the default-base path) and the shorter `origin/*` form a caller might pass explicitly. Both are "already at-tip post-fetch"; comparing them against themselves would produce nonsense. Caught this in live testing before opening the PR — the first pass used `str_starts_with($resolved_base, 'origin/')` which missed the fully-qualified form.

### Modified: `WorkspaceAbilities`

`datamachine/workspace-worktree-add` output schema gains six optional fields: `fetch_failed`, `fetch_error`, `stale_commits_behind`, `upstream`, `base_stale_commits_behind`, `base_upstream`. All optional — omitted when no meaningful value to report.

### Modified: `WorkspaceCommand`

New `render_worktree_freshness()` runs after the bootstrap block:

```
Bootstrap: ok
  - submodules skipped (no .gitmodules)
  ✓ packages   ran: npm ci
  ✓ composer   ran: composer install --no-interaction --prefer-dist
Warning: Freshness: ⚠ 47 commits behind origin/main
  Rebase before opening a PR:
    git -C /Users/…/data-machine@fix-foo pull --rebase origin main
```

Priority order: `fetch_failed` → existing-branch staleness → base staleness → up-to-date-with-label → elide. The "elide when no signal available" case is deliberate — a default invocation off `origin/HEAD` with no explicit base has no comparison to make, and printing "up to date" there would be claiming something we can't actually vouch for.

## Testing

### Smoke suite: 85/85 passing

```
$ php tests/smoke-worktree-staleness.php
23 total, 23/23 passed

$ php tests/smoke-worktree-bootstrap.php
30/30 passed

$ php tests/smoke-worktree-handles.php
Result: 32/32 passed
```

Covers: `parse_count()` tolerance, `is_missing_upstream()` heuristics across git phrasings, real-git fixtures for fetch success + fetch failure (repo with no `origin`), `behind_count()` returning `int` when behind, `null` when no upstream configured, `null` when upstream ref doesn't exist, `0` when at tip (distinct from null).

### Live CLI tests on `intelligence-chubes4` Studio site

| Scenario | `--from` | Expected | Actual |
| --- | --- | --- | --- |
| Default base (origin/HEAD) | `origin/main` | elide (already remote-tracking) | ✓ elided |
| Local stale base | `feat/workspace-worktrees` (36 behind origin/main, no origin counterpart) | elide (no origin ref) | ✓ elided |
| First-pass bug | `origin/main` resolved to `refs/remotes/origin/main` | **should elide** | ✗ hit broken guard — fixed with `is_remote_tracking_ref()` |

The first-pass bug is what motivated the `is_remote_tracking_ref()` helper. Without it, default invocations would have tried to compute `rev-list refs/remotes/origin/main..origin/refs/remotes/origin/main` and produced garbage output. Caught before commit, test added implicitly via the `origin/` short-form guard staying intact.

## Out of scope (follow-up PR)

- Hard `--allow-stale` gate with a configurable behind-threshold (default 50). This is the behavior-change half of #52.
- `--rebase-base` opt-in auto-rebase.
- Both deserve separate review. Non-breaking additive signal ships here first so the ergonomic surface is in hand before we start gating on it.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Drafted the full implementation (probe helper, Workspace integration, ability schema, CLI rendering, smoke test, PR body). Live-tested against `data-machine-code` on this Studio site — caught the `refs/remotes/origin/*` guard bug mid-session and added the `is_remote_tracking_ref()` helper before commit. Chris steered the scope (PR 1 = non-breaking additive, PR 2 = gating behavior change) and caught the original session-spawn mistake that had the work happening in the wrong checkout.