### PR TITLE
feat(github): expose read-only source context tools

### DIFF
--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -319,6 +319,202 @@ class GitHubAbilities {
 			);
 
 			wp_register_ability(
+				'datamachine/get-github-pull',
+				array(
+					'label'               => 'Get GitHub Pull Request',
+					'description'         => 'Get a single GitHub pull request with normalized metadata',
+					'category'            => 'datamachine-code-github',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'repo', 'pull_number' ),
+						'properties' => array(
+							'repo'        => array(
+								'type'        => 'string',
+								'description' => 'Repository in owner/repo format.',
+							),
+							'pull_number' => array(
+								'type'        => 'integer',
+								'description' => 'Pull request number.',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'pull'    => array( 'type' => 'object' ),
+							'error'   => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'getPull' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/list-github-pull-files',
+				array(
+					'label'               => 'List GitHub Pull Request Files',
+					'description'         => 'List changed files for a GitHub pull request',
+					'category'            => 'datamachine-code-github',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'repo', 'pull_number' ),
+						'properties' => array(
+							'repo'        => array(
+								'type'        => 'string',
+								'description' => 'Repository in owner/repo format.',
+							),
+							'pull_number' => array(
+								'type'        => 'integer',
+								'description' => 'Pull request number.',
+							),
+							'per_page'    => array(
+								'type'        => 'integer',
+								'description' => 'Results per page (default: 100, max: 100).',
+							),
+							'page'        => array(
+								'type'        => 'integer',
+								'description' => 'Page number (default: 1).',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'files'   => array( 'type' => 'array' ),
+							'count'   => array( 'type' => 'integer' ),
+							'error'   => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'listPullFiles' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/get-github-pull-review-context',
+				array(
+					'label'               => 'Get GitHub Pull Request Review Context',
+					'description'         => 'Get a review-ready payload for a GitHub pull request and its changed files',
+					'category'            => 'datamachine-code-github',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'repo', 'pull_number' ),
+						'properties' => array(
+							'repo'            => array(
+								'type'        => 'string',
+								'description' => 'Repository in owner/repo format.',
+							),
+							'pull_number'     => array(
+								'type'        => 'integer',
+								'description' => 'Pull request number.',
+							),
+							'head_sha'        => array(
+								'type'        => 'string',
+								'description' => 'Optional expected pull request head SHA.',
+							),
+							'max_patch_chars' => array(
+								'type'        => 'integer',
+								'description' => 'Maximum cumulative patch characters to include (default: 200000).',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'context' => array( 'type' => 'object' ),
+							'error'   => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'getPullReviewContext' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/list-github-tree',
+				array(
+					'label'               => 'List GitHub Repository Tree',
+					'description'         => 'List files in a GitHub repository tree at a branch or ref',
+					'category'            => 'datamachine-code-github',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'repo' ),
+						'properties' => array(
+							'repo' => array(
+								'type'        => 'string',
+								'description' => 'Repository in owner/repo format.',
+							),
+							'ref'  => array(
+								'type'        => 'string',
+								'description' => 'Branch, tag, or commit SHA. Defaults to HEAD.',
+							),
+							'path' => array(
+								'type'        => 'string',
+								'description' => 'Optional path prefix to filter returned files.',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'files'   => array( 'type' => 'array' ),
+							'count'   => array( 'type' => 'integer' ),
+							'error'   => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'getRepoTree' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/get-github-file',
+				array(
+					'label'               => 'Get GitHub File',
+					'description'         => 'Get decoded content for a single file in a GitHub repository',
+					'category'            => 'datamachine-code-github',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'repo', 'path' ),
+						'properties' => array(
+							'repo' => array(
+								'type'        => 'string',
+								'description' => 'Repository in owner/repo format.',
+							),
+							'path' => array(
+								'type'        => 'string',
+								'description' => 'File path within the repository.',
+							),
+							'ref'  => array(
+								'type'        => 'string',
+								'description' => 'Branch, tag, or commit SHA. Defaults to the repository default branch.',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'file'    => array( 'type' => 'object' ),
+							'error'   => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'getFileContents' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
 				'datamachine/create-or-update-github-file',
 				array(
 					'label'               => 'Create or Update GitHub File',
@@ -968,7 +1164,7 @@ class GitHubAbilities {
 			return self::patError();
 		}
 
-		$branch = sanitize_text_field( $input['branch'] ?? '' );
+		$branch = sanitize_text_field( $input['ref'] ?? $input['branch'] ?? '' );
 		$ref    = ! empty( $branch ) ? $branch : 'HEAD';
 
 		$url      = sprintf( '%s/repos/%s/git/trees/%s', self::API_BASE, $repo, $ref );
@@ -981,7 +1177,20 @@ class GitHubAbilities {
 		$tree = $response['data']['tree'] ?? array();
 
 		// Filter to blobs (files) only — skip trees (directories).
-		$files = array_filter( $tree, fn( $entry ) => 'blob' === ( $entry['type'] ?? '' ) );
+		$path_prefix = trim( sanitize_text_field( $input['path'] ?? '' ), '/' );
+		$files       = array_filter(
+			$tree,
+			function ( $entry ) use ( $path_prefix ) {
+				if ( 'blob' !== ( $entry['type'] ?? '' ) ) {
+					return false;
+				}
+				if ( '' === $path_prefix ) {
+					return true;
+				}
+				$entry_path = (string) ( $entry['path'] ?? '' );
+				return $entry_path === $path_prefix || str_starts_with( $entry_path, $path_prefix . '/' );
+			}
+		);
 		$files = array_values( array_map( array( self::class, 'normalizeTreeEntry' ), $files ) );
 
 		return array(
@@ -1016,7 +1225,7 @@ class GitHubAbilities {
 		}
 
 		$query_params = array();
-		$branch       = sanitize_text_field( $input['branch'] ?? '' );
+		$branch       = sanitize_text_field( $input['ref'] ?? $input['branch'] ?? '' );
 		if ( ! empty( $branch ) ) {
 			$query_params['ref'] = $branch;
 		}

--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -913,9 +913,10 @@ class GitHubAbilities {
 			}
 
 			$page_files = $file_page['files'] ?? array();
+			$page_count = count( $page_files );
 			$files      = array_merge( $files, $page_files );
-			$page++;
-		} while ( count( $page_files ) >= self::MAX_PER_PAGE );
+			++$page;
+		} while ( $page_count >= self::MAX_PER_PAGE );
 
 		$context = self::normalizePullReviewContext(
 			$repo,
@@ -1191,7 +1192,7 @@ class GitHubAbilities {
 				return $entry_path === $path_prefix || str_starts_with( $entry_path, $path_prefix . '/' );
 			}
 		);
-		$files = array_values( array_map( array( self::class, 'normalizeTreeEntry' ), $files ) );
+		$files       = array_values( array_map( array( self::class, 'normalizeTreeEntry' ), $files ) );
 
 		return array(
 			'success' => true,
@@ -1411,7 +1412,7 @@ class GitHubAbilities {
 			$include    = '' !== $patch && ( 0 === $max_patch_chars || $patch_chars + $patch_size <= $max_patch_chars );
 
 			if ( '' !== $patch && ! $include ) {
-				$truncated_files++;
+				++$truncated_files;
 			}
 
 			$entry = array(

--- a/inc/Tools/GitHubTools.php
+++ b/inc/Tools/GitHubTools.php
@@ -29,11 +29,26 @@ class GitHubTools extends BaseTool {
 		$this->registerTool( 'manage_github_issue', array( $this, 'getManageIssueDefinition' ), $contexts, array( 'access_level' => 'editor' ) );
 		$this->registerTool( 'comment_github_pull_request', array( $this, 'getCommentPullRequestDefinition' ), $contexts, array( 'access_level' => 'editor' ) );
 		$this->registerTool( 'list_github_pulls', array( $this, 'getListPullsDefinition' ), $contexts, array( 'access_level' => 'editor' ) );
-		$this->registerTool( 'get_github_pull', array( $this, 'getGetPullDefinition' ), $contexts, array( 'access_level' => 'editor', 'ability' => 'datamachine/get-github-pull' ) );
-		$this->registerTool( 'get_github_pull_files', array( $this, 'getPullFilesDefinition' ), $contexts, array( 'access_level' => 'editor', 'ability' => 'datamachine/list-github-pull-files' ) );
-		$this->registerTool( 'get_github_pull_review_context', array( $this, 'getPullReviewContextDefinition' ), $contexts, array( 'access_level' => 'editor', 'ability' => 'datamachine/get-github-pull-review-context' ) );
-		$this->registerTool( 'list_github_tree', array( $this, 'getListTreeDefinition' ), $contexts, array( 'access_level' => 'editor', 'ability' => 'datamachine/list-github-tree' ) );
-		$this->registerTool( 'get_github_file', array( $this, 'getGetFileDefinition' ), $contexts, array( 'access_level' => 'editor', 'ability' => 'datamachine/get-github-file' ) );
+		$this->registerTool( 'get_github_pull', array( $this, 'getGetPullDefinition' ), $contexts, array(
+			'access_level' => 'editor',
+			'ability'      => 'datamachine/get-github-pull',
+		) );
+		$this->registerTool( 'get_github_pull_files', array( $this, 'getPullFilesDefinition' ), $contexts, array(
+			'access_level' => 'editor',
+			'ability'      => 'datamachine/list-github-pull-files',
+		) );
+		$this->registerTool( 'get_github_pull_review_context', array( $this, 'getPullReviewContextDefinition' ), $contexts, array(
+			'access_level' => 'editor',
+			'ability'      => 'datamachine/get-github-pull-review-context',
+		) );
+		$this->registerTool( 'list_github_tree', array( $this, 'getListTreeDefinition' ), $contexts, array(
+			'access_level' => 'editor',
+			'ability'      => 'datamachine/list-github-tree',
+		) );
+		$this->registerTool( 'get_github_file', array( $this, 'getGetFileDefinition' ), $contexts, array(
+			'access_level' => 'editor',
+			'ability'      => 'datamachine/get-github-file',
+		) );
 		$this->registerTool( 'list_github_repos', array( $this, 'getListReposDefinition' ), $contexts, array( 'access_level' => 'editor' ) );
 	}
 

--- a/inc/Tools/GitHubTools.php
+++ b/inc/Tools/GitHubTools.php
@@ -29,6 +29,11 @@ class GitHubTools extends BaseTool {
 		$this->registerTool( 'manage_github_issue', array( $this, 'getManageIssueDefinition' ), $contexts, array( 'access_level' => 'editor' ) );
 		$this->registerTool( 'comment_github_pull_request', array( $this, 'getCommentPullRequestDefinition' ), $contexts, array( 'access_level' => 'editor' ) );
 		$this->registerTool( 'list_github_pulls', array( $this, 'getListPullsDefinition' ), $contexts, array( 'access_level' => 'editor' ) );
+		$this->registerTool( 'get_github_pull', array( $this, 'getGetPullDefinition' ), $contexts, array( 'access_level' => 'editor', 'ability' => 'datamachine/get-github-pull' ) );
+		$this->registerTool( 'get_github_pull_files', array( $this, 'getPullFilesDefinition' ), $contexts, array( 'access_level' => 'editor', 'ability' => 'datamachine/list-github-pull-files' ) );
+		$this->registerTool( 'get_github_pull_review_context', array( $this, 'getPullReviewContextDefinition' ), $contexts, array( 'access_level' => 'editor', 'ability' => 'datamachine/get-github-pull-review-context' ) );
+		$this->registerTool( 'list_github_tree', array( $this, 'getListTreeDefinition' ), $contexts, array( 'access_level' => 'editor', 'ability' => 'datamachine/list-github-tree' ) );
+		$this->registerTool( 'get_github_file', array( $this, 'getGetFileDefinition' ), $contexts, array( 'access_level' => 'editor', 'ability' => 'datamachine/get-github-file' ) );
 		$this->registerTool( 'list_github_repos', array( $this, 'getListReposDefinition' ), $contexts, array( 'access_level' => 'editor' ) );
 	}
 
@@ -61,6 +66,11 @@ class GitHubTools extends BaseTool {
 			'manage_github_issue',
 			'comment_github_pull_request',
 			'list_github_pulls',
+			'get_github_pull',
+			'get_github_pull_files',
+			'get_github_pull_review_context',
+			'list_github_tree',
+			'get_github_file',
 			'list_github_repos',
 		);
 		if ( ! in_array( $tool_id, $github_tools, true ) ) {
@@ -386,6 +396,245 @@ class GitHubTools extends BaseTool {
 					'type'        => 'string',
 					'required'    => false,
 					'description' => 'PR state: open, closed, or all. Default: open.',
+				),
+			),
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Read-only PR and source context tools.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Execute a registered GitHub ability for a tool call.
+	 *
+	 * @param string $ability_name Ability slug.
+	 * @param string $tool_name    Tool name for the response envelope.
+	 * @param array  $parameters   Tool parameters.
+	 * @return array
+	 */
+	private function executeGitHubAbility( string $ability_name, string $tool_name, array $parameters ): array {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			return $this->buildErrorResponse( 'WordPress Abilities API is not available.', $tool_name );
+		}
+
+		$ability = wp_get_ability( $ability_name );
+		if ( ! $ability ) {
+			return $this->buildErrorResponse( sprintf( 'GitHub ability %s is not available.', $ability_name ), $tool_name );
+		}
+
+		$result = $ability->execute( $parameters );
+		if ( is_wp_error( $result ) ) {
+			return $this->buildErrorResponse( $result->get_error_message(), $tool_name );
+		}
+
+		return array(
+			'success'   => true,
+			'data'      => $result,
+			'tool_name' => $tool_name,
+		);
+	}
+
+	/**
+	 * Handle get_github_pull tool call.
+	 *
+	 * @param array $parameters Tool parameters.
+	 * @return array
+	 */
+	public function handleGetPull( array $parameters ): array {
+		return $this->executeGitHubAbility( 'datamachine/get-github-pull', 'get_github_pull', $parameters );
+	}
+
+	/**
+	 * Get tool definition for get_github_pull.
+	 *
+	 * @return array
+	 */
+	public function getGetPullDefinition(): array {
+		return array(
+			'class'       => __CLASS__,
+			'method'      => 'handleGetPull',
+			'description' => 'Get one GitHub pull request with normalized title, body, branch, SHA, labels, and merge metadata.',
+			'parameters'  => array(
+				'repo'        => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Repository in owner/repo format.',
+				),
+				'pull_number' => array(
+					'type'        => 'integer',
+					'required'    => true,
+					'description' => 'Pull request number.',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Handle get_github_pull_files tool call.
+	 *
+	 * @param array $parameters Tool parameters.
+	 * @return array
+	 */
+	public function handlePullFiles( array $parameters ): array {
+		return $this->executeGitHubAbility( 'datamachine/list-github-pull-files', 'get_github_pull_files', $parameters );
+	}
+
+	/**
+	 * Get tool definition for get_github_pull_files.
+	 *
+	 * @return array
+	 */
+	public function getPullFilesDefinition(): array {
+		return array(
+			'class'       => __CLASS__,
+			'method'      => 'handlePullFiles',
+			'description' => 'List files changed by a GitHub pull request, including filename, status, additions, deletions, and patch when available.',
+			'parameters'  => array(
+				'repo'        => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Repository in owner/repo format.',
+				),
+				'pull_number' => array(
+					'type'        => 'integer',
+					'required'    => true,
+					'description' => 'Pull request number.',
+				),
+				'per_page'    => array(
+					'type'        => 'integer',
+					'required'    => false,
+					'description' => 'Results per page (max: 100). Default: 100.',
+				),
+				'page'        => array(
+					'type'        => 'integer',
+					'required'    => false,
+					'description' => 'Page number. Default: 1.',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Handle get_github_pull_review_context tool call.
+	 *
+	 * @param array $parameters Tool parameters.
+	 * @return array
+	 */
+	public function handlePullReviewContext( array $parameters ): array {
+		return $this->executeGitHubAbility( 'datamachine/get-github-pull-review-context', 'get_github_pull_review_context', $parameters );
+	}
+
+	/**
+	 * Get tool definition for get_github_pull_review_context.
+	 *
+	 * @return array
+	 */
+	public function getPullReviewContextDefinition(): array {
+		return array(
+			'class'       => __CLASS__,
+			'method'      => 'handlePullReviewContext',
+			'description' => 'Build a review-ready context packet for a GitHub pull request, including normalized PR metadata and changed-file patches.',
+			'parameters'  => array(
+				'repo'            => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Repository in owner/repo format.',
+				),
+				'pull_number'     => array(
+					'type'        => 'integer',
+					'required'    => true,
+					'description' => 'Pull request number.',
+				),
+				'head_sha'        => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Optional expected pull request head SHA. Returns an error if GitHub reports a different head SHA.',
+				),
+				'max_patch_chars' => array(
+					'type'        => 'integer',
+					'required'    => false,
+					'description' => 'Maximum cumulative patch characters to include. Default: 200000.',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Handle list_github_tree tool call.
+	 *
+	 * @param array $parameters Tool parameters.
+	 * @return array
+	 */
+	public function handleListTree( array $parameters ): array {
+		return $this->executeGitHubAbility( 'datamachine/list-github-tree', 'list_github_tree', $parameters );
+	}
+
+	/**
+	 * Get tool definition for list_github_tree.
+	 *
+	 * @return array
+	 */
+	public function getListTreeDefinition(): array {
+		return array(
+			'class'       => __CLASS__,
+			'method'      => 'handleListTree',
+			'description' => 'List files in a GitHub repository tree at a branch, tag, or commit SHA. Optionally filter to a path prefix.',
+			'parameters'  => array(
+				'repo' => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Repository in owner/repo format.',
+				),
+				'ref'  => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Branch, tag, or commit SHA. Defaults to HEAD.',
+				),
+				'path' => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Optional path prefix to filter returned files.',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Handle get_github_file tool call.
+	 *
+	 * @param array $parameters Tool parameters.
+	 * @return array
+	 */
+	public function handleGetFile( array $parameters ): array {
+		return $this->executeGitHubAbility( 'datamachine/get-github-file', 'get_github_file', $parameters );
+	}
+
+	/**
+	 * Get tool definition for get_github_file.
+	 *
+	 * @return array
+	 */
+	public function getGetFileDefinition(): array {
+		return array(
+			'class'       => __CLASS__,
+			'method'      => 'handleGetFile',
+			'description' => 'Get decoded content for a single file from a GitHub repository.',
+			'parameters'  => array(
+				'repo' => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Repository in owner/repo format.',
+				),
+				'path' => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'File path within the repository.',
+				),
+				'ref'  => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Branch, tag, or commit SHA. Defaults to the repository default branch.',
 				),
 			),
 		);

--- a/tests/smoke-github-readonly-tools.php
+++ b/tests/smoke-github-readonly-tools.php
@@ -31,8 +31,8 @@ namespace DataMachine\Engine\AI\Tools {
 
 namespace DataMachine\Core {
 	class PluginSettings {
-		public static function get( string $key, string $default = '' ): string {
-			return 'github_pat' === $key ? 'test-token' : $default;
+		public static function get( string $key, string $default_value = '' ): string {
+			return 'github_pat' === $key ? 'test-token' : $default_value;
 		}
 	}
 }

--- a/tests/smoke-github-readonly-tools.php
+++ b/tests/smoke-github-readonly-tools.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * Pure-PHP smoke test for read-only GitHub source and PR context tools.
+ *
+ * Run: php tests/smoke-github-readonly-tools.php
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Engine\AI\Tools {
+	class BaseTool {
+		public array $registered = array();
+
+		protected function registerTool( string $name, array $definition_callback, array $contexts, array $options = array() ): void {
+			$this->registered[ $name ] = array(
+				'definition_callback' => $definition_callback,
+				'contexts'            => $contexts,
+				'options'             => $options,
+			);
+		}
+
+		protected function buildErrorResponse( string $message, string $tool_name ): array {
+			return array(
+				'success'   => false,
+				'error'     => $message,
+				'tool_name' => $tool_name,
+			);
+		}
+	}
+}
+
+namespace DataMachine\Core {
+	class PluginSettings {
+		public static function get( string $key, string $default = '' ): string {
+			return 'github_pat' === $key ? 'test-token' : $default;
+		}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	class WP_Ability {}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			public function __construct( private string $code = '', private string $message = '' ) {}
+			public function get_error_message(): string { return $this->message; }
+			public function get_error_code(): string { return $this->code; }
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $thing ): bool { return $thing instanceof WP_Error; }
+	}
+
+	$GLOBALS['dmc_registered_abilities'] = array();
+	$GLOBALS['dmc_executed_abilities']   = array();
+
+	function wp_register_ability( string $name, array $definition ): void {
+		$GLOBALS['dmc_registered_abilities'][ $name ] = $definition;
+	}
+
+	function doing_action( string $hook ): bool {
+		return 'wp_abilities_api_init' === $hook;
+	}
+
+	function did_action( string $hook ): int {
+		return 0;
+	}
+
+	function add_action( string $hook, callable $callback ): void {}
+
+	function wp_get_ability( string $name ) {
+		if ( ! isset( $GLOBALS['dmc_registered_abilities'][ $name ] ) ) {
+			return null;
+		}
+
+		return new class( $name ) {
+			public function __construct( private string $name ) {}
+
+			public function execute( array $parameters ): array {
+				$GLOBALS['dmc_executed_abilities'][ $this->name ] = $parameters;
+
+				return match ( $this->name ) {
+					'datamachine/get-github-file' => array(
+						'success' => true,
+						'file'    => array( 'path' => $parameters['path'] ?? '', 'content' => 'file body' ),
+					),
+					'datamachine/list-github-tree' => array(
+						'success' => true,
+						'files'   => array( array( 'path' => 'inc/Foo.php' ) ),
+						'count'   => 1,
+					),
+					'datamachine/get-github-pull' => array(
+						'success' => true,
+						'pull'    => array( 'number' => $parameters['pull_number'] ?? 0 ),
+					),
+					'datamachine/list-github-pull-files' => array(
+						'success' => true,
+						'files'   => array( array( 'filename' => 'README.md' ) ),
+						'count'   => 1,
+					),
+					'datamachine/get-github-pull-review-context' => array(
+						'success' => true,
+						'context' => array( 'metadata' => array( 'github_type' => 'pull_review_context' ) ),
+					),
+					default => array( 'success' => true ),
+				};
+			}
+		};
+	}
+
+	require __DIR__ . '/../inc/Abilities/GitHubAbilities.php';
+	require __DIR__ . '/../inc/Tools/GitHubTools.php';
+
+	use DataMachineCode\Abilities\GitHubAbilities;
+	use DataMachineCode\Tools\GitHubTools;
+
+	$failures = array();
+	$assert   = function ( string $label, bool $cond ) use ( &$failures ): void {
+		if ( $cond ) {
+			echo "  ok {$label}\n";
+			return;
+		}
+		$failures[] = $label;
+		echo "  fail {$label}\n";
+	};
+
+	echo "GitHub read-only tools - smoke\n";
+
+	new GitHubAbilities();
+	$tools = new GitHubTools();
+
+	$expected = array(
+		'get_github_file'                => array(
+			'ability'  => 'datamachine/get-github-file',
+			'method'   => 'handleGetFile',
+			'callback' => array( GitHubAbilities::class, 'getFileContents' ),
+			'required' => array( 'repo', 'path' ),
+			'params'   => array( 'repo' => 'Extra-Chill/data-machine-code', 'path' => 'README.md', 'ref' => 'main' ),
+		),
+		'list_github_tree'               => array(
+			'ability'  => 'datamachine/list-github-tree',
+			'method'   => 'handleListTree',
+			'callback' => array( GitHubAbilities::class, 'getRepoTree' ),
+			'required' => array( 'repo' ),
+			'params'   => array( 'repo' => 'Extra-Chill/data-machine-code', 'ref' => 'main', 'path' => 'inc' ),
+		),
+		'get_github_pull'                => array(
+			'ability'  => 'datamachine/get-github-pull',
+			'method'   => 'handleGetPull',
+			'callback' => array( GitHubAbilities::class, 'getPull' ),
+			'required' => array( 'repo', 'pull_number' ),
+			'params'   => array( 'repo' => 'Extra-Chill/data-machine-code', 'pull_number' => 89 ),
+		),
+		'get_github_pull_files'          => array(
+			'ability'  => 'datamachine/list-github-pull-files',
+			'method'   => 'handlePullFiles',
+			'callback' => array( GitHubAbilities::class, 'listPullFiles' ),
+			'required' => array( 'repo', 'pull_number' ),
+			'params'   => array( 'repo' => 'Extra-Chill/data-machine-code', 'pull_number' => 89, 'per_page' => 10 ),
+		),
+		'get_github_pull_review_context' => array(
+			'ability'  => 'datamachine/get-github-pull-review-context',
+			'method'   => 'handlePullReviewContext',
+			'callback' => array( GitHubAbilities::class, 'getPullReviewContext' ),
+			'required' => array( 'repo', 'pull_number' ),
+			'params'   => array( 'repo' => 'Extra-Chill/data-machine-code', 'pull_number' => 89, 'head_sha' => 'abc123' ),
+		),
+	);
+
+	foreach ( $expected as $tool_name => $spec ) {
+		$ability_name = $spec['ability'];
+		$assert( "{$ability_name} ability is registered", isset( $GLOBALS['dmc_registered_abilities'][ $ability_name ] ) );
+		$assert( "{$ability_name} delegates to GitHubAbilities", $spec['callback'] === ( $GLOBALS['dmc_registered_abilities'][ $ability_name ]['execute_callback'] ?? null ) );
+
+		$tool = $tools->registered[ $tool_name ] ?? null;
+		$assert( "{$tool_name} tool is registered", null !== $tool );
+		$assert( "{$tool_name} is available in chat", in_array( 'chat', $tool['contexts'] ?? array(), true ) );
+		$assert( "{$tool_name} is available in pipeline", in_array( 'pipeline', $tool['contexts'] ?? array(), true ) );
+		$assert( "{$tool_name} records ability option", $ability_name === ( $tool['options']['ability'] ?? '' ) );
+
+		$definition = call_user_func( $tool['definition_callback'] );
+		$assert( "{$tool_name} definition uses narrow handler", $spec['method'] === ( $definition['method'] ?? '' ) );
+		foreach ( $spec['required'] as $param ) {
+			$assert( "{$tool_name} requires {$param}", true === ( $definition['parameters'][ $param ]['required'] ?? false ) );
+		}
+
+		$response = $tools->handle_tool_call( $spec['params'], $definition );
+		$assert( "{$tool_name} handler returns success", true === ( $response['success'] ?? false ) );
+		$assert( "{$tool_name} handler returns normalized data", isset( $response['data']['success'] ) && true === $response['data']['success'] );
+		$assert( "{$tool_name} handler reports tool name", $tool_name === ( $response['tool_name'] ?? '' ) );
+		$assert( "{$tool_name} executed registered ability", $spec['params'] === ( $GLOBALS['dmc_executed_abilities'][ $ability_name ] ?? array() ) );
+		$assert( "{$tool_name} configuration check is wired", true === $tools->check_configuration( false, $tool_name ) );
+	}
+
+	$ability_source = file_get_contents( __DIR__ . '/../inc/Abilities/GitHubAbilities.php' );
+	$tool_source    = file_get_contents( __DIR__ . '/../inc/Tools/GitHubTools.php' );
+
+	$assert( 'read-only tools do not expose file writes', ! str_contains( $tool_source, "'commit_message'" ) );
+	$assert( 'get_github_file uses ref naming', str_contains( $ability_source, "'datamachine/get-github-file'" ) && str_contains( $tool_source, "'ref'" ) );
+	$assert( 'list_github_tree supports optional path filtering', str_contains( $ability_source, '$path_prefix' ) );
+
+	if ( ! empty( $failures ) ) {
+		echo "\nFAIL: " . count( $failures ) . " assertion(s)\n";
+		foreach ( $failures as $failure ) {
+			echo "  - {$failure}\n";
+		}
+		exit( 1 );
+	}
+
+	echo "\nOK\n";
+	exit( 0 );
+}


### PR DESCRIPTION
## Summary

Expose DMC's existing GitHub source and PR context helpers as narrow read-only abilities and AI tools so review agents can request follow-up context during a chat or pipeline run.

## Changes

- Registers read-only abilities for fetching a GitHub file, listing a repository tree, reading one pull request, listing pull files, and building PR review context.
- Adds matching chat/pipeline tools that route through the registered abilities instead of bypassing the shared ability surface.
- Adds ref aliases for source reads and optional path-prefix filtering for tree listings.
- Adds a pure-PHP smoke test covering ability registration, tool registration, configuration checks, required params, and handler delegation.

## Tests

- `php tests/smoke-github-readonly-tools.php`
- `for file in tests/*.php; do php "$file" || exit 1; done`
- `homeboy lint data-machine-code --path /Users/chubes/Developer/data-machine-code@feat-readonly-github-tools --changed-since origin/main`
- `homeboy audit data-machine-code --path /Users/chubes/Developer/data-machine-code@feat-readonly-github-tools --changed-since origin/main`

Closes #89

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspecting the existing DMC GitHub ability/tool surface, implementing the read-only wrappers and smoke coverage, and running verification commands. Chris remains responsible for review and merge.
