### PR TITLE
fix(release): clear lint check blockers

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -217,12 +217,12 @@ add_filter( 'datamachine_tasks', function ( array $tasks ): array {
  */
 add_filter( 'datamachine_recurring_schedules', function ( array $schedules ): array {
 	$schedules['worktree_cleanup'] = array(
-		'task_type'        => 'worktree_cleanup',
-		'interval'         => 'daily',
-		'enabled_setting'  => \DataMachineCode\Tasks\WorktreeCleanupTask::SETTING_KEY,
-		'default_enabled'  => false,
-		'label'            => 'Daily — cleans up merged worktrees',
-		'task_params'      => array( 'source' => 'recurring_schedule' ),
+		'task_type'       => 'worktree_cleanup',
+		'interval'        => 'daily',
+		'enabled_setting' => \DataMachineCode\Tasks\WorktreeCleanupTask::SETTING_KEY,
+		'default_enabled' => false,
+		'label'           => 'Daily — cleans up merged worktrees',
+		'task_params'     => array( 'source' => 'recurring_schedule' ),
 	);
 	return $schedules;
 } );

--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -311,10 +311,10 @@ class GitHubAbilities {
 					'output_schema'       => array(
 						'type'       => 'object',
 						'properties' => array(
-							'success'      => array( 'type' => 'boolean' ),
-							'commit'       => array( 'type' => 'object' ),
-							'content'      => array( 'type' => 'object' ),
-							'error'        => array( 'type' => 'string' ),
+							'success' => array( 'type' => 'boolean' ),
+							'commit'  => array( 'type' => 'object' ),
+							'content' => array( 'type' => 'object' ),
+							'error'   => array( 'type' => 'string' ),
 						),
 					),
 					'execute_callback'    => array( self::class, 'createOrUpdateFile' ),
@@ -731,13 +731,13 @@ class GitHubAbilities {
 		return array(
 			'success' => true,
 			'commit'  => array(
-				'sha'       => $data['commit']['sha'] ?? '',
-				'html_url'  => $data['commit']['html_url'] ?? '',
-				'message'   => $data['commit']['message'] ?? '',
+				'sha'      => $data['commit']['sha'] ?? '',
+				'html_url' => $data['commit']['html_url'] ?? '',
+				'message'  => $data['commit']['message'] ?? '',
 			),
 			'content' => array(
-				'path'      => $data['content']['path'] ?? $file_path,
-				'html_url'  => $data['content']['html_url'] ?? '',
+				'path'     => $data['content']['path'] ?? $file_path,
+				'html_url' => $data['content']['html_url'] ?? '',
 			),
 			'message' => sprintf(
 				'File %s in %s.',
@@ -841,7 +841,7 @@ class GitHubAbilities {
 			return new \WP_Error( 'file_too_large', 'File content not available (may exceed 1 MB GitHub API limit).', array( 'status' => 400 ) );
 		}
 
-		$decoded = base64_decode( $data['content'], true );
+		$decoded = base64_decode( $data['content'], true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Required by GitHub Contents API.
 		if ( false === $decoded ) {
 			return new \WP_Error( 'decode_failed', 'Failed to decode file content.', array( 'status' => 500 ) );
 		}
@@ -985,10 +985,10 @@ class GitHubAbilities {
 	 */
 	public static function normalizeFileContent( array $data, string $decoded ): array {
 		return array(
-			'path'    => $data['path'] ?? '',
-			'size'    => (int) ( $data['size'] ?? 0 ),
-			'sha'     => $data['sha'] ?? '',
-			'content' => $decoded,
+			'path'     => $data['path'] ?? '',
+			'size'     => (int) ( $data['size'] ?? 0 ),
+			'sha'      => $data['sha'] ?? '',
+			'content'  => $decoded,
 			'html_url' => $data['html_url'] ?? '',
 		);
 	}

--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -745,37 +745,37 @@ class WorkspaceAbilities {
 					'output_schema'       => array(
 						'type'       => 'object',
 						'properties' => array(
-							'success'             => array( 'type' => 'boolean' ),
-							'handle'              => array( 'type' => 'string' ),
-							'path'                => array( 'type' => 'string' ),
-							'branch'              => array( 'type' => 'string' ),
-							'slug'                => array( 'type' => 'string' ),
-							'created_branch'      => array( 'type' => 'boolean' ),
-							'message'             => array( 'type' => 'string' ),
-							'context_injected'    => array( 'type' => 'boolean' ),
-							'context_files'       => array(
+							'success'                   => array( 'type' => 'boolean' ),
+							'handle'                    => array( 'type' => 'string' ),
+							'path'                      => array( 'type' => 'string' ),
+							'branch'                    => array( 'type' => 'string' ),
+							'slug'                      => array( 'type' => 'string' ),
+							'created_branch'            => array( 'type' => 'boolean' ),
+							'message'                   => array( 'type' => 'string' ),
+							'context_injected'          => array( 'type' => 'boolean' ),
+							'context_files'             => array(
 								'type'  => 'array',
 								'items' => array( 'type' => 'string' ),
 							),
-							'context_exclude_path' => array( 'type' => 'string' ),
-							'context_skip_reason' => array( 'type' => 'string' ),
-							'bootstrap'           => array(
+							'context_exclude_path'      => array( 'type' => 'string' ),
+							'context_skip_reason'       => array( 'type' => 'string' ),
+							'bootstrap'                 => array(
 								'type'        => 'object',
 								'description' => 'Present only when bootstrap=true. Contains success/ran_any booleans and a steps array.',
 							),
-							'fetch_failed'        => array(
+							'fetch_failed'              => array(
 								'type'        => 'boolean',
 								'description' => 'Present only when the pre-create `git fetch origin` failed. Worktree creation continues either way; staleness fields are omitted when true.',
 							),
-							'fetch_error'         => array(
+							'fetch_error'               => array(
 								'type'        => 'string',
 								'description' => 'Present only when fetch_failed=true. Trimmed error output from the failing fetch.',
 							),
-							'stale_commits_behind' => array(
+							'stale_commits_behind'      => array(
 								'type'        => 'integer',
 								'description' => 'For the existing-local-branch path, how many commits the worktree branch is behind its configured upstream. Omitted when no upstream is configured.',
 							),
-							'upstream'            => array(
+							'upstream'                  => array(
 								'type'        => 'string',
 								'description' => 'Paired with stale_commits_behind: the upstream ref label (e.g. `origin/fix/foo`).',
 							),
@@ -783,27 +783,27 @@ class WorkspaceAbilities {
 								'type'        => 'integer',
 								'description' => 'For the new-branch path cut from a local base ref: how many commits that local base is behind its origin counterpart at fetch time.',
 							),
-							'base_upstream'       => array(
+							'base_upstream'             => array(
 								'type'        => 'string',
 								'description' => 'Paired with base_stale_commits_behind: the origin ref the local base was compared against (e.g. `origin/main`).',
 							),
-							'gate_threshold'      => array(
+							'gate_threshold'            => array(
 								'type'        => 'integer',
 								'description' => 'Echo of the staleness threshold (in commits) that was evaluated. Present whenever the gate ran (i.e. `allow_stale` was false and fetch succeeded).',
 							),
-							'rebase_attempted'    => array(
+							'rebase_attempted'          => array(
 								'type'        => 'boolean',
 								'description' => 'Set when `rebase_base=true` AND there was meaningful staleness to rebase over. Absent when rebase was not requested or there was nothing to do.',
 							),
-							'rebase_target'       => array(
+							'rebase_target'             => array(
 								'type'        => 'string',
 								'description' => 'Paired with `rebase_attempted`: the ref the worktree was rebased onto (e.g. `@{upstream}` or `origin/main`).',
 							),
-							'rebase_succeeded'    => array(
+							'rebase_succeeded'          => array(
 								'type'        => 'boolean',
 								'description' => 'Paired with `rebase_attempted`: true when the rebase landed cleanly, false when it hit conflicts and was aborted.',
 							),
-							'rebase_error'       => array(
+							'rebase_error'              => array(
 								'type'        => 'string',
 								'description' => 'Present only when `rebase_succeeded=false`. Trimmed error output from the failing rebase.',
 							),

--- a/inc/Cli/Commands/GitSyncCommand.php
+++ b/inc/Cli/Commands/GitSyncCommand.php
@@ -279,14 +279,38 @@ class GitSyncCommand extends BaseCommand {
 		}
 
 		$rows = array(
-			array( 'field' => 'slug',           'value' => (string) ( $result['slug'] ?? '' ) ),
-			array( 'field' => 'local_path',     'value' => (string) ( $result['local_path'] ?? '' ) ),
-			array( 'field' => 'remote_url',     'value' => (string) ( $result['remote_url'] ?? '' ) ),
-			array( 'field' => 'tracked_branch', 'value' => (string) ( $result['tracked_branch'] ?? '' ) ),
-			array( 'field' => 'exists',         'value' => ! empty( $result['exists'] ) ? 'yes' : 'no' ),
-			array( 'field' => 'pulled_count',   'value' => (string) ( (int) ( $result['pulled_count'] ?? 0 ) ) ),
-			array( 'field' => 'last_pulled',    'value' => (string) ( $result['last_pulled'] ?? '-' ) ),
-			array( 'field' => 'last_commit',    'value' => (string) ( $result['last_commit'] ?? '-' ) ),
+			array(
+				'field' => 'slug',
+				'value' => (string) ( $result['slug'] ?? '' ),
+			),
+			array(
+				'field' => 'local_path',
+				'value' => (string) ( $result['local_path'] ?? '' ),
+			),
+			array(
+				'field' => 'remote_url',
+				'value' => (string) ( $result['remote_url'] ?? '' ),
+			),
+			array(
+				'field' => 'tracked_branch',
+				'value' => (string) ( $result['tracked_branch'] ?? '' ),
+			),
+			array(
+				'field' => 'exists',
+				'value' => ! empty( $result['exists'] ) ? 'yes' : 'no',
+			),
+			array(
+				'field' => 'pulled_count',
+				'value' => (string) ( (int) ( $result['pulled_count'] ?? 0 ) ),
+			),
+			array(
+				'field' => 'last_pulled',
+				'value' => (string) ( $result['last_pulled'] ?? '-' ),
+			),
+			array(
+				'field' => 'last_commit',
+				'value' => (string) ( $result['last_commit'] ?? '-' ),
+			),
 		);
 		$this->format_items( $rows, array( 'field', 'value' ), $assoc_args, 'field' );
 	}
@@ -452,7 +476,7 @@ class GitSyncCommand extends BaseCommand {
 			WP_CLI::error( 'Binding slug is required.' );
 		}
 
-		$patch = array();
+		$patch     = array();
 		$bool_keys = array(
 			'write-enabled'    => 'write_enabled',
 			'safe-direct-push' => 'safe_direct_push',
@@ -484,7 +508,10 @@ class GitSyncCommand extends BaseCommand {
 
 		$result = $this->execute_ability(
 			'datamachine/gitsync-policy-update',
-			array( 'slug' => $slug, 'policy' => $patch )
+			array(
+				'slug'   => $slug,
+				'policy' => $patch,
+			)
 		);
 
 		WP_CLI::success( sprintf( 'Policy updated for "%s".', $slug ) );

--- a/inc/Environment.php
+++ b/inc/Environment.php
@@ -85,6 +85,7 @@ class Environment {
 			return false;
 		}
 
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable -- Environment capability probe.
 		return is_writable( WP_CONTENT_DIR );
 	}
 }

--- a/inc/GitSync/GitSync.php
+++ b/inc/GitSync/GitSync.php
@@ -299,7 +299,8 @@ final class GitSync {
 		foreach ( $iterator as $entry ) {
 			/** @var \SplFileInfo $entry */
 			$target = $entry->getPathname();
-			$ok     = $entry->isDir() ? @rmdir( $target ) : @unlink( $target );
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_rmdir, WordPress.WP.AlternativeFunctions.unlink_unlink -- Recursive purge inside a policy-gated local binding.
+			$ok = $entry->isDir() ? @rmdir( $target ) : @unlink( $target );
 			if ( ! $ok ) {
 				return new \WP_Error(
 					'purge_failed',
@@ -309,6 +310,7 @@ final class GitSync {
 			}
 		}
 
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- Recursive purge inside a policy-gated local binding.
 		if ( ! @rmdir( $path ) ) {
 			return new \WP_Error(
 				'purge_failed',

--- a/inc/GitSync/GitSyncFetcher.php
+++ b/inc/GitSync/GitSyncFetcher.php
@@ -97,12 +97,16 @@ final class GitSyncFetcher {
 
 			if ( PathSecurity::isSensitivePath( $path ) ) {
 				// Upstream shouldn't ship credentials, but defend anyway.
-				$conflicts[] = array( 'path' => $path, 'reason' => 'sensitive_path' );
+				$conflicts[] = array(
+					'path'   => $path,
+					'reason' => 'sensitive_path',
+				);
 				continue;
 			}
 
 			$local_exists = is_file( $dest );
-			$local_sha    = $local_exists ? GitHubRemote::blobSha( (string) file_get_contents( $dest ) ) : null;
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local file SHA comparison, not a remote URL fetch.
+			$local_sha = $local_exists ? GitHubRemote::blobSha( (string) file_get_contents( $dest ) ) : null;
 
 			if ( $local_exists && $local_sha === $remote_sha ) {
 				$unchanged[] = $path;
@@ -115,11 +119,17 @@ final class GitSyncFetcher {
 			// edited it between pulls.
 			$tracked = in_array( $path, $binding->pulled_paths, true );
 			if ( $local_exists && $tracked && 'fail' === $conflict_policy && ! $allow_dirty ) {
-				$conflicts[] = array( 'path' => $path, 'reason' => 'local_modified' );
+				$conflicts[] = array(
+					'path'   => $path,
+					'reason' => 'local_modified',
+				);
 				continue;
 			}
 			if ( $local_exists && $tracked && 'manual' === $conflict_policy && ! $allow_dirty ) {
-				$conflicts[] = array( 'path' => $path, 'reason' => 'local_modified_manual' );
+				$conflicts[] = array(
+					'path'   => $path,
+					'reason' => 'local_modified_manual',
+				);
 				continue;
 			}
 			// upstream_wins or allow_dirty or untracked: fall through and overwrite.
@@ -134,7 +144,7 @@ final class GitSyncFetcher {
 				return new \WP_Error( 'mkdir_failed', sprintf( 'Could not create %s.', $parent ), array( 'status' => 500 ) );
 			}
 
-			$bytes = file_put_contents( $dest, $content );
+			$bytes = file_put_contents( $dest, $content ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- GitSync writes local bound files intentionally.
 			if ( false === $bytes ) {
 				return new \WP_Error( 'write_failed', sprintf( 'Could not write %s.', $dest ), array( 'status' => 500 ) );
 			}
@@ -151,6 +161,7 @@ final class GitSyncFetcher {
 			}
 			$victim = $absolute . '/' . $path;
 			if ( is_file( $victim ) ) {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- GitSync removes files that disappeared upstream.
 				unlink( $victim );
 			}
 			$deleted[] = $path;
@@ -166,9 +177,9 @@ final class GitSyncFetcher {
 			}
 		}
 
-		$binding->pulled_paths = array_values( $new_pulled );
+		$binding->pulled_paths = $new_pulled;
 		$binding->last_pulled  = gmdate( 'c' );
-		$binding->last_commit  = $tree_sha ?: $binding->last_commit;
+		$binding->last_commit  = $tree_sha ? $tree_sha : $binding->last_commit;
 		$this->registry->save( $binding );
 
 		return array(
@@ -196,7 +207,9 @@ final class GitSyncFetcher {
 	private function fetchBlobContent( string $slug, string $path, string $branch, string $pat ): string|\WP_Error {
 		$response = GitHubAbilities::apiGet(
 			GitHubRemote::apiUrl( $slug, 'contents/' . ltrim( $path, '/' ) ),
-			array( 'ref' => $branch ),
+			array(
+				'ref' => $branch,
+			),
 			$pat
 		);
 		if ( is_wp_error( $response ) ) {
@@ -221,7 +234,7 @@ final class GitSyncFetcher {
 			);
 		}
 
-		$decoded = base64_decode( (string) $data['content'], true );
+		$decoded = base64_decode( (string) $data['content'], true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Required by GitHub Contents API.
 		if ( false === $decoded ) {
 			return new \WP_Error( 'base64_decode_failed', sprintf( 'Could not decode base64 content for %s.', $path ), array( 'status' => 500 ) );
 		}
@@ -246,12 +259,11 @@ final class GitSyncFetcher {
 		if ( is_wp_error( $response ) ) {
 			return $response;
 		}
-		$data = is_array( $response['data'] ?? null ) ? $response['data'] : array();
-		$decoded = base64_decode( (string) ( $data['content'] ?? '' ), true );
+		$data    = is_array( $response['data'] ?? null ) ? $response['data'] : array();
+		$decoded = base64_decode( (string) ( $data['content'] ?? '' ), true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Required by GitHub Git Data API.
 		if ( false === $decoded ) {
 			return new \WP_Error( 'base64_decode_failed', sprintf( 'Could not decode large blob %s.', $sha ), array( 'status' => 500 ) );
 		}
 		return $decoded;
 	}
-
 }

--- a/inc/GitSync/GitSyncProposer.php
+++ b/inc/GitSync/GitSyncProposer.php
@@ -65,7 +65,7 @@ final class GitSyncProposer {
 			return $gate;
 		}
 
-		$message = trim( (string) ( $args['message'] ?? '' ) );
+		$message     = trim( (string) ( $args['message'] ?? '' ) );
 		$message_err = $this->validateMessage( $message );
 		if ( is_wp_error( $message_err ) ) {
 			return $message_err;
@@ -117,7 +117,11 @@ final class GitSyncProposer {
 				return new \WP_Error(
 					'upload_failed',
 					sprintf( 'Commit of %s to %s failed: %s', $change['path'], $feature_branch, $result->get_error_message() ),
-					array( 'status' => 502, 'path' => $change['path'], 'branch' => $feature_branch )
+					array(
+						'status' => 502,
+						'path'   => $change['path'],
+						'branch' => $feature_branch,
+					)
 				);
 			}
 			$commits[] = array(
@@ -131,11 +135,16 @@ final class GitSyncProposer {
 			return new \WP_Error(
 				'pr_failed',
 				sprintf( 'Branch "%s" updated, but PR open/update failed: %s', $feature_branch, $pr->get_error_message() ),
-				array( 'status' => 502, 'branch' => $feature_branch, 'commits' => $commits, 'pr_error' => $pr->get_error_code() )
+				array(
+					'status'   => 502,
+					'branch'   => $feature_branch,
+					'commits'  => $commits,
+					'pr_error' => $pr->get_error_code(),
+				)
 			);
 		}
 
-		$binding->last_commit = end( $commits )['commit'] ?? $binding->last_commit;
+		$binding->last_commit = $commits[ array_key_last( $commits ) ]['commit'];
 		$this->registry->save( $binding );
 
 		return array(
@@ -179,7 +188,7 @@ final class GitSyncProposer {
 			);
 		}
 
-		$message = trim( (string) ( $args['message'] ?? '' ) );
+		$message     = trim( (string) ( $args['message'] ?? '' ) );
 		$message_err = $this->validateMessage( $message );
 		if ( is_wp_error( $message_err ) ) {
 			return $message_err;
@@ -213,7 +222,11 @@ final class GitSyncProposer {
 				return new \WP_Error(
 					'upload_failed',
 					sprintf( 'Commit of %s to %s failed: %s', $change['path'], $binding->branch, $result->get_error_message() ),
-					array( 'status' => 502, 'path' => $change['path'], 'branch' => $binding->branch )
+					array(
+						'status' => 502,
+						'path'   => $change['path'],
+						'branch' => $binding->branch,
+					)
 				);
 			}
 			$commits[] = array(
@@ -222,7 +235,7 @@ final class GitSyncProposer {
 			);
 		}
 
-		$binding->last_commit = end( $commits )['commit'] ?? $binding->last_commit;
+		$binding->last_commit = $commits[ array_key_last( $commits ) ]['commit'];
 		$this->registry->save( $binding );
 
 		return array(
@@ -369,7 +382,10 @@ final class GitSyncProposer {
 					// No diff against upstream; skip this explicitly-requested file.
 					continue;
 				}
-				$changes[] = array( 'path' => $rel, 'content' => $content );
+				$changes[] = array(
+					'path'    => $rel,
+					'content' => $content,
+				);
 			}
 			return $changes;
 		}
@@ -389,10 +405,13 @@ final class GitSyncProposer {
 				continue;
 			}
 			$local_sha = GitHubRemote::blobSha( $content );
-			if ( $local_sha === ( $ctx['upstream'][ $rel ] ?? null ) ) {
+			if ( ( $ctx['upstream'][ $rel ] ?? null ) === $local_sha ) {
 				continue;
 			}
-			$changes[] = array( 'path' => $rel, 'content' => $content );
+			$changes[] = array(
+				'path'    => $rel,
+				'content' => $content,
+			);
 		}
 		return $changes;
 	}
@@ -402,6 +421,7 @@ final class GitSyncProposer {
 		if ( ! is_file( $full ) ) {
 			return new \WP_Error( 'missing_file', sprintf( 'Local file %s does not exist.', $full ), array( 'status' => 404 ) );
 		}
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local file proposal content, not a remote URL fetch.
 		$content = file_get_contents( $full );
 		if ( false === $content ) {
 			return new \WP_Error( 'read_failed', sprintf( 'Could not read %s.', $full ), array( 'status' => 500 ) );
@@ -494,7 +514,7 @@ final class GitSyncProposer {
 	private function putFile( string $slug, string $path, string $content, string $message, string $branch, ?string $existing_sha, string $pat ): array|\WP_Error {
 		$body = array(
 			'message' => $message,
-			'content' => base64_encode( $content ),
+			'content' => base64_encode( $content ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Required by GitHub Contents API.
 			'branch'  => $branch,
 		);
 		if ( null !== $existing_sha ) {
@@ -558,7 +578,10 @@ final class GitSyncProposer {
 			$patched = GitHubAbilities::apiRequest(
 				'PATCH',
 				GitHubRemote::apiUrl( $slug, 'pulls/' . (int) $existing_pr['number'] ),
-				array( 'title' => $title, 'body' => $body ),
+				array(
+					'title' => $title,
+					'body'  => $body,
+				),
 				$pat
 			);
 			if ( is_wp_error( $patched ) ) {
@@ -616,5 +639,4 @@ Proposed by GitSync binding **{$binding->slug}** from local edits.
 *Opened via `datamachine/gitsync-submit`. Re-running submit updates this PR in place.*
 BODY;
 	}
-
 }

--- a/inc/GitSync/GitSyncRegistry.php
+++ b/inc/GitSync/GitSyncRegistry.php
@@ -74,8 +74,8 @@ final class GitSyncRegistry {
 	 * Persist a binding (insert or update).
 	 */
 	public function save( GitSyncBinding $binding ): void {
-		$all                     = $this->loadRawArray();
-		$all[ $binding->slug ]   = $binding->toArray();
+		$all                   = $this->loadRawArray();
+		$all[ $binding->slug ] = $binding->toArray();
 		update_option( self::OPTION_KEY, $all, false );
 	}
 

--- a/inc/Handlers/GitHub/GitHub.php
+++ b/inc/Handlers/GitHub/GitHub.php
@@ -117,7 +117,7 @@ class GitHub extends FetchHandler {
 		// Apply path prefix filter.
 		if ( ! empty( $file_path ) ) {
 			$prefix = rtrim( $file_path, '/' ) . '/';
-			$files  = array_filter( $files, fn( $f ) => str_starts_with( $f['path'], $prefix ) || $f['path'] === trim( $file_path, '/' ) );
+			$files  = array_filter( $files, fn( $f ) => str_starts_with( $f['path'], $prefix ) || trim( $file_path, '/' ) === $f['path'] );
 			$files  = array_values( $files );
 		}
 
@@ -128,8 +128,8 @@ class GitHub extends FetchHandler {
 
 		// Filter out binary/large files (> 500 KB, likely not source).
 		$max_file_size = (int) ( $config['max_file_size'] ?? 512000 );
-		$files = array_filter( $files, fn( $f ) => $f['size'] > 0 && $f['size'] <= $max_file_size );
-		$files = array_values( $files );
+		$files         = array_filter( $files, fn( $f ) => $f['size'] > 0 && $f['size'] <= $max_file_size );
+		$files         = array_values( $files );
 
 		if ( empty( $files ) ) {
 			$context->log( 'info', 'GitHub: No files matched filters.' );
@@ -152,24 +152,24 @@ class GitHub extends FetchHandler {
 				continue;
 			}
 
-			$file_data   = $file_result['file'];
-			$guid        = sprintf( 'github_%s_files_%s', $repo, $file['sha'] );
+			$file_data = $file_result['file'];
+			$guid      = sprintf( 'github_%s_files_%s', $repo, $file['sha'] );
 
 			$eligible_items[] = array(
 				'title'    => $file_data['path'],
 				'content'  => $file_data['content'],
 				'metadata' => array(
-					'source_type'       => 'github',
-					'original_id'       => $guid,
-					'dedup_key'         => $guid,
-					'original_title'    => $file_data['path'],
-					'github_repo'       => $repo,
-					'github_type'       => 'files',
-					'github_file_path'  => $file_data['path'],
-					'github_file_size'  => $file_data['size'],
-					'github_file_sha'   => $file_data['sha'],
-					'github_url'        => $file_data['html_url'],
-					'source_url'        => $file_data['html_url'],
+					'source_type'      => 'github',
+					'original_id'      => $guid,
+					'dedup_key'        => $guid,
+					'original_title'   => $file_data['path'],
+					'github_repo'      => $repo,
+					'github_type'      => 'files',
+					'github_file_path' => $file_data['path'],
+					'github_file_size' => $file_data['size'],
+					'github_file_sha'  => $file_data['sha'],
+					'github_url'       => $file_data['html_url'],
+					'source_url'       => $file_data['html_url'],
 				),
 			);
 		}

--- a/inc/Handlers/GitHub/GitHubSettings.php
+++ b/inc/Handlers/GitHub/GitHubSettings.php
@@ -25,13 +25,13 @@ class GitHubSettings extends FetchHandlerSettings {
 	 */
 	public static function get_fields(): array {
 		$fields = array(
-			'repo'        => array(
+			'repo'          => array(
 				'type'        => 'text',
 				'label'       => __( 'Repository', 'data-machine-code' ),
 				'description' => __( 'GitHub repository in owner/repo format (e.g., Extra-Chill/data-machine). Falls back to default repo in settings.', 'data-machine-code' ),
 				'required'    => false,
 			),
-			'data_source' => array(
+			'data_source'   => array(
 				'type'        => 'select',
 				'label'       => __( 'Data Source', 'data-machine-code' ),
 				'description' => __( 'What to fetch from the repository.', 'data-machine-code' ),
@@ -43,7 +43,7 @@ class GitHubSettings extends FetchHandlerSettings {
 					'files'  => __( 'Source Files', 'data-machine-code' ),
 				),
 			),
-			'state'       => array(
+			'state'         => array(
 				'type'        => 'select',
 				'label'       => __( 'State Filter', 'data-machine-code' ),
 				'description' => __( 'Filter by issue/PR state.', 'data-machine-code' ),
@@ -55,25 +55,25 @@ class GitHubSettings extends FetchHandlerSettings {
 					'all'    => __( 'All', 'data-machine-code' ),
 				),
 			),
-			'labels'      => array(
+			'labels'        => array(
 				'type'        => 'text',
 				'label'       => __( 'Label Filter', 'data-machine-code' ),
 				'description' => __( 'Comma-separated label names to filter by (issues only).', 'data-machine-code' ),
 				'required'    => false,
 			),
-			'branch'       => array(
+			'branch'        => array(
 				'type'        => 'text',
 				'label'       => __( 'Branch', 'data-machine-code' ),
 				'description' => __( 'Git branch or ref to read from (files data source). Defaults to the repository default branch.', 'data-machine-code' ),
 				'required'    => false,
 			),
-			'file_path'    => array(
+			'file_path'     => array(
 				'type'        => 'text',
 				'label'       => __( 'File Path', 'data-machine-code' ),
 				'description' => __( 'Directory or file path prefix to filter (files data source). E.g., "inc/" or "src/Commands/". Leave empty for all files.', 'data-machine-code' ),
 				'required'    => false,
 			),
-			'file_pattern' => array(
+			'file_pattern'  => array(
 				'type'        => 'text',
 				'label'       => __( 'File Pattern', 'data-machine-code' ),
 				'description' => __( 'Glob pattern to filter filenames (files data source). E.g., "*.php" or "*.php,*.json". Leave empty for all file types.', 'data-machine-code' ),

--- a/inc/Handlers/GitHub/GitHubUpsert.php
+++ b/inc/Handlers/GitHub/GitHubUpsert.php
@@ -163,11 +163,11 @@ class GitHubUpsert extends UpsertHandler {
 		return array(
 			'success'   => true,
 			'data'      => array(
-				'repo'        => $repo,
-				'file_path'   => $file_path,
-				'commit_sha'  => $result['commit']['sha'] ?? '',
-				'commit_url'  => $result['commit']['html_url'] ?? '',
-				'file_url'    => $result['content']['html_url'] ?? '',
+				'repo'       => $repo,
+				'file_path'  => $file_path,
+				'commit_sha' => $result['commit']['sha'] ?? '',
+				'commit_url' => $result['commit']['html_url'] ?? '',
+				'file_url'   => $result['content']['html_url'] ?? '',
 			),
 			'tool_name' => 'github_upsert',
 		);

--- a/inc/Homeboy.php
+++ b/inc/Homeboy.php
@@ -53,7 +53,8 @@ class Homeboy {
 			return false;
 		}
 
-		$output = @shell_exec( 'command -v homeboy 2>/dev/null' );
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_shell_exec -- Host CLI capability probe.
+		$output                = shell_exec( 'command -v homeboy 2>/dev/null' );
 		self::$available_cache = ! empty( trim( (string) $output ) );
 		return self::$available_cache;
 	}

--- a/inc/Tasks/WorktreeCleanupTask.php
+++ b/inc/Tasks/WorktreeCleanupTask.php
@@ -150,19 +150,19 @@ class WorktreeCleanupTask extends SystemTask {
 				'error',
 				'Worktree cleanup task failed',
 				array(
-					'task'   => $this->getTaskType(),
-					'jobId'  => $jobId,
-					'error'  => $result->get_error_message(),
-					'code'   => $result->get_error_code(),
+					'task'  => $this->getTaskType(),
+					'jobId' => $jobId,
+					'error' => $result->get_error_message(),
+					'code'  => $result->get_error_code(),
 				)
 			);
 			$this->failJob( $jobId, $result->get_error_message() );
 			return;
 		}
 
-		$removed_count  = count( $result['removed'] ?? array() );
-		$skipped_count  = count( $result['skipped'] ?? array() );
-		$candidate_count = count( $result['candidates'] ?? array() );
+		$removed_count   = count( $result['removed'] );
+		$skipped_count   = count( $result['skipped'] );
+		$candidate_count = count( $result['candidates'] );
 
 		do_action(
 			'datamachine_log',
@@ -175,23 +175,23 @@ class WorktreeCleanupTask extends SystemTask {
 				$skipped_count
 			),
 			array(
-				'task'      => $this->getTaskType(),
-				'jobId'     => $jobId,
-				'dry_run'   => $opts['dry_run'],
-				'removed'   => $result['removed'] ?? array(),
-				'skipped'   => $result['skipped'] ?? array(),
+				'task'    => $this->getTaskType(),
+				'jobId'   => $jobId,
+				'dry_run' => $opts['dry_run'],
+				'removed' => $result['removed'],
+				'skipped' => $result['skipped'],
 			)
 		);
 
 		$this->completeJob(
 			$jobId,
 			array(
-				'dry_run'        => $opts['dry_run'],
-				'candidates'     => $candidate_count,
-				'removed_count'  => $removed_count,
-				'skipped_count'  => $skipped_count,
-				'removed'        => $result['removed'] ?? array(),
-				'skipped'        => $result['skipped'] ?? array(),
+				'dry_run'       => $opts['dry_run'],
+				'candidates'    => $candidate_count,
+				'removed_count' => $removed_count,
+				'skipped_count' => $skipped_count,
+				'removed'       => $result['removed'],
+				'skipped'       => $result['skipped'],
 			)
 		);
 	}

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -262,10 +262,10 @@ class Workspace {
 				continue;
 			}
 
-			$git_path  = $entry_path . '/.git';
-			$is_git    = is_dir( $git_path ) || is_file( $git_path );
-			$is_wt     = is_file( $git_path );
-			$parsed    = $this->parse_handle( $entry );
+			$git_path = $entry_path . '/.git';
+			$is_git   = is_dir( $git_path ) || is_file( $git_path );
+			$is_wt    = is_file( $git_path );
+			$parsed   = $this->parse_handle( $entry );
 
 			$repo_info = array(
 				'name'        => $entry,
@@ -365,7 +365,7 @@ class Workspace {
 	/**
 	 * Remove a repository from the workspace.
 	 *
-	 * @param string $name Repository directory name.
+	 * @param string $handle Workspace handle.
 	 * @return array{success: bool, message: string}|\WP_Error
 	 */
 	public function remove_repo( string $handle ): array|\WP_Error {
@@ -386,7 +386,7 @@ class Workspace {
 		if ( ! $parsed['is_worktree'] ) {
 			$worktrees = $this->worktree_list( $parsed['repo'] );
 			if ( ! is_wp_error( $worktrees ) ) {
-				$linked = array_filter( $worktrees['worktrees'] ?? array(), fn( $wt ) => ! empty( $wt['is_worktree'] ) );
+				$linked = array_filter( $worktrees['worktrees'], fn( $wt ) => ! empty( $wt['is_worktree'] ) );
 				if ( ! empty( $linked ) ) {
 					$slugs = array_map( fn( $wt ) => $wt['branch_slug'] ?? '?', $linked );
 					return new \WP_Error( 'has_worktrees', sprintf( 'Cannot remove primary "%s": linked worktrees exist (%s). Remove them first with "workspace worktree remove".', $parsed['repo'], implode( ', ', $slugs ) ), array( 'status' => 400 ) );
@@ -422,7 +422,7 @@ class Workspace {
 	/**
 	 * Show detailed info about a workspace repo.
 	 *
-	 * @param string $name Repository directory name.
+	 * @param string $handle Workspace handle.
 	 * @return array{success: bool, name?: string, path?: string, branch?: string, remote?: string, commit?: string, dirty?: int}|\WP_Error
 	 */
 	public function show_repo( string $handle ): array|\WP_Error {
@@ -458,7 +458,7 @@ class Workspace {
 	/**
 	 * Get git status details for a workspace repository.
 	 *
-	 * @param string $name Repository directory name.
+	 * @param string $handle Workspace handle.
 	 * @return array
 	 */
 	public function git_status( string $handle ): array|\WP_Error {
@@ -496,7 +496,7 @@ class Workspace {
 	/**
 	 * Pull latest changes for a workspace repository.
 	 *
-	 * @param string $name        Repository directory name.
+	 * @param string $handle      Workspace handle.
 	 * @param bool   $allow_dirty Allow pull with dirty working tree.
 	 * @return array
 	 */
@@ -542,7 +542,7 @@ class Workspace {
 	/**
 	 * Stage paths in a workspace repository.
 	 *
-	 * @param string $name  Repository directory name.
+	 * @param string $handle Workspace handle.
 	 * @param array  $paths Relative paths to stage.
 	 * @return array
 	 */
@@ -935,9 +935,9 @@ class Workspace {
 		if ( 0 === $exists_local ) {
 			$cmd = sprintf( 'worktree add %s %s', escapeshellarg( $wt_path ), escapeshellarg( $branch ) );
 		} else {
-			$base          = $from && '' !== trim( $from ) ? trim( $from ) : $this->resolve_default_base( $primary_path );
-			$resolved_base = $base;
-			$cmd           = sprintf( 'worktree add -b %s %s %s', escapeshellarg( $branch ), escapeshellarg( $wt_path ), escapeshellarg( $base ) );
+			$base           = $from && '' !== trim( $from ) ? trim( $from ) : $this->resolve_default_base( $primary_path );
+			$resolved_base  = $base;
+			$cmd            = sprintf( 'worktree add -b %s %s %s', escapeshellarg( $branch ), escapeshellarg( $wt_path ), escapeshellarg( $base ) );
 			$created_branch = true;
 		}
 
@@ -1022,23 +1022,23 @@ class Workspace {
 			 * @param string $repo      Repository name.
 			 * @param string $branch    Branch being materialized.
 			 */
-			$threshold                   = (int) apply_filters( 'datamachine_worktree_stale_threshold', 50, $repo, $branch );
-			$response['gate_threshold']  = $threshold;
-			$effective_behind            = $this->effective_behind_count( $response );
+			$threshold                  = (int) apply_filters( 'datamachine_worktree_stale_threshold', 50, $repo, $branch );
+			$response['gate_threshold'] = $threshold;
+			$effective_behind           = $this->effective_behind_count( $response );
 
 			if ( null !== $effective_behind && $effective_behind > $threshold ) {
 				// Tear the worktree down so we don't leak a half-cooked
 				// checkout on the user's disk.
 				$this->run_git( $primary_path, sprintf( 'worktree remove --force %s', escapeshellarg( $wt_path ) ) );
 
-				$label = $response['upstream'] ?? ( $response['base_upstream'] ?? 'upstream' );
+				$label    = $response['upstream'] ?? ( $response['base_upstream'] ?? 'upstream' );
 				$guidance = sprintf(
-					"Worktree base is %d commits behind %s (threshold: %d).\n"
-					. "Options:\n"
-					. "  - workspace git-pull %s --allow-primary-mutation  (refresh primary first)\n"
-					. "  - worktree add … --from=origin/%s  (cut from remote ref directly)\n"
-					. "  - worktree add … --rebase-base  (auto-rebase onto upstream)\n"
-					. "  - worktree add … --allow-stale  (proceed with known-stale base)",
+					'Worktree base is %d commits behind %s (threshold: %d).' . "\n"
+					. 'Options:' . "\n"
+					. '  - workspace git-pull %s --allow-primary-mutation  (refresh primary first)' . "\n"
+					. '  - worktree add … --from=origin/%s  (cut from remote ref directly)' . "\n"
+					. '  - worktree add … --rebase-base  (auto-rebase onto upstream)' . "\n"
+					. '  - worktree add … --allow-stale  (proceed with known-stale base)',
 					$effective_behind,
 					$label,
 					$threshold,
@@ -1378,7 +1378,7 @@ class Workspace {
 		// Fetch + prune each primary once up-front so upstream-gone signals are fresh.
 		$fetched = array();
 
-		foreach ( $listing['worktrees'] ?? array() as $wt ) {
+		foreach ( $listing['worktrees'] as $wt ) {
 			if ( ! empty( $wt['is_primary'] ) ) {
 				continue;
 			}
@@ -1457,14 +1457,14 @@ class Workspace {
 			}
 
 			$candidates[] = array(
-				'handle'  => $wt['handle'],
-				'repo'    => $repo,
-				'branch'  => $branch,
-				'path'    => $wt_path,
-				'dirty'   => $dirty_count,
-				'signal'  => $signal['signal'],
-				'reason'  => $signal['reason'],
-				'pr_url'  => $signal['pr_url'] ?? null,
+				'handle' => $wt['handle'],
+				'repo'   => $repo,
+				'branch' => $branch,
+				'path'   => $wt_path,
+				'dirty'  => $dirty_count,
+				'signal' => $signal['signal'],
+				'reason' => $signal['reason'],
+				'pr_url' => $signal['pr_url'] ?? null,
 			);
 		}
 
@@ -1685,7 +1685,7 @@ class Workspace {
 			return null;
 		}
 
-		$owner = explode( '/', $slug )[0] ?? '';
+		$owner = explode( '/', $slug )[0];
 		if ( '' === $owner ) {
 			return null;
 		}
@@ -1843,9 +1843,7 @@ class Workspace {
 		}
 
 		// Success: zero out the behind-count so the gate sees a fresh worktree.
-		if ( null !== $clear ) {
-			unset( $response[ $clear ] );
-		}
+		unset( $response[ $clear ] );
 
 		return array(
 			'rebase_attempted' => true,
@@ -1873,8 +1871,8 @@ class Workspace {
 			} elseif ( str_starts_with( $line, 'HEAD ' ) ) {
 				$out['head'] = substr( $line, strlen( 'HEAD ' ) );
 			} elseif ( str_starts_with( $line, 'branch ' ) ) {
-				$ref            = substr( $line, strlen( 'branch ' ) );
-				$out['branch']  = preg_replace( '#^refs/heads/#', '', $ref );
+				$ref           = substr( $line, strlen( 'branch ' ) );
+				$out['branch'] = preg_replace( '#^refs/heads/#', '', $ref );
 			} elseif ( 'detached' === $line ) {
 				$out['branch'] = null;
 			}
@@ -2030,10 +2028,6 @@ class Workspace {
 		// No entry = permissive default. Callers should still respect
 		// primary-vs-worktree separation via ensure_primary_mutation_allowed.
 		if ( null === $repo ) {
-			return true;
-		}
-
-		if ( ! is_array( $repo ) ) {
 			return true;
 		}
 
@@ -2204,7 +2198,7 @@ class Workspace {
 		 */
 		$settings = apply_filters( 'datamachine_workspace_git_policies', $settings );
 
-		if ( ! is_array( $settings ) || ! isset( $settings['repos'] ) || ! is_array( $settings['repos'] ) ) {
+		if ( ! isset( $settings['repos'] ) || ! is_array( $settings['repos'] ) ) {
 			return $defaults;
 		}
 

--- a/inc/Workspace/WorktreeBootstrapper.php
+++ b/inc/Workspace/WorktreeBootstrapper.php
@@ -302,7 +302,7 @@ final class WorktreeBootstrapper {
 	 * invocations, not user input. The `cd` target is escaped.
 	 */
 	private static function run_command( string $step, string $worktree_path, string $command ): array {
-		$cd = escapeshellarg( $worktree_path );
+		$cd        = escapeshellarg( $worktree_path );
 		$shell_cmd = sprintf( 'cd %s && %s 2>&1', $cd, $command );
 
 		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec

--- a/inc/Workspace/WorktreeContextInjector.php
+++ b/inc/Workspace/WorktreeContextInjector.php
@@ -221,7 +221,7 @@ class WorktreeContextInjector {
 		foreach ( self::INJECTED_PATHS as $relative ) {
 			$abs = rtrim( $worktree_path, '/' ) . '/' . $relative;
 			if ( is_file( $abs ) ) {
-				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_unlink
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Removes DMC-injected local-only context files from a worktree.
 				unlink( $abs );
 				$removed[] = $abs;
 			}
@@ -426,7 +426,7 @@ class WorktreeContextInjector {
 			$current = (string) file_get_contents( $exclude );
 		}
 
-		$existing = array_filter( array_map( 'trim', explode( "\n", $current ) ), 'strlen' );
+		$existing = array_filter( array_map( 'trim', explode( "\n", $current ) ), static fn( string $line ): bool => '' !== $line );
 		$missing  = array();
 		foreach ( $paths as $path ) {
 			$needle = trim( $path );

--- a/inc/Workspace/WorktreeStalenessProbe.php
+++ b/inc/Workspace/WorktreeStalenessProbe.php
@@ -80,7 +80,7 @@ final class WorktreeStalenessProbe {
 			return $result;
 		}
 
-		$count = self::parse_count( (string) ( $result['output'] ?? '' ) );
+		$count = self::parse_count( $result['output'] );
 		return $count;
 	}
 


### PR DESCRIPTION
## Summary
- Run the DMC codebase through the Homeboy WordPress PHPCS ruleset and clear all current PHPCS errors/warnings.
- Clear PHPStan findings surfaced once the Homeboy WordPress extension temp-file bug is fixed.
- Add targeted PHPCS ignores for intentional local filesystem/GitHub API operations that the generic WordPress ruleset cannot infer safely.

## Testing
- `php -l` on changed PHP files
- `git diff --check`
- `~/.config/homeboy/extensions/wordpress/vendor/bin/phpcs --standard=~/.config/homeboy/extensions/wordpress/phpcs.xml.dist --runtime-set testVersion 8.2- --report=summary .`
- Patched Homeboy WordPress lint runner from Extra-Chill/homeboy-extensions#244 against this branch: PHPCS passed, PHPStan passed, linting passed.

## Notes
- This PR intentionally does **not** add a PHPUnit wrapper for existing smoke scripts. Smoke-script execution belongs in the Homeboy WordPress extension and is handled in Extra-Chill/homeboy-extensions#244.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the DMC-side lint/PHPStan release-check failures, applied PHPCS cleanup/targeted ignores, and ran focused validation. Chris remains responsible for review and merge.