### PR TITLE
fix(workspace): collect repeatable --rel flag from argv (closes #67)

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -693,6 +693,46 @@ class WorkspaceCommand extends BaseCommand {
 	}
 
 	/**
+	 * Collect every `--<flag>=<value>` occurrence from the raw process argv.
+	 *
+	 * WP-CLI's parsed `$assoc_args` is last-wins for repeated assoc flags —
+	 * it never returns an array, even when the synopsis declares the flag as
+	 * repeatable (`...`). For commands that document a flag as repeatable
+	 * (`--rel`, `--include`, etc.), we walk $GLOBALS['argv'] directly so
+	 * every occurrence is preserved in argv order.
+	 *
+	 * Empty values are filtered out. Bare `--<flag>` (no value) is ignored
+	 * because it's ambiguous in the assoc-flag context.
+	 *
+	 * @param string $flag Flag name without the leading `--` (e.g. 'rel').
+	 * @return string[] Every value, in argv order, for the named flag.
+	 */
+	private function collectRepeatableFlag( string $flag ): array {
+		$argv = $GLOBALS['argv'] ?? array();
+		if ( ! is_array( $argv ) ) {
+			return array();
+		}
+
+		$prefix    = '--' . $flag . '=';
+		$prefix_len = strlen( $prefix );
+		$values    = array();
+
+		foreach ( $argv as $token ) {
+			if ( ! is_string( $token ) ) {
+				continue;
+			}
+			if ( 0 === strpos( $token, $prefix ) ) {
+				$value = substr( $token, $prefix_len );
+				if ( '' !== $value ) {
+					$values[] = $value;
+				}
+			}
+		}
+
+		return $values;
+	}
+
+	/**
 	 * Resolve @file syntax — if a string starts with @, read file contents.
 	 *
 	 * Mirrors curl's -d @filename convention. If the value doesn't start
@@ -840,11 +880,7 @@ class WorkspaceCommand extends BaseCommand {
 		}
 
 		if ( 'add' === $operation ) {
-			$paths = $assoc_args['rel'] ?? array();
-			if ( ! is_array( $paths ) ) {
-				$paths = array( $paths );
-			}
-			$input['paths'] = array_values( array_filter( array_map( 'strval', $paths ) ) );
+			$input['paths'] = $this->collectRepeatableFlag( 'rel' );
 
 			if ( empty( $input['paths'] ) ) {
 				WP_CLI::error( 'git add requires at least one --rel=<relative/path>.' );
@@ -884,9 +920,9 @@ class WorkspaceCommand extends BaseCommand {
 			if ( ! empty( $assoc_args['staged'] ) ) {
 				$input['staged'] = true;
 			}
-			if ( isset( $assoc_args['rel'] ) ) {
-				$rel           = $assoc_args['rel'];
-				$input['path'] = is_array( $rel ) ? (string) reset( $rel ) : (string) $rel;
+			$diff_paths = $this->collectRepeatableFlag( 'rel' );
+			if ( ! empty( $diff_paths ) ) {
+				$input['path'] = (string) $diff_paths[0];
 			}
 		}
 


### PR DESCRIPTION
## Summary

Closes #67. `wp datamachine-code workspace git add <repo> --rel=A --rel=B --rel=C` was silently staging only the last `--rel`. The CLI returned "Paths staged successfully" but the others were dropped before reaching the ability.

This caused PR #65's incomplete merge — three files were staged via three `--rel` flags, but only one made it into the commit.

## Root cause

WP-CLI gap, surfaced in DMC. WP-CLI's `$assoc_args` is **always last-wins for repeated `--flag=value` occurrences** — verified by reading [`SynopsisParser.php`](https://github.com/wp-cli/wp-cli/blob/main/php/WP_CLI/SynopsisParser.php). The `repeating` concept only renders the `...` synopsis marker; the parsed assoc-args layer never collects multiple values into an array. Plugins that document a flag as repeatable have to walk `$GLOBALS['argv']` directly. That's the documented (de-facto) pattern across the WP-CLI ecosystem.

DMC documents `--rel` as repeatable but never implemented the argv walk. The dead-code `is_array($paths)` guard (and `reset($rel)` in the `diff` branch) was a tell — `$assoc_args['rel']` is always a string when set, so those branches never fired.

## What this PR adds

A new private helper `collectRepeatableFlag(string $flag): array` on `WorkspaceCommand` that walks `$GLOBALS['argv']` and returns every `--<flag>=<value>` occurrence in argv order, filtering empty values and ignoring bare `--<flag>` (no value).

Replaces both callsites (`add` and `diff` branches in `git()`) with the helper. Drops the dead `is_array` and `reset` branches.

## Why a private helper, not a static utility

One callsite-shape today, both inside the same class. If a second DMC command needs repeatable flags later, promote it then; YAGNI for now.

## Verification (live on intelligence-chubes4)

- `git add <repo> --rel=A --rel=B --rel=C` → all three staged. ✓
- `git add <repo> --rel=A` (single) → A staged. ✓
- `git add <repo>` (no flags) → `git add requires at least one --rel=<relative/path>.` ✓

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Spotting the bug while shipping #65/#66; reading WP-CLI's SynopsisParser to confirm the gap is upstream-by-design and not a WP-CLI core bug; implementing the helper + replacing callsites; live-smoke-testing on intelligence-chubes4. Chris asked for the fix and reviewed the framing.