### PR TITLE
feat(github): add narrow PR comment tool

### DIFF
--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -234,6 +234,48 @@ class GitHubAbilities {
 			);
 
 			wp_register_ability(
+				'datamachine/comment-github-pull-request',
+				array(
+					'label'               => 'Comment on GitHub Pull Request',
+					'description'         => 'Add a comment to a GitHub pull request without broader issue-management permissions',
+					'category'            => 'datamachine-code-github',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'repo', 'pull_number', 'body' ),
+						'properties' => array(
+							'repo'        => array(
+								'type'        => 'string',
+								'description' => 'Repository in owner/repo format.',
+							),
+							'pull_number' => array(
+								'type'        => 'integer',
+								'description' => 'Pull request number.',
+							),
+							'body'        => array(
+								'type'        => 'string',
+								'description' => 'Comment body (supports GitHub Markdown).',
+							),
+							'marker'      => array(
+								'type'        => 'string',
+								'description' => 'Optional stable marker appended as an HTML comment for future update-by-marker support.',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'comment' => array( 'type' => 'object' ),
+							'error'   => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'commentOnPullRequest' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
 				'datamachine/list-github-pulls',
 				array(
 					'label'               => 'List GitHub Pull Requests',
@@ -578,6 +620,24 @@ class GitHubAbilities {
 				'created_at' => $response['data']['created_at'] ?? '',
 			),
 			'message' => sprintf( 'Comment added to issue #%d.', $issue_number ),
+		);
+	}
+
+	public static function commentOnPullRequest( array $input ): array|\WP_Error {
+		return self::commentOnIssue( self::buildPullRequestCommentInput( $input ) );
+	}
+
+	private static function buildPullRequestCommentInput( array $input ): array {
+		$body = $input['body'] ?? '';
+		if ( isset( $input['marker'] ) && '' !== (string) $input['marker'] ) {
+			$marker = str_replace( '--', '-', trim( (string) $input['marker'] ) );
+			$body  .= "\n\n<!-- {$marker} -->";
+		}
+
+		return array(
+			'repo'         => $input['repo'] ?? '',
+			'issue_number' => (int) ( $input['pull_number'] ?? 0 ),
+			'body'         => $body,
 		);
 	}
 

--- a/inc/Tools/GitHubTools.php
+++ b/inc/Tools/GitHubTools.php
@@ -27,6 +27,7 @@ class GitHubTools extends BaseTool {
 		$this->registerTool( 'list_github_issues', array( $this, 'getListIssuesDefinition' ), $contexts, array( 'access_level' => 'editor' ) );
 		$this->registerTool( 'get_github_issue', array( $this, 'getGetIssueDefinition' ), $contexts, array( 'access_level' => 'editor' ) );
 		$this->registerTool( 'manage_github_issue', array( $this, 'getManageIssueDefinition' ), $contexts, array( 'access_level' => 'editor' ) );
+		$this->registerTool( 'comment_github_pull_request', array( $this, 'getCommentPullRequestDefinition' ), $contexts, array( 'access_level' => 'editor' ) );
 		$this->registerTool( 'list_github_pulls', array( $this, 'getListPullsDefinition' ), $contexts, array( 'access_level' => 'editor' ) );
 		$this->registerTool( 'list_github_repos', array( $this, 'getListReposDefinition' ), $contexts, array( 'access_level' => 'editor' ) );
 	}
@@ -58,6 +59,7 @@ class GitHubTools extends BaseTool {
 			'list_github_issues',
 			'get_github_issue',
 			'manage_github_issue',
+			'comment_github_pull_request',
 			'list_github_pulls',
 			'list_github_repos',
 		);
@@ -274,6 +276,66 @@ class GitHubTools extends BaseTool {
 					'type'        => 'array',
 					'required'    => false,
 					'description' => 'Labels to set (update action). Replaces existing labels.',
+				),
+			),
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Comment Pull Request
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Handle comment_github_pull_request tool call.
+	 *
+	 * @param array $parameters Tool parameters.
+	 * @param array $tool_def   Tool definition.
+	 * @return array
+	 */
+	public function handleCommentPullRequest( array $parameters, array $tool_def = array() ): array {
+		$result = GitHubAbilities::commentOnPullRequest( $parameters );
+
+		if ( is_wp_error( $result ) ) {
+			return $this->buildErrorResponse( $result->get_error_message(), 'comment_github_pull_request' );
+		}
+
+		return array(
+			'success'   => true,
+			'data'      => $result,
+			'tool_name' => 'comment_github_pull_request',
+		);
+	}
+
+	/**
+	 * Get tool definition for comment_github_pull_request.
+	 *
+	 * @return array
+	 */
+	public function getCommentPullRequestDefinition(): array {
+		return array(
+			'class'       => __CLASS__,
+			'method'      => 'handleCommentPullRequest',
+			'description' => 'Comment on a GitHub pull request without granting broader issue update or close capabilities.',
+			'parameters'  => array(
+				'repo'        => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Repository in owner/repo format.',
+				),
+				'pull_number' => array(
+					'type'        => 'integer',
+					'required'    => true,
+					'description' => 'Pull request number.',
+				),
+				'body'        => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Comment body (supports GitHub Markdown).',
+				),
+				'marker'      => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Optional stable marker appended as an HTML comment for future update-by-marker support.',
 				),
 			),
 		);

