### PR TITLE
fix(lint): align $metadata assignment with surrounding block

### DIFF
--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -1220,7 +1220,7 @@ class Workspace {
 				$dirty_files  = is_wp_error( $dirty_result )
 					? 0
 					: count( array_filter( array_map( 'trim', explode( "\n", $dirty_result['output'] ?? '' ) ) ) );
-				$metadata = ( ! $is_primary && $inside_ws ) ? WorktreeContextInjector::get_metadata( $relative ) : null;
+				$metadata     = ( ! $is_primary && $inside_ws ) ? WorktreeContextInjector::get_metadata( $relative ) : null;
 
 				$worktrees[] = array(
 					'handle'      => $handle,


### PR DESCRIPTION
## Summary

- Fix the only PHPCS `Generic.Formatting.MultipleStatementAlignment` warning in DMC.
- One-space → five-space fix on `inc/Workspace/Workspace.php:1223` to align `$metadata =` with the surrounding `$dirty_result =` / `$dirty_files  =` block.

## Why

`homeboy release data-machine-code` runs the lint phase before tagging and refused to release `main` because of this single warning:

```
inc/Workspace/Workspace.php::Generic.Formatting.MultipleStatementAlignment.NotSameWarning::1223
Equals sign not aligned with surrounding assignments; expected 5 spaces but found 1 space
```

`homeboy refactor data-machine-code --from lint --write` collected the finding but could not produce an automated edit, so this is a manual fix.

Pre-existing since #60 (`feat(worktree): expose metadata in listings`) — landed in the listing block where the surrounding lines are already 4-space-aligned.

## Validation

- `homeboy lint data-machine-code` passes (PHPCS clean, PHPStan clean).
- Diff is one space.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** spotted the alignment finding while running `homeboy release` post-#61, applied the one-space fix, ran lint locally to confirm.