### PR TITLE
feat(workspace): add delete primitive (workspace-delete ability + CLI)

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -616,6 +616,83 @@ class WorkspaceCommand extends BaseCommand {
 	}
 
 	/**
+	 * Delete a tracked or untracked path from a workspace repo.
+	 *
+	 * Tracked paths are removed via `git rm` (working tree + index in one
+	 * shot). Untracked paths are unlinked from disk; directories require
+	 * --recursive. Sensitive-path, traversal, allowlist, and primary-mutation
+	 * gates apply just like `workspace git add`.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <repo>
+	 * : Workspace handle: `<repo>` (primary) or `<repo>@<branch-slug>` (worktree).
+	 *
+	 * <path>
+	 * : Relative path within the repo (file or directory).
+	 *
+	 * [--recursive]
+	 * : Required when target is a directory.
+	 *
+	 * [--allow-primary-mutation]
+	 * : Permit mutation on the primary checkout (default off). Worktrees are always allowed.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Delete a tracked file (staged via git rm)
+	 *     wp datamachine-code workspace delete homeboy@my-branch src/old_module.rs
+	 *
+	 *     # Delete an entire directory tree
+	 *     wp datamachine-code workspace delete homeboy@my-branch src/legacy --recursive
+	 *
+	 *     # Delete on the primary checkout (rare, gated)
+	 *     wp datamachine-code workspace delete homeboy notes.md --allow-primary-mutation
+	 *
+	 * @subcommand delete
+	 */
+	public function delete( array $args, array $assoc_args ): void {
+		if ( empty( $args[0] ) || empty( $args[1] ) ) {
+			WP_CLI::error( 'Usage: wp datamachine-code workspace delete <repo> <path> [--recursive] [--allow-primary-mutation]' );
+			return;
+		}
+
+		$ability = wp_get_ability( 'datamachine/workspace-delete' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'Workspace delete ability not available.' );
+			return;
+		}
+
+		$input = array(
+			'repo' => $args[0],
+			'path' => $args[1],
+		);
+
+		if ( ! empty( $assoc_args['recursive'] ) ) {
+			$input['recursive'] = true;
+		}
+		if ( ! empty( $assoc_args['allow-primary-mutation'] ) ) {
+			$input['allow_primary_mutation'] = true;
+		}
+
+		$result = $ability->execute( $input );
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
+
+		$count = is_array( $result['deleted'] ?? null ) ? count( $result['deleted'] ) : 1;
+		$mode  = ! empty( $result['was_tracked'] ) ? 'git rm' : 'unlink';
+		WP_CLI::success( sprintf(
+			'Deleted %s via %s (%d path%s removed)',
+			$result['path'],
+			$mode,
+			$count,
+			1 === $count ? '' : 's'
+		) );
+	}
+
+	/**
 	 * Resolve @file syntax — if a string starts with @, read file contents.
 	 *
 	 * Mirrors curl's -d @filename convention. If the value doesn't start


### PR DESCRIPTION
## Summary

Closes #64. Fills a gap where agents had to drop out of the workspace API to remove tracked files (the `git rm` / `rm -rf` workaround that bypassed containment, sensitive-path, allowlist, and primary-mutation gates).

New ability `datamachine/workspace-delete` plus a `wp datamachine-code workspace delete <repo> <path>` CLI subcommand. Tracked paths are removed via `git rm` so the deletion lands in working tree and index in one shot. Untracked paths are unlinked from disk; directories require `--recursive`.

## What's added

- `Workspace::delete_path()` (inc/Workspace/Workspace.php) — sits next to `git_add` and reuses its existing gate ladder: traversal, sensitive-path, allowlist, primary-mutation. Detects tracked vs untracked via `git ls-files --error-unmatch` and dispatches to either `git rm [-r]` or a recursive filesystem unlink.
- `Workspace::remove_directory_recursive()` — private helper that walks an untracked directory deepest-first and reports every removed entry.
- `datamachine/workspace-delete` ability (inc/Abilities/WorkspaceAbilities.php) — input `{ repo, path, recursive?, allow_primary_mutation? }`, output `{ success, name, repo, path, deleted[], was_tracked }`. Description and category match the existing workspace abilities.
- `wp datamachine-code workspace delete` subcommand (inc/Cli/Commands/WorkspaceCommand.php) — same docblock + `@subcommand` shape as `edit`/`write`.

## Why a single primitive

Splitting into `delete-file` + `delete-directory` doubles the surface for no gain. `recursive` flag covers directories and makes accidental recursive deletes opt-in (rejecting directories without `recursive=true` matches POSIX `rm` semantics).

## Verification (live on intelligence-chubes4)

- Untracked file: `delete homeboy@<branch> tmp.txt` → `unlink (1 path removed)`. ✓
- Tracked file: created → committed → `delete` → `git status` showed staged `D` entry. ✓
- Directory without `--recursive` → `directory_requires_recursive` error. ✓
- Directory with `--recursive` → `unlink (4 paths removed)` (file + nested file + subdir + dir). ✓
- Sensitive path (`.env`) → `sensitive_path` error. ✓
- Path traversal (`../escape`) → `invalid_path` error. ✓
- Absolute path (`/abs/path`) → `invalid_path` error. ✓
- Primary checkout without override → `primary_mutation_not_allowed` error. ✓
- Primary checkout with `--allow-primary-mutation` → succeeds. ✓
- Path not found → `not_found` (404) error. ✓

## Out of scope

- No glob/pattern support — agents enumerate paths themselves. Consistent with `git_add`.
- No "soft delete" / trash semantics — git history is the undo path.
- No batch ability `workspace-delete-many` — agents can call once per path. Add later if it becomes a real need.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafting the gap issue (#64), implementing the ability + CLI by mirroring `git_add` / `workspace edit` shapes, and live-smoke-testing every gate path on intelligence-chubes4. Chris reviewed the gap framing and authorized the upstream-first fix.