### PR TITLE
docs(agents): split bench + rig in homeboy section, frame rig as dev-env-as-code

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -434,7 +434,9 @@ MD;
 
 **Git:** prefer `homeboy git changes | status | commit | push | pull | tag` — auto-baselines, structured output, `--json` bulk. One-off reads (`git diff`, `git show`, `git blame`) stay on raw `git`.
 
-**Perf + envs:** `homeboy bench` for pinned benchmarks, `homeboy rig` for reproducible dev environments.
+**Bench:** `homeboy bench` for pinned benchmarks with baseline + ratchet.
+
+**Rig:** `homeboy rig up | check | down | status` — dev-environment-as-code at `~/.config/homeboy/rigs/<id>.json`. When a project's setup is multi-component (a fork wired up next to its consumer, checkouts symlinked into a runtime, app + sidecar service), declare it in a rig spec rather than reproducing setup by hand. `rig check` is the structured answer to "is my dev environment currently in the declared state" — reach for it before any "I tested this" claim.
 
 **Repo rules** (when `homeboy.json` is present):
 - **NEVER edit `CHANGELOG.md`** — generated from conventional commits at release time.


### PR DESCRIPTION
## Summary

Splits \`bench\` and \`rig\` apart in the Homeboy section of the composed AGENTS.md, and reframes \`rig\` as **dev-environment-as-code** rather than a vague \"reproducible dev environments\" footnote.

## Why

The previous one-line treatment buried \`rig\` next to \`bench\` as if they were the same family of verb. They aren't — \`bench\` runs benchmarks, \`rig\` declaratively materializes a multi-component dev environment (Studio + Playground, app + sidecar, checkout symlinked into a runtime, etc.). Sessions consistently rediscovered the rig pattern by hand because the AGENTS.md never pointed them at it.

The new framing also calls out \`rig check\` as the structured pre-flight answer for \"is my dev environment currently in the declared state\" — a real failure-mode that bites agent sessions repeatedly when env state drifts silently between tasks (stale daemons, repointed symlinks, half-rebuilt tarballs). \`rig check\` is the verb that replaces \`readlink\` / \`ps\` / \`curl\` muscle-memory before any \"I tested this\" claim.

## Scope

The wording stays **deliberately generic**. DMC's homeboy section composes onto every site that has DMC + homeboy installed (intelligence-chubes4, extrachill.com, future installs). Site-specific rig conventions — e.g. \"intelligence-chubes4's plugin symlinks are owned by intelligence-chubes4.json, never \`ln -sfn\` them by hand\" — belong in per-site MEMORY.md / RULES.md, not in this plugin's globally-composed section.

## Diff

\`\`\`
-**Perf + envs:** \`homeboy bench\` for pinned benchmarks, \`homeboy rig\` for reproducible dev environments.
+**Bench:** \`homeboy bench\` for pinned benchmarks with baseline + ratchet.
+
+**Rig:** \`homeboy rig up | check | down | status\` — dev-environment-as-code at \`~/.config/homeboy/rigs/<id>.json\`. When a project's setup is multi-component (a fork wired up next to its consumer, checkouts symlinked into a runtime, app + sidecar service), declare it in a rig spec rather than reproducing setup by hand. \`rig check\` is the structured answer to \"is my dev environment currently in the declared state\" — reach for it before any \"I tested this\" claim.
\`\`\`

## Tests

- \`php -l\` clean on \`data-machine-code.php\`.
- \`tests/smoke-homeboy.php\` passes (5/5 — capability-helper assertions unaffected by docs-only change).
- The section is gated by \`Homeboy::is_available()\`, unchanged by this PR.

## House-style notes

Followed the AGENTS.md house style captured in MEMORY: bold sub-label, terse verb pipe, one-line definition, ends with a discoverability hint that points the reader at \`rig check\`. Section length stays in line with the reference shape (\`## Data Machine\`, \`## Abilities\`).

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Drafting the new framing wording after a back-and-forth on whether the change belonged in DMC's globally-composed section vs per-site MEMORY. Reviewed by Chris before commit; he caught and rejected an earlier draft that was too site-specific.