### PR TITLE
feat(github): strengthen PR review context loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Sibling extensions like `data-machine-socials` and `data-machine-business` are *
 - Create issues (async via Action Scheduler)
 - GitHub fetch handler for pipeline workflows
 - GitHub pull request webhook validation mode for review-flow triggers
-- PR review flow scaffold for webhook-triggered review automation
+- PR review flow scaffold for webhook-triggered review automation with bounded context gathering and managed comment upsert
 
 ### Workspace Management
 - Clone and manage git repositories in a secure workspace directory
@@ -40,7 +40,7 @@ Sibling extensions like `data-machine-socials` and `data-machine-business` are *
 - Per-repo write/push policies with path allowlists and branch restrictions
 
 ### AI Agent Tools
-- 10 chat tools for GitHub and workspace operations
+- GitHub and workspace chat tools for read-only context gathering plus managed PR review comments
 - Async GitHub issue creation via system tasks
 - All tools register through Data Machine's tool system
 

--- a/inc/GitHub/PrReviewFlowScaffold.php
+++ b/inc/GitHub/PrReviewFlowScaffold.php
@@ -93,11 +93,15 @@ class PrReviewFlowScaffold {
 	public static function default_prompt(): string {
 		return implode( "\n", array(
 			'You are reviewing a GitHub pull request. Return findings first, ordered by severity.',
+			'Read the initial pull_review_context packet first, then identify what you still need to know before reviewing.',
+			'Use read-only GitHub tools on demand to inspect specific PR metadata, changed files, base/head file contents, neighboring files, dependency files, or repository tree paths that are necessary to verify a finding.',
+			'Keep context gathering bounded: fetch only targeted paths, avoid broad repository scans, and stop when you have enough evidence for or against high-confidence findings.',
 			'Only report high-confidence bugs, security risks, behavioral regressions, or missing tests that directly matter for this PR.',
 			'Do not praise the change, summarize obvious edits, or leave generic style feedback.',
 			'Each finding must include a concise title, severity, affected file/path when known, and why it matters.',
 			'If there are no findings, say exactly: No high-confidence findings.',
-			'Use read-only GitHub tools for additional context when needed. Use the PR comment tool only for the final review comment.',
+			'Use the managed PR review comment tool exactly once, after all context gathering is complete, to publish the final review.',
+			'When calling that final tool, pass repo, pull_number, body, marker "data-machine-code-pr-review", mode "per_head_sha", and the PR head_sha so repeated runs update the managed comment for the same head only.',
 		) );
 	}
 
@@ -175,12 +179,14 @@ class PrReviewFlowScaffold {
 				'get_github_pull_review_context',
 				'get_github_file',
 				'list_github_tree',
-				'comment_github_pull_request',
+				'upsert_github_pull_review_comment',
 			),
 			'comment_policy' => array(
-				'tool'   => 'comment_github_pull_request',
-				'mode'   => $comment_mode,
-				'marker' => 'data-machine-code-pr-review',
+				'tool'      => 'upsert_github_pull_review_comment',
+				'mode'      => 'per_head_sha',
+				'head_sha'  => '{{metadata.head_sha}}',
+				'marker'    => 'data-machine-code-pr-review',
+				'requested' => $comment_mode,
 			),
 		);
 	}

