### PR TITLE
feat(github): validate PR review webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Sibling extensions like `data-machine-socials` and `data-machine-business` are *
 - List pull requests and repositories
 - Create issues (async via Action Scheduler)
 - GitHub fetch handler for pipeline workflows
+- GitHub pull request webhook validation mode for review-flow triggers
 
 ### Workspace Management
 - Clone and manage git repositories in a secure workspace directory
@@ -119,6 +120,29 @@ on it are how parallel agents corrupt each other's work.
 Set your GitHub Personal Access Token and default repository in Data Machine settings:
 - `github_pat` — GitHub Personal Access Token with repo access
 - `github_default_repo` — Default repository in `owner/repo` format
+
+### GitHub PR review webhooks
+
+DMC registers a Data Machine webhook verifier mode named `github_pull_request` for PR-review flows. Configure the flow's webhook auth verifier with that mode and the same secret configured in the GitHub repository webhook.
+
+The verifier checks `X-Hub-Signature-256` against the raw request body, requires `X-GitHub-Event: pull_request`, accepts only `opened`, `reopened`, `synchronize`, and `ready_for_review` actions by default, optionally restricts `repository.full_name`, and skips draft PRs unless `allow_drafts` is true.
+
+Example verifier config:
+
+```php
+array(
+    'mode'            => 'github_pull_request',
+    'secrets'         => array(
+        array(
+            'id'    => 'github_webhook',
+            'value' => '<shared webhook secret>',
+        ),
+    ),
+    'repo'            => 'Extra-Chill/data-machine-code',
+    'allowed_actions' => array( 'opened', 'reopened', 'synchronize', 'ready_for_review' ),
+    'allow_drafts'    => false,
+)
+```
 
 Workspace git policies are configured via the `datamachine_workspace_git_policies` option for per-repo write/push controls.
 

