### PR TITLE
feat(github): add PR review flow scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Sibling extensions like `data-machine-socials` and `data-machine-business` are *
 - Create issues (async via Action Scheduler)
 - GitHub fetch handler for pipeline workflows
 - GitHub pull request webhook validation mode for review-flow triggers
+- PR review flow scaffold for webhook-triggered review automation
 
 ### Workspace Management
 - Clone and manage git repositories in a secure workspace directory
@@ -52,6 +53,7 @@ wp datamachine-code github close 123 --repo=owner/repo
 wp datamachine-code github comment 123 "Fixed." --repo=owner/repo
 wp datamachine-code github pulls --repo=owner/repo
 wp datamachine-code github repos owner
+wp datamachine-code github review-flow create --repo=owner/repo --agent=code-reviewer
 wp datamachine-code github status
 
 # Workspace

--- a/inc/Cli/Commands/GitHubCommand.php
+++ b/inc/Cli/Commands/GitHubCommand.php
@@ -14,6 +14,7 @@ namespace DataMachineCode\Cli\Commands;
 use WP_CLI;
 use DataMachine\Cli\BaseCommand;
 use DataMachineCode\Abilities\GitHubAbilities;
+use DataMachineCode\GitHub\PrReviewFlowScaffold;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -499,6 +500,84 @@ class GitHubCommand extends BaseCommand {
 
 			$this->format_items( $repo_items, array( 'repo', 'label' ), $assoc_args );
 		}
