### PR TITLE
feat(github): add PR review context fetch

### DIFF
--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -614,6 +614,145 @@ class GitHubAbilities {
 		);
 	}
 
+	/**
+	 * Get one pull request with full review context.
+	 *
+	 * @param array $input {
+	 *     Required: repo, pull_number. Optional: head_sha, max_patch_chars.
+	 * }
+	 * @return array|\WP_Error Success payload or error.
+	 */
+	public static function getPullReviewContext( array $input ): array|\WP_Error {
+		$repo        = sanitize_text_field( $input['repo'] ?? '' );
+		$pull_number = (int) ( $input['pull_number'] ?? $input['pr_number'] ?? 0 );
+
+		if ( empty( $repo ) || $pull_number <= 0 ) {
+			return new \WP_Error( 'missing_params', 'Repository (owner/repo) and pull_number are required.', array( 'status' => 400 ) );
+		}
+
+		$pat = self::getPat();
+		if ( empty( $pat ) ) {
+			return self::patError();
+		}
+
+		$pull = self::getPull( array(
+			'repo'        => $repo,
+			'pull_number' => $pull_number,
+		) );
+		if ( is_wp_error( $pull ) ) {
+			return $pull;
+		}
+
+		$files = array();
+		$page  = 1;
+		do {
+			$file_page = self::listPullFiles( array(
+				'repo'        => $repo,
+				'pull_number' => $pull_number,
+				'per_page'    => self::MAX_PER_PAGE,
+				'page'        => $page,
+			) );
+			if ( is_wp_error( $file_page ) ) {
+				return $file_page;
+			}
+
+			$page_files = $file_page['files'] ?? array();
+			$files      = array_merge( $files, $page_files );
+			$page++;
+		} while ( count( $page_files ) >= self::MAX_PER_PAGE );
+
+		$context = self::normalizePullReviewContext(
+			$repo,
+			$pull['pull'],
+			$files,
+			array(
+				'head_sha'        => sanitize_text_field( $input['head_sha'] ?? '' ),
+				'max_patch_chars' => (int) ( $input['max_patch_chars'] ?? 200000 ),
+			)
+		);
+
+		if ( is_wp_error( $context ) ) {
+			return $context;
+		}
+
+		return array(
+			'success' => true,
+			'context' => $context,
+		);
+	}
+
+	/**
+	 * Get a single pull request.
+	 *
+	 * @param array $input Required: repo, pull_number.
+	 * @return array|\WP_Error { success: bool, pull: normalized } or error.
+	 */
+	public static function getPull( array $input ): array|\WP_Error {
+		$repo        = sanitize_text_field( $input['repo'] ?? '' );
+		$pull_number = (int) ( $input['pull_number'] ?? $input['pr_number'] ?? 0 );
+
+		if ( empty( $repo ) || $pull_number <= 0 ) {
+			return new \WP_Error( 'missing_params', 'Repository (owner/repo) and pull_number are required.', array( 'status' => 400 ) );
+		}
+
+		$pat = self::getPat();
+		if ( empty( $pat ) ) {
+			return self::patError();
+		}
+
+		$url      = sprintf( '%s/repos/%s/pulls/%d', self::API_BASE, $repo, $pull_number );
+		$response = self::apiGet( $url, array(), $pat );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		return array(
+			'success' => true,
+			'pull'    => self::normalizePull( $response['data'] ),
+		);
+	}
+
+	/**
+	 * List changed files for a pull request.
+	 *
+	 * @param array $input Required: repo, pull_number. Optional: per_page, page.
+	 * @return array|\WP_Error { success: bool, files: normalized[], count: int } or error.
+	 */
+	public static function listPullFiles( array $input ): array|\WP_Error {
+		$repo        = sanitize_text_field( $input['repo'] ?? '' );
+		$pull_number = (int) ( $input['pull_number'] ?? $input['pr_number'] ?? 0 );
+
+		if ( empty( $repo ) || $pull_number <= 0 ) {
+			return new \WP_Error( 'missing_params', 'Repository (owner/repo) and pull_number are required.', array( 'status' => 400 ) );
+		}
+
+		$pat = self::getPat();
+		if ( empty( $pat ) ) {
+			return self::patError();
+		}
+
+		$query_params = array(
+			'per_page' => self::clampPerPage( $input['per_page'] ?? self::MAX_PER_PAGE ),
+			'page'     => max( 1, (int) ( $input['page'] ?? 1 ) ),
+		);
+
+		$url      = sprintf( '%s/repos/%s/pulls/%d/files', self::API_BASE, $repo, $pull_number );
+		$response = self::apiGet( $url, $query_params, $pat );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$normalized = array_map( array( self::class, 'normalizePullFile' ), $response['data'] );
+
+		return array(
+			'success' => true,
+			'files'   => $normalized,
+			'count'   => count( $normalized ),
+		);
+	}
+
 	public static function listRepos( array $input ): array|\WP_Error {
 		$owner = sanitize_text_field( $input['owner'] ?? '' );
 		if ( empty( $owner ) ) {
@@ -939,7 +1078,11 @@ class GitHubAbilities {
 			'html_url'   => $pr['html_url'] ?? '',
 			'user'       => $pr['user']['login'] ?? '',
 			'head'       => $pr['head']['ref'] ?? '',
+			'head_ref'   => $pr['head']['ref'] ?? '',
+			'head_sha'   => $pr['head']['sha'] ?? '',
 			'base'       => $pr['base']['ref'] ?? '',
+			'base_ref'   => $pr['base']['ref'] ?? '',
+			'base_sha'   => $pr['base']['sha'] ?? '',
 			'draft'      => $pr['draft'] ?? false,
 			'merged'     => ! empty( $pr['merged_at'] ),
 			'labels'     => array_map( fn( $label ) => $label['name'] ?? '', $pr['labels'] ?? array() ),
@@ -947,6 +1090,121 @@ class GitHubAbilities {
 			'updated_at' => $pr['updated_at'] ?? '',
 			'closed_at'  => $pr['closed_at'] ?? '',
 			'merged_at'  => $pr['merged_at'] ?? '',
+		);
+	}
+
+	/**
+	 * Normalize one changed file from the pull files API.
+	 */
+	public static function normalizePullFile( array $file ): array {
+		return array(
+			'filename'  => $file['filename'] ?? '',
+			'status'    => $file['status'] ?? '',
+			'additions' => (int) ( $file['additions'] ?? 0 ),
+			'deletions' => (int) ( $file['deletions'] ?? 0 ),
+			'changes'   => (int) ( $file['changes'] ?? 0 ),
+			'patch'     => $file['patch'] ?? '',
+			'raw_url'   => $file['raw_url'] ?? '',
+			'blob_url'  => $file['blob_url'] ?? '',
+		);
+	}
+
+	/**
+	 * Build a review-ready DataPacket for one pull request.
+	 *
+	 * @param string $repo Repository in owner/repo format.
+	 * @param array  $pull Normalized pull request payload.
+	 * @param array  $files Normalized changed file payloads.
+	 * @param array  $options Optional head_sha and max_patch_chars.
+	 * @return array|\WP_Error DataPacket-compatible array or validation error.
+	 */
+	public static function normalizePullReviewContext( string $repo, array $pull, array $files, array $options = array() ): array|\WP_Error {
+		$pull_number = (int) ( $pull['number'] ?? 0 );
+		$head_sha    = (string) ( $pull['head_sha'] ?? '' );
+		$expected    = (string) ( $options['head_sha'] ?? '' );
+
+		if ( '' !== $expected && '' !== $head_sha && $expected !== $head_sha ) {
+			return new \WP_Error(
+				'github_pr_head_sha_mismatch',
+				sprintf( 'GitHub PR head SHA mismatch for %s#%d: expected %s, found %s.', $repo, $pull_number, $expected, $head_sha ),
+				array( 'status' => 409 )
+			);
+		}
+
+		$max_patch_chars = max( 0, (int) ( $options['max_patch_chars'] ?? 200000 ) );
+		$patch_chars     = 0;
+		$truncated_files = 0;
+		$changed_files   = array();
+
+		foreach ( $files as $file ) {
+			$patch      = (string) ( $file['patch'] ?? '' );
+			$patch_size = strlen( $patch );
+			$include    = '' !== $patch && ( 0 === $max_patch_chars || $patch_chars + $patch_size <= $max_patch_chars );
+
+			if ( '' !== $patch && ! $include ) {
+				$truncated_files++;
+			}
+
+			$entry = array(
+				'filename'       => $file['filename'] ?? '',
+				'status'         => $file['status'] ?? '',
+				'additions'      => (int) ( $file['additions'] ?? 0 ),
+				'deletions'      => (int) ( $file['deletions'] ?? 0 ),
+				'changes'        => (int) ( $file['changes'] ?? 0 ),
+				'patch'          => $include ? $patch : '',
+				'patch_included' => $include,
+				'patch_bytes'    => $patch_size,
+			);
+
+			if ( $include ) {
+				$patch_chars += $patch_size;
+			}
+
+			$changed_files[] = $entry;
+		}
+
+		$item_identifier = sprintf( '%s#%d@%s', $repo, $pull_number, $head_sha );
+		$title           = sprintf( 'PR review context: %s#%d %s', $repo, $pull_number, $pull['title'] ?? '' );
+
+		$context = array(
+			'repo'          => $repo,
+			'pull_number'   => $pull_number,
+			'url'           => $pull['html_url'] ?? '',
+			'title'         => $pull['title'] ?? '',
+			'body'          => $pull['body'] ?? '',
+			'author'        => $pull['user'] ?? '',
+			'base_ref'      => $pull['base_ref'] ?? $pull['base'] ?? '',
+			'base_sha'      => $pull['base_sha'] ?? '',
+			'head_ref'      => $pull['head_ref'] ?? $pull['head'] ?? '',
+			'head_sha'      => $head_sha,
+			'changed_files' => $changed_files,
+			'truncation'    => array(
+				'max_patch_chars'      => $max_patch_chars,
+				'included_patch_chars' => $patch_chars,
+				'truncated_files'      => $truncated_files,
+				'truncated'            => $truncated_files > 0,
+			),
+		);
+
+		return array(
+			'title'    => $title,
+			'content'  => wp_json_encode( $context, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ),
+			'metadata' => array(
+				'source_type'       => 'github_pr_review',
+				'item_identifier'   => $item_identifier,
+				'original_id'       => $item_identifier,
+				'dedup_key'         => $item_identifier,
+				'original_title'    => $pull['title'] ?? '',
+				'original_date_gmt' => $pull['updated_at'] ?? $pull['created_at'] ?? '',
+				'github_repo'       => $repo,
+				'github_type'       => 'pull_review_context',
+				'github_number'     => $pull_number,
+				'github_head_sha'   => $head_sha,
+				'github_base_sha'   => $pull['base_sha'] ?? '',
+				'github_url'        => $pull['html_url'] ?? '',
+				'source_url'        => $pull['html_url'] ?? '',
+				'review_context'    => $context,
+			),
 		);
 	}
 

--- a/inc/Handlers/GitHub/GitHub.php
+++ b/inc/Handlers/GitHub/GitHub.php
@@ -72,11 +72,53 @@ class GitHub extends FetchHandler {
 			'data_source' => $data_source,
 		) );
 
+		if ( 'pull_review_context' === $data_source ) {
+			return $this->fetchPullReviewContext( $config, $context, $repo );
+		}
+
 		if ( 'files' === $data_source ) {
 			return $this->fetchFiles( $config, $context, $repo );
 		}
 
 		return $this->fetchIssuesOrPulls( $config, $context, $repo, $data_source );
+	}
+
+	/**
+	 * Fetch one pull request as review-ready context.
+	 *
+	 * @param array            $config  Handler configuration.
+	 * @param ExecutionContext $context Execution context.
+	 * @param string           $repo    Repository in owner/repo format.
+	 * @return array DataPacket-compatible array or empty on no data.
+	 */
+	private function fetchPullReviewContext( array $config, ExecutionContext $context, string $repo ): array {
+		$pull_number = (int) ( $config['pull_number'] ?? $config['pr_number'] ?? 0 );
+
+		if ( $pull_number <= 0 ) {
+			$context->log( 'error', 'GitHub: pull_number is required for pull_review_context.' );
+			return array();
+		}
+
+		$result = GitHubAbilities::getPullReviewContext( array(
+			'repo'            => $repo,
+			'pull_number'     => $pull_number,
+			'head_sha'        => $config['head_sha'] ?? '',
+			'max_patch_chars' => $config['max_patch_chars'] ?? 200000,
+		) );
+
+		if ( is_wp_error( $result ) ) {
+			$context->log( 'error', 'GitHub: PR review context error — ' . $result->get_error_message() );
+			return array();
+		}
+
+		$packet = $result['context'] ?? array();
+		if ( empty( $packet ) ) {
+			$context->log( 'info', 'GitHub: No PR review context returned.' );
+			return array();
+		}
+
+		$context->log( 'info', sprintf( 'GitHub: Prepared PR review context for %s#%d.', $repo, $pull_number ) );
+		return array( 'items' => array( $packet ) );
 	}
 
 	/**

--- a/inc/Handlers/GitHub/GitHubSettings.php
+++ b/inc/Handlers/GitHub/GitHubSettings.php
@@ -38,10 +38,30 @@ class GitHubSettings extends FetchHandlerSettings {
 				'required'    => true,
 				'default'     => 'issues',
 				'options'     => array(
-					'issues' => __( 'Issues', 'data-machine-code' ),
-					'pulls'  => __( 'Pull Requests', 'data-machine-code' ),
-					'files'  => __( 'Source Files', 'data-machine-code' ),
+					'issues'              => __( 'Issues', 'data-machine-code' ),
+					'pulls'               => __( 'Pull Requests', 'data-machine-code' ),
+					'pull_review_context' => __( 'PR Review Context', 'data-machine-code' ),
+					'files'               => __( 'Source Files', 'data-machine-code' ),
 				),
+			),
+			'pull_number'   => array(
+				'type'        => 'number',
+				'label'       => __( 'Pull Request Number', 'data-machine-code' ),
+				'description' => __( 'Pull request number to prepare for review context.', 'data-machine-code' ),
+				'required'    => false,
+			),
+			'head_sha'      => array(
+				'type'        => 'text',
+				'label'       => __( 'Expected Head SHA', 'data-machine-code' ),
+				'description' => __( 'Optional guard SHA. If set, the fetch fails when the live PR head differs.', 'data-machine-code' ),
+				'required'    => false,
+			),
+			'max_patch_chars' => array(
+				'type'        => 'number',
+				'label'       => __( 'Max Patch Characters', 'data-machine-code' ),
+				'description' => __( 'Maximum cumulative patch characters included in PR review context. Set 0 for unlimited.', 'data-machine-code' ),
+				'required'    => false,
+				'default'     => 200000,
 			),
 			'state'         => array(
 				'type'        => 'select',

--- a/tests/smoke-github-pr-review-context.php
+++ b/tests/smoke-github-pr-review-context.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Pure-PHP smoke for GitHub PR review context normalization.
+ *
+ * No GitHub network calls: this pins the DataPacket shape produced from
+ * normalized pull + files payloads.
+ *
+ * Run: php tests/smoke-github-pr-review-context.php
+ */
+
+declare( strict_types=1 );
+
+namespace {
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', sys_get_temp_dir() . '/dmc-pr-review-context/' );
+	}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			public string $code;
+			public string $message;
+			public array $data;
+
+			public function __construct( string $code = '', string $message = '', array $data = array() ) {
+				$this->code    = $code;
+				$this->message = $message;
+				$this->data    = $data;
+			}
+
+			public function get_error_code(): string { return $this->code; }
+			public function get_error_message(): string { return $this->message; }
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $thing ): bool { return $thing instanceof \WP_Error; }
+	}
+
+	if ( ! function_exists( 'wp_json_encode' ) ) {
+		function wp_json_encode( $data, int $options = 0 ) { return json_encode( $data, $options ); }
+	}
+
+	require __DIR__ . '/../inc/Abilities/GitHubAbilities.php';
+
+	$failures = 0;
+	$total    = 0;
+
+	$assert = function ( $cond, string $message ) use ( &$failures, &$total ): void {
+		$total++;
+		if ( $cond ) {
+			echo "  ✓ {$message}\n";
+			return;
+		}
+		$failures++;
+		echo "  ✗ {$message}\n";
+	};
+
+	echo "GitHub PR review context — smoke\n\n";
+
+	$raw_pull = array(
+		'number'     => 85,
+		'title'      => 'Add PR review context primitive',
+		'state'      => 'open',
+		'body'       => 'Review context body.',
+		'html_url'   => 'https://github.com/Extra-Chill/data-machine-code/pull/85',
+		'user'       => array( 'login' => 'octocat' ),
+		'head'       => array(
+			'ref' => 'feat-pr-review-context',
+			'sha' => 'abc123head',
+		),
+		'base'       => array(
+			'ref' => 'main',
+			'sha' => 'def456base',
+		),
+		'labels'     => array( array( 'name' => 'enhancement' ) ),
+		'created_at' => '2026-04-27T00:00:00Z',
+		'updated_at' => '2026-04-27T01:00:00Z',
+	);
+
+	$raw_files = array(
+		array(
+			'filename'  => 'inc/Handlers/GitHub/GitHub.php',
+			'status'    => 'modified',
+			'additions' => 50,
+			'deletions' => 2,
+			'changes'   => 52,
+			'patch'     => "@@ -1 +1 @@\n-old\n+new\n",
+		),
+		array(
+			'filename'  => 'tests/huge-fixture.php',
+			'status'    => 'modified',
+			'additions' => 5000,
+			'deletions' => 0,
+			'changes'   => 5000,
+			'patch'     => str_repeat( '+line\n', 20 ),
+		),
+		array(
+			'filename'  => 'assets/logo.png',
+			'status'    => 'added',
+			'additions' => 0,
+			'deletions' => 0,
+			'changes'   => 0,
+		),
+	);
+
+	$pull  = \DataMachineCode\Abilities\GitHubAbilities::normalizePull( $raw_pull );
+	$files = array_map( array( \DataMachineCode\Abilities\GitHubAbilities::class, 'normalizePullFile' ), $raw_files );
+
+	$packet = \DataMachineCode\Abilities\GitHubAbilities::normalizePullReviewContext(
+		'Extra-Chill/data-machine-code',
+		$pull,
+		$files,
+		array(
+			'head_sha'        => 'abc123head',
+			'max_patch_chars' => 40,
+		)
+	);
+
+	$assert( ! is_wp_error( $packet ), 'normalization succeeds with matching head SHA' );
+	$assert( 'github_pr_review' === $packet['metadata']['source_type'], 'metadata source_type is github_pr_review' );
+	$assert( 'Extra-Chill/data-machine-code#85@abc123head' === $packet['metadata']['item_identifier'], 'item identifier includes repo, PR number, head SHA' );
+	$assert( $packet['metadata']['item_identifier'] === $packet['metadata']['dedup_key'], 'dedup_key mirrors item identifier' );
+	$assert( 'pull_review_context' === $packet['metadata']['github_type'], 'github_type names the review context source' );
+	$assert( 'abc123head' === $packet['metadata']['github_head_sha'], 'metadata includes head SHA' );
+
+	$content = json_decode( $packet['content'], true );
+	$assert( is_array( $content ), 'content is JSON review context' );
+	$assert( 'Extra-Chill/data-machine-code' === $content['repo'], 'content includes repo' );
+	$assert( 85 === $content['pull_number'], 'content includes PR number' );
+	$assert( 'https://github.com/Extra-Chill/data-machine-code/pull/85' === $content['url'], 'content includes PR URL' );
+	$assert( 'Add PR review context primitive' === $content['title'], 'content includes title' );
+	$assert( 'Review context body.' === $content['body'], 'content includes body' );
+	$assert( 'octocat' === $content['author'], 'content includes author' );
+	$assert( 'main' === $content['base_ref'], 'content includes base ref' );
+	$assert( 'def456base' === $content['base_sha'], 'content includes base SHA' );
+	$assert( 'feat-pr-review-context' === $content['head_ref'], 'content includes head ref' );
+	$assert( 'abc123head' === $content['head_sha'], 'content includes head SHA' );
+	$assert( 3 === count( $content['changed_files'] ), 'content includes every changed file' );
+	$assert( 'inc/Handlers/GitHub/GitHub.php' === $content['changed_files'][0]['filename'], 'changed file includes filename' );
+	$assert( 'modified' === $content['changed_files'][0]['status'], 'changed file includes status' );
+	$assert( 50 === $content['changed_files'][0]['additions'], 'changed file includes additions' );
+	$assert( 2 === $content['changed_files'][0]['deletions'], 'changed file includes deletions' );
+	$assert( str_contains( $content['changed_files'][0]['patch'], '+new' ), 'small patch is included' );
+	$assert( true === $content['changed_files'][0]['patch_included'], 'small patch marks patch_included true' );
+	$assert( '' === $content['changed_files'][1]['patch'], 'large patch is omitted after cumulative limit' );
+	$assert( false === $content['changed_files'][1]['patch_included'], 'large patch marks patch_included false' );
+	$assert( false === $content['changed_files'][2]['patch_included'], 'missing binary patch marks patch_included false' );
+	$assert( 40 === $content['truncation']['max_patch_chars'], 'truncation records configured limit' );
+	$assert( 1 === $content['truncation']['truncated_files'], 'truncation counts omitted patches' );
+	$assert( true === $content['truncation']['truncated'], 'truncation boolean is true when a patch is omitted' );
+	$assert( $content === $packet['metadata']['review_context'], 'metadata carries same review context for downstream consumers' );
+
+	$mismatch = \DataMachineCode\Abilities\GitHubAbilities::normalizePullReviewContext(
+		'Extra-Chill/data-machine-code',
+		$pull,
+		$files,
+		array( 'head_sha' => 'stalehead' )
+	);
+	$assert( is_wp_error( $mismatch ), 'head SHA mismatch returns WP_Error' );
+	$assert( is_wp_error( $mismatch ) && 'github_pr_head_sha_mismatch' === $mismatch->get_error_code(), 'head SHA mismatch uses clear error code' );
+
+	echo "\nAssertions: {$total}, Failures: {$failures}\n";
+	exit( $failures > 0 ? 1 : 0 );
+}


