### PR TITLE
feat(worktree): expose metadata in listings

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -886,6 +886,8 @@ class WorkspaceAbilities {
 										'head'        => array( 'type' => 'string' ),
 										'path'        => array( 'type' => 'string' ),
 										'dirty'       => array( 'type' => 'integer' ),
+										'created_at'  => array( 'type' => array( 'string', 'null' ) ),
+										'metadata'    => array( 'type' => array( 'object', 'null' ) ),
 									),
 								),
 							),

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -1220,6 +1220,7 @@ class Workspace {
 				$dirty_files  = is_wp_error( $dirty_result )
 					? 0
 					: count( array_filter( array_map( 'trim', explode( "\n", $dirty_result['output'] ?? '' ) ) ) );
+				$metadata = ( ! $is_primary && $inside_ws ) ? WorktreeContextInjector::get_metadata( $relative ) : null;
 
 				$worktrees[] = array(
 					'handle'      => $handle,
@@ -1232,6 +1233,8 @@ class Workspace {
 					'head'        => $wt['head'],
 					'path'        => $wt['path'],
 					'dirty'       => $dirty_files,
+					'created_at'  => is_array( $metadata ) ? ( $metadata['created_at'] ?? null ) : null,
+					'metadata'    => $metadata,
 				);
 			}
 		}

--- a/tests/smoke-worktree-cleanup.php
+++ b/tests/smoke-worktree-cleanup.php
@@ -74,7 +74,22 @@ namespace {
 
 	if ( ! function_exists( 'get_option' ) ) {
 		function get_option( string $name, $default = false ) {
-			return $default;
+			global $datamachine_code_test_options;
+			return $datamachine_code_test_options[ $name ] ?? $default;
+		}
+	}
+
+	if ( ! function_exists( 'update_option' ) ) {
+		function update_option( string $name, $value, $autoload = null ): bool {
+			global $datamachine_code_test_options;
+			$datamachine_code_test_options[ $name ] = $value;
+			return true;
+		}
+	}
+
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( string $hook_name, $value ) {
+			return $value;
 		}
 	}
 
@@ -84,6 +99,10 @@ namespace {
 		}
 	}
 
+	require __DIR__ . '/../inc/Support/GitHubRemote.php';
+	require __DIR__ . '/../inc/Support/GitRunner.php';
+	require __DIR__ . '/../inc/Support/PathSecurity.php';
+	require __DIR__ . '/../inc/Workspace/WorktreeContextInjector.php';
 	require __DIR__ . '/../inc/Workspace/Workspace.php';
 
 	// Skip if git missing.
@@ -102,10 +121,11 @@ namespace {
 		}
 	} );
 
-	define( 'DATAMACHINE_WORKSPACE_PATH', $tmp );
+	define( 'DATAMACHINE_WORKSPACE_PATH', realpath( $tmp ) ?: $tmp );
 
 	$failures = 0;
 	$total    = 0;
+	$datamachine_code_test_options = array();
 
 	$assert = function ( $expected, $actual, string $message ) use ( &$failures, &$total ): void {
 		$total++;
@@ -191,6 +211,17 @@ namespace {
 	// Dirty the dirty worktree.
 	file_put_contents( $tmp . '/demo@dirty-branch/scratch.txt', 'dirty' );
 
+	\DataMachineCode\Workspace\WorktreeContextInjector::store_metadata(
+		'demo@unmerged-feature',
+		array(
+			'site_url'   => 'http://example.test',
+			'site_name'  => 'Example',
+			'agent_slug' => 'agent-one',
+			'abspath'    => '/example',
+			'timestamp'  => '2026-04-25T00:00:00+00:00',
+		)
+	);
+
 	// Simulate "remote deleted the merged-autodelete branch" — classic
 	// GitHub auto-delete-on-merge scenario. After a fetch --prune, the
 	// local branch's upstream tracking ref will be "gone".
@@ -215,6 +246,12 @@ namespace {
 
 	$assert( true, ! is_wp_error( $plan ) && ( $plan['success'] ?? false ), 'dry_run returns success' );
 	$assert( true, $plan['dry_run'] ?? false, 'dry_run flag echoes back true' );
+
+	$list = $ws->worktree_list( 'demo' );
+	$metadata_items = array_filter( $list['worktrees'] ?? array(), fn( $wt ) => ( $wt['handle'] ?? '' ) === 'demo@unmerged-feature' );
+	$metadata_item  = array_values( $metadata_items )[0] ?? array();
+	$assert( '2026-04-25T00:00:00+00:00', $metadata_item['created_at'] ?? null, 'worktree list exposes creation metadata for agent runtime' );
+	$assert( 'agent-one', $metadata_item['metadata']['agent_slug'] ?? null, 'worktree list exposes agent metadata for agent runtime' );
 
 	$assert_contains( $plan['candidates'] ?? array(), 'demo@merged-autodelete', 'canonical merged worktree flagged prunable' );
 
@@ -277,7 +314,6 @@ namespace {
 
 	// Verify validate_containment catches a primary being passed in.
 	$reflection = new \ReflectionMethod( \DataMachineCode\Workspace\Workspace::class, 'remove_worktree_by_path' );
-	$reflection->setAccessible( true );
 	$safety = $reflection->invoke( $ws, 'demo', 'main', $primary, false );
 	$is_error = is_wp_error( $safety );
 	$assert( true, $is_error, 'remove_worktree_by_path refuses primary (is WP_Error)' );


### PR DESCRIPTION
## Summary
- Expose persisted worktree creation metadata from `workspace worktree list` / `workspace-worktree-list` so external agent runtimes can reason about lifecycle state.
- Keep cleanup semantics unchanged; no new diagnostic command or scheduled-task behavior.
- Update the cleanup smoke test bootstrap to load the support classes it exercises and assert metadata is surfaced.

## Tests
- `php -l inc/Workspace/Workspace.php`
- `php -l inc/Abilities/WorkspaceAbilities.php`
- `php -l inc/Cli/Commands/WorkspaceCommand.php`
- `php -l tests/smoke-worktree-cleanup.php`
- `php tests/smoke-worktree-cleanup.php`
- `php tests/smoke-worktree-handles.php`
- `php tests/smoke-worktree-staleness.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the implementation and smoke-test updates under Chris's direction; Chris steered the architecture away from task modes / diagnostic verbs toward external-runtime-consumable metadata.