+	}
+
+	/**
+	 * Scaffold a GitHub PR review flow definition.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <action>
+	 * : Scaffold action. Currently supports: create.
+	 *
+	 * [--repo=<repo>]
+	 * : Repository in owner/repo format. Falls back to default repo in settings.
+	 *
+	 * [--agent=<agent>]
+	 * : Agent slug or ID that should own the generated flow when imported.
+	 *
+	 * [--name=<name>]
+	 * : Pipeline/flow display name.
+	 * ---
+	 * default: GitHub PR review
+	 * ---
+	 *
+	 * [--comment-mode=<mode>]
+	 * : PR comment behavior hint for the generated AI step.
+	 * ---
+	 * default: managed
+	 * options:
+	 *   - managed
+	 *   - append
+	 *   - dry_run
+	 * ---
+	 *
+	 * [--actions=<actions>]
+	 * : Comma-separated GitHub pull_request actions.
+	 * ---
+	 * default: opened,reopened,synchronize,ready_for_review
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: json
+	 * options:
+	 *   - json
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-code github review-flow create \
+	 *       --repo=Extra-Chill/data-machine-code \
+	 *       --agent=code-reviewer \
+	 *       --name="DMC PR review" \
+	 *       --comment-mode=managed
+	 *
+	 * @subcommand review-flow
+	 */
+	public function review_flow( array $args, array $assoc_args ): void {
+		$action = $args[0] ?? '';
+		if ( 'create' !== $action ) {
+			WP_CLI::error( 'Usage: wp datamachine-code github review-flow create [--repo=<owner/repo>] [--agent=<agent>] [--name=<name>] [--comment-mode=<managed|append|dry_run>] [--actions=<csv>]' );
+			return;
+		}
+
+		$repo = GitHubAbilities::resolveRepo( $assoc_args['repo'] ?? '' );
+		if ( empty( $repo ) ) {
+			WP_CLI::error( 'Required: --repo=<owner/repo> (or set a default repo in settings).' );
+			return;
+		}
+
+		$definition = PrReviewFlowScaffold::build( array(
+			'repo'         => $repo,
+			'agent'        => $assoc_args['agent'] ?? '',
+			'name'         => $assoc_args['name'] ?? 'GitHub PR review',
+			'comment_mode' => $assoc_args['comment-mode'] ?? 'managed',
+			'actions'      => $assoc_args['actions'] ?? PrReviewFlowScaffold::DEFAULT_ACTIONS,
+		) );
+
+		WP_CLI::line( wp_json_encode( $definition, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
 	}
 
 	// -------------------------------------------------------------------------

--- a/inc/GitHub/PrReviewFlowScaffold.php
+++ b/inc/GitHub/PrReviewFlowScaffold.php
@@ -1,0 +1,209 @@
+<?php
+/**
+ * GitHub PR review flow scaffold.
+ *
+ * @package DataMachineCode\GitHub
+ */
+
+namespace DataMachineCode\GitHub;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Builds a machine-readable Data Machine workflow scaffold for PR reviews.
+ */
+class PrReviewFlowScaffold {
+
+	public const DEFAULT_ACTIONS = array( 'opened', 'reopened', 'synchronize', 'ready_for_review' );
+
+	/**
+	 * Build the scaffold definition.
+	 *
+	 * @param array $args Scaffold options.
+	 * @return array<string,mixed>
+	 */
+	public static function build( array $args ): array {
+		$repo         = self::clean_string( $args['repo'] ?? '' );
+		$name         = self::clean_string( $args['name'] ?? 'GitHub PR review' );
+		$agent        = self::clean_string( $args['agent'] ?? '' );
+		$comment_mode = self::normalize_comment_mode( $args['comment_mode'] ?? 'managed' );
+
+		$actions = $args['actions'] ?? self::DEFAULT_ACTIONS;
+		if ( is_string( $actions ) ) {
+			$actions = array_filter( array_map( 'trim', explode( ',', $actions ) ) );
+		}
+		$actions = array_values( array_unique( array_filter( array_map( 'sanitize_key', is_array( $actions ) ? $actions : self::DEFAULT_ACTIONS ) ) ) );
+		if ( empty( $actions ) ) {
+			$actions = self::DEFAULT_ACTIONS;
+		}
+
+		$dedupe_key = '{repository.full_name}#{pull_request.number}@{pull_request.head.sha}';
+
+		return array(
+			'schema'       => 'data-machine-code/github-pr-review-flow-scaffold/v1',
+			'name'         => $name,
+			'description'  => 'Template for a webhook-triggered GitHub pull request review flow.',
+			'repo'         => $repo,
+			'agent'        => $agent,
+			'comment_mode' => $comment_mode,
+			'status'       => 'definition_only',
+			'notes'        => array(
+				'This scaffold is intentionally a normal Data Machine workflow definition, not runtime magic.',
+				'Import/create the pipeline and flow through Data Machine, then inspect and edit the generated steps normally.',
+				'The GitHub pull_review_context step uses webhook-derived placeholders for the PR number and head SHA.',
+			),
+			'webhook'      => array(
+				'provider'      => 'github',
+				'event'         => 'pull_request',
+				'actions'       => $actions,
+				'dedupe_key'    => $dedupe_key,
+				'auth_mode'     => 'hmac',
+				'preset_hint'   => 'github',
+				'payload_paths' => array(
+					'repo'        => 'repository.full_name',
+					'pull_number' => 'pull_request.number',
+					'action'      => 'action',
+					'head_sha'    => 'pull_request.head.sha',
+				),
+			),
+			'workflow'     => array(
+				'type'  => 'pipeline_template',
+				'steps' => array(
+					self::webhook_payload_step( $dedupe_key ),
+					self::pull_review_context_step( $repo ),
+					self::ai_review_step( $comment_mode ),
+				),
+			),
+			'import_hint'  => array(
+				'pipeline_name'     => $name,
+				'flow_name'         => $name,
+				'scheduling_config' => array(
+					'interval'        => 'manual',
+					'webhook_enabled' => true,
+					'webhook_event'   => 'pull_request',
+					'webhook_actions' => $actions,
+				),
+			),
+		);
+	}
+
+	/**
+	 * Get the default PR review prompt.
+	 */
+	public static function default_prompt(): string {
+		return implode( "\n", array(
+			'You are reviewing a GitHub pull request. Return findings first, ordered by severity.',
+			'Only report high-confidence bugs, security risks, behavioral regressions, or missing tests that directly matter for this PR.',
+			'Do not praise the change, summarize obvious edits, or leave generic style feedback.',
+			'Each finding must include a concise title, severity, affected file/path when known, and why it matters.',
+			'If there are no findings, say exactly: No high-confidence findings.',
+			'Use read-only GitHub tools for additional context when needed. Use the PR comment tool only for the final review comment.',
+		) );
+	}
+
+	/**
+	 * Build webhook payload fetch step.
+	 *
+	 * @param string $dedupe_key Dedupe key template.
+	 * @return array<string,mixed>
+	 */
+	private static function webhook_payload_step( string $dedupe_key ): array {
+		return array(
+			'id'             => 'github_pull_request_payload',
+			'type'           => 'fetch',
+			'label'          => 'GitHub pull request webhook payload',
+			'handler_slug'   => 'webhook_payload',
+			'handler_config' => array(
+				'source_type'              => 'github_pull_request_webhook',
+				'title_path'               => 'pull_request.title',
+				'content_path'             => 'pull_request.body',
+				'item_identifier_template' => $dedupe_key,
+				'ignore_missing_paths'     => false,
+				'metadata'                 => array(
+					'repo'        => 'repository.full_name',
+					'pull_number' => 'pull_request.number',
+					'action'      => 'action',
+					'head_sha'    => 'pull_request.head.sha',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Build PR review context fetch step.
+	 *
+	 * @param string $repo GitHub repo.
+	 * @return array<string,mixed>
+	 */
+	private static function pull_review_context_step( string $repo ): array {
+		return array(
+			'id'             => 'github_pull_review_context',
+			'type'           => 'fetch',
+			'label'          => 'GitHub PR review context',
+			'handler_slug'   => 'github',
+			'handler_config' => array(
+				'repo'                    => '' !== $repo ? $repo : '{{metadata.repo}}',
+				'data_source'             => 'pull_review_context',
+				'pull_number'             => '{{metadata.pull_number}}',
+				'head_sha'                => '{{metadata.head_sha}}',
+				'max_patch_chars'         => 200000,
+				'include_file_contents'   => false,
+				'include_base_contents'   => false,
+				'context_paths'           => array(),
+				'max_file_content_chars'  => 20000,
+				'max_context_files'       => 10,
+				'max_total_context_chars' => 100000,
+			),
+		);
+	}
+
+	/**
+	 * Build AI review step.
+	 *
+	 * @param string $comment_mode Comment mode.
+	 * @return array<string,mixed>
+	 */
+	private static function ai_review_step( string $comment_mode ): array {
+		return array(
+			'id'             => 'ai_pr_review',
+			'type'           => 'ai',
+			'label'          => 'AI PR review',
+			'user_message'   => self::default_prompt(),
+			'enabled_tools'  => array(
+				'get_github_pull',
+				'get_github_pull_files',
+				'get_github_pull_review_context',
+				'get_github_file',
+				'list_github_tree',
+				'comment_github_pull_request',
+			),
+			'comment_policy' => array(
+				'tool'   => 'comment_github_pull_request',
+				'mode'   => $comment_mode,
+				'marker' => 'data-machine-code-pr-review',
+			),
+		);
+	}
+
+	/**
+	 * Normalize comment mode.
+	 *
+	 * @param mixed $mode Raw mode.
+	 */
+	private static function normalize_comment_mode( mixed $mode ): string {
+		$mode = function_exists( 'sanitize_key' )
+			? sanitize_key( (string) $mode )
+			: strtolower( preg_replace( '/[^a-z0-9_\-]/i', '', (string) $mode ) );
+		return in_array( $mode, array( 'managed', 'append', 'dry_run' ), true ) ? $mode : 'managed';
+	}
+
+	/**
+	 * Clean a string with WordPress helpers when available.
+	 *
+	 * @param mixed $value Raw value.
+	 */
+	private static function clean_string( mixed $value ): string {
+		$value = trim( (string) $value );
+		return function_exists( 'sanitize_text_field' ) ? sanitize_text_field( $value ) : $value;
+	}
+}

--- a/tests/smoke-github-pr-review-flow-scaffold.php
+++ b/tests/smoke-github-pr-review-flow-scaffold.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Pure-PHP smoke for the GitHub PR review flow scaffold definition.
+ *
+ * Run: php tests/smoke-github-pr-review-flow-scaffold.php
+ */
+
+declare( strict_types=1 );
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', sys_get_temp_dir() . '/dmc-pr-review-flow-scaffold/' );
+	}
+
+	if ( ! function_exists( 'sanitize_text_field' ) ) {
+		function sanitize_text_field( $value ): string { return trim( (string) $value ); }
+	}
+
+	if ( ! function_exists( 'sanitize_key' ) ) {
+		function sanitize_key( $value ): string { return strtolower( preg_replace( '/[^a-z0-9_\-]/i', '', (string) $value ) ); }
+	}
+
+	require __DIR__ . '/../inc/GitHub/PrReviewFlowScaffold.php';
+
+	use DataMachineCode\GitHub\PrReviewFlowScaffold;
+
+	$failures = array();
+	$total    = 0;
+
+	$assert = function ( string $label, bool $condition ) use ( &$failures, &$total ): void {
+		++$total;
+		if ( $condition ) {
+			echo "  ok {$label}\n";
+			return;
+		}
+
+		$failures[] = $label;
+		echo "  fail {$label}\n";
+	};
+
+	echo "GitHub PR review flow scaffold - smoke\n";
+
+	$definition = PrReviewFlowScaffold::build( array(
+		'repo'         => 'Extra-Chill/data-machine-code',
+		'agent'        => 'code-reviewer',
+		'name'         => 'DMC PR review',
+		'comment_mode' => 'managed',
+	) );
+
+	$assert( 'schema identifies scaffold version', 'data-machine-code/github-pr-review-flow-scaffold/v1' === $definition['schema'] );
+	$assert( 'definition is explicit that it is not direct runtime magic', 'definition_only' === $definition['status'] );
+	$assert( 'repo carries through', 'Extra-Chill/data-machine-code' === $definition['repo'] );
+	$assert( 'agent carries through', 'code-reviewer' === $definition['agent'] );
+	$assert( 'name carries through', 'DMC PR review' === $definition['name'] );
+	$assert( 'comment mode defaults to managed', 'managed' === $definition['comment_mode'] );
+
+	$webhook = $definition['webhook'];
+	$assert( 'webhook provider is GitHub', 'github' === $webhook['provider'] );
+	$assert( 'webhook event is pull_request', 'pull_request' === $webhook['event'] );
+	$assert( 'default actions include opened', in_array( 'opened', $webhook['actions'], true ) );
+	$assert( 'default actions include reopened', in_array( 'reopened', $webhook['actions'], true ) );
+	$assert( 'default actions include synchronize', in_array( 'synchronize', $webhook['actions'], true ) );
+	$assert( 'default actions include ready_for_review', in_array( 'ready_for_review', $webhook['actions'], true ) );
+	$assert( 'dedupe key is repo plus PR number plus head SHA', '{repository.full_name}#{pull_request.number}@{pull_request.head.sha}' === $webhook['dedupe_key'] );
+	$assert( 'repo payload path documented', 'repository.full_name' === $webhook['payload_paths']['repo'] );
+	$assert( 'PR number payload path documented', 'pull_request.number' === $webhook['payload_paths']['pull_number'] );
+	$assert( 'action payload path documented', 'action' === $webhook['payload_paths']['action'] );
+	$assert( 'head SHA payload path documented', 'pull_request.head.sha' === $webhook['payload_paths']['head_sha'] );
+
+	$steps = $definition['workflow']['steps'];
+	$assert( 'three scaffold steps are present', 3 === count( $steps ) );
+	$assert( 'step 1 is webhook_payload fetch', 'fetch' === $steps[0]['type'] && 'webhook_payload' === $steps[0]['handler_slug'] );
+	$assert( 'step 2 is GitHub pull_review_context fetch', 'fetch' === $steps[1]['type'] && 'github' === $steps[1]['handler_slug'] && 'pull_review_context' === $steps[1]['handler_config']['data_source'] );
+	$assert( 'step 3 is AI review', 'ai' === $steps[2]['type'] );
+
+	$payload_config = $steps[0]['handler_config'];
+	$assert( 'webhook payload source_type is explicit', 'github_pull_request_webhook' === $payload_config['source_type'] );
+	$assert( 'webhook payload maps repo metadata', 'repository.full_name' === $payload_config['metadata']['repo'] );
+	$assert( 'webhook payload maps PR number metadata', 'pull_request.number' === $payload_config['metadata']['pull_number'] );
+	$assert( 'webhook payload maps action metadata', 'action' === $payload_config['metadata']['action'] );
+	$assert( 'webhook payload maps head SHA metadata', 'pull_request.head.sha' === $payload_config['metadata']['head_sha'] );
+	$assert( 'webhook payload stores dedupe template', $webhook['dedupe_key'] === $payload_config['item_identifier_template'] );
+
+	$review_config = $steps[1]['handler_config'];
+	$assert( 'GitHub review context repo is carried through', 'Extra-Chill/data-machine-code' === $review_config['repo'] );
+	$assert( 'GitHub review context uses webhook PR placeholder', '{{metadata.pull_number}}' === $review_config['pull_number'] );
+	$assert( 'GitHub review context uses webhook head SHA placeholder', '{{metadata.head_sha}}' === $review_config['head_sha'] );
+	$assert( 'review context expansion is conservative by default', false === $review_config['include_file_contents'] && false === $review_config['include_base_contents'] );
+
+	$ai_step = $steps[2];
+	$prompt  = $ai_step['user_message'];
+	$tools   = $ai_step['enabled_tools'];
+	$assert( 'prompt requires findings-first review', str_contains( $prompt, 'findings first' ) || str_contains( $prompt, 'findings' ) );
+	$assert( 'prompt rejects praise spam', str_contains( $prompt, 'Do not praise' ) );
+	$assert( 'prompt asks for high-confidence findings', str_contains( $prompt, 'high-confidence' ) );
+	$assert( 'read-only get_github_pull tool enabled', in_array( 'get_github_pull', $tools, true ) );
+	$assert( 'read-only get_github_pull_files tool enabled', in_array( 'get_github_pull_files', $tools, true ) );
+	$assert( 'read-only get_github_pull_review_context tool enabled', in_array( 'get_github_pull_review_context', $tools, true ) );
+	$assert( 'read-only get_github_file tool enabled', in_array( 'get_github_file', $tools, true ) );
+	$assert( 'read-only list_github_tree tool enabled', in_array( 'list_github_tree', $tools, true ) );
+	$assert( 'PR comment tool enabled', in_array( 'comment_github_pull_request', $tools, true ) );
+	$assert( 'comment policy points at PR comment tool', 'comment_github_pull_request' === $ai_step['comment_policy']['tool'] );
+	$assert( 'comment policy includes managed marker', 'data-machine-code-pr-review' === $ai_step['comment_policy']['marker'] );
+
+	$custom = PrReviewFlowScaffold::build( array(
+		'actions'      => 'opened,synchronize,invalid action',
+		'comment_mode' => 'nonsense',
+	) );
+	$assert( 'custom actions are normalized', array( 'opened', 'synchronize', 'invalidaction' ) === $custom['webhook']['actions'] );
+	$assert( 'invalid comment mode falls back to managed', 'managed' === $custom['comment_mode'] );
+	$assert( 'empty repo falls back to metadata placeholder', '{{metadata.repo}}' === $custom['workflow']['steps'][1]['handler_config']['repo'] );
+
+	$command_source = file_get_contents( __DIR__ . '/../inc/Cli/Commands/GitHubCommand.php' );
+	$assert( 'CLI exposes review-flow subcommand', str_contains( $command_source, '@subcommand review-flow' ) );
+	$assert( 'CLI calls scaffold builder', str_contains( $command_source, 'PrReviewFlowScaffold::build' ) );
+
+	if ( ! empty( $failures ) ) {
+		echo "\nFAIL: " . count( $failures ) . " assertion(s) failed out of {$total}\n";
+		foreach ( $failures as $failure ) {
+			echo "  - {$failure}\n";
+		}
+		exit( 1 );
+	}
+
+	echo "\nOK ({$total} assertions)\n";
+	exit( 0 );
+}


### PR DESCRIPTION
## Summary
- Adds a `datamachine-code github review-flow create` scaffold command that emits a machine-readable PR review workflow definition.
- Includes webhook payload mapping, GitHub PR review context fetch config, conservative findings-first review prompt, read-only GitHub tools, and the narrow PR comment tool.
- Documents the new CLI surface in the README.

## Changes
- Adds `DataMachineCode\GitHub\PrReviewFlowScaffold` as the reusable definition builder.
- Adds a `review-flow create` GitHub CLI subcommand that outputs JSON for normal Data Machine import/inspection.
- Adds pure-PHP smoke coverage for step ordering, webhook actions, dedupe template, prompt guidance, and enabled tools.

## Tests
- `php -l inc/GitHub/PrReviewFlowScaffold.php`
- `php -l inc/Cli/Commands/GitHubCommand.php`
- `php -l tests/smoke-github-pr-review-flow-scaffold.php`
- `php tests/smoke-github-pr-review-flow-scaffold.php`
- `homeboy lint data-machine-code --path /Users/chubes/Developer/data-machine-code@feat-pr-review-flow-scaffold --changed-since origin/main`
- `git diff --check`

Closes #95

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the scaffold command/builder and smoke test; Chris remains responsible for review and merge.