### PR TITLE
feat(github): expose expanded review context tool params

### DIFF
--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -405,21 +405,45 @@ class GitHubAbilities {
 						'type'       => 'object',
 						'required'   => array( 'repo', 'pull_number' ),
 						'properties' => array(
-							'repo'            => array(
+							'repo'                    => array(
 								'type'        => 'string',
 								'description' => 'Repository in owner/repo format.',
 							),
-							'pull_number'     => array(
+							'pull_number'             => array(
 								'type'        => 'integer',
 								'description' => 'Pull request number.',
 							),
-							'head_sha'        => array(
+							'head_sha'                => array(
 								'type'        => 'string',
 								'description' => 'Optional expected pull request head SHA.',
 							),
-							'max_patch_chars' => array(
+							'max_patch_chars'         => array(
 								'type'        => 'integer',
 								'description' => 'Maximum cumulative patch characters to include (default: 200000).',
+							),
+							'include_file_contents'   => array(
+								'type'        => 'boolean',
+								'description' => 'Whether to include bounded full-file contents for changed files.',
+							),
+							'include_base_contents'   => array(
+								'type'        => 'boolean',
+								'description' => 'Whether to include bounded base-file contents for changed files.',
+							),
+							'context_paths'           => array(
+								'type'        => array( 'array', 'string' ),
+								'description' => 'Additional repository paths to include from the PR head ref, as an array or comma/newline-separated string.',
+							),
+							'max_file_content_chars'  => array(
+								'type'        => 'integer',
+								'description' => 'Maximum characters included per expanded file content block (default: 20000).',
+							),
+							'max_context_files'       => array(
+								'type'        => 'integer',
+								'description' => 'Maximum number of files included in expanded PR review context (default: 10).',
+							),
+							'max_total_context_chars' => array(
+								'type'        => 'integer',
+								'description' => 'Maximum cumulative characters included across expanded PR review context files (default: 100000).',
 							),
 						),
 					),

--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -983,14 +983,16 @@ class GitHubAbilities {
 		}
 
 		$limits = array(
-			'max_file_content_chars' => max( 1, (int) ( $options['max_file_content_chars'] ?? 20000 ) ),
-			'max_context_files'      => max( 1, (int) ( $options['max_context_files'] ?? 10 ) ),
+			'max_file_content_chars'  => max( 1, (int) ( $options['max_file_content_chars'] ?? 20000 ) ),
+			'max_context_files'       => max( 1, (int) ( $options['max_context_files'] ?? 10 ) ),
 			'max_total_context_chars' => max( 1, (int) ( $options['max_total_context_chars'] ?? 100000 ) ),
 		);
 
 		$head_ref = (string) ( $pull['head_sha'] ?? $pull['head_ref'] ?? $pull['head'] ?? '' );
 		$base_ref = (string) ( $pull['base_sha'] ?? $pull['base_ref'] ?? $pull['base'] ?? '' );
-		$fetcher  = $fetcher ?? static function ( string $path, string $ref, string $_side ) use ( $repo ): array|\WP_Error {
+		$fetcher  = $fetcher ?? static function ( string $path, string $ref, string $side ) use ( $repo ): array|\WP_Error {
+			unset( $side );
+
 			return self::getFileContents(
 				array(
 					'repo'   => $repo,
@@ -1043,7 +1045,7 @@ class GitHubAbilities {
 				}
 
 				$expanded['changed_files'][] = $entry;
-				$remaining_files--;
+				--$remaining_files;
 			}
 		}
 
@@ -1059,7 +1061,7 @@ class GitHubAbilities {
 				'path' => $path,
 				'head' => $file_context,
 			);
-			$remaining_files--;
+			--$remaining_files;
 		}
 
 		$expanded['summary']['included_files'] = count( $expanded['changed_files'] ) + count( $expanded['extra_files'] );
@@ -1071,7 +1073,8 @@ class GitHubAbilities {
 	 */
 	private static function normalizeContextPaths( mixed $paths ): array {
 		if ( is_string( $paths ) ) {
-			$paths = preg_split( '/[\r\n,]+/', $paths ) ?: array();
+			$split_paths = preg_split( '/[\r\n,]+/', $paths );
+			$paths       = false === $split_paths ? array() : $split_paths;
 		}
 
 		if ( ! is_array( $paths ) ) {
@@ -1146,13 +1149,13 @@ class GitHubAbilities {
 	 */
 	private static function applyContextFileAccounting( array &$expanded, array $file_context, int &$remaining_chars ): void {
 		if ( empty( $file_context['included'] ) ) {
-			$expanded['summary']['skipped_files']++;
+			++$expanded['summary']['skipped_files'];
 			return;
 		}
 
-		$included_chars = (int) ( $file_context['included_chars'] ?? 0 );
+		$included_chars                         = (int) ( $file_context['included_chars'] ?? 0 );
 		$expanded['summary']['included_chars'] += $included_chars;
-		$remaining_chars                       = max( 0, $remaining_chars - $included_chars );
+		$remaining_chars                        = max( 0, $remaining_chars - $included_chars );
 
 		if ( ! empty( $file_context['truncated'] ) ) {
 			$expanded['summary']['truncated'] = true;
@@ -1168,7 +1171,7 @@ class GitHubAbilities {
 			'source' => $source,
 			'reason' => $reason,
 		);
-		$expanded['summary']['skipped_files']++;
+		++$expanded['summary']['skipped_files'];
 	}
 
 	/**

--- a/inc/Tools/GitHubTools.php
+++ b/inc/Tools/GitHubTools.php
@@ -551,25 +551,55 @@ class GitHubTools extends BaseTool {
 			'method'      => 'handlePullReviewContext',
 			'description' => 'Build a review-ready context packet for a GitHub pull request, including normalized PR metadata and changed-file patches.',
 			'parameters'  => array(
-				'repo'            => array(
+				'repo'                    => array(
 					'type'        => 'string',
 					'required'    => true,
 					'description' => 'Repository in owner/repo format.',
 				),
-				'pull_number'     => array(
+				'pull_number'             => array(
 					'type'        => 'integer',
 					'required'    => true,
 					'description' => 'Pull request number.',
 				),
-				'head_sha'        => array(
+				'head_sha'                => array(
 					'type'        => 'string',
 					'required'    => false,
 					'description' => 'Optional expected pull request head SHA. Returns an error if GitHub reports a different head SHA.',
 				),
-				'max_patch_chars' => array(
+				'max_patch_chars'         => array(
 					'type'        => 'integer',
 					'required'    => false,
 					'description' => 'Maximum cumulative patch characters to include. Default: 200000.',
+				),
+				'include_file_contents'   => array(
+					'type'        => 'boolean',
+					'required'    => false,
+					'description' => 'Opt in to bounded full-file contents for changed files.',
+				),
+				'include_base_contents'   => array(
+					'type'        => 'boolean',
+					'required'    => false,
+					'description' => 'When changed file contents are enabled, also include bounded base-branch contents for comparison.',
+				),
+				'context_paths'           => array(
+					'type'        => 'array',
+					'required'    => false,
+					'description' => 'Additional repository paths to include from the PR head ref.',
+				),
+				'max_file_content_chars'  => array(
+					'type'        => 'integer',
+					'required'    => false,
+					'description' => 'Maximum characters included per expanded file content block. Default: 20000.',
+				),
+				'max_context_files'       => array(
+					'type'        => 'integer',
+					'required'    => false,
+					'description' => 'Maximum number of files included in expanded PR review context. Default: 10.',
+				),
+				'max_total_context_chars' => array(
+					'type'        => 'integer',
+					'required'    => false,
+					'description' => 'Maximum cumulative characters included across expanded PR review context files. Default: 100000.',
 				),
 			),
 		);

--- a/tests/smoke-github-readonly-tools.php
+++ b/tests/smoke-github-readonly-tools.php
@@ -168,7 +168,18 @@ namespace {
 			'method'   => 'handlePullReviewContext',
 			'callback' => array( GitHubAbilities::class, 'getPullReviewContext' ),
 			'required' => array( 'repo', 'pull_number' ),
-			'params'   => array( 'repo' => 'Extra-Chill/data-machine-code', 'pull_number' => 89, 'head_sha' => 'abc123' ),
+			'optional' => array( 'head_sha', 'max_patch_chars', 'include_file_contents', 'include_base_contents', 'context_paths', 'max_file_content_chars', 'max_context_files', 'max_total_context_chars' ),
+			'params'   => array(
+				'repo'                    => 'Extra-Chill/data-machine-code',
+				'pull_number'             => 89,
+				'head_sha'                => 'abc123',
+				'include_file_contents'   => true,
+				'include_base_contents'   => true,
+				'context_paths'           => array( 'README.md' ),
+				'max_file_content_chars'  => 20000,
+				'max_context_files'       => 10,
+				'max_total_context_chars' => 100000,
+			),
 		),
 	);
 
@@ -187,6 +198,11 @@ namespace {
 		$assert( "{$tool_name} definition uses narrow handler", $spec['method'] === ( $definition['method'] ?? '' ) );
 		foreach ( $spec['required'] as $param ) {
 			$assert( "{$tool_name} requires {$param}", true === ( $definition['parameters'][ $param ]['required'] ?? false ) );
+		}
+		foreach ( $spec['optional'] ?? array() as $param ) {
+			$assert( "{$tool_name} exposes optional {$param}", array_key_exists( $param, $definition['parameters'] ?? array() ) );
+			$assert( "{$tool_name} does not require optional {$param}", false === ( $definition['parameters'][ $param ]['required'] ?? false ) );
+			$assert( "{$tool_name} ability schema exposes optional {$param}", array_key_exists( $param, $GLOBALS['dmc_registered_abilities'][ $ability_name ]['input_schema']['properties'] ?? array() ) );
 		}
 
 		$response = $tools->handle_tool_call( $spec['params'], $definition );


### PR DESCRIPTION
## Summary

Follow up on #92 after #91 landed by exposing the optional expanded PR review context parameters through the read-only review-context ability and tool.

## Changes

- Adds `include_file_contents`, `include_base_contents`, `context_paths`, `max_file_content_chars`, `max_context_files`, and `max_total_context_chars` to the `datamachine/get-github-pull-review-context` ability schema.
- Adds the same optional params to the `get_github_pull_review_context` AI tool definition.
- Extends the read-only GitHub smoke to prove the params are exposed in both ability and tool surfaces and pass through to the registered ability call.
- Includes narrow style fixes in the merged PR #91 expansion helper so changed-since lint remains clean for the touched file.

## Tests

- `php -l inc/Abilities/GitHubAbilities.php && php -l inc/Tools/GitHubTools.php && php -l tests/smoke-github-readonly-tools.php`
- `php tests/smoke-github-readonly-tools.php`
- `homeboy lint data-machine-code --path /Users/chubes/Developer/data-machine-code@feat-readonly-github-tools --changed-since origin/main`

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Updating the read-only GitHub ability/tool schemas for PR #91's expanded context parameters, adjusting smoke coverage, and running verification commands. Chris remains responsible for review and merge.
