### PR TITLE
feat(github): upsert managed PR review comments

### DIFF
--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -276,6 +276,58 @@ class GitHubAbilities {
 			);
 
 			wp_register_ability(
+				'datamachine/upsert-github-pull-review-comment',
+				array(
+					'label'               => 'Upsert GitHub Pull Request Review Comment',
+					'description'         => 'Create or update one managed bot-authored GitHub pull request review comment identified by a hidden marker',
+					'category'            => 'datamachine-code-github',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'repo', 'pull_number', 'body' ),
+						'properties' => array(
+							'repo'        => array(
+								'type'        => 'string',
+								'description' => 'Repository in owner/repo format.',
+							),
+							'pull_number' => array(
+								'type'        => 'integer',
+								'description' => 'Pull request number.',
+							),
+							'body'        => array(
+								'type'        => 'string',
+								'description' => 'Review comment body (supports GitHub Markdown). Hidden marker text is appended automatically.',
+							),
+							'marker'      => array(
+								'type'        => 'string',
+								'description' => 'Hidden HTML comment marker used to find the managed comment. Default: <!-- datamachine-pr-review -->.',
+							),
+							'head_sha'    => array(
+								'type'        => 'string',
+								'description' => 'Optional pull request head SHA. Required to separate comments when mode is per_head_sha.',
+							),
+							'mode'        => array(
+								'type'        => 'string',
+								'description' => 'Comment policy: update_existing or per_head_sha. Default: update_existing.',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'    => array( 'type' => 'boolean' ),
+							'action'     => array( 'type' => 'string' ),
+							'comment_id' => array( 'type' => 'integer' ),
+							'html_url'   => array( 'type' => 'string' ),
+							'error'      => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'upsertPullReviewComment' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
 				'datamachine/list-github-pulls',
 				array(
 					'label'               => 'List GitHub Pull Requests',
@@ -845,6 +897,185 @@ class GitHubAbilities {
 
 	public static function commentOnPullRequest( array $input ): array|\WP_Error {
 		return self::commentOnIssue( self::buildPullRequestCommentInput( $input ) );
+	}
+
+	/**
+	 * Create or update one managed bot-authored PR review comment.
+	 *
+	 * @param array         $input       Ability input.
+	 * @param callable|null $api_get     Optional test seam: fn(string $url, array $query, string $pat): array|WP_Error.
+	 * @param callable|null $api_request Optional test seam: fn(string $method, string $url, array $body, string $pat): array|WP_Error.
+	 * @return array|\WP_Error Success payload or error.
+	 */
+	public static function upsertPullReviewComment( array $input, ?callable $api_get = null, ?callable $api_request = null ): array|\WP_Error {
+		$repo        = sanitize_text_field( $input['repo'] ?? '' );
+		$pull_number = (int) ( $input['pull_number'] ?? 0 );
+		$body        = (string) ( $input['body'] ?? '' );
+		$mode        = sanitize_text_field( $input['mode'] ?? 'update_existing' );
+		$head_sha    = sanitize_text_field( $input['head_sha'] ?? '' );
+
+		if ( empty( $repo ) || $pull_number <= 0 || '' === $body ) {
+			return new \WP_Error( 'missing_params', 'Repository, pull_number, and body are required.', array( 'status' => 400 ) );
+		}
+
+		if ( ! in_array( $mode, array( 'update_existing', 'per_head_sha' ), true ) ) {
+			return new \WP_Error( 'invalid_mode', 'Mode must be update_existing or per_head_sha.', array( 'status' => 400 ) );
+		}
+
+		if ( 'per_head_sha' === $mode && '' === $head_sha ) {
+			return new \WP_Error( 'missing_head_sha', 'head_sha is required when mode is per_head_sha.', array( 'status' => 400 ) );
+		}
+
+		$pat = self::getPat();
+		if ( empty( $pat ) ) {
+			return self::patError();
+		}
+
+		$api_get     = $api_get ?? array( self::class, 'apiGet' );
+		$api_request = $api_request ?? array( self::class, 'apiRequest' );
+		$marker      = self::normalizeManagedCommentMarker( $input['marker'] ?? '<!-- datamachine-pr-review -->' );
+		$target_body = self::buildManagedPullReviewCommentBody( $body, $marker, $head_sha, $mode );
+
+		$user_response = $api_get( self::API_BASE . '/user', array(), $pat );
+		if ( is_wp_error( $user_response ) ) {
+			return $user_response;
+		}
+
+		$login = (string) ( $user_response['data']['login'] ?? '' );
+		if ( '' === $login ) {
+			return new \WP_Error( 'github_identity_missing', 'GitHub API did not return the authenticated user login.', array( 'status' => 500 ) );
+		}
+
+		$comments = array();
+		$page     = 1;
+		do {
+			$comments_url = sprintf( '%s/repos/%s/issues/%d/comments', self::API_BASE, $repo, $pull_number );
+			$page_result  = $api_get(
+				$comments_url,
+				array(
+					'per_page' => self::MAX_PER_PAGE,
+					'page'     => $page,
+				),
+				$pat
+			);
+			if ( is_wp_error( $page_result ) ) {
+				return $page_result;
+			}
+
+			$page_comments = is_array( $page_result['data'] ?? null ) ? $page_result['data'] : array();
+			$page_count    = count( $page_comments );
+			$comments      = array_merge( $comments, $page_comments );
+			++$page;
+		} while ( $page_count >= self::MAX_PER_PAGE );
+
+		$existing = self::findManagedPullReviewComment( $comments, $login, $marker, $head_sha, $mode );
+		if ( null !== $existing ) {
+			$comment_id = (int) ( $existing['id'] ?? 0 );
+			if ( $comment_id <= 0 ) {
+				return new \WP_Error( 'github_comment_missing_id', 'Matched GitHub comment did not include an id.', array( 'status' => 500 ) );
+			}
+
+			$response = $api_request(
+				'PATCH',
+				sprintf( '%s/repos/%s/issues/comments/%d', self::API_BASE, $repo, $comment_id ),
+				array( 'body' => $target_body ),
+				$pat
+			);
+			if ( is_wp_error( $response ) ) {
+				return $response;
+			}
+
+			return self::buildManagedCommentResponse( 'updated', $response['data'] ?? array() );
+		}
+
+		$response = $api_request(
+			'POST',
+			sprintf( '%s/repos/%s/issues/%d/comments', self::API_BASE, $repo, $pull_number ),
+			array( 'body' => $target_body ),
+			$pat
+		);
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		return self::buildManagedCommentResponse( 'created', $response['data'] ?? array() );
+	}
+
+	private static function normalizeManagedCommentMarker( string $marker ): string {
+		$marker = trim( $marker );
+		if ( '' === $marker ) {
+			$marker = '<!-- datamachine-pr-review -->';
+		}
+
+		if ( str_starts_with( $marker, '<!--' ) && str_ends_with( $marker, '-->' ) ) {
+			$inner = trim( substr( $marker, 4, -3 ) );
+		} else {
+			$inner = $marker;
+		}
+
+		$inner = str_replace( '--', '-', $inner );
+		return '<!-- ' . trim( $inner ) . ' -->';
+	}
+
+	private static function buildManagedPullReviewCommentBody( string $body, string $marker, string $head_sha, string $mode ): string {
+		$markers = array( $marker );
+		if ( 'per_head_sha' === $mode ) {
+			$markers[] = self::buildManagedHeadMarker( $head_sha );
+		}
+
+		return rtrim( $body ) . "\n\n" . implode( "\n", $markers );
+	}
+
+	private static function buildManagedHeadMarker( string $head_sha ): string {
+		return '<!-- datamachine-pr-review-head-sha: ' . str_replace( '--', '-', $head_sha ) . ' -->';
+	}
+
+	private static function findManagedPullReviewComment( array $comments, string $login, string $marker, string $head_sha, string $mode ): ?array {
+		$matched = null;
+		foreach ( $comments as $comment ) {
+			if ( ! is_array( $comment ) ) {
+				continue;
+			}
+
+			if ( (string) ( $comment['user']['login'] ?? '' ) !== $login ) {
+				continue;
+			}
+
+			$comment_body = (string) ( $comment['body'] ?? '' );
+			if ( ! str_contains( $comment_body, $marker ) ) {
+				continue;
+			}
+
+			if ( 'per_head_sha' === $mode && ! str_contains( $comment_body, self::buildManagedHeadMarker( $head_sha ) ) ) {
+				continue;
+			}
+
+			if ( null === $matched || self::isNewerGitHubComment( $comment, $matched ) ) {
+				$matched = $comment;
+			}
+		}
+
+		return $matched;
+	}
+
+	private static function isNewerGitHubComment( array $candidate, array $current ): bool {
+		$candidate_time = (string) ( $candidate['updated_at'] ?? $candidate['created_at'] ?? '' );
+		$current_time   = (string) ( $current['updated_at'] ?? $current['created_at'] ?? '' );
+
+		if ( '' === $candidate_time || '' === $current_time ) {
+			return true;
+		}
+
+		return $current_time <= $candidate_time;
+	}
+
+	private static function buildManagedCommentResponse( string $action, array $comment ): array {
+		return array(
+			'success'    => true,
+			'action'     => $action,
+			'comment_id' => (int) ( $comment['id'] ?? 0 ),
+			'html_url'   => (string) ( $comment['html_url'] ?? '' ),
+		);
 	}
 
 	private static function buildPullRequestCommentInput( array $input ): array {

--- a/inc/Tools/GitHubTools.php
+++ b/inc/Tools/GitHubTools.php
@@ -28,6 +28,10 @@ class GitHubTools extends BaseTool {
 		$this->registerTool( 'get_github_issue', array( $this, 'getGetIssueDefinition' ), $contexts, array( 'access_level' => 'editor' ) );
 		$this->registerTool( 'manage_github_issue', array( $this, 'getManageIssueDefinition' ), $contexts, array( 'access_level' => 'editor' ) );
 		$this->registerTool( 'comment_github_pull_request', array( $this, 'getCommentPullRequestDefinition' ), $contexts, array( 'access_level' => 'editor' ) );
+		$this->registerTool( 'upsert_github_pull_review_comment', array( $this, 'getUpsertPullReviewCommentDefinition' ), $contexts, array(
+			'access_level' => 'editor',
+			'ability'      => 'datamachine/upsert-github-pull-review-comment',
+		) );
 		$this->registerTool( 'list_github_pulls', array( $this, 'getListPullsDefinition' ), $contexts, array( 'access_level' => 'editor' ) );
 		$this->registerTool( 'get_github_pull', array( $this, 'getGetPullDefinition' ), $contexts, array(
 			'access_level' => 'editor',
@@ -80,6 +84,7 @@ class GitHubTools extends BaseTool {
 			'get_github_issue',
 			'manage_github_issue',
 			'comment_github_pull_request',
+			'upsert_github_pull_review_comment',
 			'list_github_pulls',
 			'get_github_pull',
 			'get_github_pull_files',
@@ -361,6 +366,61 @@ class GitHubTools extends BaseTool {
 					'type'        => 'string',
 					'required'    => false,
 					'description' => 'Optional stable marker appended as an HTML comment for future update-by-marker support.',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Handle upsert_github_pull_review_comment tool call.
+	 *
+	 * @param array $parameters Tool parameters.
+	 * @return array
+	 */
+	public function handleUpsertPullReviewComment( array $parameters ): array {
+		return $this->executeGitHubAbility( 'datamachine/upsert-github-pull-review-comment', 'upsert_github_pull_review_comment', $parameters );
+	}
+
+	/**
+	 * Get tool definition for upsert_github_pull_review_comment.
+	 *
+	 * @return array
+	 */
+	public function getUpsertPullReviewCommentDefinition(): array {
+		return array(
+			'class'       => __CLASS__,
+			'method'      => 'handleUpsertPullReviewComment',
+			'description' => 'Create or update one managed bot-authored GitHub pull request review comment identified by a hidden marker.',
+			'parameters'  => array(
+				'repo'        => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Repository in owner/repo format.',
+				),
+				'pull_number' => array(
+					'type'        => 'integer',
+					'required'    => true,
+					'description' => 'Pull request number.',
+				),
+				'body'        => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Review comment body (supports GitHub Markdown). Hidden marker text is appended automatically.',
+				),
+				'marker'      => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Hidden HTML comment marker used to find the managed comment. Default: <!-- datamachine-pr-review -->.',
+				),
+				'head_sha'    => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Optional pull request head SHA. Required to separate comments when mode is per_head_sha.',
+				),
+				'mode'        => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Comment policy: update_existing or per_head_sha. Default: update_existing.',
 				),
 			),
 		);

--- a/tests/smoke-github-pr-review-comment-upsert.php
+++ b/tests/smoke-github-pr-review-comment-upsert.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * Pure-PHP smoke test for managed GitHub PR review comment upsert.
+ *
+ * Run: php tests/smoke-github-pr-review-comment-upsert.php
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Core {
+    class PluginSettings {
+        public static function get( string $key, string $default = '' ): string {
+            return 'github_pat' === $key ? 'test-token' : $default;
+        }
+    }
+}
+
+namespace {
+    if ( ! defined( 'ABSPATH' ) ) {
+        define( 'ABSPATH', __DIR__ . '/' );
+    }
+
+    class WP_Error {
+        private string $code;
+        private string $message;
+        private array $data;
+
+        public function __construct( string $code, string $message, array $data = array() ) {
+            $this->code    = $code;
+            $this->message = $message;
+            $this->data    = $data;
+        }
+
+        public function get_error_code(): string {
+            return $this->code;
+        }
+
+        public function get_error_message(): string {
+            return $this->message;
+        }
+
+        public function get_error_data(): array {
+            return $this->data;
+        }
+    }
+
+    function is_wp_error( $value ): bool {
+        return $value instanceof WP_Error;
+    }
+
+    function sanitize_text_field( $value ): string {
+        return trim( (string) $value );
+    }
+
+    require __DIR__ . '/../inc/Abilities/GitHubAbilities.php';
+
+    use DataMachineCode\Abilities\GitHubAbilities;
+
+    $failures = array();
+    $assert   = function ( string $label, bool $cond ) use ( &$failures ): void {
+        if ( $cond ) {
+            echo "  ok {$label}\n";
+            return;
+        }
+
+        $failures[] = $label;
+        echo "  fail {$label}\n";
+    };
+
+    $comment = function ( int $id, string $author, string $body, string $updated_at = '' ): array {
+        return array(
+            'id'         => $id,
+            'body'       => $body,
+            'updated_at' => $updated_at,
+            'html_url'   => "https://github.test/comment/{$id}",
+            'user'       => array( 'login' => $author ),
+        );
+    };
+
+    $run = function ( array $comments, array $input = array() ) use ( &$requests ): array|WP_Error {
+        $requests = array();
+
+        $api_get = function ( string $url, array $query, string $pat ) use ( $comments, &$requests ): array {
+            $requests[] = array( 'GET', $url, $query, null, $pat );
+            if ( str_ends_with( $url, '/user' ) ) {
+                return array(
+                    'success' => true,
+                    'data'    => array( 'login' => 'datamachine-bot' ),
+                );
+            }
+
+            return array(
+                'success' => true,
+                'data'    => 1 === (int) ( $query['page'] ?? 1 ) ? $comments : array(),
+            );
+        };
+
+        $api_request = function ( string $method, string $url, array $body, string $pat ) use ( &$requests ): array {
+            $requests[] = array( $method, $url, array(), $body, $pat );
+            $id         = 'PATCH' === $method ? (int) basename( $url ) : 9001;
+
+            return array(
+                'success' => true,
+                'data'    => array(
+                    'id'       => $id,
+                    'html_url' => "https://github.test/comment/{$id}",
+                    'body'     => $body['body'] ?? '',
+                ),
+            );
+        };
+
+        return GitHubAbilities::upsertPullReviewComment(
+            array_merge(
+                array(
+                    'repo'        => 'Extra-Chill/data-machine-code',
+                    'pull_number' => 97,
+                    'body'        => 'Managed review body',
+                ),
+                $input
+            ),
+            $api_get,
+            $api_request
+        );
+    };
+
+    echo "GitHub PR review comment upsert - smoke\n";
+
+    $result = $run( array() );
+    $assert( 'no existing marker comment creates', 'created' === ( $result['action'] ?? '' ) );
+    $assert( 'create returns comment id', 9001 === ( $result['comment_id'] ?? 0 ) );
+    $assert( 'create returns html_url', 'https://github.test/comment/9001' === ( $result['html_url'] ?? '' ) );
+    $assert( 'create uses POST to PR issue comments endpoint', 'POST' === ( $requests[2][0] ?? '' ) && str_contains( $requests[2][1] ?? '', '/issues/97/comments' ) );
+    $assert( 'create appends default hidden marker', str_contains( $requests[2][3]['body'] ?? '', '<!-- datamachine-pr-review -->' ) );
+
+    $result = $run( array(
+        $comment( 100, 'datamachine-bot', "Previous review\n\n<!-- datamachine-pr-review -->" ),
+    ) );
+    $assert( 'same-author marker comment updates', 'updated' === ( $result['action'] ?? '' ) );
+    $assert( 'update returns existing comment id', 100 === ( $result['comment_id'] ?? 0 ) );
+    $assert( 'update uses PATCH to issue comment endpoint', 'PATCH' === ( $requests[2][0] ?? '' ) && str_ends_with( $requests[2][1] ?? '', '/issues/comments/100' ) );
+
+    $result = $run( array(
+        $comment( 105, 'datamachine-bot', "Older review\n\n<!-- datamachine-pr-review -->", '2026-01-01T00:00:00Z' ),
+        $comment( 106, 'datamachine-bot', "Newer review\n\n<!-- datamachine-pr-review -->", '2026-01-02T00:00:00Z' ),
+    ) );
+    $assert( 'latest same-author marker comment wins', 'updated' === ( $result['action'] ?? '' ) && 106 === ( $result['comment_id'] ?? 0 ) );
+
+    $result = $run( array(
+        $comment( 101, 'someone-else', "Previous review\n\n<!-- datamachine-pr-review -->" ),
+    ) );
+    $assert( 'other-author marker comment is not overwritten', 'created' === ( $result['action'] ?? '' ) );
+    $assert( 'other-author marker create does not patch foreign comment', 'POST' === ( $requests[2][0] ?? '' ) );
+
+    $result = $run( array(
+        $comment( 102, 'datamachine-bot', 'Plain comment without marker' ),
+    ) );
+    $assert( 'comments without marker are ignored', 'created' === ( $result['action'] ?? '' ) );
+
+    $result = $run(
+        array(
+            $comment( 103, 'datamachine-bot', "Old head review\n\n<!-- datamachine-pr-review -->\n<!-- datamachine-pr-review-head-sha: oldsha -->" ),
+        ),
+        array(
+            'mode'     => 'per_head_sha',
+            'head_sha' => 'newsha',
+        )
+    );
+    $assert( 'per_head_sha ignores matching base marker with different head', 'created' === ( $result['action'] ?? '' ) );
+    $assert( 'per_head_sha appends head-specific marker', str_contains( $requests[2][3]['body'] ?? '', '<!-- datamachine-pr-review-head-sha: newsha -->' ) );
+
+    $result = $run(
+        array(
+            $comment( 104, 'datamachine-bot', "Same head review\n\n<!-- datamachine-pr-review -->\n<!-- datamachine-pr-review-head-sha: newsha -->" ),
+        ),
+        array(
+            'mode'     => 'per_head_sha',
+            'head_sha' => 'newsha',
+        )
+    );
+    $assert( 'per_head_sha updates same-head managed comment', 'updated' === ( $result['action'] ?? '' ) );
+    $assert( 'per_head_sha returns matched comment id', 104 === ( $result['comment_id'] ?? 0 ) );
+
+    $result = $run( array(), array( 'marker' => 'custom-review-marker' ) );
+    $assert( 'plain marker input is normalized to hidden HTML comment', str_contains( $requests[2][3]['body'] ?? '', '<!-- custom-review-marker -->' ) );
+
+    if ( ! empty( $failures ) ) {
+        echo "\nFAIL: " . count( $failures ) . " assertion(s)\n";
+        foreach ( $failures as $failure ) {
+            echo "  - {$failure}\n";
+        }
+        exit( 1 );
+    }
+
+    echo "\nOK\n";
+    exit( 0 );
+}


### PR DESCRIPTION
## Summary
- Adds a managed GitHub PR review comment upsert primitive so automated review flows update one bot-authored marker comment instead of appending on every rerun.
- Keeps the existing append-only PR comment tool unchanged for simple comment workflows.

## Changes
- Registers `datamachine/upsert-github-pull-review-comment` and `upsert_github_pull_review_comment`.
- Lists PR issue comments, resolves the authenticated GitHub login, updates only matching same-author marker comments, and creates a new comment otherwise.
- Supports `update_existing` and `per_head_sha` marker policies and returns `action`, `comment_id`, and `html_url`.

## Tests
- `php -l inc/Abilities/GitHubAbilities.php && php -l inc/Tools/GitHubTools.php && php -l tests/smoke-github-pr-review-comment-upsert.php`
- `php tests/smoke-github-pr-review-comment-upsert.php && php tests/smoke-github-pr-comment-tool.php`
- `homeboy lint data-machine-code --path /Users/chubes/Developer/data-machine-code@feat-managed-pr-review-comment --changed-since origin/main` passed, but reported no changed files in this uncommitted-worktree mode.
- Full `homeboy lint data-machine-code --path /Users/chubes/Developer/data-machine-code@feat-managed-pr-review-comment` still fails on pre-existing workspace/settings PHPCS drift plus the PHPStan temp-file runner error; touched GitHub files no longer appear in findings.

Closes #97

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the managed comment upsert ability/tool, drafting smoke coverage, and running verification commands. Chris remains responsible for review and merge.