### PR TITLE
feat(github): install PR review flows

### DIFF
--- a/inc/Cli/Commands/GitHubCommand.php
+++ b/inc/Cli/Commands/GitHubCommand.php
@@ -14,6 +14,7 @@ namespace DataMachineCode\Cli\Commands;
 use WP_CLI;
 use DataMachine\Cli\BaseCommand;
 use DataMachineCode\Abilities\GitHubAbilities;
+use DataMachineCode\GitHub\PrReviewFlowInstaller;
 use DataMachineCode\GitHub\PrReviewFlowScaffold;
 
 defined( 'ABSPATH' ) || exit;
@@ -528,12 +529,12 @@ class GitHubCommand extends BaseCommand {
 	}
 
 	/**
-	 * Scaffold a GitHub PR review flow definition.
+	 * Scaffold or install a GitHub PR review flow definition.
 	 *
 	 * ## OPTIONS
 	 *
 	 * <action>
-	 * : Scaffold action. Currently supports: create.
+	 * : Review-flow action. Supports: create, install.
 	 *
 	 * [--repo=<repo>]
 	 * : Repository in owner/repo format. Falls back to default repo in settings.
@@ -563,6 +564,30 @@ class GitHubCommand extends BaseCommand {
 	 * default: opened,reopened,synchronize,ready_for_review
 	 * ---
 	 *
+	 * [--mode=<mode>]
+	 * : create action mode. `scaffold` preserves the historical JSON-only output; `install` creates the Data Machine pipeline/flow.
+	 * ---
+	 * default: scaffold
+	 * options:
+	 *   - scaffold
+	 *   - install
+	 * ---
+	 *
+	 * [--secret-id=<id>]
+	 * : Webhook secret roster id used when installing. A secret is generated unless --secret is supplied.
+	 * ---
+	 * default: github_webhook
+	 * ---
+	 *
+	 * [--secret=<secret>]
+	 * : Explicit webhook secret. Prefer the generated secret to avoid putting secrets in shell history.
+	 *
+	 * [--allow-drafts]
+	 * : Allow draft pull_request events through the GitHub verifier.
+	 *
+	 * [--force]
+	 * : Install even when an existing DMC PR review flow marker exists for the repo.
+	 *
 	 * [--format=<format>]
 	 * : Output format.
 	 * ---
@@ -579,12 +604,17 @@ class GitHubCommand extends BaseCommand {
 	 *       --name="DMC PR review" \
 	 *       --comment-mode=managed
 	 *
+	 *     wp datamachine-code github review-flow install \
+	 *       --repo=Extra-Chill/data-machine-code \
+	 *       --agent=code-reviewer \
+	 *       --secret-id=github_pr_review
+	 *
 	 * @subcommand review-flow
 	 */
 	public function review_flow( array $args, array $assoc_args ): void {
 		$action = $args[0] ?? '';
-		if ( 'create' !== $action ) {
-			WP_CLI::error( 'Usage: wp datamachine-code github review-flow create [--repo=<owner/repo>] [--agent=<agent>] [--name=<name>] [--comment-mode=<managed|append|dry_run>] [--actions=<csv>]' );
+		if ( ! in_array( $action, array( 'create', 'install' ), true ) ) {
+			WP_CLI::error( 'Usage: wp datamachine-code github review-flow <create|install> [--repo=<owner/repo>] [--agent=<agent>] [--name=<name>] [--comment-mode=<managed|append|dry_run>] [--actions=<csv>]' );
 			return;
 		}
 
@@ -594,13 +624,36 @@ class GitHubCommand extends BaseCommand {
 			return;
 		}
 
-		$definition = PrReviewFlowScaffold::build( array(
+		$options = array(
 			'repo'         => $repo,
 			'agent'        => $assoc_args['agent'] ?? '',
 			'name'         => $assoc_args['name'] ?? 'GitHub PR review',
 			'comment_mode' => $assoc_args['comment-mode'] ?? 'managed',
 			'actions'      => $assoc_args['actions'] ?? PrReviewFlowScaffold::DEFAULT_ACTIONS,
-		) );
+			'secret_id'    => $assoc_args['secret-id'] ?? 'github_webhook',
+			'secret'       => $assoc_args['secret'] ?? '',
+			'allow_drafts' => ! empty( $assoc_args['allow-drafts'] ),
+			'force'        => ! empty( $assoc_args['force'] ),
+		);
+
+		$mode = 'install' === $action ? 'install' : (string) ( $assoc_args['mode'] ?? 'scaffold' );
+		if ( ! in_array( $mode, array( 'scaffold', 'install' ), true ) ) {
+			WP_CLI::error( 'Invalid --mode. Expected scaffold or install.' );
+			return;
+		}
+
+		if ( 'install' === $mode ) {
+			$installed = PrReviewFlowInstaller::install( $options );
+			if ( is_wp_error( $installed ) ) {
+				WP_CLI::error( $installed->get_error_message() );
+				return;
+			}
+
+			WP_CLI::line( wp_json_encode( $installed, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		$definition = PrReviewFlowScaffold::build( $options );
 
 		WP_CLI::line( wp_json_encode( $definition, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
 	}

--- a/inc/GitHub/PrReviewFlowInstaller.php
+++ b/inc/GitHub/PrReviewFlowInstaller.php
@@ -1,0 +1,229 @@
+<?php
+/**
+ * GitHub PR review flow installer.
+ *
+ * @package DataMachineCode\GitHub
+ */
+
+namespace DataMachineCode\GitHub;
+
+use DataMachineCode\Support\GitHubWebhookValidator;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Installs repo-scoped PR review flows through Data Machine public abilities.
+ */
+class PrReviewFlowInstaller {
+
+	const SCHEDULING_MARKER_KEY = 'data_machine_code_github_pr_review';
+
+	/**
+	 * Install a repo-specific PR review pipeline + flow.
+	 *
+	 * @param array<string,mixed> $args Installer options.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public static function install( array $args ): array|\WP_Error {
+		$definition = PrReviewFlowScaffold::build( $args );
+		$repo       = (string) ( $definition['repo'] ?? '' );
+		if ( '' === $repo ) {
+			return new \WP_Error( 'missing_repo', 'Repository is required.' );
+		}
+
+		$force = ! empty( $args['force'] );
+		if ( ! $force ) {
+			$existing = self::findExistingInstall( $repo );
+			if ( $existing ) {
+				return new \WP_Error(
+					'github_pr_review_flow_exists',
+					sprintf( 'A GitHub PR review flow already exists for %s (flow_id=%d). Pass --force to create another one.', $repo, (int) $existing['flow_id'] ),
+					array( 'existing' => $existing )
+				);
+			}
+		}
+
+		$agent_id = self::resolveAgentId( (string) ( $args['agent'] ?? '' ) );
+		if ( is_wp_error( $agent_id ) ) {
+			return $agent_id;
+		}
+
+		$create_pipeline = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'datamachine/create-pipeline' ) : null;
+		if ( ! $create_pipeline ) {
+			return new \WP_Error( 'create_pipeline_missing', 'Data Machine create-pipeline ability is not available. Ensure Data Machine 0.86.0 or newer is active.' );
+		}
+
+		$actions = $definition['webhook']['actions'] ?? GitHubWebhookValidator::DEFAULT_ALLOWED_ACTIONS;
+		$name    = (string) ( $definition['name'] ?? 'GitHub PR review' );
+
+		$create_input = array(
+			'pipeline_name' => $name,
+			'workflow'      => $definition['workflow'] ?? array(),
+			'flow_config'   => array(
+				'flow_name'         => $name,
+				'scheduling_config' => self::buildSchedulingConfig( $repo, $actions, $definition ),
+			),
+		);
+
+		if ( null !== $agent_id ) {
+			$create_input['agent_id'] = $agent_id;
+		}
+
+		$created = $create_pipeline->execute( $create_input );
+		if ( empty( $created['success'] ) || empty( $created['flow_id'] ) ) {
+			return new \WP_Error( 'create_pipeline_failed', (string) ( $created['error'] ?? 'Failed to create Data Machine pipeline/flow.' ), $created );
+		}
+
+		$webhook = self::enableWebhook( (int) $created['flow_id'], $repo, $actions, $args );
+		if ( is_wp_error( $webhook ) ) {
+			return $webhook;
+		}
+
+		return array(
+			'success'         => true,
+			'status'          => 'installed',
+			'repo'            => $repo,
+			'pipeline_id'     => (int) $created['pipeline_id'],
+			'pipeline_name'   => (string) $created['pipeline_name'],
+			'flow_id'         => (int) $created['flow_id'],
+			'flow_name'       => (string) $created['flow_name'],
+			'flow_step_ids'   => $created['flow_step_ids'] ?? array(),
+			'webhook_url'     => (string) ( $webhook['webhook_url'] ?? '' ),
+			'webhook_event'   => 'pull_request',
+			'webhook_actions' => array_values( (array) $actions ),
+			'webhook_auth'    => array(
+				'mode'         => 'github_pull_request',
+				'secret_ids'   => $webhook['secret_ids'] ?? array(),
+				'secret'       => $webhook['secret'] ?? null,
+				'instructions' => 'Configure the GitHub repository webhook for pull_request events, use the webhook_url, and set the secret shown here or stored under the listed secret id.',
+			),
+			'scaffold_schema' => (string) ( $definition['schema'] ?? '' ),
+		);
+	}
+
+	/**
+	 * @param array<int,string> $actions
+	 * @param array<string,mixed> $definition
+	 * @return array<string,mixed>
+	 */
+	private static function buildSchedulingConfig( string $repo, array $actions, array $definition ): array {
+		$config = array(
+			'interval'        => 'manual',
+			'webhook_event'   => 'pull_request',
+			'webhook_actions' => array_values( $actions ),
+		);
+
+		$config[ self::SCHEDULING_MARKER_KEY ] = array(
+			'schema' => (string) ( $definition['schema'] ?? '' ),
+			'repo'   => $repo,
+		);
+
+		return $config;
+	}
+
+	/**
+	 * @param array<int,string> $actions
+	 * @param array<string,mixed> $args
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private static function enableWebhook( int $flow_id, string $repo, array $actions, array $args ): array|\WP_Error {
+		$enable_webhook = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'datamachine/webhook-trigger-enable' ) : null;
+		if ( ! $enable_webhook ) {
+			return new \WP_Error( 'webhook_enable_missing', 'Data Machine webhook-trigger-enable ability is not available.' );
+		}
+
+		$secret = isset( $args['secret'] ) ? (string) $args['secret'] : '';
+		$input  = array(
+			'flow_id'         => $flow_id,
+			'auth_mode'       => 'hmac',
+			'template'        => GitHubWebhookValidator::buildVerifierConfig(
+				'',
+				array(
+					'repo'            => $repo,
+					'allowed_repos'   => array( $repo ),
+					'allowed_actions' => array_values( $actions ),
+					'allow_drafts'    => ! empty( $args['allow_drafts'] ),
+				)
+			),
+			'secret_id'       => self::sanitizeSecretId( (string) ( $args['secret_id'] ?? 'github_webhook' ) ),
+			'generate_secret' => '' === $secret,
+		);
+
+		// WebhookTriggerAbility owns the secret roster; the template only carries policy.
+		unset( $input['template']['secrets'] );
+		if ( '' !== $secret ) {
+			$input['secret'] = $secret;
+		}
+
+		$result = $enable_webhook->execute( $input );
+		if ( empty( $result['success'] ) ) {
+			return new \WP_Error( 'webhook_enable_failed', (string) ( $result['error'] ?? 'Failed to enable webhook trigger.' ), $result );
+		}
+
+		return $result;
+	}
+
+	private static function sanitizeSecretId( string $secret_id ): string {
+		$secret_id = function_exists( 'sanitize_key' ) ? sanitize_key( $secret_id ) : strtolower( preg_replace( '/[^a-z0-9_\-]/i', '', $secret_id ) );
+		return '' !== $secret_id ? $secret_id : 'github_webhook';
+	}
+
+	/**
+	 * @return int|null|\WP_Error
+	 */
+	private static function resolveAgentId( string $agent ): int|null|\WP_Error {
+		$agent = trim( $agent );
+		if ( '' === $agent ) {
+			return null;
+		}
+
+		if ( ctype_digit( $agent ) ) {
+			return (int) $agent;
+		}
+
+		if ( ! class_exists( '\\DataMachine\\Core\\Database\\Agents\\Agents' ) ) {
+			return new \WP_Error( 'agent_repository_missing', 'Data Machine agent repository is not available; pass a numeric --agent ID or omit --agent.' );
+		}
+
+		$slug = function_exists( 'sanitize_title' ) ? sanitize_title( $agent ) : strtolower( preg_replace( '/[^a-z0-9_\-]/i', '-', $agent ) );
+		$repo = new \DataMachine\Core\Database\Agents\Agents();
+		$row  = $repo->get_by_slug( $slug );
+		if ( ! $row ) {
+			return new \WP_Error( 'agent_not_found', sprintf( 'Agent "%s" was not found.', $agent ) );
+		}
+
+		return (int) $row['agent_id'];
+	}
+
+	/**
+	 * @return array<string,mixed>|null
+	 */
+	private static function findExistingInstall( string $repo ): ?array {
+		if ( ! class_exists( '\\DataMachine\\Core\\Database\\Flows\\Flows' ) ) {
+			return null;
+		}
+
+		$flows_repo = new \DataMachine\Core\Database\Flows\Flows();
+		$offset     = 0;
+		$per_page   = 100;
+		$flow_count = 0;
+		do {
+			$flows      = $flows_repo->get_all_flows_summary( $per_page, $offset );
+			$flow_count = count( $flows );
+			foreach ( $flows as $flow ) {
+				$config = is_array( $flow['scheduling_config'] ?? null ) ? $flow['scheduling_config'] : array();
+				$marker = is_array( $config[ self::SCHEDULING_MARKER_KEY ] ?? null ) ? $config[ self::SCHEDULING_MARKER_KEY ] : array();
+				if ( strtolower( $repo ) === strtolower( (string) ( $marker['repo'] ?? '' ) ) ) {
+					return array(
+						'flow_id'     => (int) $flow['flow_id'],
+						'flow_name'   => (string) $flow['flow_name'],
+						'pipeline_id' => (int) $flow['pipeline_id'],
+					);
+				}
+			}
+			$offset += $per_page;
+		} while ( $flow_count === $per_page );
+
+		return null;
+	}
+}

--- a/tests/smoke-github-pr-review-flow-installer.php
+++ b/tests/smoke-github-pr-review-flow-installer.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Pure-PHP smoke for installing GitHub PR review flows from the scaffold.
+ *
+ * Run: php tests/smoke-github-pr-review-flow-installer.php
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Core\Database\Flows {
+	class Flows {
+		public static array $summary_rows = array();
+
+		public function get_all_flows_summary( int $per_page = 20, int $offset = 0, ?int $user_id = null, ?int $agent_id = null ): array {
+			unset( $per_page, $user_id, $agent_id );
+			return array_slice( self::$summary_rows, $offset );
+		}
+	}
+}
+
+namespace DataMachine\Core\Database\Agents {
+	class Agents {
+		public function get_by_slug( string $agent_slug ): ?array {
+			return 'code-reviewer' === $agent_slug ? array( 'agent_id' => 42, 'agent_slug' => $agent_slug ) : null;
+		}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	class WP_Error {
+		public function __construct( private string $code = '', private string $message = '', private array $data = array() ) {}
+		public function get_error_code(): string { return $this->code; }
+		public function get_error_message(): string { return $this->message; }
+		public function get_error_data(): array { return $this->data; }
+	}
+
+	function is_wp_error( $value ): bool { return $value instanceof WP_Error; }
+	function sanitize_key( $value ): string { return strtolower( preg_replace( '/[^a-z0-9_\-]/i', '', (string) $value ) ); }
+	function sanitize_title( $value ): string { return strtolower( preg_replace( '/[^a-z0-9_\-]/i', '-', trim( (string) $value ) ) ); }
+	function sanitize_text_field( $value ): string { return trim( (string) $value ); }
+	function wp_json_encode( $value, int $flags = 0 ) { return json_encode( $value, $flags ); }
+
+	class TestCreatePipelineAbility {
+		public array $last_input = array();
+		public function execute( array $input ): array {
+			$this->last_input = $input;
+			return array(
+				'success'       => true,
+				'pipeline_id'   => 88,
+				'pipeline_name' => $input['pipeline_name'],
+				'flow_id'       => 144,
+				'flow_name'     => $input['flow_config']['flow_name'],
+				'flow_step_ids' => array( 'step-a', 'step-b', 'step-c' ),
+			);
+		}
+	}
+
+	class TestWebhookEnableAbility {
+		public array $last_input = array();
+		public function execute( array $input ): array {
+			$this->last_input = $input;
+			return array(
+				'success'     => true,
+				'flow_id'     => $input['flow_id'],
+				'webhook_url' => 'https://example.test/wp-json/datamachine/v1/webhook/144',
+				'auth_mode'   => 'hmac',
+				'secret'      => 'generated-secret',
+				'secret_ids'  => array( 'github_pr_review' ),
+			);
+		}
+	}
+
+	$GLOBALS['dmc_test_create_pipeline'] = new TestCreatePipelineAbility();
+	$GLOBALS['dmc_test_webhook_enable']  = new TestWebhookEnableAbility();
+
+	function wp_get_ability( string $name ) {
+		return match ( $name ) {
+			'datamachine/create-pipeline'        => $GLOBALS['dmc_test_create_pipeline'],
+			'datamachine/webhook-trigger-enable' => $GLOBALS['dmc_test_webhook_enable'],
+			default                              => null,
+		};
+	}
+
+	require __DIR__ . '/../inc/Support/GitHubWebhookValidator.php';
+	require __DIR__ . '/../inc/GitHub/PrReviewFlowScaffold.php';
+	require __DIR__ . '/../inc/GitHub/PrReviewFlowInstaller.php';
+
+	use DataMachine\Core\Database\Flows\Flows;
+	use DataMachineCode\GitHub\PrReviewFlowInstaller;
+
+	$failures = 0;
+	$total    = 0;
+	$assert   = function ( bool $condition, string $message ) use ( &$failures, &$total ): void {
+		++$total;
+		if ( $condition ) {
+			echo "  ok {$message}\n";
+			return;
+		}
+		++$failures;
+		echo "  fail {$message}\n";
+	};
+
+	echo "GitHub PR review flow installer - smoke\n";
+
+	Flows::$summary_rows = array();
+	$result = PrReviewFlowInstaller::install( array(
+		'repo'      => 'Extra-Chill/data-machine-code',
+		'agent'     => 'code-reviewer',
+		'name'      => 'DMC PR review',
+		'actions'   => 'opened,synchronize',
+		'secret_id' => 'github_pr_review',
+	) );
+
+	$create_input  = $GLOBALS['dmc_test_create_pipeline']->last_input;
+	$webhook_input = $GLOBALS['dmc_test_webhook_enable']->last_input;
+
+	$assert( ! is_wp_error( $result ), 'installer succeeds through public abilities' );
+	$assert( 88 === ( $result['pipeline_id'] ?? null ), 'result returns pipeline id' );
+	$assert( 144 === ( $result['flow_id'] ?? null ), 'result returns flow id' );
+	$assert( 'https://example.test/wp-json/datamachine/v1/webhook/144' === ( $result['webhook_url'] ?? '' ), 'result returns webhook URL' );
+	$assert( 'generated-secret' === ( $result['webhook_auth']['secret'] ?? '' ), 'result returns generated secret once' );
+	$assert( 42 === ( $create_input['agent_id'] ?? null ), 'agent slug resolves to agent id' );
+	$assert( 3 === count( $create_input['workflow']['steps'] ?? array() ), 'create-pipeline receives three scaffold workflow steps' );
+	$assert( 'manual' === ( $create_input['flow_config']['scheduling_config']['interval'] ?? '' ), 'flow scheduling starts manual' );
+	$assert( 'Extra-Chill/data-machine-code' === ( $create_input['flow_config']['scheduling_config']['data_machine_code_github_pr_review']['repo'] ?? '' ), 'flow scheduling carries repo marker' );
+	$assert( 144 === ( $webhook_input['flow_id'] ?? null ), 'webhook enable targets created flow' );
+	$assert( 'github_pull_request' === ( $webhook_input['template']['mode'] ?? '' ), 'webhook template uses GitHub PR verifier mode' );
+	$assert( array( 'Extra-Chill/data-machine-code' ) === ( $webhook_input['template']['allowed_repos'] ?? array() ), 'webhook verifier scopes repo allow-list' );
+	$assert( array( 'opened', 'synchronize' ) === ( $webhook_input['template']['allowed_actions'] ?? array() ), 'webhook verifier scopes allowed actions' );
+	$assert( ! isset( $webhook_input['template']['secrets'] ), 'template does not carry raw secret storage' );
+	$assert( true === ( $webhook_input['generate_secret'] ?? null ), 'installer generates secret by default' );
+	$assert( 'github_pr_review' === ( $webhook_input['secret_id'] ?? '' ), 'installer passes requested secret id' );
+
+	Flows::$summary_rows = array(
+		array(
+			'flow_id'           => 99,
+			'flow_name'         => 'Existing review',
+			'pipeline_id'       => 77,
+			'scheduling_config' => array(
+				'data_machine_code_github_pr_review' => array( 'repo' => 'extra-chill/data-machine-code' ),
+			),
+		),
+	);
+	$existing = PrReviewFlowInstaller::install( array( 'repo' => 'Extra-Chill/data-machine-code' ) );
+	$assert( is_wp_error( $existing ) && 'github_pr_review_flow_exists' === $existing->get_error_code(), 'existing repo install fails clearly' );
+
+	$forced = PrReviewFlowInstaller::install( array( 'repo' => 'Extra-Chill/data-machine-code', 'force' => true ) );
+	$assert( ! is_wp_error( $forced ), '--force bypasses existing install guard' );
+
+	$command_source = file_get_contents( __DIR__ . '/../inc/Cli/Commands/GitHubCommand.php' );
+	$assert( str_contains( $command_source, "array( 'create', 'install' )" ), 'CLI accepts install action' );
+	$assert( str_contains( $command_source, "'mode'" ), 'CLI keeps scaffold/install mode option' );
+	$assert( str_contains( $command_source, 'PrReviewFlowInstaller::install' ), 'CLI routes install mode to installer' );
+
+	echo "\nAssertions: {$total}, Failures: {$failures}\n";
+	exit( $failures > 0 ? 1 : 0 );
+}

--- a/tests/smoke-github-pr-review-flow-scaffold.php
+++ b/tests/smoke-github-pr-review-flow-scaffold.php
@@ -133,6 +133,7 @@ namespace {
 	$command_source = file_get_contents( __DIR__ . '/../inc/Cli/Commands/GitHubCommand.php' );
 	$assert( 'CLI exposes review-flow subcommand', str_contains( $command_source, '@subcommand review-flow' ) );
 	$assert( 'CLI calls scaffold builder', str_contains( $command_source, 'PrReviewFlowScaffold::build' ) );
+	$assert( 'CLI exposes review-flow installer', str_contains( $command_source, 'PrReviewFlowInstaller::install' ) );
 
 	if ( ! empty( $failures ) ) {
 		echo "\nFAIL: " . count( $failures ) . " assertion(s) failed out of {$total}\n";


### PR DESCRIPTION
## Summary
- Add an install mode for `wp datamachine-code github review-flow` that creates the Data Machine pipeline and flow from the scaffold.
- Configure GitHub pull_request webhook verification through Data Machine's public create-pipeline and webhook-trigger abilities.
- Add smoke coverage for scaffold-to-install mapping, repo-scoped verifier policy, generated webhook secrets, and existing-flow guardrails.

## Behaviour
- Existing `review-flow create` output remains scaffold-only by default.
- Operators can run `review-flow install --repo=owner/repo --agent=<agent> --secret-id=<id>` to create the repo-specific flow.
- Re-running for the same repo fails clearly unless `--force` is passed.

## Tests
- `php tests/smoke-github-pr-review-flow-installer.php`
- `php tests/smoke-github-pr-review-flow-scaffold.php`
- Broader GitHub/DMC smoke suite passed locally.
- Targeted PHPCS passed for the changed command/installer files; Homeboy's PHPStan wrapper currently errors on temp files without `.php` extension during single-file lint.

Closes #105

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the installer composition around Data Machine's public workflow/webhook abilities, added smoke coverage, and ran verification. Chris remains responsible for review and merge.