### PR TITLE
feat(agents-md): contribute homeboy CLI section when on PATH

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -393,6 +393,37 @@ MD;
 		'description' => 'Pointers to WordPress source directories.',
 	) );
 
+	// Homeboy — conditional, only on hosts where the `homeboy` CLI is
+	// callable from PATH. Mirrors the house style of other AGENTS.md
+	// sections: lead with a one-line definition, group with bold
+	// sub-labels, end with a discoverability hint. `homeboy --help`
+	// is the canonical verb list; this section just surfaces the
+	// verbs agents reach for and the repo-level rules.
+	if ( \DataMachineCode\Homeboy::is_available() ) {
+		\DataMachine\Engine\AI\SectionRegistry::register( 'AGENTS.md', 'homeboy', 35, function () {
+			return <<<'MD'
+## Homeboy
+
+`homeboy` is a Rust CLI on this host. Every verb runs the same locally as in CI.
+
+**Quality:** `homeboy audit | lint | test | refactor`
+
+**Git:** prefer `homeboy git changes | status | commit | push | pull | tag` — auto-baselines, structured output, `--json` bulk. One-off reads (`git diff`, `git show`, `git blame`) stay on raw `git`.
+
+**Perf + envs:** `homeboy bench` for pinned benchmarks, `homeboy rig` for reproducible dev environments.
+
+**Repo rules** (when `homeboy.json` is present):
+- **NEVER edit `CHANGELOG.md`** — generated from conventional commits at release time.
+- **NEVER hand-bump version strings** — `feat:`/`fix:`/`BREAKING CHANGE` drive semver; Homeboy rewrites version targets in `homeboy.json`.
+
+Run `homeboy --help` for the full verb list. Operator verbs (`release`, `deploy`, `fleet`, `ssh`) only on explicit ask.
+MD;
+		}, array(
+			'label'       => 'Homeboy',
+			'description' => 'Homeboy CLI — verbs agents reach for + repo rules.',
+		) );
+	}
+
 	// Multisite — conditional, only on multisite installs.
 	if ( is_multisite() ) {
 		\DataMachine\Engine\AI\SectionRegistry::register( 'AGENTS.md', 'multisite', 40, function () use ( $wp ) {

--- a/inc/Homeboy.php
+++ b/inc/Homeboy.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Homeboy capability helper.
+ *
+ * Detects whether the [Homeboy](https://github.com/Extra-Chill/homeboy)
+ * Rust CLI is callable from this host's shell. Homeboy is a code-factory
+ * tool that runs release automation, audits, lints, tests, and git
+ * primitives over local projects. It operates outside WordPress and
+ * never speaks PHP — the only thing DMC needs to know is whether the
+ * binary is on PATH so it can teach agents about the verbs.
+ *
+ * Detection runs once per request and is memoized. Callers should not
+ * shell out themselves; use `is_available()` and rely on Data Machine
+ * Code's `Environment::has_shell()` for the hard gate.
+ *
+ * @package DataMachineCode
+ * @since   0.11.0
+ */
+
+namespace DataMachineCode;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Homeboy {
+
+	/**
+	 * Memoized detection result. Null until the first probe; bool after.
+	 *
+	 * @var bool|null
+	 */
+	private static $available_cache = null;
+
+	/**
+	 * Is the `homeboy` CLI on this host's PATH?
+	 *
+	 * Probes via `command -v homeboy` exactly once per request. Returns
+	 * false on hosts that disable shell functions, on hosts that lack
+	 * the binary, and any time `Environment::has_shell()` returns false.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @return bool True when the binary is callable from the current shell.
+	 */
+	public static function is_available(): bool {
+		if ( null !== self::$available_cache ) {
+			return self::$available_cache;
+		}
+
+		if ( ! Environment::has_shell() ) {
+			self::$available_cache = false;
+			return false;
+		}
+
+		$output = @shell_exec( 'command -v homeboy 2>/dev/null' );
+		self::$available_cache = ! empty( trim( (string) $output ) );
+		return self::$available_cache;
+	}
+
+	/**
+	 * Reset the detection cache.
+	 *
+	 * Test-only seam — production code never needs to re-probe because
+	 * PATH does not change mid-request.
+	 *
+	 * @since 0.11.0
+	 */
+	public static function reset_cache(): void {
+		self::$available_cache = null;
+	}
+}

--- a/tests/smoke-homeboy.php
+++ b/tests/smoke-homeboy.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Pure-PHP smoke test for the Homeboy capability helper.
+ *
+ * Run: php tests/smoke-homeboy.php
+ *
+ * Exercises the shell-probe path against a synthetic PATH so the
+ * result is deterministic regardless of whether the host actually
+ * has `homeboy` installed. Avoids a WP bootstrap.
+ */
+
+declare( strict_types=1 );
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+require __DIR__ . '/../inc/Environment.php';
+require __DIR__ . '/../inc/Homeboy.php';
+
+use DataMachineCode\Environment;
+use DataMachineCode\Homeboy;
+
+$failures = array();
+$assert = function ( string $label, bool $cond ) use ( &$failures ): void {
+	if ( $cond ) {
+		echo "  ✓ {$label}\n";
+		return;
+	}
+	$failures[] = $label;
+	echo "  ✗ {$label}\n";
+};
+
+echo "Homeboy capability helper — smoke\n";
+
+// ── Branch 1: shell unavailable ────────────────────────────────
+// Skip when the host disabled shell_exec entirely.
+if ( Environment::has_shell() ) {
+	echo "  (host has shell — exercising probe paths)\n";
+} else {
+	echo "  (host has no shell — only the absent branch is testable)\n";
+	Homeboy::reset_cache();
+	$assert( 'no shell: is_available() returns false', false === Homeboy::is_available() );
+	echo "\nOK\n";
+	exit( 0 );
+}
+
+$original_path = getenv( 'PATH' ) ?: '';
+$tmp_root      = sys_get_temp_dir() . '/dmc-homeboy-smoke-' . uniqid( '', true );
+mkdir( $tmp_root, 0755, true );
+
+// ── Branch 2: empty PATH → binary not found ────────────────────
+putenv( 'PATH=' . $tmp_root );
+Homeboy::reset_cache();
+$assert( 'empty PATH: is_available() returns false', false === Homeboy::is_available() );
+$assert( 'absent: result is memoized (second call same as first)', false === Homeboy::is_available() );
+
+// ── Branch 3: synthetic homeboy on PATH → detected ─────────────
+$fake_bin = $tmp_root . '/homeboy';
+file_put_contents( $fake_bin, "#!/bin/sh\nexit 0\n" );
+chmod( $fake_bin, 0755 );
+
+putenv( 'PATH=' . $tmp_root );
+Homeboy::reset_cache();
+$assert( 'synthetic on PATH: is_available() returns true', true === Homeboy::is_available() );
+
+// Removing the binary mid-request should NOT flip the result —
+// detection is memoized exactly once.
+unlink( $fake_bin );
+$assert( 'memoization: result sticky after PATH change', true === Homeboy::is_available() );
+
+// reset_cache() lets tests re-probe.
+Homeboy::reset_cache();
+$assert( 'reset_cache: re-probe sees current state', false === Homeboy::is_available() );
+
+// ── Cleanup ────────────────────────────────────────────────────
+@rmdir( $tmp_root );
+putenv( 'PATH=' . $original_path );
+
+if ( ! empty( $failures ) ) {
+	echo "\nFAIL: " . count( $failures ) . " assertion(s)\n";
+	foreach ( $failures as $f ) {
+		echo "  - {$f}\n";
+	}
+	exit( 1 );
+}
+
+echo "\nOK\n";
+exit( 0 );


### PR DESCRIPTION
## Summary

When the [`homeboy`](https://github.com/Extra-Chill/homeboy) Rust CLI is on PATH, AGENTS.md gains a `## Homeboy` section that maps the verbs agents reach for and the repo-level rules they must respect.

Adds:
- `inc/Homeboy.php` — capability helper. Single `command -v homeboy` probe, memoized, hard-gated on `Environment::has_shell()`.
- SectionRegistry contributor at priority 35 (between `wordpress-source` and `multisite`).
- `tests/smoke-homeboy.php` — 5 assertions across no-shell / empty-PATH / synthetic-on-PATH / memoization / reset_cache.

## Design

Sits on top of #57 (DMC = WP↔runtime bridge). Mirrors the house style of `## Data Machine` and `## Abilities`: terse map, bold sub-labels, one discoverability hint at the end. The CLI is its own source of truth — `homeboy --help` enumerates everything; this section calls out the verbs agents should reach for and the repo rules that protect release automation.

## Section content (preview)

```
## Homeboy

`homeboy` is a Rust CLI on this host. Every verb runs the same locally as in CI.

**Quality:** `homeboy audit | lint | test | refactor`

**Git:** prefer `homeboy git changes | status | commit | push | pull | tag`
— auto-baselines, structured output, `--json` bulk. One-off reads
(`git diff`, `git show`, `git blame`) stay on raw `git`.

**Perf + envs:** `homeboy bench` for pinned benchmarks, `homeboy rig` for
reproducible dev environments.

**Repo rules** (when `homeboy.json` is present):
- **NEVER edit `CHANGELOG.md`** — generated from conventional commits at
  release time.
- **NEVER hand-bump version strings** — `feat:`/`fix:`/`BREAKING CHANGE`
  drive semver; Homeboy rewrites version targets in `homeboy.json`.

Run `homeboy --help` for the full verb list. Operator verbs
(`release`, `deploy`, `fleet`, `ssh`) only on explicit ask.
```

## Tests

```
$ php tests/smoke-homeboy.php
✓ empty PATH: is_available() returns false
✓ absent: result is memoized
✓ synthetic on PATH: is_available() returns true
✓ memoization: result sticky after PATH change
✓ reset_cache: re-probe sees current state
OK
```

Pure-PHP, no WP bootstrap. Deterministic via PATH override.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafted helper, contributor, smoke, and this body. Iterated section content twice — first draft over-enumerated verbs (mentioned `release`, `deploy`, `fleet` as primary; missed `bench` and `rig`); second draft over-explained ("prefer-over-raw-git" essay paragraphs). Chris pushed back on both ("you overcorrected"; "match the house style — minimal, clean map") and the section was tightened to mirror `## Data Machine` density.