### PR TITLE
feat(github): support GitHub App authentication

### DIFF
--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -7,7 +7,7 @@
  * comment). All GitHub operations — CLI, REST, chat tools, fetch handler —
  * route through here.
  *
- * Auth: Uses the github_pat stored in Data Machine PluginSettings.
+ * Auth: Uses either github_pat or GitHub App settings stored in Data Machine PluginSettings.
  *
  * @package DataMachineCode\Abilities
  * @since 0.1.0
@@ -17,12 +17,19 @@ namespace DataMachineCode\Abilities;
 
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\PluginSettings;
+use DataMachineCode\Support\GitHubCredentialResolver;
 
 defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( GitHubCredentialResolver::class ) ) {
+	require_once dirname( __DIR__ ) . '/Support/GitHubCredentialResolver.php';
+}
 
 class GitHubAbilities {
 
 	private static bool $registered = false;
+
+	private static ?\WP_Error $last_auth_error = null;
 
 	/**
 	 * GitHub API base URL.
@@ -2024,8 +2031,10 @@ class GitHubAbilities {
 	}
 
 	private static function getHeaders( string $pat ): array {
+		$authorization = 'app' === GitHubCredentialResolver::mode() ? 'Bearer ' . $pat : 'token ' . $pat;
+
 		return array(
-			'Authorization' => 'token ' . $pat,
+			'Authorization' => $authorization,
 			'Accept'        => 'application/vnd.github.v3+json',
 			'User-Agent'    => 'DataMachineCode',
 			'Content-Type'  => 'application/json',
@@ -2408,11 +2417,27 @@ class GitHubAbilities {
 	// -------------------------------------------------------------------------
 
 	public static function getPat(): string {
-		return trim( PluginSettings::get( 'github_pat', '' ) );
+		$credential = GitHubCredentialResolver::resolve();
+		if ( is_wp_error( $credential ) ) {
+			self::$last_auth_error = $credential;
+			return '';
+		}
+
+		self::$last_auth_error = null;
+		return (string) $credential['token'];
 	}
 
 	public static function isConfigured(): bool {
-		return ! empty( self::getPat() );
+		return GitHubCredentialResolver::isConfigured();
+	}
+
+	/**
+	 * Return non-secret GitHub auth status for CLI/status surfaces.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public static function getAuthStatus(): array {
+		return GitHubCredentialResolver::status();
 	}
 
 	public static function getDefaultRepo(): string {
@@ -2467,7 +2492,11 @@ class GitHubAbilities {
 	}
 
 	private static function patError(): \WP_Error {
-		return new \WP_Error( 'pat_not_configured', 'GitHub Personal Access Token not configured. Set github_pat in Data Machine settings.', array( 'status' => 403 ) );
+		if ( self::$last_auth_error ) {
+			return self::$last_auth_error;
+		}
+
+		return new \WP_Error( 'github_auth_not_configured', 'GitHub authentication is not configured. Set github_pat for PAT mode or GitHub App credentials for app mode.', array( 'status' => 403 ) );
 	}
 
 	private static function clampPerPage( $per_page ): int {

--- a/inc/Cli/Commands/GitHubCommand.php
+++ b/inc/Cli/Commands/GitHubCommand.php
@@ -468,17 +468,42 @@ class GitHubCommand extends BaseCommand {
 	 * @subcommand status
 	 */
 	public function status( array $args, array $assoc_args ): void {
-		$configured   = GitHubAbilities::isConfigured();
+		$auth_status  = GitHubAbilities::getAuthStatus();
+		$configured   = ! empty( $auth_status['configured'] );
 		$default_repo = GitHubAbilities::getDefaultRepo();
 
 		$items = array(
 			array(
-				'setting' => 'GitHub PAT',
+				'setting' => 'Auth Mode',
+				'value'   => $auth_status['mode'] ?? 'pat',
+			),
+			array(
+				'setting' => 'Configured',
 				'value'   => $configured ? 'Configured' : 'Not configured',
+			),
+			array(
+				'setting' => 'GitHub PAT',
+				'value'   => ! empty( $auth_status['pat_configured'] ) ? 'Configured' : 'Not configured',
+			),
+			array(
+				'setting' => 'GitHub App ID',
+				'value'   => ! empty( $auth_status['app_id_configured'] ) ? 'Configured' : 'Not configured',
+			),
+			array(
+				'setting' => 'GitHub App Installation ID',
+				'value'   => ! empty( $auth_status['app_installation_configured'] ) ? 'Configured' : 'Not configured',
+			),
+			array(
+				'setting' => 'GitHub App Private Key',
+				'value'   => ! empty( $auth_status['app_private_key_configured'] ) ? 'Configured' : 'Not configured',
 			),
 			array(
 				'setting' => 'Default Repository',
 				'value'   => $default_repo ? $default_repo : 'Not set',
+			),
+			array(
+				'setting' => 'App Permissions',
+				'value'   => 'Contents: read, Issues: read/write, Pull requests: read/write, Checks: read, Commit statuses: read, Actions: read for artifacts',
 			),
 		);
 
@@ -589,7 +614,7 @@ class GitHubCommand extends BaseCommand {
 	 */
 	private function requireConfig(): void {
 		if ( ! GitHubAbilities::isConfigured() ) {
-			WP_CLI::error( 'GitHub PAT not configured. Set github_pat in Data Machine settings.' );
+			WP_CLI::error( 'GitHub authentication is not configured. Set github_pat for PAT mode or GitHub App credentials for app mode.' );
 		}
 	}
 

--- a/inc/GitSync/GitSyncFetcher.php
+++ b/inc/GitSync/GitSyncFetcher.php
@@ -58,7 +58,7 @@ final class GitSyncFetcher {
 
 		$pat = (string) GitHubAbilities::getPat();
 		if ( '' === $pat ) {
-			return new \WP_Error( 'missing_pat', 'GitHub PAT not configured.', array( 'status' => 500 ) );
+			return new \WP_Error( 'missing_github_auth', 'GitHub authentication is not configured.', array( 'status' => 500 ) );
 		}
 
 		$absolute = $binding->resolveAbsolutePath();

--- a/inc/GitSync/GitSyncProposer.php
+++ b/inc/GitSync/GitSyncProposer.php
@@ -308,7 +308,7 @@ final class GitSyncProposer {
 
 		$pat = (string) GitHubAbilities::getPat();
 		if ( '' === $pat ) {
-			return new \WP_Error( 'missing_pat', 'GitHub PAT not configured — cannot write.', array( 'status' => 500 ) );
+			return new \WP_Error( 'missing_github_auth', 'GitHub authentication is not configured — cannot write.', array( 'status' => 500 ) );
 		}
 
 		$absolute = $binding->resolveAbsolutePath();

--- a/inc/Support/GitHubCredentialResolver.php
+++ b/inc/Support/GitHubCredentialResolver.php
@@ -1,0 +1,236 @@
+<?php
+/**
+ * GitHub credential resolver.
+ *
+ * Supports the legacy PAT path and GitHub App installation tokens behind the
+ * same API-token contract used by GitHubAbilities.
+ *
+ * @package DataMachineCode\Support
+ */
+
+namespace DataMachineCode\Support;
+
+use DataMachine\Core\PluginSettings;
+
+defined( 'ABSPATH' ) || exit;
+
+final class GitHubCredentialResolver {
+
+	private const APP_TOKEN_CACHE_PREFIX = 'datamachine_code_github_app_token_';
+	private const APP_TOKEN_EXPIRY_SKEW  = 60;
+
+	/**
+	 * Resolve the active GitHub credential.
+	 *
+	 * @param callable|null $http_request Test seam: fn(string $url, array $args): array|\WP_Error.
+	 * @param int|null      $now          Test seam for cache expiry checks.
+	 * @return array{mode:string,token:string,authorization:string,cached?:bool,expires_at?:string}|\WP_Error
+	 */
+	public static function resolve( ?callable $http_request = null, ?int $now = null ): array|\WP_Error {
+		$mode = self::mode();
+		if ( 'pat' === $mode ) {
+			$pat = self::setting( 'github_pat' );
+			if ( '' === $pat ) {
+				return new \WP_Error( 'github_pat_not_configured', 'GitHub Personal Access Token not configured. Set github_pat in Data Machine settings.', array( 'status' => 403 ) );
+			}
+
+			return array(
+				'mode'          => 'pat',
+				'token'         => $pat,
+				'authorization' => 'token ' . $pat,
+			);
+		}
+
+		if ( 'app' !== $mode ) {
+			return new \WP_Error( 'github_auth_mode_invalid', 'Invalid github_auth_mode. Expected "pat" or "app".', array( 'status' => 400 ) );
+		}
+
+		return self::resolveApp( $http_request, $now );
+	}
+
+	/**
+	 * Return non-secret configuration status for CLI output.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public static function status(): array {
+		$mode = self::mode();
+
+		return array(
+			'mode'                         => $mode,
+			'pat_configured'               => '' !== self::setting( 'github_pat' ),
+			'app_id_configured'            => '' !== self::setting( 'github_app_id' ),
+			'app_installation_configured'  => '' !== self::setting( 'github_app_installation_id' ),
+			'app_private_key_configured'   => '' !== self::setting( 'github_app_private_key' ),
+			'configured'                   => self::isConfigured(),
+			'checks_permission'            => 'read',
+			'commit_statuses_permission'   => 'read',
+			'actions_permission'           => 'read recommended when fetching workflow artifacts',
+		);
+	}
+
+	public static function isConfigured(): bool {
+		$mode = self::mode();
+		if ( 'pat' === $mode ) {
+			return '' !== self::setting( 'github_pat' );
+		}
+
+		return 'app' === $mode
+			&& '' !== self::setting( 'github_app_id' )
+			&& '' !== self::setting( 'github_app_installation_id' )
+			&& '' !== self::setting( 'github_app_private_key' );
+	}
+
+	public static function mode(): string {
+		$mode = strtolower( self::setting( 'github_auth_mode', 'pat' ) );
+		return '' === $mode ? 'pat' : $mode;
+	}
+
+	/**
+	 * Mint a GitHub App JWT.
+	 */
+	public static function mintJwt( string $app_id, string $private_key, int $now ): string|\WP_Error {
+		$private_key = self::normalizePrivateKey( $private_key );
+		$header      = array(
+			'alg' => 'RS256',
+			'typ' => 'JWT',
+		);
+		$payload     = array(
+			'iat' => $now - 60,
+			'exp' => $now + 540,
+			'iss' => $app_id,
+		);
+
+		$unsigned = self::base64UrlEncode( wp_json_encode( $header ) ) . '.' . self::base64UrlEncode( wp_json_encode( $payload ) );
+		$signature = '';
+		$ok        = @openssl_sign( $unsigned, $signature, $private_key, OPENSSL_ALGO_SHA256 );
+		if ( ! $ok ) {
+			return new \WP_Error( 'github_app_private_key_invalid', 'GitHub App private key is invalid or could not sign a JWT.', array( 'status' => 400 ) );
+		}
+
+		return $unsigned . '.' . self::base64UrlEncode( $signature );
+	}
+
+	/**
+	 * Build standard API headers for an already-resolved credential.
+	 *
+	 * @param array{authorization:string} $credential
+	 */
+	public static function headers( array $credential ): array {
+		return array(
+			'Authorization' => $credential['authorization'],
+			'Accept'        => 'application/vnd.github.v3+json',
+			'User-Agent'    => 'DataMachineCode',
+			'Content-Type'  => 'application/json',
+		);
+	}
+
+	/**
+	 * @return array{mode:string,token:string,authorization:string,cached?:bool,expires_at?:string}|\WP_Error
+	 */
+	private static function resolveApp( ?callable $http_request, ?int $now ): array|\WP_Error {
+		$now             = $now ?? time();
+		$app_id          = self::setting( 'github_app_id' );
+		$installation_id = self::setting( 'github_app_installation_id' );
+		$private_key     = self::setting( 'github_app_private_key' );
+
+		if ( '' === $app_id ) {
+			return new \WP_Error( 'github_app_id_missing', 'GitHub App auth selected but github_app_id is not configured.', array( 'status' => 400 ) );
+		}
+		if ( '' === $installation_id ) {
+			return new \WP_Error( 'github_app_installation_id_missing', 'GitHub App auth selected but github_app_installation_id is not configured.', array( 'status' => 400 ) );
+		}
+		if ( '' === $private_key ) {
+			return new \WP_Error( 'github_app_private_key_missing', 'GitHub App auth selected but github_app_private_key is not configured.', array( 'status' => 400 ) );
+		}
+
+		$cache_key = self::cacheKey( $app_id, $installation_id );
+		$cached    = get_transient( $cache_key );
+		if ( is_array( $cached ) ) {
+			$token      = (string) ( $cached['token'] ?? '' );
+			$expires_at = (string) ( $cached['expires_at'] ?? '' );
+			$expires_ts = strtotime( $expires_at );
+			if ( '' !== $token && $expires_ts && $expires_ts > ( $now + self::APP_TOKEN_EXPIRY_SKEW ) ) {
+				return array(
+					'mode'          => 'app',
+					'token'         => $token,
+					'authorization' => 'Bearer ' . $token,
+					'cached'        => true,
+					'expires_at'    => $expires_at,
+				);
+			}
+		}
+
+		$jwt = self::mintJwt( $app_id, $private_key, $now );
+		if ( is_wp_error( $jwt ) ) {
+			return $jwt;
+		}
+
+		$http_request = $http_request ?? 'wp_remote_request';
+		$response     = $http_request(
+			'https://api.github.com/app/installations/' . rawurlencode( $installation_id ) . '/access_tokens',
+			array(
+				'method'  => 'POST',
+				'headers' => array(
+					'Authorization' => 'Bearer ' . $jwt,
+					'Accept'        => 'application/vnd.github.v3+json',
+					'User-Agent'    => 'DataMachineCode',
+					'Content-Type'  => 'application/json',
+				),
+				'timeout' => 30,
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return new \WP_Error( 'github_app_token_request_failed', 'GitHub App installation token request failed: ' . $response->get_error_message(), array( 'status' => 500 ) );
+		}
+
+		$status_code = wp_remote_retrieve_response_code( $response );
+		$body        = json_decode( wp_remote_retrieve_body( $response ), true );
+		if ( $status_code >= 400 ) {
+			$message = is_array( $body ) ? (string) ( $body['message'] ?? 'Unknown error' ) : 'Unknown error';
+			return new \WP_Error( 'github_app_token_exchange_failed', sprintf( 'GitHub App installation token exchange failed (%d): %s', $status_code, $message ), array( 'status' => $status_code ) );
+		}
+
+		$token      = is_array( $body ) ? (string) ( $body['token'] ?? '' ) : '';
+		$expires_at = is_array( $body ) ? (string) ( $body['expires_at'] ?? '' ) : '';
+		$expires_ts = strtotime( $expires_at );
+		if ( '' === $token || ! $expires_ts ) {
+			return new \WP_Error( 'github_app_token_exchange_invalid', 'GitHub App installation token exchange response did not include a token and expires_at.', array( 'status' => 502 ) );
+		}
+
+		$ttl = max( 1, $expires_ts - $now );
+		set_transient(
+			$cache_key,
+			array(
+				'token'      => $token,
+				'expires_at' => $expires_at,
+			),
+			$ttl
+		);
+
+		return array(
+			'mode'          => 'app',
+			'token'         => $token,
+			'authorization' => 'Bearer ' . $token,
+			'cached'        => false,
+			'expires_at'    => $expires_at,
+		);
+	}
+
+	private static function setting( string $key, string $default = '' ): string {
+		return trim( (string) PluginSettings::get( $key, $default ) );
+	}
+
+	private static function cacheKey( string $app_id, string $installation_id ): string {
+		return self::APP_TOKEN_CACHE_PREFIX . md5( $app_id . ':' . $installation_id );
+	}
+
+	private static function normalizePrivateKey( string $private_key ): string {
+		return str_replace( '\\n', "\n", trim( $private_key ) );
+	}
+
+	private static function base64UrlEncode( string $value ): string {
+		return rtrim( strtr( base64_encode( $value ), '+/', '-_' ), '=' );
+	}
+}

--- a/inc/Support/GitHubRemote.php
+++ b/inc/Support/GitHubRemote.php
@@ -5,7 +5,7 @@
  * One place for GitHub-specific URL manipulation:
  *   - "is this a GitHub remote?"
  *   - "parse owner/repo out of the URL"
- *   - "rewrite the URL with a PAT injected for authenticated push"
+ *   - shared API URL and tree helpers for authenticated GitHub operations
  *
  * Shared by GitSync (push + submit) and Workspace (merge-signal lookup)
  * so the regex + host-detection logic has a single source of truth.

--- a/tests/smoke-github-app-auth.php
+++ b/tests/smoke-github-app-auth.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * Pure-PHP smoke test for GitHub App auth resolution.
+ *
+ * Run: php tests/smoke-github-app-auth.php
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Core {
+	class PluginSettings {
+		public static function get( string $key, string $default = '' ): string {
+			return $GLOBALS['dmc_settings'][ $key ] ?? $default;
+		}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	class WP_Error {
+		private string $code;
+		private string $message;
+		private array $data;
+
+		public function __construct( string $code, string $message, array $data = array() ) {
+			$this->code    = $code;
+			$this->message = $message;
+			$this->data    = $data;
+		}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+
+		public function get_error_data(): array {
+			return $this->data;
+		}
+	}
+
+	function is_wp_error( $value ): bool {
+		return $value instanceof WP_Error;
+	}
+
+	function wp_json_encode( $value, $flags = 0, $depth = 512 ) {
+		return json_encode( $value, $flags, $depth );
+	}
+
+	function get_transient( string $key ) {
+		return $GLOBALS['dmc_transients'][ $key ] ?? false;
+	}
+
+	function set_transient( string $key, $value, int $expiration ): bool {
+		$GLOBALS['dmc_transients'][ $key ] = $value;
+		$GLOBALS['dmc_transient_ttls'][ $key ] = $expiration;
+		return true;
+	}
+
+	function wp_remote_retrieve_response_code( $response ): int {
+		return (int) ( $response['response']['code'] ?? 0 );
+	}
+
+	function wp_remote_retrieve_body( $response ): string {
+		return (string) ( $response['body'] ?? '' );
+	}
+
+	require __DIR__ . '/../inc/Support/GitHubCredentialResolver.php';
+	require __DIR__ . '/../inc/Abilities/GitHubAbilities.php';
+
+	use DataMachineCode\Abilities\GitHubAbilities;
+	use DataMachineCode\Support\GitHubCredentialResolver;
+
+	$failures = array();
+	$assert   = function ( string $label, bool $cond ) use ( &$failures ): void {
+		if ( $cond ) {
+			echo "  ok {$label}\n";
+			return;
+		}
+
+		$failures[] = $label;
+		echo "  fail {$label}\n";
+	};
+
+	$reset = function ( array $settings = array() ): void {
+		$GLOBALS['dmc_settings']       = $settings;
+		$GLOBALS['dmc_transients']     = array();
+		$GLOBALS['dmc_transient_ttls'] = array();
+	};
+
+	$key_resource = openssl_pkey_new( array(
+		'private_key_bits' => 2048,
+		'private_key_type' => OPENSSL_KEYTYPE_RSA,
+	) );
+	openssl_pkey_export( $key_resource, $private_key );
+	$escaped_private_key = str_replace( "\n", '\\n', $private_key );
+
+	echo "GitHub App auth — smoke\n";
+
+	$reset( array( 'github_pat' => 'pat-token' ) );
+	$pat_credential = GitHubCredentialResolver::resolve();
+	$assert( 'PAT mode resolves configured PAT', ! is_wp_error( $pat_credential ) && 'pat-token' === $pat_credential['token'] );
+	$assert( 'PAT mode keeps legacy token authorization scheme', ! is_wp_error( $pat_credential ) && 'token pat-token' === $pat_credential['authorization'] );
+	$assert( 'PAT status defaults mode to pat', 'pat' === GitHubCredentialResolver::status()['mode'] );
+
+	$reset( array( 'github_auth_mode' => 'app' ) );
+	$missing = GitHubCredentialResolver::resolve();
+	$assert( 'app mode reports missing app id', is_wp_error( $missing ) && 'github_app_id_missing' === $missing->get_error_code() );
+
+	$jwt = GitHubCredentialResolver::mintJwt( '12345', $private_key, 1700000000 );
+	$assert( 'JWT mint succeeds with valid private key', ! is_wp_error( $jwt ) && 3 === count( explode( '.', $jwt ) ) );
+	if ( ! is_wp_error( $jwt ) ) {
+		$parts   = explode( '.', $jwt );
+		$payload = json_decode( base64_decode( strtr( $parts[1], '-_', '+/' ) ), true );
+		$assert( 'JWT payload carries app id issuer', '12345' === (string) ( $payload['iss'] ?? '' ) );
+		$assert( 'JWT expires within GitHub max window', 1700000540 === (int) ( $payload['exp'] ?? 0 ) );
+	}
+
+	$invalid = GitHubCredentialResolver::mintJwt( '12345', 'not a key', 1700000000 );
+	$assert( 'invalid private key returns actionable error', is_wp_error( $invalid ) && 'github_app_private_key_invalid' === $invalid->get_error_code() );
+
+	$settings = array(
+		'github_auth_mode'                => 'app',
+		'github_app_id'                   => '12345',
+		'github_app_installation_id'      => '67890',
+		'github_app_private_key'          => $escaped_private_key,
+	);
+	$reset( $settings );
+	$requests = array();
+	$fake_http = function ( string $url, array $args ) use ( &$requests ): array {
+		$requests[] = array( $url, $args );
+		return array(
+			'response' => array( 'code' => 201 ),
+			'body'     => json_encode( array(
+				'token'      => 'installation-token-' . count( $requests ),
+				'expires_at' => gmdate( 'c', 1700003600 ),
+			) ),
+		);
+	};
+
+	$app_credential = GitHubCredentialResolver::resolve( $fake_http, 1700000000 );
+	$assert( 'app mode exchanges JWT for installation token', ! is_wp_error( $app_credential ) && 'installation-token-1' === $app_credential['token'] );
+	$assert( 'app mode uses bearer authorization for API calls', ! is_wp_error( $app_credential ) && 'Bearer installation-token-1' === $app_credential['authorization'] );
+	$assert( 'token exchange hits installation access-token endpoint', false !== strpos( $requests[0][0] ?? '', '/app/installations/67890/access_tokens' ) );
+	$assert( 'token exchange authenticates with app JWT bearer', str_starts_with( $requests[0][1]['headers']['Authorization'] ?? '', 'Bearer ' ) );
+	$assert( 'installation token is cached', 1 === count( $GLOBALS['dmc_transients'] ) );
+	$assert( 'cache ttl follows expires_at', 3600 === array_values( $GLOBALS['dmc_transient_ttls'] )[0] );
+
+	$cached_credential = GitHubCredentialResolver::resolve( $fake_http, 1700000100 );
+	$assert( 'cached token is reused before early-expiry window', ! is_wp_error( $cached_credential ) && ! empty( $cached_credential['cached'] ) && 'installation-token-1' === $cached_credential['token'] );
+	$assert( 'cached token avoids second HTTP request', 1 === count( $requests ) );
+
+	$cache_key = array_key_first( $GLOBALS['dmc_transients'] );
+	$GLOBALS['dmc_transients'][ $cache_key ]['expires_at'] = gmdate( 'c', 1700000150 );
+	$refreshed = GitHubCredentialResolver::resolve( $fake_http, 1700000100 );
+	$assert( 'token refreshes inside early-expiry window', ! is_wp_error( $refreshed ) && empty( $refreshed['cached'] ) && 'installation-token-2' === $refreshed['token'] );
+	$assert( 'early-expiry refresh makes second HTTP request', 2 === count( $requests ) );
+
+	$headers = GitHubCredentialResolver::headers( $refreshed );
+	$assert( 'resolver headers select bearer token for app credential', 'Bearer installation-token-2' === $headers['Authorization'] );
+
+	$reset( $settings );
+	$exchange_failure = GitHubCredentialResolver::resolve(
+		fn(): array => array(
+			'response' => array( 'code' => 403 ),
+			'body'     => json_encode( array( 'message' => 'Resource not accessible by integration' ) ),
+		),
+		1700000000
+	);
+	$assert( 'token exchange failure keeps GitHub message', is_wp_error( $exchange_failure ) && str_contains( $exchange_failure->get_error_message(), 'Resource not accessible by integration' ) );
+
+	$reset( $settings );
+	$ability_now = time();
+	$fake_http_for_ability = function () use ( $ability_now ): array {
+		return array(
+			'response' => array( 'code' => 201 ),
+			'body'     => json_encode( array(
+				'token'      => 'ability-installation-token',
+				'expires_at' => gmdate( 'c', $ability_now + 3600 ),
+			) ),
+		);
+	};
+	GitHubCredentialResolver::resolve( $fake_http_for_ability, $ability_now );
+	$ability_token = GitHubAbilities::getPat();
+	$assert( 'GitHubAbilities getPat resolves active app token for existing callers', 'ability-installation-token' === $ability_token );
+	$assert( 'GitHubAbilities reports app mode configured without printing secrets', GitHubAbilities::isConfigured() && GitHubAbilities::getAuthStatus()['app_private_key_configured'] );
+
+	if ( $failures ) {
+		echo "\nFailures:\n";
+		foreach ( $failures as $failure ) {
+			echo " - {$failure}\n";
+		}
+		exit( 1 );
+	}
+
+	echo "All assertions passed.\n";
+}


### PR DESCRIPTION
## Summary
- Add first-class GitHub App authentication alongside the existing PAT path.
- Keep PAT mode unchanged while resolving app installation tokens behind the existing GitHub API call surface.
- Surface non-secret auth mode/configuration details in `wp datamachine-code github status`.

## Changes
- Adds `GitHubCredentialResolver` for `github_auth_mode=pat|app`, app JWT minting, installation-token exchange, and early-expiry transient caching.
- Uses app installation tokens for existing GitHub API callers without changing the PAT-mode authorization scheme.
- Updates GitSync/auth status messages to refer to generic GitHub auth instead of PAT-only configuration.
- Includes current review-bot permission guidance: Contents, Issues, Pull requests, Checks, Commit statuses, and Actions for workflow artifacts.

## Tests
- `php tests/smoke-github-app-auth.php`
- `php tests/smoke-github-readonly-tools.php`
- `php tests/smoke-github-pr-review-comment-upsert.php`
- `php tests/smoke-github-pr-comment-tool.php`
- `php tests/smoke-github-pr-review-context.php`
- `php tests/smoke-github-check-status-context.php`
- `php tests/smoke-github-pr-review-flow-scaffold.php`
- `php tests/smoke-gitsync.php`

Closes #94

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the GitHub App credential resolver, status output updates, and focused smoke coverage; Chris remains responsible for review and merge.