### PR DESCRIPTION
## Summary
- Adds a GitHub fetch data source that prepares one pull request as review-ready context for Data Machine AI review flows.
- Emits a stable processed-items identifier from repo, PR number, and live head SHA so existing dedupe can handle repeated runs.

## Changes
- Adds GitHub API helpers for `GET /repos/{repo}/pulls/{pull_number}` and `GET /repos/{repo}/pulls/{pull_number}/files`.
- Normalizes PR review context into a single DataPacket with PR metadata, changed files, patch inclusion, truncation metadata, and `github_pr_review` source metadata.
- Adds optional `head_sha` validation and handler settings for PR number, expected head SHA, and max patch characters.
- Adds a pure PHP smoke test for packet shape, patch truncation, and head SHA mismatch behavior.

## Tests
- `php tests/smoke-github-pr-review-context.php`
- `php -l inc/Abilities/GitHubAbilities.php && php -l inc/Handlers/GitHub/GitHub.php && php -l inc/Handlers/GitHub/GitHubSettings.php && php -l tests/smoke-github-pr-review-context.php`
- `homeboy audit data-machine-code --path /Users/chubes/Developer/data-machine-code@feat-pr-review-context --changed-since origin/main`

`homeboy lint data-machine-code --path /Users/chubes/Developer/data-machine-code@feat-pr-review-context` currently fails in the WordPress extension runner before findings with `PLUGIN_PATH: unbound variable`.

Closes #85

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted implementation and tests for the PR review context primitive; Chris remains responsible for review and merge.