--- a/tests/smoke-github-pr-comment-tool.php
+++ b/tests/smoke-github-pr-comment-tool.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Pure-PHP smoke test for the GitHub PR comment tool wrapper.
+ *
+ * Run: php tests/smoke-github-pr-comment-tool.php
+ *
+ * Verifies the narrow PR-comment surface without bootstrapping WordPress or
+ * sending a real GitHub API request.
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Engine\AI\Tools {
+    class BaseTool {
+        public array $registered = array();
+
+        protected function registerTool( string $name, array $definition_callback, array $contexts, array $options = array() ): void {
+            $this->registered[ $name ] = array(
+                'definition_callback' => $definition_callback,
+                'contexts'            => $contexts,
+                'options'             => $options,
+            );
+        }
+
+        protected function buildErrorResponse( string $message, string $tool_name ): array {
+            return array(
+                'success'   => false,
+                'error'     => $message,
+                'tool_name' => $tool_name,
+            );
+        }
+    }
+}
+
+namespace {
+    if ( ! defined( 'ABSPATH' ) ) {
+        define( 'ABSPATH', __DIR__ . '/' );
+    }
+
+    require __DIR__ . '/../inc/Abilities/GitHubAbilities.php';
+    require __DIR__ . '/../inc/Tools/GitHubTools.php';
+
+    use DataMachineCode\Abilities\GitHubAbilities;
+    use DataMachineCode\Tools\GitHubTools;
+
+    $failures = array();
+    $assert   = function ( string $label, bool $cond ) use ( &$failures ): void {
+        if ( $cond ) {
+            echo "  ok {$label}\n";
+            return;
+        }
+        $failures[] = $label;
+        echo "  fail {$label}\n";
+    };
+
+    echo "GitHub PR comment tool wrapper - smoke\n";
+
+	$mapper = new ReflectionMethod( GitHubAbilities::class, 'buildPullRequestCommentInput' );
+
+	$mapped = $mapper->invoke( null, array(
+        'repo'        => 'Extra-Chill/data-machine-code',
+        'pull_number' => 86,
+        'body'        => 'Review body',
+    ) );
+
+    $assert( 'pull_number maps to issue_number', 86 === $mapped['issue_number'] );
+    $assert( 'repo passes through unchanged', 'Extra-Chill/data-machine-code' === $mapped['repo'] );
+    $assert( 'body passes through without marker', 'Review body' === $mapped['body'] );
+    $assert( 'pull_number is the only numeric input in mapped payload', ! array_key_exists( 'pull_number', $mapped ) );
+
+    $marked = $mapper->invoke( null, array(
+        'repo'        => 'Extra-Chill/data-machine-code',
+        'pull_number' => 87,
+        'body'        => 'Review body',
+        'marker'      => 'dmc-pr-review-marker',
+    ) );
+
+    $assert( 'marker appends as HTML comment', str_contains( $marked['body'], '<!-- dmc-pr-review-marker -->' ) );
+    $assert( 'marker preserves visible comment body', str_starts_with( $marked['body'], 'Review body' ) );
+
+    $tools = new GitHubTools();
+
+    $assert( 'comment_github_pull_request tool is registered', isset( $tools->registered['comment_github_pull_request'] ) );
+    $assert( 'tool is available in pipeline context', in_array( 'pipeline', $tools->registered['comment_github_pull_request']['contexts'] ?? array(), true ) );
+
+    $definition = $tools->getCommentPullRequestDefinition();
+    $params     = $definition['parameters'] ?? array();
+
+    $assert( 'tool delegates to narrow PR comment handler', 'handleCommentPullRequest' === ( $definition['method'] ?? '' ) );
+    $assert( 'tool requires repo', true === ( $params['repo']['required'] ?? false ) );
+    $assert( 'tool requires pull_number', true === ( $params['pull_number']['required'] ?? false ) );
+    $assert( 'tool requires body', true === ( $params['body']['required'] ?? false ) );
+    $assert( 'tool accepts optional marker', false === ( $params['marker']['required'] ?? true ) );
+    $assert( 'tool does not expose broad issue action parameter', ! array_key_exists( 'action', $params ) );
+    $assert( 'tool does not expose issue close state parameter', ! array_key_exists( 'state', $params ) );
+    $assert( 'tool does not expose issue update title parameter', ! array_key_exists( 'title', $params ) );
+    $assert( 'tool does not expose issue labels update parameter', ! array_key_exists( 'labels', $params ) );
+
+    $ability_source = file_get_contents( __DIR__ . '/../inc/Abilities/GitHubAbilities.php' );
+    $tool_source    = file_get_contents( __DIR__ . '/../inc/Tools/GitHubTools.php' );
+
+    $assert( 'PR comment ability is registered', str_contains( $ability_source, 'datamachine/comment-github-pull-request' ) );
+    $assert( 'ability executes commentOnPullRequest', str_contains( $ability_source, "'execute_callback'    => array( self::class, 'commentOnPullRequest' )" ) );
+    $assert( 'tool is included in configuration checks', str_contains( $tool_source, "'comment_github_pull_request'" ) );
+
+    if ( ! empty( $failures ) ) {
+        echo "\nFAIL: " . count( $failures ) . " assertion(s)\n";
+        foreach ( $failures as $failure ) {
+            echo "  - {$failure}\n";
+        }
+        exit( 1 );
+    }
+
+    echo "\nOK\n";
+    exit( 0 );
+}


