### PR TITLE
fix(workspace): accept base-branch worktree alias

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1013,6 +1013,10 @@ class WorkspaceCommand extends BaseCommand {
 	 * [--from=<ref>]
 	 * : Base ref when creating a branch on add (default origin/HEAD).
 	 *
+	 * [--base-branch=<branch>]
+	 * : Convenience alias for branch-shaped bases. `--base-branch=main`
+	 *   maps to `--from=origin/main`. Use `--from` for exact refs.
+	 *
 	 * [--skip-context-injection]
 	 * : Skip injecting the originating site's agent context into a new
 	 *   worktree (applies to `add` only). Default behavior is to write
@@ -1074,6 +1078,7 @@ class WorkspaceCommand extends BaseCommand {
 	 *
 	 *     # Create off a specific base
 	 *     wp datamachine workspace worktree add data-machine feat/bar --from=origin/develop
+	 *     wp datamachine workspace worktree add data-machine feat/bar --base-branch=develop
 	 *
 	 *     # List all worktrees
 	 *     wp datamachine workspace worktree list
@@ -1153,13 +1158,19 @@ class WorkspaceCommand extends BaseCommand {
 		switch ( $operation ) {
 			case 'add':
 				if ( empty( $args[1] ) || empty( $args[2] ) ) {
-					WP_CLI::error( 'Usage: worktree add <repo> <branch> [--from=<ref>] [--skip-context-injection] [--skip-bootstrap] [--allow-stale] [--rebase-base]' );
+					WP_CLI::error( 'Usage: worktree add <repo> <branch> [--from=<ref>|--base-branch=<branch>] [--skip-context-injection] [--skip-bootstrap] [--allow-stale] [--rebase-base]' );
 					return;
 				}
 				$input['repo']   = $args[1];
 				$input['branch'] = $args[2];
+				if ( ! empty( $assoc_args['from'] ) && ! empty( $assoc_args['base-branch'] ) ) {
+					WP_CLI::error( 'Use either --from=<ref> or --base-branch=<branch>, not both.' );
+					return;
+				}
 				if ( ! empty( $assoc_args['from'] ) ) {
 					$input['from'] = (string) $assoc_args['from'];
+				} elseif ( ! empty( $assoc_args['base-branch'] ) ) {
+					$input['from'] = self::base_branch_to_ref( (string) $assoc_args['base-branch'] );
 				}
 				// --skip-context-injection disables the default-on injection step.
 				$input['inject_context'] = empty( $assoc_args['skip-context-injection'] );
@@ -1437,5 +1448,24 @@ class WorkspaceCommand extends BaseCommand {
 		// No signal available (default base was origin/HEAD, or no upstream
 		// configured for the existing branch). Elide the line rather than
 		// print a potentially-misleading "up to date".
+	}
+
+	/**
+	 * Convert a branch-shaped CLI alias into the exact ref expected downstream.
+	 *
+	 * `--from` remains the exact-ref escape hatch. `--base-branch` is for the
+	 * common branch-name case agents reach for, so bare names become origin refs.
+	 *
+	 * @param string $base_branch Branch or ref passed to --base-branch.
+	 * @return string Ref to pass to the worktree-add ability.
+	 */
+	private static function base_branch_to_ref( string $base_branch ): string {
+		$base_branch = trim( $base_branch );
+
+		if ( preg_match( '/^(?:refs\/|(?:origin|upstream)\/|HEAD$|[a-f0-9]{7,40}$)/i', $base_branch ) ) {
+			return $base_branch;
+		}
+
+		return 'origin/' . ltrim( $base_branch, '/' );
 	}
 }

--- a/tests/smoke-worktree-base-branch-cli.php
+++ b/tests/smoke-worktree-base-branch-cli.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Smoke test for the workspace worktree --base-branch CLI alias.
+ *
+ *   php tests/smoke-worktree-base-branch-cli.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ );
+	}
+
+	class WP_CLI {
+		public static array $logs = array();
+
+		public static function error( string $message ): void {
+			throw new RuntimeException( $message );
+		}
+
+		public static function success( string $message ): void {
+			self::$logs[] = 'success: ' . $message;
+		}
+
+		public static function log( string $message ): void {
+			self::$logs[] = $message;
+		}
+
+		public static function warning( string $message ): void {
+			self::$logs[] = 'warning: ' . $message;
+		}
+	}
+
+	function is_wp_error( $value ): bool {
+		return false;
+	}
+
+	function wp_get_ability( string $name ) {
+		return $GLOBALS['__abilities'][ $name ] ?? null;
+	}
+}
+
+namespace DataMachine\Cli {
+	class BaseCommand {
+		protected function format_items( array $items, array $fields, array $assoc_args, string $default_sort = '' ): void {}
+	}
+}
+
+namespace {
+	require_once dirname( __DIR__ ) . '/inc/Cli/Commands/WorkspaceCommand.php';
+
+	function datamachine_code_assert( bool $condition, string $message ): void {
+		if ( $condition ) {
+			echo "  [PASS] {$message}\n";
+			return;
+		}
+		echo "  [FAIL] {$message}\n";
+		exit( 1 );
+	}
+
+	class FakeWorktreeAddAbility {
+		public array $last_input = array();
+
+		public function execute( array $input ): array {
+			$this->last_input = $input;
+			return array(
+				'success'        => true,
+				'message'        => 'created',
+				'handle'         => 'data-machine@feat-test',
+				'path'           => '/tmp/worktree',
+				'branch'         => $input['branch'] ?? '',
+				'created_branch' => true,
+			);
+		}
+	}
+
+	echo "=== smoke-worktree-base-branch-cli ===\n";
+
+	$ability = new FakeWorktreeAddAbility();
+	$GLOBALS['__abilities'] = array(
+		'datamachine/workspace-worktree-add' => $ability,
+	);
+	$command = new \DataMachineCode\Cli\Commands\WorkspaceCommand();
+
+	echo "\n[1] bare base branch maps to origin ref\n";
+	$command->worktree(
+		array( 'add', 'data-machine', 'feat/test' ),
+		array( 'base-branch' => 'main', 'skip-bootstrap' => true, 'skip-context-injection' => true )
+	);
+	datamachine_code_assert( 'origin/main' === $ability->last_input['from'], 'main maps to origin/main' );
+	datamachine_code_assert( false === $ability->last_input['bootstrap'], 'skip-bootstrap still forwarded' );
+	datamachine_code_assert( false === $ability->last_input['inject_context'], 'skip-context-injection still forwarded' );
+
+	echo "\n[2] branch names with slashes still map to origin refs\n";
+	$command->worktree(
+		array( 'add', 'data-machine', 'feat/test' ),
+		array( 'base-branch' => 'release/next' )
+	);
+	datamachine_code_assert( 'origin/release/next' === $ability->last_input['from'], 'release/next maps to origin/release/next' );
+
+	echo "\n[3] full ref is preserved\n";
+	$command->worktree(
+		array( 'add', 'data-machine', 'feat/test' ),
+		array( 'base-branch' => 'upstream/develop' )
+	);
+	datamachine_code_assert( 'upstream/develop' === $ability->last_input['from'], 'remote ref preserved' );
+
+	echo "\n[4] --from wins by rejecting ambiguous input\n";
+	try {
+		$command->worktree(
+			array( 'add', 'data-machine', 'feat/test' ),
+			array( 'from' => 'origin/main', 'base-branch' => 'develop' )
+		);
+		datamachine_code_assert( false, 'ambiguous flags should throw' );
+	} catch ( RuntimeException $e ) {
+		datamachine_code_assert( str_contains( $e->getMessage(), 'not both' ), 'ambiguous flags fail clearly' );
+	}
+
+	echo "\nAll worktree base-branch CLI smoke tests passed.\n";
+}


### PR DESCRIPTION
## Summary

- Accept `--base-branch=<branch>` on `workspace worktree add` as a CLI-only alias for the existing `from` ability input.
- Map bare branch names to `origin/<branch>` while preserving explicit refs like `origin/main`, `upstream/develop`, `refs/...`, `HEAD`, and SHAs.
- Fail clearly when `--from` and `--base-branch` are both provided.

Closes #73.

## Tests

- `php tests/smoke-worktree-base-branch-cli.php`
- `php -l inc/Cli/Commands/WorkspaceCommand.php`
- `php -l tests/smoke-worktree-base-branch-cli.php`
- `git diff --check`

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Reproducing the unsupported-flag CLI mismatch, drafting the alias implementation and smoke coverage, and validating the command behavior. Chris reviewed and requested the change.
