### PR TITLE
fix(agents-md): point Memory verb at `datamachine memory`, not `datamachine agent`

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -323,7 +323,7 @@ Data Machine is your operating layer — memory, automation, and orchestration v
 Discover the full command surface: `{$wp} datamachine --help`. The groups below are the major command families — always run `--help` on any subcommand to see its options.
 
 **Memory & Agents:** Persistent files across sessions plus agent identity management.
-- Memory paths / read / write / search: `{$wp} datamachine agent paths|read|write|search`
+- Memory paths / read / write / search: `{$wp} datamachine memory paths|read|write|search`
 - Agent management: `{$wp} datamachine agents list|create|access|tokens` — identities, permissions, bearer tokens
 - Update MEMORY.md when you learn something persistent — read it first, append new info.
 


### PR DESCRIPTION
## Summary

- The composed AGENTS.md "Data Machine" section sent agents to `{wp} datamachine agent paths|read|write|search` for memory ops. Those verbs live under `datamachine memory`, not `datamachine agent`.
- One-character fix in the SectionRegistry callback.

## Repro

```
$ studio wp datamachine agent read --help
Error: 'read' is not a registered subcommand of 'datamachine agent'.
        See 'wp help datamachine agent' for available subcommands.
```

The actual surface (data-machine v0.80.3):

```
$ studio wp datamachine memory
usage: wp datamachine memory compose [...]
   or: wp datamachine memory daily   [...]
   or: wp datamachine memory files   [...]
   or: wp datamachine memory paths   [...]
   or: wp datamachine memory read    [...]
   or: wp datamachine memory search  [...]
   or: wp datamachine memory sections [...]
   or: wp datamachine memory write   [...]
```

The `agent` group covers identity / access / config / tokens (`agent show|create|delete|access|token|config|export|import|rename|cleanup-legacy-context-files`). Memory ops moved to their own group at some point and the AGENTS.md text never followed.

## Change

`data-machine-code.php:326`:

```diff
- - Memory paths / read / write / search: `{$wp} datamachine agent paths|read|write|search`
+ - Memory paths / read / write / search: `{$wp} datamachine memory paths|read|write|search`
```

The next line — `agents list|create|access|tokens` (plural) — is correct as-is. That's the agent identity surface and stays put.

## Validation

- `php -l data-machine-code.php` clean.
- After regenerating AGENTS.md with `wp datamachine memory compose AGENTS.md`, the Data Machine section will reference the working verbs.

## Out of scope

- Other AGENTS.md sections in this file (Abilities, WordPress Source, Code, etc.) were not audited for similar drift in this PR. Reasonably-fast follow-up if useful.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** spotted the stale verb while running `wp datamachine agent read --help` mid-task and bouncing off the error; tracked the section source back to DMC's SectionRegistry callback; one-character fix.