### PR TITLE
fix(workspace): bootstrap nested dependency roots

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -758,7 +758,7 @@ class WorkspaceAbilities {
 				'datamachine/workspace-worktree-add',
 				array(
 					'label'               => 'Add Workspace Worktree',
-					'description'         => 'Create a git worktree for a branch under `<repo>@<branch-slug>`. Branches are created off the supplied `from` ref (default `origin/HEAD`) when they do not yet exist locally. When `inject_context` is true (default), the originating site\'s agent memory is snapshotted into `.claude/CLAUDE.local.md` and `.opencode/AGENTS.local.md` and added to the worktree\'s per-checkout `info/exclude`. When `bootstrap` is true (default), submodule init + package-manager install + composer install run after creation so the worktree is immediately test/build-ready; set false to create a bare checkout.',
+					'description'         => 'Create a git worktree for a branch under `<repo>@<branch-slug>`. Branches are created off the supplied `from` ref (default `origin/HEAD`) when they do not yet exist locally. When `inject_context` is true (default), the originating site\'s agent memory is snapshotted into `.claude/CLAUDE.local.md` and `.opencode/AGENTS.local.md` and added to the worktree\'s per-checkout `info/exclude`. When `bootstrap` is true (default), submodule init plus root or one-level nested package-manager/composer installs run after creation so the worktree is immediately test/build-ready; set false to create a bare checkout.',
 					'category'            => 'datamachine-code-workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
@@ -781,7 +781,7 @@ class WorkspaceAbilities {
 							),
 							'bootstrap'      => array(
 								'type'        => 'boolean',
-								'description' => 'Run detected bootstrap steps (submodule init, package-manager install, composer install) after creating the worktree. Default true. Steps are skipped gracefully when their trigger file or tool is missing. Set false for a bare checkout (e.g. when only reading code).',
+								'description' => 'Run detected bootstrap steps (submodule init plus root or one-level nested package-manager/composer installs) after creating the worktree. Default true. Steps are skipped gracefully when their trigger file or tool is missing. Set false for a bare checkout (e.g. when only reading code).',
 							),
 							'allow_stale'    => array(
 								'type'        => 'boolean',

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1030,8 +1030,8 @@ class WorkspaceCommand extends BaseCommand {
 	 *   `worktree add` runs detected setup so the checkout is immediately
 	 *   test/build-ready:
 	 *     - git submodule update --init --recursive (if .gitmodules)
-	 *     - pnpm/bun/yarn/npm install (based on lockfile)
-	 *     - composer install --no-interaction (if composer.lock)
+	 *     - pnpm/bun/yarn/npm install (based on root or one-level nested lockfiles)
+	 *     - composer install --no-interaction (based on root or one-level nested composer.lock)
 	 *   Each step is skipped gracefully when its trigger file or tool is
 	 *   missing. Pass `--skip-bootstrap` to create a bare checkout for pure
 	 *   read use (faster, no deps installed). The ability-level input is

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -1009,9 +1009,10 @@ class Workspace {
 	 *
 	 * When `$bootstrap` is true (default), a bootstrap pass runs after the
 	 * worktree is created: `git submodule update --init --recursive` if
-	 * `.gitmodules` is present, a package-manager install if a lockfile is
-	 * present (pnpm/bun/yarn/npm), and `composer install` if `composer.lock`
-	 * is present. Steps are independent and each one is skipped gracefully
+	 * `.gitmodules` is present, package-manager installs for root or one-level
+	 * nested dependency roots with lockfiles (pnpm/bun/yarn/npm), and
+	 * `composer install` for root or one-level nested dependency roots with
+	 * `composer.lock`. Steps are independent and each one is skipped gracefully
 	 * when its tool is unavailable. A failing step is surfaced in the result
 	 * but does not roll back the worktree — the checkout exists either way.
 	 * Pass `$bootstrap = false` (or `--no-bootstrap` on the CLI) for a bare

--- a/inc/Workspace/WorktreeBootstrapper.php
+++ b/inc/Workspace/WorktreeBootstrapper.php
@@ -17,12 +17,17 @@
  * run in a fixed order:
  *
  *   1. `git submodule update --init --recursive` if `.gitmodules` exists
- *   2. Package-manager install, based on lockfile presence:
+ *   2. Package-manager install per dependency root, based on lockfile presence:
  *        pnpm-lock.yaml   → pnpm install --frozen-lockfile
  *        bun.lockb/.lock  → bun install --frozen-lockfile
  *        yarn.lock        → yarn install --immutable
  *        package-lock.json → npm ci
- *   3. `composer install --no-interaction --prefer-dist` if `composer.lock` exists
+ *   3. `composer install --no-interaction --prefer-dist` per dependency root
+ *      if `composer.lock` exists
+ *
+ * Dependency roots include the worktree root plus one-level child directories
+ * with lockfiles. This covers lightweight monorepos where each top-level
+ * component is installable on its own without requiring repo-specific config.
  *
  * Each step is optional. Missing binaries (no `pnpm` on PATH, etc.) downgrade
  * to a `skipped` result rather than failing. Command failures are returned as
@@ -63,6 +68,18 @@ final class WorktreeBootstrapper {
 	private const OUTPUT_CAP_BYTES = 4096;
 
 	/**
+	 * Directories that should never be treated as nested component roots.
+	 */
+	private const NESTED_ROOT_EXCLUDE_DIRS = array(
+		'.git',
+		'.github',
+		'.claude',
+		'.opencode',
+		'node_modules',
+		'vendor',
+	);
+
+	/**
 	 * Run all applicable bootstrap steps inside the given worktree.
 	 *
 	 * @param string $worktree_path Absolute path to the worktree root.
@@ -83,8 +100,8 @@ final class WorktreeBootstrapper {
 		$steps = array();
 
 		$steps[] = self::run_submodules( $worktree_path );
-		$steps[] = self::run_packages( $worktree_path );
-		$steps[] = self::run_composer( $worktree_path );
+		$steps = array_merge( $steps, self::run_packages( $worktree_path ) );
+		$steps = array_merge( $steps, self::run_composer( $worktree_path ) );
 
 		$failed  = array_filter( $steps, fn( $s ) => self::STATUS_FAILED === ( $s['status'] ?? '' ) );
 		$ran_any = (bool) array_filter( $steps, fn( $s ) => self::STATUS_RAN === ( $s['status'] ?? '' ) );
@@ -103,15 +120,22 @@ final class WorktreeBootstrapper {
 	 * @param string $worktree_path Absolute path to the worktree root.
 	 * @return array{
 	 *     submodules: bool,
-	 *     packages: ?string,  // Package manager slug ("pnpm", "bun", "yarn", "npm") or null.
+	 *     packages: ?string,  // Root package manager slug or null.
 	 *     composer: bool,
+	 *     package_roots: array<int, array{path: string, relative: string, manager: string}>,
+	 *     composer_roots: array<int, array{path: string, relative: string}>,
 	 * }
 	 */
 	public static function detect( string $worktree_path ): array {
+		$package_roots = self::discover_package_roots( $worktree_path );
+		$composer_roots = self::discover_composer_roots( $worktree_path );
+
 		return array(
-			'submodules' => is_file( rtrim( $worktree_path, '/' ) . '/.gitmodules' ),
-			'packages'   => self::detect_package_manager( $worktree_path ),
-			'composer'   => is_file( rtrim( $worktree_path, '/' ) . '/composer.lock' ),
+			'submodules'    => is_file( rtrim( $worktree_path, '/' ) . '/.gitmodules' ),
+			'packages'      => self::detect_package_manager( $worktree_path ),
+			'composer'      => is_file( rtrim( $worktree_path, '/' ) . '/composer.lock' ),
+			'package_roots'  => $package_roots,
+			'composer_roots' => $composer_roots,
 		);
 	}
 
@@ -130,20 +154,22 @@ final class WorktreeBootstrapper {
 		$lines = array();
 		foreach ( $steps as $step ) {
 			$kind   = (string) ( $step['step'] ?? '?' );
+			$target = (string) ( $step['relative'] ?? '' );
+			$label  = '.' === $target || '' === $target ? $kind : sprintf( '%s[%s]', $kind, $target );
 			$status = (string) ( $step['status'] ?? '?' );
 			$reason = (string) ( $step['reason'] ?? '' );
 			$cmd    = (string) ( $step['command'] ?? '' );
 
 			switch ( $status ) {
 				case self::STATUS_RAN:
-					$lines[] = sprintf( '  ✓ %-10s ran: %s', $kind, $cmd );
+					$lines[] = sprintf( '  ✓ %-18s ran: %s', $label, $cmd );
 					break;
 				case self::STATUS_SKIPPED:
-					$lines[] = sprintf( '  - %-10s skipped (%s)', $kind, '' !== $reason ? $reason : 'no trigger' );
+					$lines[] = sprintf( '  - %-18s skipped (%s)', $label, '' !== $reason ? $reason : 'no trigger' );
 					break;
 				case self::STATUS_FAILED:
 					$exit    = isset( $step['exit_code'] ) ? (int) $step['exit_code'] : -1;
-					$lines[] = sprintf( '  ✗ %-10s FAILED (exit %d): %s', $kind, $exit, $cmd );
+					$lines[] = sprintf( '  ✗ %-18s FAILED (exit %d): %s', $label, $exit, $cmd );
 					if ( ! empty( $step['output_tail'] ) ) {
 						foreach ( explode( "\n", (string) $step['output_tail'] ) as $out_line ) {
 							$lines[] = '      ' . $out_line;
@@ -151,7 +177,7 @@ final class WorktreeBootstrapper {
 					}
 					break;
 				default:
-					$lines[] = sprintf( '  ? %-10s %s', $kind, $status );
+					$lines[] = sprintf( '  ? %-18s %s', $label, $status );
 			}
 		}
 
@@ -189,67 +215,164 @@ final class WorktreeBootstrapper {
 	 * Run the detected package manager's install command, if any.
 	 */
 	private static function run_packages( string $worktree_path ): array {
-		$pm = self::detect_package_manager( $worktree_path );
-		if ( null === $pm ) {
+		$roots = self::discover_package_roots( $worktree_path );
+		if ( empty( $roots ) ) {
 			return array(
-				'step'   => self::STEP_PACKAGES,
-				'status' => self::STATUS_SKIPPED,
-				'reason' => 'no lockfile',
+				array(
+					'step'   => self::STEP_PACKAGES,
+					'status' => self::STATUS_SKIPPED,
+					'reason' => 'no lockfile',
+				),
 			);
 		}
 
-		if ( ! self::binary_available( $pm ) ) {
-			return array(
-				'step'   => self::STEP_PACKAGES,
-				'status' => self::STATUS_SKIPPED,
-				'reason' => sprintf( '%s not on PATH (lockfile present)', $pm ),
-			);
+		$steps = array();
+		foreach ( $roots as $root ) {
+			$pm = $root['manager'];
+
+			if ( ! self::binary_available( $pm ) ) {
+				$steps[] = array(
+					'step'     => self::STEP_PACKAGES,
+					'status'   => self::STATUS_SKIPPED,
+					'reason'   => sprintf( '%s not on PATH (lockfile present)', $pm ),
+					'relative' => $root['relative'],
+				);
+				continue;
+			}
+
+			$command = match ( $pm ) {
+				'pnpm'  => 'pnpm install --frozen-lockfile',
+				'bun'   => 'bun install --frozen-lockfile',
+				'yarn'  => 'yarn install --immutable',
+				'npm'   => 'npm ci',
+				default => '',
+			};
+
+			if ( '' === $command ) {
+				$steps[] = array(
+					'step'     => self::STEP_PACKAGES,
+					'status'   => self::STATUS_SKIPPED,
+					'reason'   => sprintf( 'unsupported package manager %s', $pm ),
+					'relative' => $root['relative'],
+				);
+				continue;
+			}
+
+			$steps[] = self::run_command( self::STEP_PACKAGES, $root['path'], $command, $root['relative'] );
 		}
 
-		$command = match ( $pm ) {
-			'pnpm'  => 'pnpm install --frozen-lockfile',
-			'bun'   => 'bun install --frozen-lockfile',
-			'yarn'  => 'yarn install --immutable',
-			'npm'   => 'npm ci',
-			default => '',
-		};
-
-		if ( '' === $command ) {
-			return array(
-				'step'   => self::STEP_PACKAGES,
-				'status' => self::STATUS_SKIPPED,
-				'reason' => sprintf( 'unsupported package manager %s', $pm ),
-			);
-		}
-
-		return self::run_command( self::STEP_PACKAGES, $worktree_path, $command );
+		return $steps;
 	}
 
 	/**
 	 * Run `composer install` if `composer.lock` is present.
 	 */
 	private static function run_composer( string $worktree_path ): array {
-		if ( ! is_file( rtrim( $worktree_path, '/' ) . '/composer.lock' ) ) {
+		$roots = self::discover_composer_roots( $worktree_path );
+		if ( empty( $roots ) ) {
 			return array(
-				'step'   => self::STEP_COMPOSER,
-				'status' => self::STATUS_SKIPPED,
-				'reason' => 'no composer.lock',
+				array(
+					'step'   => self::STEP_COMPOSER,
+					'status' => self::STATUS_SKIPPED,
+					'reason' => 'no composer.lock',
+				),
 			);
 		}
 
-		if ( ! self::binary_available( 'composer' ) ) {
-			return array(
-				'step'   => self::STEP_COMPOSER,
-				'status' => self::STATUS_SKIPPED,
-				'reason' => 'composer not on PATH',
+		$steps = array();
+		foreach ( $roots as $root ) {
+			if ( ! self::binary_available( 'composer' ) ) {
+				$steps[] = array(
+					'step'     => self::STEP_COMPOSER,
+					'status'   => self::STATUS_SKIPPED,
+					'reason'   => 'composer not on PATH',
+					'relative' => $root['relative'],
+				);
+				continue;
+			}
+
+			$steps[] = self::run_command(
+				self::STEP_COMPOSER,
+				$root['path'],
+				'composer install --no-interaction --prefer-dist',
+				$root['relative']
 			);
 		}
 
-		return self::run_command(
-			self::STEP_COMPOSER,
-			$worktree_path,
-			'composer install --no-interaction --prefer-dist'
+		return $steps;
+	}
+
+	/**
+	 * Discover package-manager roots at the repo root and one directory deep.
+	 *
+	 * @return array<int, array{path: string, relative: string, manager: string}>
+	 */
+	private static function discover_package_roots( string $worktree_path ): array {
+		$roots = array();
+		foreach ( self::candidate_dependency_roots( $worktree_path ) as $candidate ) {
+			$manager = self::detect_package_manager( $candidate['path'] );
+			if ( null === $manager ) {
+				continue;
+			}
+			$roots[] = array(
+				'path'     => $candidate['path'],
+				'relative' => $candidate['relative'],
+				'manager'  => $manager,
+			);
+		}
+		return $roots;
+	}
+
+	/**
+	 * Discover Composer roots at the repo root and one directory deep.
+	 *
+	 * @return array<int, array{path: string, relative: string}>
+	 */
+	private static function discover_composer_roots( string $worktree_path ): array {
+		$roots = array();
+		foreach ( self::candidate_dependency_roots( $worktree_path ) as $candidate ) {
+			if ( ! is_file( $candidate['path'] . '/composer.lock' ) ) {
+				continue;
+			}
+			$roots[] = $candidate;
+		}
+		return $roots;
+	}
+
+	/**
+	 * Return the repo root plus one-level child directories that may own deps.
+	 *
+	 * @return array<int, array{path: string, relative: string}>
+	 */
+	private static function candidate_dependency_roots( string $worktree_path ): array {
+		$root       = rtrim( $worktree_path, '/' );
+		$candidates = array(
+			array(
+				'path'     => $root,
+				'relative' => '.',
+			),
 		);
+
+		$entries = @scandir( $root );
+		if ( false === $entries ) {
+			return $candidates;
+		}
+
+		foreach ( $entries as $entry ) {
+			if ( '.' === $entry || '..' === $entry || in_array( $entry, self::NESTED_ROOT_EXCLUDE_DIRS, true ) ) {
+				continue;
+			}
+			$path = $root . '/' . $entry;
+			if ( ! is_dir( $path ) || is_link( $path ) ) {
+				continue;
+			}
+			$candidates[] = array(
+				'path'     => $path,
+				'relative' => $entry,
+			);
+		}
+
+		return $candidates;
 	}
 
 	/**
@@ -290,9 +413,74 @@ final class WorktreeBootstrapper {
 		if ( '' === $binary || ! preg_match( '/^[a-zA-Z0-9_.\-]+$/', $binary ) ) {
 			return false;
 		}
+		$env = self::shell_env_prefix();
 		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
-		exec( sprintf( 'command -v %s 2>/dev/null', escapeshellarg( $binary ) ), $_unused, $exit );
+		exec( sprintf( '%scommand -v %s 2>/dev/null', $env, escapeshellarg( $binary ) ), $_unused, $exit );
 		return 0 === $exit;
+	}
+
+	/**
+	 * Build a shell env prefix with non-interactive toolchain path fallbacks.
+	 */
+	private static function shell_env_prefix(): string {
+		$path = self::augmented_path();
+		if ( null === $path ) {
+			return '';
+		}
+		return sprintf( 'PATH=%s ', escapeshellarg( $path ) );
+	}
+
+	/**
+	 * Add common nvm binary dirs for shells that do not source .zshrc/.bashrc.
+	 */
+	private static function augmented_path(): ?string {
+		$current = getenv( 'PATH' );
+		$current = is_string( $current ) ? $current : '';
+		$extra   = self::discover_nvm_bin_dirs();
+		if ( empty( $extra ) ) {
+			return null;
+		}
+
+		$parts = array_filter( explode( PATH_SEPARATOR, $current ), static fn( $part ) => '' !== $part );
+		foreach ( array_reverse( $extra ) as $dir ) {
+			if ( ! in_array( $dir, $parts, true ) ) {
+				array_unshift( $parts, $dir );
+			}
+		}
+
+		return implode( PATH_SEPARATOR, $parts );
+	}
+
+	/**
+	 * Find installed nvm Node versions without requiring shell startup files.
+	 *
+	 * @return string[] Absolute bin directories, newest-looking first.
+	 */
+	private static function discover_nvm_bin_dirs(): array {
+		$home = getenv( 'HOME' );
+		if ( ! is_string( $home ) || '' === $home ) {
+			return array();
+		}
+
+		$versions_dir = rtrim( $home, '/' ) . '/.nvm/versions/node';
+		$entries      = @scandir( $versions_dir );
+		if ( false === $entries ) {
+			return array();
+		}
+
+		$bins = array();
+		foreach ( $entries as $entry ) {
+			if ( '.' === $entry || '..' === $entry ) {
+				continue;
+			}
+			$bin = $versions_dir . '/' . $entry . '/bin';
+			if ( is_dir( $bin ) ) {
+				$bins[] = $bin;
+			}
+		}
+
+		rsort( $bins, SORT_NATURAL );
+		return $bins;
 	}
 
 	/**
@@ -301,9 +489,9 @@ final class WorktreeBootstrapper {
 	 * Note: we do not shell-escape the command itself — these are hard-coded
 	 * invocations, not user input. The `cd` target is escaped.
 	 */
-	private static function run_command( string $step, string $worktree_path, string $command ): array {
+	private static function run_command( string $step, string $worktree_path, string $command, string $relative = '.' ): array {
 		$cd        = escapeshellarg( $worktree_path );
-		$shell_cmd = sprintf( 'cd %s && %s 2>&1', $cd, $command );
+		$shell_cmd = sprintf( 'cd %s && %s%s 2>&1', $cd, self::shell_env_prefix(), $command );
 
 		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
 		exec( $shell_cmd, $output, $exit_code );
@@ -317,6 +505,7 @@ final class WorktreeBootstrapper {
 			return array(
 				'step'        => $step,
 				'status'      => self::STATUS_FAILED,
+				'relative'    => $relative,
 				'command'     => $command,
 				'exit_code'   => $exit_code,
 				'output_tail' => $joined,
@@ -326,6 +515,7 @@ final class WorktreeBootstrapper {
 		return array(
 			'step'        => $step,
 			'status'      => self::STATUS_RAN,
+			'relative'    => $relative,
 			'command'     => $command,
 			'exit_code'   => 0,
 			'output_tail' => $joined,

--- a/tests/smoke-worktree-bootstrap.php
+++ b/tests/smoke-worktree-bootstrap.php
@@ -6,7 +6,7 @@
  *
  * Covers:
  *   - detect() returns the expected booleans / package-manager slug for
- *     synthetic worktree fixtures with various lockfile combinations
+ *     synthetic worktree fixtures with root and nested lockfile combinations
  *   - bootstrap() skips gracefully when nothing is present (all STATUS_SKIPPED)
  *   - bootstrap() runs `git submodule update` successfully against a real
  *     on-disk repo with an empty `.gitmodules`
@@ -140,6 +140,26 @@ $pkg_only = $make_fixture( array( 'package.json' => '{}' ) );
 $assert( null, WorktreeBootstrapper::detect( $pkg_only )['packages'], 'package.json alone → null (no lockfile)' );
 $cleanup( $pkg_only );
 
+$monorepo = $make_fixture(
+	array(
+		'wordpress/package.json'       => '{"name":"wordpress-extension"}',
+		'wordpress/package-lock.json'  => '{}',
+		'wordpress/composer.json'      => '{"name":"example/wordpress-extension"}',
+		'wordpress/composer.lock'      => '{"packages":[]}',
+		'node_modules/package-lock.json' => '{}',
+		'vendor/composer.lock'         => '{"packages":[]}',
+	)
+);
+$d = WorktreeBootstrapper::detect( $monorepo );
+$assert( null, $d['packages'], 'monorepo fixture: root packages still null' );
+$assert( false, $d['composer'], 'monorepo fixture: root composer still false' );
+$assert( 1, count( $d['package_roots'] ), 'monorepo fixture: one nested package root' );
+$assert( 'wordpress', $d['package_roots'][0]['relative'], 'monorepo fixture: package root relative path' );
+$assert( 'npm', $d['package_roots'][0]['manager'], 'monorepo fixture: nested package manager detected' );
+$assert( 1, count( $d['composer_roots'] ), 'monorepo fixture: one nested composer root' );
+$assert( 'wordpress', $d['composer_roots'][0]['relative'], 'monorepo fixture: composer root relative path' );
+$cleanup( $monorepo );
+
 // -----------------------------------------------------------------------------
 // bootstrap() skip behavior
 // -----------------------------------------------------------------------------
@@ -191,6 +211,72 @@ if ( 0 !== $init_exit ) {
 	$assert( WorktreeBootstrapper::STATUS_SKIPPED, $by_step['composer']['status'], 'composer: skipped (no composer.lock)' );
 }
 $cleanup( $repo );
+
+// -----------------------------------------------------------------------------
+// bootstrap() nested monorepo dependency roots
+// -----------------------------------------------------------------------------
+
+echo "\nbootstrap() discovers nested monorepo roots\n";
+
+$mono = $make_fixture(
+	array(
+		'wordpress/package-lock.json' => '{}',
+		'wordpress/composer.lock'     => '{"packages":[]}',
+	)
+);
+$r = WorktreeBootstrapper::bootstrap( $mono );
+
+$by_step = array();
+foreach ( $r['steps'] as $step ) {
+	$key             = $step['step'] . ':' . ( $step['relative'] ?? '.' );
+	$by_step[ $key ] = $step;
+}
+
+$assert_true( isset( $by_step['packages:wordpress'] ), 'nested package root produces package step' );
+$assert_true( isset( $by_step['composer:wordpress'] ), 'nested composer root produces composer step' );
+$assert_true(
+	in_array( $by_step['packages:wordpress']['status'], array( WorktreeBootstrapper::STATUS_RAN, WorktreeBootstrapper::STATUS_SKIPPED, WorktreeBootstrapper::STATUS_FAILED ), true ),
+	'nested package step has valid status'
+);
+$assert_true(
+	in_array( $by_step['composer:wordpress']['status'], array( WorktreeBootstrapper::STATUS_RAN, WorktreeBootstrapper::STATUS_SKIPPED, WorktreeBootstrapper::STATUS_FAILED ), true ),
+	'nested composer step has valid status'
+);
+
+$mono_format = WorktreeBootstrapper::format( $r );
+$assert_true( str_contains( $mono_format, 'packages[wordpress]' ), 'format: nested package label includes relative path' );
+$assert_true( str_contains( $mono_format, 'composer[wordpress]' ), 'format: nested composer label includes relative path' );
+$cleanup( $mono );
+
+// -----------------------------------------------------------------------------
+// bootstrap() nvm fallback for non-interactive shells
+// -----------------------------------------------------------------------------
+
+echo "\nbootstrap() resolves npm from nvm when PATH is sparse\n";
+
+$old_home = getenv( 'HOME' );
+$old_path = getenv( 'PATH' );
+$home     = $make_fixture( array() );
+$npm_bin  = $home . '/.nvm/versions/node/v99.0.0/bin';
+mkdir( $npm_bin, 0755, true );
+file_put_contents( $npm_bin . '/npm', "#!/bin/sh\nexit 0\n" );
+chmod( $npm_bin . '/npm', 0755 );
+
+$npm_fixture = $make_fixture( array( 'package-lock.json' => '{}' ) );
+putenv( 'HOME=' . $home );
+putenv( 'PATH=/nonexistent' );
+$r = WorktreeBootstrapper::bootstrap( $npm_fixture );
+
+$by_step = array();
+foreach ( $r['steps'] as $step ) {
+	$by_step[ $step['step'] ] = $step;
+}
+$assert( WorktreeBootstrapper::STATUS_RAN, $by_step['packages']['status'], 'npm runs from nvm fallback path' );
+
+false === $old_home ? putenv( 'HOME' ) : putenv( 'HOME=' . $old_home );
+false === $old_path ? putenv( 'PATH' ) : putenv( 'PATH=' . $old_path );
+$cleanup( $npm_fixture );
+$cleanup( $home );
 
 // -----------------------------------------------------------------------------
 // format() output shape


### PR DESCRIPTION
## Summary
- Discover root and one-level nested dependency roots during worktree bootstrap, so monorepos like `homeboy-extensions/wordpress` get package and Composer installs instead of a misleading "nothing to do" result.
- Add a non-interactive shell PATH fallback for nvm-managed Node installs, allowing bootstrap to find `npm` even when `.zshrc` was not sourced.
- Surface nested bootstrap steps as `packages[dir]` / `composer[dir]` in CLI output and update ability/help text.

## Tests
- `php -l inc/Workspace/WorktreeBootstrapper.php && php -l inc/Workspace/Workspace.php && php -l inc/Cli/Commands/WorkspaceCommand.php && php -l inc/Abilities/WorkspaceAbilities.php`
- `php tests/smoke-worktree-bootstrap.php`
- `for f in tests/*.php; do php "$f" || exit 1; done`
- `git diff --check`

Closes #76.
Closes #77.
Closes #78.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the bootstrap discovery/PATH fix, adding smoke coverage, and running validation. Chris remains responsible for review and merge.