### PR TITLE
fix(cli): rename workspace --path to --rel to avoid WP-CLI global collision

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ wp datamachine-code workspace edit repo-name@fix-foo path/to/file.txt --old="foo
 wp datamachine-code workspace remove repo-name
 wp datamachine-code workspace git status repo-name@fix-foo
 wp datamachine-code workspace git pull repo-name@fix-foo
-wp datamachine-code workspace git add repo-name@fix-foo --path=src/file.php
+wp datamachine-code workspace git add repo-name@fix-foo --rel=src/file.php
 wp datamachine-code workspace git commit repo-name@fix-foo "fix: something"
 wp datamachine-code workspace git push repo-name@fix-foo
 wp datamachine-code workspace git log repo-name@fix-foo

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -667,8 +667,9 @@ class WorkspaceCommand extends BaseCommand {
 	 * [<value>]
 	 * : Optional operation value (e.g., commit message for commit).
 	 *
-	 * [--path=<path>]
-	 * : Relative path (repeatable) for add/diff operations.
+	 * [--rel=<path>]
+	 * : Relative path (repeatable) for add/diff operations. Named `--rel`
+	 *   to avoid colliding with WP-CLI's documented global `--path` flag.
 	 *
 	 * [--allow-dirty]
 	 * : Allow pull with dirty working tree.
@@ -703,7 +704,7 @@ class WorkspaceCommand extends BaseCommand {
 	 *     wp datamachine workspace git pull data-machine
 	 *
 	 *     # Stage docs paths
-	 *     wp datamachine workspace git add extrachill-docs --path=ec_docs/community/getting-started.md
+	 *     wp datamachine workspace git add extrachill-docs --rel=ec_docs/community/getting-started.md
 	 *
 	 *     # Commit staged changes
 	 *     wp datamachine workspace git commit extrachill-docs "docs: update community guide"
@@ -715,7 +716,7 @@ class WorkspaceCommand extends BaseCommand {
 	 *     wp datamachine workspace git log data-machine --limit=10
 	 *
 	 *     # Show diff for a path
-	 *     wp datamachine workspace git diff data-machine --path=inc/Core/FilesRepository/Workspace.php
+	 *     wp datamachine workspace git diff data-machine --rel=inc/Core/FilesRepository/Workspace.php
 	 *
 	 * @subcommand git
 	 */
@@ -762,14 +763,14 @@ class WorkspaceCommand extends BaseCommand {
 		}
 
 		if ( 'add' === $operation ) {
-			$paths = $assoc_args['path'] ?? array();
+			$paths = $assoc_args['rel'] ?? array();
 			if ( ! is_array( $paths ) ) {
 				$paths = array( $paths );
 			}
 			$input['paths'] = array_values( array_filter( array_map( 'strval', $paths ) ) );
 
 			if ( empty( $input['paths'] ) ) {
-				WP_CLI::error( 'git add requires at least one --path=<relative/path>.' );
+				WP_CLI::error( 'git add requires at least one --rel=<relative/path>.' );
 				return;
 			}
 		}
@@ -806,9 +807,9 @@ class WorkspaceCommand extends BaseCommand {
 			if ( ! empty( $assoc_args['staged'] ) ) {
 				$input['staged'] = true;
 			}
-			if ( isset( $assoc_args['path'] ) ) {
-				$path          = $assoc_args['path'];
-				$input['path'] = is_array( $path ) ? (string) reset( $path ) : (string) $path;
+			if ( isset( $assoc_args['rel'] ) ) {
+				$rel           = $assoc_args['rel'];
+				$input['path'] = is_array( $rel ) ? (string) reset( $rel ) : (string) $rel;
 			}
 		}
 

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -142,7 +142,7 @@ option). For this smoke pass, set `write_enabled` and `push_enabled` for
 ```bash
 wp datamachine-code workspace write data-machine-code@feat-test-worktree tests/SMOKE.txt --content="hello"
 wp datamachine-code workspace git status data-machine-code@feat-test-worktree
-wp datamachine-code workspace git add data-machine-code@feat-test-worktree --path=tests/SMOKE.txt
+wp datamachine-code workspace git add data-machine-code@feat-test-worktree --rel=tests/SMOKE.txt
 wp datamachine-code workspace git commit data-machine-code@feat-test-worktree "test: smoke worktree commit"
 wp datamachine-code workspace git log data-machine-code@feat-test-worktree --limit=3
 ```


### PR DESCRIPTION
## Summary

- Rename `--path` to `--rel` on `wp datamachine-code workspace git add` and `git diff` — `--path` collides with WP-CLI's documented global `--path=<path>` (path to the WordPress files) and is unusable from any `wp` / `studio wp` invocation.
- CLI surface only — ability input-schema property names remain `path`. PHP / REST / MCP callers are unaffected.
- No back-compat alias. The old name was broken in every WP-CLI context — there's nothing to preserve.

## Root cause

WP-CLI ships a documented global flag `--path=<path>` ("Path to the WordPress files") that every subcommand inherits. Studio's CLI passes it through correctly to WP-CLI.

`WorkspaceCommand::git()` registered `[--path=<path>]` as a subcommand-level option for `add` and `diff`. That name **always** collides with WP-CLI's global — yargs/WP-CLI captures `--path` as the global before the subcommand sees it. There's no escape syntax for end users; the subcommand-level `--path` is unreachable through any `wp` / `studio wp` invocation. Flag-naming defect on our side, not a Studio bug.

## Reproduction (before the fix)

```
$ studio wp datamachine-code workspace git add homeboy@feat-foo --path=Cargo.toml
✖ The specified directory is not added to Studio.
```

The error comes from Studio's site-resolution layer, which receives `--path=Cargo.toml` and tries to interpret it as a WordPress install path. The DMC subcommand never sees the flag.

## Changes

**`inc/Cli/Commands/WorkspaceCommand.php`**
- Synopsis: `[--path=<path>]` → `[--rel=<path>]` on the `git` subcommand. Description annotated to explain the rename.
- `git add` operation: reads `$assoc_args['rel']` instead of `$assoc_args['path']`. Error message updated.
- `git diff` operation: reads `$assoc_args['rel']` instead of `$assoc_args['path']`. Local var renamed to `$rel` for clarity. Internal ability input key (`$input['path']`) is unchanged — that's the ability's contract.
- Two doc-block examples updated.

**`README.md`**
- Quickstart example updated to `--rel=src/file.php`.

**`tests/TESTING.md`**
- Worktree smoke recipe updated to `--rel=tests/SMOKE.txt`.

## Validation

Tested live on `intelligence-chubes4` after rsyncing the modified `WorkspaceCommand.php` into `wp-content/plugins/data-machine-code/`.

**New flag works (real diff returned):**
```
$ studio wp datamachine-code workspace git diff data-machine-code@rename-path-to-rel --rel=README.md
@@ -73,7 +73,7 @@ wp datamachine-code workspace edit repo-name@fix-foo path/to/file.txt --old="foo
-wp datamachine-code workspace git add repo-name@fix-foo --path=src/file.php
+wp datamachine-code workspace git add repo-name@fix-foo --rel=src/file.php
```

**Repeatable form works (multi-file stage):**
```
$ studio wp datamachine-code workspace git add data-machine-code@rename-path-to-rel \
    --rel=README.md \
    --rel=inc/Cli/Commands/WorkspaceCommand.php \
    --rel=tests/TESTING.md
Success: Paths staged successfully.
```

**Old flag still demonstrates the underlying collision (expected — Studio still owns `--path` globally):**
```
$ studio wp datamachine-code workspace git add data-machine-code@rename-path-to-rel --path=README.md
✖ The specified directory is not added to Studio.
```

This is the bug we can't fix from inside DMC. It's why the rename was necessary.

PHP lint clean. Plugin loads cleanly (`workspace list` returns full repo table).

## No back-compat

Per the no-shim rule. The `--path` flag was unreachable in every `wp` / `studio wp` invocation, so there are no callers in the wild that successfully passed it. Accepting both names would just keep the broken-looking syntax in docs and tab-completion. One-shot rename, gone.

`MEMORY.md` previously documented this as the "Workspace git wrapper bug" requiring a raw-git fallback (`git -C <worktree> add ...`). That fallback can be retired once this lands.

## Out of scope

- **Ability input-schema property names are unchanged.** `datamachine/workspace-git-add` still takes `paths` (array); `datamachine/workspace-git-diff` still takes `path`. PHP, REST, and MCP consumers see no change.
- **Positional `<path>` args** on `workspace read` / `ls` / `write` / `edit` are not affected — those are positional arguments, not flags, and don't collide with WP-CLI's global `--path`.
- **`GitSyncCommand`'s `--paths=<paths>`** (plural) is a different name entirely. WP-CLI's global is singular `--path`. No collision.
- **`data-machine-code.php`'s `--path=`** usage is intentional: it constructs WP-CLI command strings to spawn subprocesses against a specific WordPress install, which is exactly what the WP-CLI global is for.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** drafted the rename and discovery sweep; Chris caught the root cause that this is a DMC flag-name collision with WP-CLI's documented global `--path`, not a Studio bug.