### PR TITLE
docs(agents): refresh homeboy command map

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -434,8 +434,6 @@ MD;
 
 **Git:** prefer `homeboy git changes | status | commit | push | pull | tag` — auto-baselines, structured output, `--json` bulk. One-off reads (`git diff`, `git show`, `git blame`) stay on raw `git`.
 
-**Triage:** `homeboy triage component|project|fleet|rig` for read-only attention reports across configured repos — open issues, PRs, review/check state, stale work, and clickable GitHub URLs.
-
 **Perf + envs:** `homeboy bench` for pinned benchmarks with baseline + ratchet; `homeboy rig up|check|down|status` for reproducible multi-component dev environments.
 
 **Stacks:** `homeboy stack list|show|apply|status|sync|inspect` for combined-fixes branches built from upstream PRs.

--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -434,9 +434,11 @@ MD;
 
 **Git:** prefer `homeboy git changes | status | commit | push | pull | tag` — auto-baselines, structured output, `--json` bulk. One-off reads (`git diff`, `git show`, `git blame`) stay on raw `git`.
 
-**Bench:** `homeboy bench` for pinned benchmarks with baseline + ratchet.
+**Triage:** `homeboy triage component|project|fleet|rig` for read-only attention reports across configured repos — open issues, PRs, review/check state, stale work, and clickable GitHub URLs.
 
-**Rig:** `homeboy rig up | check | down | status` — dev-environment-as-code at `~/.config/homeboy/rigs/<id>.json`. When a project's setup is multi-component (a fork wired up next to its consumer, checkouts symlinked into a runtime, app + sidecar service), declare it in a rig spec rather than reproducing setup by hand. `rig check` is the structured answer to "is my dev environment currently in the declared state" — reach for it before any "I tested this" claim.
+**Perf + envs:** `homeboy bench` for pinned benchmarks with baseline + ratchet; `homeboy rig up|check|down|status` for reproducible multi-component dev environments.
+
+**Stacks:** `homeboy stack list|show|apply|status|sync|inspect` for combined-fixes branches built from upstream PRs.
 
 **Repo rules** (when `homeboy.json` is present):
 - **NEVER edit `CHANGELOG.md`** — generated from conventional commits at release time.


### PR DESCRIPTION
## Summary
- Add the new `homeboy triage` surface to the composed AGENTS.md Homeboy section.
- Add the shipped `homeboy stack` surface and tighten bench/rig wording into the current map-style house language.
- Keep the repo-rule reminders intact while reducing the tutorial-shaped rig paragraph.

## Tests
- `php -l data-machine-code.php`
- `php tests/smoke-homeboy.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Updated the AGENTS.md Homeboy section wording after dogfooding the new Homeboy triage primitive; Chris reviewed the framing.
