### PR TITLE
fix(workspace): serialize worktree mutations per repo

### DIFF
--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -408,8 +408,11 @@ class Workspace {
 		if ( $parsed['is_worktree'] ) {
 			$primary_path = $this->get_primary_path( $parsed['repo'] );
 			if ( is_dir( $primary_path . '/.git' ) ) {
-				// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
-				exec( sprintf( 'git -C %s worktree prune 2>&1', escapeshellarg( $primary_path ) ) );
+				WorkspaceMutationLock::with_repo(
+					$this->workspace_path,
+					$parsed['repo'],
+					fn() => $this->run_git( $primary_path, 'worktree prune' )
+				);
 			}
 		}
 
@@ -1066,6 +1069,65 @@ class Workspace {
 			return new \WP_Error( 'worktree_exists', sprintf( 'Worktree handle "%s" already exists.', $wt_handle ), array( 'status' => 400 ) );
 		}
 
+		$response = WorkspaceMutationLock::with_repo(
+			$this->workspace_path,
+			$repo,
+			fn() => $this->worktree_add_locked(
+				$repo,
+				$branch,
+				$from,
+				$inject_context,
+				$allow_stale,
+				$rebase_base,
+				$slug,
+				$wt_handle,
+				$wt_path,
+				$primary_path
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		if ( $bootstrap ) {
+			$response['bootstrap'] = WorktreeBootstrapper::bootstrap( $wt_path );
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Create a worktree while the primary repo lifecycle lock is held.
+	 *
+	 * @param string      $repo           Primary repo name.
+	 * @param string      $branch         Branch to check out.
+	 * @param string|null $from           Base ref when creating the branch.
+	 * @param bool        $inject_context Whether to inject site-agent context.
+	 * @param bool        $allow_stale    Bypass the staleness gate.
+	 * @param bool        $rebase_base    Rebase onto upstream after creation.
+	 * @param string      $slug           Branch slug.
+	 * @param string      $wt_handle      Worktree handle.
+	 * @param string      $wt_path        Worktree path.
+	 * @param string      $primary_path   Primary checkout path.
+	 * @return array|\WP_Error
+	 */
+	private function worktree_add_locked(
+		string $repo,
+		string $branch,
+		?string $from,
+		bool $inject_context,
+		bool $allow_stale,
+		bool $rebase_base,
+		string $slug,
+		string $wt_handle,
+		string $wt_path,
+		string $primary_path
+	): array|\WP_Error {
+		if ( is_dir( $wt_path ) ) {
+			return new \WP_Error( 'worktree_exists', sprintf( 'Worktree handle "%s" already exists.', $wt_handle ), array( 'status' => 400 ) );
+		}
+
 		// Always fetch first so staleness data (and the default base) reflects the
 		// current remote. Failure is logged but never aborts — offline work should
 		// still be possible, the agent just needs to know staleness is unknown.
@@ -1231,10 +1293,6 @@ class Workspace {
 					}
 				}
 			}
-		}
-
-		if ( $bootstrap ) {
-			$response['bootstrap'] = WorktreeBootstrapper::bootstrap( $wt_path );
 		}
 
 		return $response;
@@ -1425,14 +1483,25 @@ class Workspace {
 			return new \WP_Error( 'worktree_not_found', sprintf( 'Worktree "%s" not found.', $wt_handle ), array( 'status' => 404 ) );
 		}
 
-		$cmd    = sprintf( 'worktree remove %s%s', $force ? '--force ' : '', escapeshellarg( $wt_path ) );
-		$result = $this->run_git( $primary_path, $cmd );
+		$result = WorkspaceMutationLock::with_repo(
+			$this->workspace_path,
+			$repo,
+			function () use ( $primary_path, $wt_path, $force, $wt_handle ) {
+				$cmd    = sprintf( 'worktree remove %s%s', $force ? '--force ' : '', escapeshellarg( $wt_path ) );
+				$result = $this->run_git( $primary_path, $cmd );
+
+				if ( is_wp_error( $result ) ) {
+					return $result;
+				}
+
+				WorktreeContextInjector::forget_metadata( $wt_handle );
+				return $result;
+			}
+		);
 
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
-
-		WorktreeContextInjector::forget_metadata( $wt_handle );
 
 		return array(
 			'success' => true,
@@ -1444,9 +1513,9 @@ class Workspace {
 	/**
 	 * Prune stale worktree registry entries across all primaries.
 	 *
-	 * @return array{success: bool, pruned: array}
+	 * @return array{success: bool, pruned: array}|\WP_Error
 	 */
-	public function worktree_prune(): array {
+	public function worktree_prune(): array|\WP_Error {
 		$pruned = array();
 
 		if ( ! is_dir( $this->workspace_path ) ) {
@@ -1465,7 +1534,14 @@ class Workspace {
 			if ( ! is_dir( $primary_path . '/.git' ) ) {
 				continue;
 			}
-			$this->run_git( $primary_path, 'worktree prune -v' );
+			$result = WorkspaceMutationLock::with_repo(
+				$this->workspace_path,
+				$entry,
+				fn() => $this->run_git( $primary_path, 'worktree prune -v' )
+			);
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
 			$pruned[] = $entry;
 		}
 
@@ -1631,7 +1707,22 @@ class Workspace {
 		$removed = array();
 
 		foreach ( $candidates as $cand ) {
-			$remove = $this->remove_worktree_by_path( $cand['repo'], $cand['branch'], $cand['path'], $force );
+			$remove = WorkspaceMutationLock::with_repo(
+				$this->workspace_path,
+				$cand['repo'],
+				function () use ( $cand, $force ) {
+					$remove = $this->remove_worktree_by_path( $cand['repo'], $cand['branch'], $cand['path'], $force );
+					if ( is_wp_error( $remove ) ) {
+						return $remove;
+					}
+
+					// Delete the now-detached local branch while the repo lock still covers
+					// shared git metadata.
+					$primary_path = $this->get_primary_path( $cand['repo'] );
+					$branch       = $this->run_git( $primary_path, sprintf( 'branch -D %s', escapeshellarg( $cand['branch'] ) ) );
+					return is_wp_error( $branch ) ? $branch : $remove;
+				}
+			);
 			if ( is_wp_error( $remove ) ) {
 				$skipped[] = array(
 					'handle' => $cand['handle'],
@@ -1639,11 +1730,6 @@ class Workspace {
 				);
 				continue;
 			}
-
-			// Delete the now-detached local branch.
-			$primary_path = $this->get_primary_path( $cand['repo'] );
-			$this->run_git( $primary_path, sprintf( 'branch -D %s', escapeshellarg( $cand['branch'] ) ) );
-
 			$removed[] = $cand;
 		}
 

--- a/inc/Workspace/WorkspaceMutationLock.php
+++ b/inc/Workspace/WorkspaceMutationLock.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Workspace mutation lock.
+ *
+ * Serializes worktree lifecycle operations that mutate a primary checkout's
+ * shared Git metadata and Data Machine Code's workspace registry state.
+ *
+ * @package DataMachineCode\Workspace
+ */
+
+namespace DataMachineCode\Workspace;
+
+defined( 'ABSPATH' ) || exit;
+
+final class WorkspaceMutationLock {
+
+	private const POLL_USEC = 100000;
+
+	/** @var resource|null */
+	private $handle = null;
+
+	private function __construct( $handle ) {
+		$this->handle = $handle;
+	}
+
+	/**
+	 * Run a callback while holding a per-primary-repo workspace mutation lock.
+	 *
+	 * @param string   $workspace_path Workspace root.
+	 * @param string   $repo           Primary repo handle.
+	 * @param callable $callback       Callback to run while locked.
+	 * @param int      $timeout        Seconds to wait for the lock.
+	 * @return mixed|\WP_Error Callback result or lock acquisition error.
+	 */
+	public static function with_repo(
+		string $workspace_path,
+		string $repo,
+		callable $callback,
+		int $timeout = 30
+	): mixed {
+		$lock = self::acquire( $workspace_path, $repo, $timeout );
+		if ( is_wp_error( $lock ) ) {
+			return $lock;
+		}
+
+		try {
+			return $callback();
+		} finally {
+			$lock->release();
+		}
+	}
+
+	/**
+	 * Acquire a per-primary-repo lock.
+	 *
+	 * @param string $workspace_path Workspace root.
+	 * @param string $repo           Primary repo handle.
+	 * @param int    $timeout        Seconds to wait for the lock.
+	 * @return self|\WP_Error Lock object or retryable error.
+	 */
+	public static function acquire( string $workspace_path, string $repo, int $timeout = 30 ): self|\WP_Error {
+		$workspace_path = rtrim( $workspace_path, '/' );
+		$repo           = self::sanitize_repo_key( $repo );
+
+		if ( '' === $workspace_path || '' === $repo ) {
+			return new \WP_Error(
+				'workspace_lock_invalid_target',
+				'Workspace mutation lock requires a workspace path and repo handle.',
+				array( 'status' => 400 )
+			);
+		}
+
+		$lock_dir = $workspace_path . '/.locks';
+		if ( ! is_dir( $lock_dir ) ) {
+			$created = function_exists( 'wp_mkdir_p' )
+				? wp_mkdir_p( $lock_dir )
+				: mkdir( $lock_dir, 0755, true );
+			if ( ! $created && ! is_dir( $lock_dir ) ) {
+				return new \WP_Error(
+					'workspace_lock_create_failed',
+					sprintf( 'Failed to create workspace lock directory: %s', $lock_dir ),
+					array( 'status' => 500 )
+				);
+			}
+		}
+
+		$lock_path = $lock_dir . '/worktree-' . $repo . '.lock';
+		$handle    = fopen( $lock_path, 'c' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+		if ( false === $handle ) {
+			return new \WP_Error(
+				'workspace_lock_open_failed',
+				sprintf( 'Failed to open workspace mutation lock: %s', $lock_path ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$started = microtime( true );
+		$timeout = max( 0, $timeout );
+
+		do {
+			if ( flock( $handle, LOCK_EX | LOCK_NB ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock
+				return new self( $handle );
+			}
+
+			if ( 0 === $timeout || ( microtime( true ) - $started ) >= $timeout ) {
+				fclose( $handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+				return new \WP_Error(
+					'workspace_repo_busy',
+					sprintf(
+						'Workspace repo "%s" is busy with another worktree lifecycle mutation. Retry after the current add/remove/cleanup/prune operation completes.',
+						$repo
+					),
+					array(
+						'status'    => 423,
+						'retryable' => true,
+						'repo'      => $repo,
+						'lock_path' => $lock_path,
+					)
+				);
+			}
+
+			usleep( self::POLL_USEC );
+		} while ( true );
+	}
+
+	public function release(): void {
+		if ( null === $this->handle ) {
+			return;
+		}
+
+		flock( $this->handle, LOCK_UN ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock
+		fclose( $this->handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+		$this->handle = null;
+	}
+
+	public function __destruct() {
+		$this->release();
+	}
+
+	private static function sanitize_repo_key( string $repo ): string {
+		$repo = preg_replace( '/[^a-zA-Z0-9._-]/', '', $repo );
+		return trim( (string) $repo, '-.' );
+	}
+}

--- a/tests/smoke-workspace-mutation-lock.php
+++ b/tests/smoke-workspace-mutation-lock.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Pure-PHP smoke test for WorkspaceMutationLock.
+ *
+ * Run: php tests/smoke-workspace-mutation-lock.php
+ */
+
+declare( strict_types=1 );
+
+namespace {
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			public string $code;
+			public string $message;
+			public array $data;
+
+			public function __construct( $code = '', $message = '', $data = array() ) {
+				$this->code    = (string) $code;
+				$this->message = (string) $message;
+				$this->data    = (array) $data;
+			}
+
+			public function get_error_code(): string {
+				return $this->code;
+			}
+
+			public function get_error_message(): string {
+				return $this->message;
+			}
+
+			public function get_error_data(): array {
+				return $this->data;
+			}
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $thing ): bool {
+			return $thing instanceof \WP_Error;
+		}
+	}
+
+	if ( ! function_exists( 'wp_mkdir_p' ) ) {
+		function wp_mkdir_p( string $path ): bool {
+			return is_dir( $path ) || mkdir( $path, 0755, true );
+		}
+	}
+
+	require __DIR__ . '/../inc/Workspace/WorkspaceMutationLock.php';
+
+	$failures = 0;
+	$total    = 0;
+
+	$assert = function ( $expected, $actual, string $message ) use ( &$failures, &$total ): void {
+		$total++;
+		if ( $expected === $actual ) {
+			echo "  ✓ {$message}\n";
+			return;
+		}
+		$failures++;
+		echo "  ✗ {$message}\n";
+		echo '    expected: ' . var_export( $expected, true ) . "\n";
+		echo '    actual:   ' . var_export( $actual, true ) . "\n";
+	};
+
+	$tmp = sys_get_temp_dir() . '/dmc-workspace-lock-smoke-' . bin2hex( random_bytes( 4 ) );
+	mkdir( $tmp, 0755, true );
+	register_shutdown_function( function () use ( $tmp ) {
+		if ( is_dir( $tmp ) ) {
+			exec( 'rm -rf ' . escapeshellarg( $tmp ) );
+		}
+	} );
+
+	echo "Workspace mutation lock\n";
+
+	$first = \DataMachineCode\Workspace\WorkspaceMutationLock::acquire( $tmp, 'demo', 1 );
+	$assert( false, is_wp_error( $first ), 'first acquisition succeeds' );
+	$assert( true, is_file( $tmp . '/.locks/worktree-demo.lock' ), 'lock file is created under workspace .locks directory' );
+
+	$busy = \DataMachineCode\Workspace\WorkspaceMutationLock::acquire( $tmp, 'demo', 0 );
+	$assert( true, is_wp_error( $busy ), 'same repo acquisition fails fast while held' );
+	$assert( 'workspace_repo_busy', is_wp_error( $busy ) ? $busy->get_error_code() : '', 'busy failure uses DMC-shaped retryable code' );
+	$assert( true, is_wp_error( $busy ) ? (bool) ( $busy->get_error_data()['retryable'] ?? false ) : false, 'busy failure is marked retryable' );
+
+	$other = \DataMachineCode\Workspace\WorkspaceMutationLock::acquire( $tmp, 'other', 0 );
+	$assert( false, is_wp_error( $other ), 'different repo acquisition is independent' );
+	if ( ! is_wp_error( $other ) ) {
+		$other->release();
+	}
+
+	if ( ! is_wp_error( $first ) ) {
+		$first->release();
+	}
+
+	$after_release = \DataMachineCode\Workspace\WorkspaceMutationLock::acquire( $tmp, 'demo', 0 );
+	$assert( false, is_wp_error( $after_release ), 'same repo acquisition succeeds after release' );
+	if ( ! is_wp_error( $after_release ) ) {
+		$after_release->release();
+	}
+
+	$result = \DataMachineCode\Workspace\WorkspaceMutationLock::with_repo(
+		$tmp,
+		'demo',
+		fn() => array( 'success' => true ),
+		0
+	);
+	$assert( array( 'success' => true ), $result, 'with_repo returns callback result' );
+
+	$post_callback = \DataMachineCode\Workspace\WorkspaceMutationLock::acquire( $tmp, 'demo', 0 );
+	$assert( false, is_wp_error( $post_callback ), 'with_repo releases after normal callback return' );
+	if ( ! is_wp_error( $post_callback ) ) {
+		$post_callback->release();
+	}
+
+	try {
+		\DataMachineCode\Workspace\WorkspaceMutationLock::with_repo(
+			$tmp,
+			'demo',
+			function () {
+				throw new \RuntimeException( 'boom' );
+			},
+			0
+		);
+		$assert( true, false, 'with_repo exception path throws' );
+	} catch ( \RuntimeException $e ) {
+		$assert( 'boom', $e->getMessage(), 'with_repo propagates callback exception' );
+	}
+
+	$post_exception = \DataMachineCode\Workspace\WorkspaceMutationLock::acquire( $tmp, 'demo', 0 );
+	$assert( false, is_wp_error( $post_exception ), 'with_repo releases after callback exception' );
+	if ( ! is_wp_error( $post_exception ) ) {
+		$post_exception->release();
+	}
+
+	echo "\nResult: " . ( $total - $failures ) . "/{$total} passed\n";
+	exit( $failures > 0 ? 1 : 0 );
+}

--- a/tests/smoke-worktree-cleanup.php
+++ b/tests/smoke-worktree-cleanup.php
@@ -102,6 +102,7 @@ namespace {
 	require __DIR__ . '/../inc/Support/GitHubRemote.php';
 	require __DIR__ . '/../inc/Support/GitRunner.php';
 	require __DIR__ . '/../inc/Support/PathSecurity.php';
+	require __DIR__ . '/../inc/Workspace/WorkspaceMutationLock.php';
 	require __DIR__ . '/../inc/Workspace/WorktreeContextInjector.php';
 	require __DIR__ . '/../inc/Workspace/Workspace.php';
 


### PR DESCRIPTION
## Summary
- Serialize workspace worktree lifecycle mutations per primary repo so parallel adds/removes do not race on shared Git metadata.
- Surface a retryable DMC-shaped `workspace_repo_busy` error when the per-repo lock cannot be acquired within the bounded wait.

## Changes
- Adds `WorkspaceMutationLock`, a file-lock helper under the workspace `.locks/` directory.
- Wraps `worktree add`, `worktree remove`, `worktree prune`, and cleanup removal/branch deletion windows with the per-repo lock.
- Keeps post-create bootstrap outside the lock so dependency installs do not block unrelated lifecycle mutations longer than necessary.
- Adds smoke coverage for lock acquisition, independent repo keys, busy errors, and release on normal and exception paths.

## Tests
- `php tests/smoke-workspace-mutation-lock.php`
- `php tests/smoke-worktree-cleanup.php`
- `php tests/smoke-worktree-handles.php`
- `php tests/smoke-worktree-staleness.php`
- `php tests/smoke-worktree-bootstrap.php`
- `php tests/smoke-worktree-context-injection.php`
- `php tests/smoke-worktree-base-branch-cli.php`
- `for f in tests/smoke-*.php; do php "$f" || exit 1; done`
- `git diff --check`
- `homeboy audit data-machine-code --path /Users/chubes/Developer/data-machine-code@fix-worktree-mutation-lock --changed-since origin/main`

Notes: `homeboy lint data-machine-code --path /Users/chubes/Developer/data-machine-code@fix-worktree-mutation-lock` currently fails in the WordPress extension runner with `PLUGIN_PATH: unbound variable`. `homeboy test data-machine-code --path /Users/chubes/Developer/data-machine-code@fix-worktree-mutation-lock` reaches Playground but fails because no PHPUnit files are discovered. The repo's PHP smoke suite passes.

Closes #83

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the per-repo workspace mutation lock, added focused smoke coverage, and ran verification. Chris remains responsible for review and merge.
