### PR TITLE
fix(workspace): surface minion routing in injected context

### DIFF
--- a/inc/Workspace/WorktreeContextInjector.php
+++ b/inc/Workspace/WorktreeContextInjector.php
@@ -60,6 +60,11 @@ class WorktreeContextInjector {
 	private const MEMORY_FILES = array( 'MEMORY.md', 'USER.md', 'RULES.md' );
 
 	/**
+	 * Site-provided sections that should be visible before long memory snapshots.
+	 */
+	private const PRIORITY_RULE_SECTIONS = array( 'Minion Session Routing' );
+
+	/**
 	 * Build a payload capturing the originating site's agent context.
 	 *
 	 * Returns null when Data Machine's agent memory layer is unavailable
@@ -127,6 +132,14 @@ class WorktreeContextInjector {
 		$out .= "on {$timestamp}. The agent that created it has the following\n";
 		$out .= "persistent context snapshotted below.\n\n";
 
+		$priority_rules = self::extract_priority_rules( (string) ( $files['RULES.md'] ?? '' ) );
+		if ( '' !== $priority_rules ) {
+			$out .= "## Priority rules from RULES.md\n\n";
+			$out .= "These site-provided rules are repeated here before the full context snapshot\n";
+			$out .= "so spawned agents see them before long memory sections.\n\n";
+			$out .= $priority_rules . "\n\n";
+		}
+
 		foreach ( self::MEMORY_FILES as $filename ) {
 			if ( empty( $files[ $filename ] ) ) {
 				continue;
@@ -149,6 +162,64 @@ class WorktreeContextInjector {
 		$out .= '- Studio path: ' . ( '' !== $abspath ? $abspath : '(unknown)' ) . "\n";
 
 		return $out;
+	}
+
+	/**
+	 * Extract high-priority site rules that need to survive long memory payloads.
+	 *
+	 * @param string $rules_md Full RULES.md body from the originating site.
+	 * @return string Markdown containing matched rule sections, or empty string.
+	 */
+	private static function extract_priority_rules( string $rules_md ): string {
+		$rules_md = trim( $rules_md );
+		if ( '' === $rules_md ) {
+			return '';
+		}
+
+		$sections = array();
+		foreach ( self::PRIORITY_RULE_SECTIONS as $section_title ) {
+			$section = self::extract_markdown_h2_section( $rules_md, $section_title );
+			if ( '' !== $section ) {
+				$sections[] = $section;
+			}
+		}
+
+		return implode( "\n\n", $sections );
+	}
+
+	/**
+	 * Extract one H2 markdown section by exact title.
+	 *
+	 * @param string $markdown      Markdown document.
+	 * @param string $section_title H2 title without the leading `##`.
+	 * @return string Section markdown including its H2 heading, or empty string.
+	 */
+	private static function extract_markdown_h2_section( string $markdown, string $section_title ): string {
+		$lines      = preg_split( '/\r\n|\r|\n/', $markdown );
+		if ( false === $lines ) {
+			return '';
+		}
+		$capturing  = false;
+		$captured   = array();
+		$wanted_h2  = '## ' . $section_title;
+
+		foreach ( $lines as $line ) {
+			$is_h2 = str_starts_with( $line, '## ' ) && ! str_starts_with( $line, '### ' );
+			if ( $is_h2 ) {
+				if ( $capturing ) {
+					break;
+				}
+				if ( trim( $line ) === $wanted_h2 ) {
+					$capturing = true;
+				}
+			}
+
+			if ( $capturing ) {
+				$captured[] = $line;
+			}
+		}
+
+		return trim( implode( "\n", $captured ) );
 	}
 
 	/**

--- a/tests/smoke-worktree-context-injection.php
+++ b/tests/smoke-worktree-context-injection.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Smoke test for worktree context rendering.
+ *
+ *   php tests/smoke-worktree-context-injection.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+require_once __DIR__ . '/../inc/Workspace/WorktreeContextInjector.php';
+
+function datamachine_code_context_assert( bool $condition, string $message ): void {
+	if ( $condition ) {
+		echo "  [PASS] {$message}\n";
+		return;
+	}
+	echo "  [FAIL] {$message}\n";
+	exit( 1 );
+}
+
+function datamachine_code_pos( string $haystack, string $needle, string $label ): int {
+	$pos = strpos( $haystack, $needle );
+	datamachine_code_context_assert( false !== $pos, $label );
+	return (int) $pos;
+}
+
+echo "=== smoke-worktree-context-injection ===\n";
+
+$rules = <<<'MD'
+# Site Rules
+
+## General
+- Be helpful.
+
+## Minion Session Routing
+- All minion sessions for this agent go in the canonical agent channel.
+- Never route sessions to per-repo project channels.
+
+## Pull Requests
+- Open pull requests from the correct remote.
+MD;
+
+$rendered = \DataMachineCode\Workspace\WorktreeContextInjector::render(
+	array(
+		'site_name'  => 'Test Site',
+		'site_url'   => 'https://example.test',
+		'agent_slug' => 'agent-one',
+		'abspath'    => '/wordpress',
+		'timestamp'  => '2026-04-27T00:00:00+00:00',
+		'files'      => array(
+			'MEMORY.md' => "# Memory\n\n" . str_repeat( "Lots of context.\n", 20 ),
+			'USER.md'   => "# User\n",
+			'RULES.md'  => $rules,
+		),
+	)
+);
+
+$priority_pos = datamachine_code_pos( $rendered, '## Priority rules from RULES.md', 'priority rules section rendered' );
+$memory_pos   = datamachine_code_pos( $rendered, '## MEMORY.md', 'full memory snapshot still rendered' );
+$rules_pos    = datamachine_code_pos( $rendered, '## RULES.md', 'full rules snapshot still rendered' );
+
+datamachine_code_context_assert( $priority_pos < $memory_pos, 'priority rules appear before long memory snapshot' );
+datamachine_code_context_assert( $memory_pos < $rules_pos, 'full snapshot order stays unchanged' );
+datamachine_code_context_assert( str_contains( $rendered, '## Minion Session Routing' ), 'minion routing heading is visible' );
+datamachine_code_context_assert( str_contains( $rendered, 'canonical agent channel' ), 'site-provided routing text is preserved' );
+$priority_excerpt = substr( $rendered, $priority_pos, $memory_pos - $priority_pos );
+datamachine_code_context_assert(
+	! str_contains( $priority_excerpt, '## Pull Requests' ),
+	'priority excerpt stops before next H2 section'
+);
+
+$without_routing = \DataMachineCode\Workspace\WorktreeContextInjector::render(
+	array(
+		'site_name' => 'Test Site',
+		'files'     => array(
+			'RULES.md' => "# Site Rules\n\n## General\n- Be helpful.\n",
+		),
+	)
+);
+
+datamachine_code_context_assert(
+	! str_contains( $without_routing, '## Priority rules from RULES.md' ),
+	'priority section is omitted when source rules do not define routing'
+);
+
+echo "\nAll worktree context injection smoke tests passed.\n";


### PR DESCRIPTION
## Summary
- Surface site-provided minion routing rules near the top of worktree-injected context so spawned agents see channel routing before long memory snapshots.
- Keep the fix generic: DMC extracts the `Minion Session Routing` section from the originating site's `RULES.md` when present, without hardcoding a repo or channel.

## Changes
- Add a priority rules excerpt to `WorktreeContextInjector::render()` before the full MEMORY/USER/RULES snapshot.
- Preserve the existing full context snapshot unchanged below the priority excerpt.
- Add a focused smoke test covering routing extraction, ordering, and the no-routing-section fallback.

## Tests
- `php tests/smoke-worktree-context-injection.php` ✅
- `php -l inc/Workspace/WorktreeContextInjector.php` ✅
- `php -l tests/smoke-worktree-context-injection.php` ✅
- `php tests/smoke-worktree-handles.php && php tests/smoke-worktree-bootstrap.php && php tests/smoke-worktree-base-branch-cli.php && php tests/smoke-worktree-staleness.php` ✅
- `homeboy test data-machine-code` ⚠️ fails because the PHPUnit runner discovers zero `*UnitTest.php` files in this repo.
- `homeboy lint data-machine-code --json` ⚠️ fails on the existing PHPStan/audit backlog (298 findings after this change); the new `WorktreeContextInjector` finding from the first lint run was fixed.

Closes #49

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the context-rendering change, adding focused smoke coverage, and running verification. Chris remains responsible for review and merge.