--- a/tests/smoke-github-pr-review-flow-scaffold.php
+++ b/tests/smoke-github-pr-review-flow-scaffold.php
@@ -91,16 +91,27 @@ namespace {
 	$prompt  = $ai_step['user_message'];
 	$tools   = $ai_step['enabled_tools'];
 	$assert( 'prompt requires findings-first review', str_contains( $prompt, 'findings first' ) || str_contains( $prompt, 'findings' ) );
+	$assert( 'prompt requires initial context packet read', str_contains( $prompt, 'initial pull_review_context packet' ) );
+	$assert( 'prompt requires on-demand context gathering', str_contains( $prompt, 'on demand' ) && str_contains( $prompt, 'specific PR metadata' ) );
+	$assert( 'prompt bounds context gathering', str_contains( $prompt, 'Keep context gathering bounded' ) && str_contains( $prompt, 'targeted paths' ) );
 	$assert( 'prompt rejects praise spam', str_contains( $prompt, 'Do not praise' ) );
 	$assert( 'prompt asks for high-confidence findings', str_contains( $prompt, 'high-confidence' ) );
+	$assert( 'prompt requires exactly one final managed comment', str_contains( $prompt, 'managed PR review comment tool exactly once' ) );
+	$assert( 'prompt instructs same-head managed upsert parameters', str_contains( $prompt, 'mode "per_head_sha"' ) && str_contains( $prompt, 'head_sha' ) && str_contains( $prompt, 'same head only' ) );
 	$assert( 'read-only get_github_pull tool enabled', in_array( 'get_github_pull', $tools, true ) );
 	$assert( 'read-only get_github_pull_files tool enabled', in_array( 'get_github_pull_files', $tools, true ) );
 	$assert( 'read-only get_github_pull_review_context tool enabled', in_array( 'get_github_pull_review_context', $tools, true ) );
 	$assert( 'read-only get_github_file tool enabled', in_array( 'get_github_file', $tools, true ) );
 	$assert( 'read-only list_github_tree tool enabled', in_array( 'list_github_tree', $tools, true ) );
-	$assert( 'PR comment tool enabled', in_array( 'comment_github_pull_request', $tools, true ) );
-	$assert( 'comment policy points at PR comment tool', 'comment_github_pull_request' === $ai_step['comment_policy']['tool'] );
+	$assert( 'plain PR comment tool is not enabled', ! in_array( 'comment_github_pull_request', $tools, true ) );
+	$assert( 'managed PR review comment upsert tool enabled', in_array( 'upsert_github_pull_review_comment', $tools, true ) );
+	$assert( 'comment policy points at managed upsert tool', 'upsert_github_pull_review_comment' === $ai_step['comment_policy']['tool'] );
+	$assert( 'comment policy uses per-head SHA dedupe', 'per_head_sha' === $ai_step['comment_policy']['mode'] && '{{metadata.head_sha}}' === $ai_step['comment_policy']['head_sha'] );
 	$assert( 'comment policy includes managed marker', 'data-machine-code-pr-review' === $ai_step['comment_policy']['marker'] );
+	$assert( 'comment policy records requested mode for importer visibility', 'managed' === $ai_step['comment_policy']['requested'] );
+
+	$read_only_tools = array_diff( $tools, array( 'upsert_github_pull_review_comment' ) );
+	$assert( 'all pre-final context tools are read-only', empty( array_intersect( $read_only_tools, array( 'manage_github_issue', 'comment_github_pull_request' ) ) ) );
 
 	$custom = PrReviewFlowScaffold::build( array(
 		'actions'      => 'opened,synchronize,invalid action',


### PR DESCRIPTION
## Summary
- Strengthens the GitHub PR review scaffold so the AI step follows an explicit context-gathering loop before publishing a final review.
- Switches the scaffold from the plain PR comment tool to the managed upsert tool with per-head-SHA dedupe.

## Changes
- Expands the default PR review prompt to require reading the initial `pull_review_context`, targeted read-only context gathering, bounded fetches, and exactly one final managed comment.
- Keeps the review tool policy read-only until the final `upsert_github_pull_review_comment` tool call.
- Updates README feature wording to reflect bounded context gathering and managed review comments.
- Extends the PR review scaffold smoke to pin the prompt, tool policy, and comment policy contract.

## Tests
- `php -l inc/GitHub/PrReviewFlowScaffold.php`
- `php tests/smoke-github-pr-review-flow-scaffold.php`
- `php tests/smoke-github-readonly-tools.php`
- `php tests/smoke-github-pr-review-context.php`
- `php tests/smoke-github-pr-comment-tool.php`
- `php tests/smoke-github-pr-review-comment-upsert.php`

Closes #102

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the scaffold prompt/tool-policy change, smoke-test updates, and PR description; Chris supplied the issue goal and reviewed direction through the task prompt.