--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -62,6 +62,14 @@ function datamachine_code_bootstrap() {
 add_action( 'plugins_loaded', 'datamachine_code_bootstrap', 20 );
 
 /**
+ * Register DMC-owned webhook verifier modes with Data Machine core.
+ */
+add_filter( 'datamachine_webhook_verifier_modes', function ( array $modes ): array {
+	$modes['github_pull_request'] = \DataMachineCode\Support\GitHubWebhookValidator::class;
+	return $modes;
+} );
+
+/**
  * Register ability categories for data-machine-code.
  *
  * Must be called on `wp_abilities_api_categories_init` — WordPress core

--- a/inc/Support/GitHubWebhookValidator.php
+++ b/inc/Support/GitHubWebhookValidator.php
@@ -1,0 +1,225 @@
+<?php
+/**
+ * GitHub webhook verifier mode for pull-request review flows.
+ *
+ * @package DataMachineCode\Support
+ */
+
+namespace DataMachineCode\Support;
+
+use DataMachine\Api\WebhookVerificationResult;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Validates GitHub pull_request webhooks before Data Machine runs a flow.
+ */
+class GitHubWebhookValidator {
+
+	const DEFAULT_ALLOWED_ACTIONS = array( 'opened', 'reopened', 'synchronize', 'ready_for_review' );
+
+	const WRONG_EVENT       = 'github_wrong_event';
+	const DISALLOWED_ACTION = 'github_disallowed_action';
+	const REPO_MISMATCH     = 'github_repo_mismatch';
+	const DRAFT_SKIPPED     = 'github_draft_skipped';
+	const MALFORMED_PAYLOAD = 'github_malformed_payload';
+
+	/**
+	 * Verify a GitHub pull_request webhook.
+	 *
+	 * This method matches Data Machine's pluggable webhook verifier mode
+	 * signature, so DMC can own GitHub-specific policy without changing DM core.
+	 *
+	 * @param string              $raw_body     Raw request body bytes.
+	 * @param array<string,mixed> $headers      Request headers.
+	 * @param array<string,mixed> $query_params Query parameters.
+	 * @param array<string,mixed> $post_params  Form body parameters.
+	 * @param string              $url          Request URL.
+	 * @param array               $config       Verifier config.
+	 * @param int|null            $now          Current timestamp override.
+	 * @return WebhookVerificationResult
+	 */
+	public static function verify(
+		string $raw_body,
+		array $headers,
+		array $query_params,
+		array $post_params,
+		string $url,
+		array $config,
+		?int $now = null
+	): WebhookVerificationResult {
+		unset( $query_params, $post_params, $url );
+
+		$headers = self::lowerCaseKeys( $headers );
+		$now     = $now ?? time();
+
+		$max_body_bytes = (int) ( $config['max_body_bytes'] ?? 1048576 );
+		if ( $max_body_bytes > 0 && strlen( $raw_body ) > $max_body_bytes ) {
+			return WebhookVerificationResult::fail( WebhookVerificationResult::PAYLOAD_TOO_LARGE, 'body too large' );
+		}
+
+		$signature = trim( (string) ( $headers['x-hub-signature-256'] ?? '' ) );
+		if ( '' === $signature ) {
+			return WebhookVerificationResult::fail( WebhookVerificationResult::MISSING_SIGNATURE, 'header=x-hub-signature-256' );
+		}
+
+		if ( 0 !== strpos( $signature, 'sha256=' ) ) {
+			return WebhookVerificationResult::fail( WebhookVerificationResult::BAD_SIGNATURE, 'signature format mismatch' );
+		}
+
+		$secrets = self::activeSecrets( $config, $now );
+		if ( empty( $secrets ) ) {
+			return WebhookVerificationResult::fail( WebhookVerificationResult::NO_ACTIVE_SECRET );
+		}
+
+		$matched_secret_id = null;
+		foreach ( $secrets as $secret ) {
+			$expected = 'sha256=' . hash_hmac( 'sha256', $raw_body, $secret['value'] );
+			if ( hash_equals( $expected, $signature ) ) {
+				$matched_secret_id = $secret['id'];
+				break;
+			}
+		}
+
+		if ( null === $matched_secret_id ) {
+			return WebhookVerificationResult::fail( WebhookVerificationResult::BAD_SIGNATURE, 'signature mismatch' );
+		}
+
+		$event = trim( (string) ( $headers['x-github-event'] ?? '' ) );
+		if ( 'pull_request' !== $event ) {
+			return WebhookVerificationResult::fail( self::WRONG_EVENT, 'event is not pull_request' );
+		}
+
+		$payload = json_decode( $raw_body, true );
+		if ( ! is_array( $payload ) ) {
+			return WebhookVerificationResult::fail( self::MALFORMED_PAYLOAD, 'payload is not valid JSON' );
+		}
+
+		$action = (string) ( $payload['action'] ?? '' );
+		if ( '' === $action ) {
+			return WebhookVerificationResult::fail( self::MALFORMED_PAYLOAD, 'payload action missing' );
+		}
+
+		$allowed_actions = self::allowedActions( $config );
+		if ( ! in_array( $action, $allowed_actions, true ) ) {
+			return WebhookVerificationResult::fail( self::DISALLOWED_ACTION, 'action=' . $action );
+		}
+
+		$repo = (string) ( $payload['repository']['full_name'] ?? '' );
+		if ( '' === $repo ) {
+			return WebhookVerificationResult::fail( self::MALFORMED_PAYLOAD, 'repository.full_name missing' );
+		}
+
+		$allowed_repos = self::allowedRepos( $config );
+		if ( ! empty( $allowed_repos ) && ! in_array( strtolower( $repo ), $allowed_repos, true ) ) {
+			return WebhookVerificationResult::fail( self::REPO_MISMATCH, 'repo=' . $repo );
+		}
+
+		$allow_drafts = ! empty( $config['allow_drafts'] );
+		$is_draft     = ! empty( $payload['pull_request']['draft'] );
+		if ( $is_draft && ! $allow_drafts ) {
+			return WebhookVerificationResult::fail( self::DRAFT_SKIPPED, 'draft pull request' );
+		}
+
+		return WebhookVerificationResult::ok( $matched_secret_id );
+	}
+
+	/**
+	 * Build a Data Machine webhook verifier config for GitHub PR review flows.
+	 *
+	 * @param string $secret  Webhook secret from GitHub.
+	 * @param array  $options Optional allowed_actions, repo, allowed_repos, allow_drafts.
+	 * @return array
+	 */
+	public static function buildVerifierConfig( string $secret, array $options = array() ): array {
+		$config = array_merge(
+			array(
+				'mode'            => 'github_pull_request',
+				'secrets'         => array(
+					array(
+						'id'    => 'github_webhook',
+						'value' => $secret,
+					),
+				),
+				'allowed_actions' => self::DEFAULT_ALLOWED_ACTIONS,
+				'allow_drafts'    => false,
+			),
+			$options
+		);
+
+		return $config;
+	}
+
+	/**
+	 * @param array<string,mixed> $headers
+	 * @return array<string,string>
+	 */
+	private static function lowerCaseKeys( array $headers ): array {
+		$out = array();
+		foreach ( $headers as $name => $value ) {
+			$key         = strtolower( str_replace( '_', '-', (string) $name ) );
+			$out[ $key ] = is_array( $value ) ? implode( ',', array_map( 'strval', $value ) ) : (string) $value;
+		}
+		return $out;
+	}
+
+	/**
+	 * @return array<int,array{id:string,value:string}>
+	 */
+	private static function activeSecrets( array $config, int $now ): array {
+		$secrets = array();
+
+		if ( isset( $config['secret'] ) && is_string( $config['secret'] ) && '' !== $config['secret'] ) {
+			$secrets[] = array(
+				'id'    => 'github_webhook',
+				'value' => $config['secret'],
+			);
+		}
+
+		foreach ( (array) ( $config['secrets'] ?? array() ) as $index => $secret ) {
+			if ( ! is_array( $secret ) ) {
+				continue;
+			}
+			$value = (string) ( $secret['value'] ?? '' );
+			if ( '' === $value ) {
+				continue;
+			}
+			$expires_at = (string) ( $secret['expires_at'] ?? '' );
+			if ( '' !== $expires_at && strtotime( $expires_at ) < $now ) {
+				continue;
+			}
+			$secrets[] = array(
+				'id'    => (string) ( $secret['id'] ?? 'secret_' . $index ),
+				'value' => $value,
+			);
+		}
+
+		return $secrets;
+	}
+
+	/**
+	 * @return array<int,string>
+	 */
+	private static function allowedActions( array $config ): array {
+		$actions = $config['allowed_actions'] ?? self::DEFAULT_ALLOWED_ACTIONS;
+		if ( is_string( $actions ) ) {
+			$actions = array_map( 'trim', explode( ',', $actions ) );
+		}
+		$actions = array_values( array_filter( array_map( 'strval', (array) $actions ) ) );
+		return ! empty( $actions ) ? $actions : self::DEFAULT_ALLOWED_ACTIONS;
+	}
+
+	/**
+	 * @return array<int,string>
+	 */
+	private static function allowedRepos( array $config ): array {
+		$repos = array();
+		if ( isset( $config['repo'] ) ) {
+			$repos[] = (string) $config['repo'];
+		}
+		foreach ( (array) ( $config['allowed_repos'] ?? array() ) as $repo ) {
+			$repos[] = (string) $repo;
+		}
+		return array_values( array_filter( array_map( 'strtolower', array_map( 'trim', $repos ) ) ) );
+	}
+}

--- a/tests/smoke-github-webhook-validator.php
+++ b/tests/smoke-github-webhook-validator.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * Pure-PHP smoke test for GitHub pull request webhook validation.
+ *
+ * Run: php tests/smoke-github-webhook-validator.php
+ */
+
+namespace DataMachine\Api {
+	if ( ! class_exists( __NAMESPACE__ . '\\WebhookVerificationResult' ) ) {
+		class WebhookVerificationResult {
+			const OK                = 'ok';
+			const BAD_SIGNATURE     = 'bad_signature';
+			const MISSING_SIGNATURE = 'missing_signature';
+			const NO_ACTIVE_SECRET  = 'no_active_secret';
+			const PAYLOAD_TOO_LARGE = 'payload_too_large';
+
+			public bool $ok;
+			public string $reason;
+			public ?string $secret_id;
+			public ?int $timestamp;
+			public ?int $skew_seconds;
+			public ?string $detail;
+
+			public function __construct( bool $ok, string $reason, ?string $secret_id = null, ?int $timestamp = null, ?int $skew_seconds = null, ?string $detail = null ) {
+				$this->ok           = $ok;
+				$this->reason       = $reason;
+				$this->secret_id    = $secret_id;
+				$this->timestamp    = $timestamp;
+				$this->skew_seconds = $skew_seconds;
+				$this->detail       = $detail;
+			}
+
+			public static function ok( ?string $secret_id = null, ?int $timestamp = null, ?int $skew = null ): self {
+				return new self( true, self::OK, $secret_id, $timestamp, $skew );
+			}
+
+			public static function fail( string $reason, ?string $detail = null, ?int $timestamp = null, ?int $skew = null ): self {
+				return new self( false, $reason, null, $timestamp, $skew, $detail );
+			}
+		}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', sys_get_temp_dir() . '/dmc-github-webhook-validator/' );
+	}
+
+	require __DIR__ . '/../inc/Support/GitHubWebhookValidator.php';
+
+	use DataMachine\Api\WebhookVerificationResult;
+	use DataMachineCode\Support\GitHubWebhookValidator;
+
+	$passes   = 0;
+	$failures = 0;
+
+	$assert = function ( bool $condition, string $message ) use ( &$passes, &$failures ): void {
+		if ( $condition ) {
+			++$passes;
+			echo "  PASS: {$message}\n";
+			return;
+		}
+		++$failures;
+		echo "  FAIL: {$message}\n";
+	};
+
+	$secret = 'test-webhook-secret';
+	$body   = json_encode(
+		array(
+			'action'       => 'opened',
+			'repository'   => array( 'full_name' => 'Extra-Chill/data-machine-code' ),
+			'pull_request' => array(
+				'number' => 96,
+				'draft'  => false,
+			),
+		)
+	);
+	$signature = 'sha256=' . hash_hmac( 'sha256', $body, $secret );
+	$config    = GitHubWebhookValidator::buildVerifierConfig(
+		$secret,
+		array( 'repo' => 'Extra-Chill/data-machine-code' )
+	);
+
+	$verify = function ( string $request_body, array $headers, array $override = array() ) use ( $config ) {
+		return GitHubWebhookValidator::verify(
+			$request_body,
+			$headers,
+			array(),
+			array(),
+			'https://example.test/wp-json/datamachine/v1/trigger/1',
+			array_merge( $config, $override ),
+			1700000000
+		);
+	};
+
+	echo "GitHub webhook validator smoke\n\n";
+
+	$valid = $verify(
+		$body,
+		array(
+			'X-Hub-Signature-256' => $signature,
+			'X-GitHub-Event'       => 'pull_request',
+		)
+	);
+	$assert( $valid->ok, 'valid signature passes' );
+	$assert( 'github_webhook' === $valid->secret_id, 'valid result carries secret id only' );
+
+	$missing = $verify( $body, array( 'X-GitHub-Event' => 'pull_request' ) );
+	$assert( ! $missing->ok && WebhookVerificationResult::MISSING_SIGNATURE === $missing->reason, 'missing signature fails' );
+
+	$invalid = $verify(
+		$body,
+		array(
+			'X-Hub-Signature-256' => 'sha256=' . str_repeat( '0', 64 ),
+			'X-GitHub-Event'       => 'pull_request',
+		)
+	);
+	$assert( ! $invalid->ok && WebhookVerificationResult::BAD_SIGNATURE === $invalid->reason, 'invalid signature fails' );
+
+	$wrong_event = $verify(
+		$body,
+		array(
+			'X-Hub-Signature-256' => $signature,
+			'X-GitHub-Event'       => 'issues',
+		)
+	);
+	$assert( ! $wrong_event->ok && GitHubWebhookValidator::WRONG_EVENT === $wrong_event->reason, 'wrong event fails' );
+
+	$closed_body = str_replace( '"opened"', '"closed"', $body );
+	$closed_sig  = 'sha256=' . hash_hmac( 'sha256', $closed_body, $secret );
+	$closed      = $verify(
+		$closed_body,
+		array(
+			'X-Hub-Signature-256' => $closed_sig,
+			'X-GitHub-Event'       => 'pull_request',
+		)
+	);
+	$assert( ! $closed->ok && GitHubWebhookValidator::DISALLOWED_ACTION === $closed->reason, 'disallowed action fails' );
+
+	$repo_mismatch = $verify(
+		$body,
+		array(
+			'X-Hub-Signature-256' => $signature,
+			'X-GitHub-Event'       => 'pull_request',
+		),
+		array( 'repo' => 'Extra-Chill/data-machine' )
+	);
+	$assert( ! $repo_mismatch->ok && GitHubWebhookValidator::REPO_MISMATCH === $repo_mismatch->reason, 'repo mismatch fails' );
+
+	$draft_body = str_replace( '"draft":false', '"draft":true', $body );
+	$draft_sig  = 'sha256=' . hash_hmac( 'sha256', $draft_body, $secret );
+	$draft      = $verify(
+		$draft_body,
+		array(
+			'X-Hub-Signature-256' => $draft_sig,
+			'X-GitHub-Event'       => 'pull_request',
+		)
+	);
+	$assert( ! $draft->ok && GitHubWebhookValidator::DRAFT_SKIPPED === $draft->reason, 'draft PRs skip by default' );
+
+	$draft_allowed = $verify(
+		$draft_body,
+		array(
+			'X-Hub-Signature-256' => $draft_sig,
+			'X-GitHub-Event'       => 'pull_request',
+		),
+		array( 'allow_drafts' => true )
+	);
+	$assert( $draft_allowed->ok, 'draft PR behavior can be explicitly enabled' );
+
+	foreach ( array( $missing, $invalid, $wrong_event, $closed, $repo_mismatch, $draft ) as $result ) {
+		$encoded = json_encode( $result );
+		$assert( false === strpos( $encoded, $secret ), 'errors do not leak secret' );
+		$assert( false === strpos( $encoded, $signature ), 'errors do not leak full signature' );
+	}
+
+	$plugin_source = file_get_contents( __DIR__ . '/../data-machine-code.php' );
+	$assert( str_contains( $plugin_source, "'github_pull_request'" ), 'plugin registers github_pull_request verifier mode' );
+
+	echo "\n{$passes} passed, {$failures} failed\n";
+	if ( $failures > 0 ) {
+		exit( 1 );
+	}
+}


### PR DESCRIPTION
## Summary
- Add a DMC-owned GitHub pull request webhook verifier mode for PR review flows.
- Validate GitHub signatures and event/action/repo/draft policy before Data Machine executes the downstream flow.
- Document the verifier config shape for review-flow webhook setup.

## Changes
- Registers `github_pull_request` on `datamachine_webhook_verifier_modes`.
- Adds `GitHubWebhookValidator` for `X-Hub-Signature-256`, `X-GitHub-Event`, allowed actions, optional repo allow-list, and draft PR policy.
- Adds a pure-PHP smoke test covering valid/invalid signatures, wrong event, disallowed action, repo mismatch, draft behavior, and secret/signature non-leakage.

## Tests
- `php -l inc/Support/GitHubWebhookValidator.php && php -l data-machine-code.php && php -l tests/smoke-github-webhook-validator.php`
- `php tests/smoke-github-webhook-validator.php`
- `php tests/smoke-github-pr-review-context.php && php tests/smoke-github-readonly-tools.php && php tests/smoke-github-pr-comment-tool.php`
- Focused PHPCS via `homeboy lint ... --file <changed-php-file>` passed for each changed PHP file; the PHPStan phase still hits the existing Homeboy temp-file extension runner bug (`Unknown file extension /var/.../tmp.*`).
- Full `homeboy lint data-machine-code --path ...` still reports pre-existing findings outside this change.

Closes #96

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the verifier mode, tests, docs, and verification commands; Chris remains responsible for review and merge.