### PR DESCRIPTION
## Summary
- Adds a PR-specific GitHub comment ability/tool so review flows can comment on pull requests without granting broader issue update/close tools.
- Reuses the existing issue comment implementation because GitHub pull requests are backed by issue comments.

## Changes
- Adds `datamachine/comment-github-pull-request` ability with `repo`, `pull_number`, `body`, and optional `marker` inputs.
- Adds `comment_github_pull_request` pipeline/chat tool that delegates to the PR comment ability.
- Adds focused smoke coverage for PR-to-issue parameter mapping, marker insertion, pipeline availability, and the absence of broad issue-management parameters.

## Tests
- `php tests/smoke-github-pr-comment-tool.php`
- `php -l inc/Abilities/GitHubAbilities.php && php -l inc/Tools/GitHubTools.php && php -l tests/smoke-github-pr-comment-tool.php`
- `homeboy audit data-machine-code --path /Users/chubes/Developer/data-machine-code@feat-pr-comment-tool --changed-since origin/main`

Note: `homeboy lint data-machine-code --path /Users/chubes/Developer/data-machine-code@feat-pr-comment-tool` is currently blocked by the known WordPress extension runner error: `PLUGIN_PATH: unbound variable`.

Closes #86

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Drafted implementation and tests for the narrow PR comment ability/tool; Chris remains responsible for review and merge.