### PR TITLE
feat(github): add PR review escalation policy

### DIFF
--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -17,12 +17,17 @@ namespace DataMachineCode\Abilities;
 
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\PluginSettings;
+use DataMachineCode\GitHub\PrReviewEscalationPolicy;
 use DataMachineCode\Support\GitHubCredentialResolver;
 
 defined( 'ABSPATH' ) || exit;
 
 if ( ! class_exists( GitHubCredentialResolver::class ) ) {
 	require_once dirname( __DIR__ ) . '/Support/GitHubCredentialResolver.php';
+}
+
+if ( ! class_exists( PrReviewEscalationPolicy::class ) ) {
+	require_once dirname( __DIR__ ) . '/GitHub/PrReviewEscalationPolicy.php';
 }
 
 class GitHubAbilities {
@@ -1499,6 +1504,7 @@ class GitHubAbilities {
 
 			if ( is_wp_error( $checks ) ) {
 				$context['errors']['check_runs'] = $checks->get_error_message();
+				$context['error_codes']['check_runs'] = $checks->get_error_code();
 			} else {
 				$context['check_runs'] = array(
 					'summary' => $checks['summary'] ?? array(),
@@ -1518,6 +1524,7 @@ class GitHubAbilities {
 
 			if ( is_wp_error( $statuses ) ) {
 				$context['errors']['commit_statuses'] = $statuses->get_error_message();
+				$context['error_codes']['commit_statuses'] = $statuses->get_error_code();
 			} else {
 				$context['commit_statuses'] = array(
 					'summary' => $statuses['summary'] ?? array(),
@@ -1540,6 +1547,7 @@ class GitHubAbilities {
 
 			if ( is_wp_error( $homeboy ) ) {
 				$context['errors']['homeboy_ci_results'] = $homeboy->get_error_message();
+				$context['error_codes']['homeboy_ci_results'] = $homeboy->get_error_code();
 			} else {
 				$context['homeboy_ci_results'] = $homeboy['results'] ?? array();
 			}
@@ -2776,6 +2784,16 @@ class GitHubAbilities {
 
 		if ( isset( $options['checks'] ) && is_array( $options['checks'] ) ) {
 			$context['checks'] = $options['checks'];
+		}
+
+		if ( false !== ( $options['include_escalation_policy'] ?? true ) ) {
+			$context['escalation_policy'] = PrReviewEscalationPolicy::evaluate(
+				$repo,
+				$pull,
+				$changed_files,
+				isset( $context['checks'] ) && is_array( $context['checks'] ) ? $context['checks'] : array(),
+				isset( $options['escalation_policy'] ) && is_array( $options['escalation_policy'] ) ? $options['escalation_policy'] : array()
+			);
 		}
 
 		return array(

--- a/inc/GitHub/PrReviewEscalationPolicy.php
+++ b/inc/GitHub/PrReviewEscalationPolicy.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * GitHub PR review escalation policy.
+ *
+ * @package DataMachineCode\GitHub
+ */
+
+namespace DataMachineCode\GitHub;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Decides when a PR review needs checkout-backed validation.
+ */
+class PrReviewEscalationPolicy {
+
+	private const SCHEMA = 'data-machine-code/pr-review-escalation/v1';
+	private const VERSION = 'v1';
+
+	private const DEFAULT_MAX_FILES = 20;
+	private const DEFAULT_MAX_PATCH_BYTES = 100000;
+	private const DEFAULT_MAX_TOTAL_CHANGES = 1000;
+
+	/**
+	 * Evaluate checkout-backed validation risk signals.
+	 *
+	 * @param string $repo Repository in owner/repo format.
+	 * @param array  $pull Normalized pull request payload.
+	 * @param array  $files Normalized review-context changed files.
+	 * @param array  $checks Optional check/Homeboy context.
+	 * @param array  $options Optional thresholds.
+	 * @return array<string,mixed>
+	 */
+	public static function evaluate( string $repo, array $pull, array $files, array $checks = array(), array $options = array() ): array {
+		$head_sha = (string) ( $pull['head_sha'] ?? '' );
+		$reasons  = array();
+		$metrics  = array(
+			'file_count'     => count( $files ),
+			'patch_bytes'    => 0,
+			'total_changes'  => 0,
+			'touched_groups' => array(),
+		);
+
+		$thresholds = array(
+			'max_files'         => max( 1, (int) ( $options['max_files'] ?? self::DEFAULT_MAX_FILES ) ),
+			'max_patch_bytes'   => max( 1, (int) ( $options['max_patch_bytes'] ?? self::DEFAULT_MAX_PATCH_BYTES ) ),
+			'max_total_changes' => max( 1, (int) ( $options['max_total_changes'] ?? self::DEFAULT_MAX_TOTAL_CHANGES ) ),
+		);
+
+		foreach ( $files as $file ) {
+			$path = (string) ( $file['filename'] ?? '' );
+			if ( '' === $path ) {
+				continue;
+			}
+
+			$metrics['patch_bytes']   += (int) ( $file['patch_bytes'] ?? strlen( (string) ( $file['patch'] ?? '' ) ) );
+			$metrics['total_changes'] += (int) ( $file['changes'] ?? 0 );
+
+			foreach ( self::classifyPath( $path ) as $group => $reason ) {
+				$metrics['touched_groups'][ $group ] = true;
+				$reasons[] = $reason;
+			}
+		}
+
+		if ( $metrics['file_count'] > $thresholds['max_files'] ) {
+			$reasons[] = 'file_count_threshold';
+		}
+
+		if ( $metrics['patch_bytes'] > $thresholds['max_patch_bytes'] ) {
+			$reasons[] = 'patch_size_threshold';
+		}
+
+		if ( $metrics['total_changes'] > $thresholds['max_total_changes'] ) {
+			$reasons[] = 'change_count_threshold';
+		}
+
+		$reasons = array_merge( $reasons, self::checkReasons( $checks, $head_sha ) );
+		$reasons = array_values( array_unique( array_filter( $reasons ) ) );
+
+		$metrics['touched_groups'] = array_keys( $metrics['touched_groups'] );
+
+		return array(
+			'schema'                  => self::SCHEMA,
+			'should_escalate'         => ! empty( $reasons ),
+			'reasons'                 => $reasons,
+			'policy_version'          => self::VERSION,
+			'action_recommendation'   => ! empty( $reasons ) ? 'run_checkout_backed_validation_when_available' : 'github_context_only_review_is_sufficient',
+			'execution_result_source' => ! empty( $reasons ) ? 'not_run_issue_111_pending' : 'not_required',
+			'thresholds'              => $thresholds,
+			'metrics'                 => $metrics,
+			'repo'                    => $repo,
+			'head_sha'                => $head_sha,
+		);
+	}
+
+	/**
+	 * Classify a changed path into risk buckets.
+	 *
+	 * @return array<string,string> Map of bucket => reason.
+	 */
+	private static function classifyPath( string $path ): array {
+		$path_lower = strtolower( $path );
+		$groups     = array();
+
+		if (
+			preg_match( '#(^|/)(auth|permissions?|secrets?|tokens?|webhooks?)(/|[-_.]|$)#', $path_lower )
+			|| preg_match( '#(credential|hmac|oauth|jwt|permission|capabilit|secret|token|webhook)#', $path_lower )
+		) {
+			$groups['webhook_auth'] = 'touches_webhook_auth';
+		}
+
+		if (
+			preg_match( '#(^|/)(migrations?|schema|jobs?|queues?|action-scheduler|actionscheduler)(/|[-_.]|$)#', $path_lower )
+			|| preg_match( '#(migration|schema|job|queue|action_scheduler|actionscheduler)#', $path_lower )
+		) {
+			$groups['migration_jobs_queue'] = 'touches_migrations_jobs_queues';
+		}
+
+		if (
+			preg_match( '#(^|/)(inc/abilities|inc/tools|inc/cli|inc/rest|rest|cli|abilities?|tools?)(/|[-_.]|$)#', $path_lower )
+		) {
+			$groups['public_api'] = 'touches_public_api_surface';
+		}
+
+		if (
+			preg_match( '#(^|/)(readme|docs?|documentation|examples?|assets|templates?)(/|[-_.]|$)#', $path_lower )
+			|| preg_match( '#\.(md|mdx|txt|rst)$#', $path_lower )
+		) {
+			$groups['docs_user_facing'] = 'touches_docs_user_facing_content';
+		}
+
+		return $groups;
+	}
+
+	/**
+	 * Convert check/Homeboy context into escalation reasons.
+	 *
+	 * @return string[]
+	 */
+	private static function checkReasons( array $checks, string $head_sha ): array {
+		$reasons = array();
+
+		$homeboy = $checks['homeboy_ci_results'] ?? null;
+		if ( is_array( $homeboy ) && ! empty( $homeboy ) ) {
+			$artifact_sha = (string) ( $homeboy['workflow']['head_sha'] ?? $homeboy['head_sha'] ?? '' );
+			if ( '' !== $head_sha && '' !== $artifact_sha && $head_sha !== $artifact_sha ) {
+				$reasons[] = 'stale_homeboy_artifact';
+			}
+		} else {
+			$homeboy_error = (string) ( $checks['error_codes']['homeboy_ci_results'] ?? '' );
+			$reasons[]     = str_contains( $homeboy_error, 'expired' ) || str_contains( $homeboy_error, 'stale' ) ? 'stale_homeboy_artifact' : 'missing_homeboy_artifact';
+		}
+
+		foreach ( array( 'check_runs', 'commit_statuses' ) as $key ) {
+			$state = (string) ( $checks[ $key ]['summary']['state'] ?? '' );
+			if ( in_array( $state, array( 'failure', 'pending', 'cancelled' ), true ) ) {
+				$reasons[] = 'failing_or_unknown_checks';
+			}
+		}
+
+		if ( isset( $checks['errors']['check_runs'] ) || isset( $checks['errors']['commit_statuses'] ) ) {
+			$reasons[] = 'failing_or_unknown_checks';
+		}
+
+		return $reasons;
+	}
+}

--- a/inc/GitHub/PrReviewFlowScaffold.php
+++ b/inc/GitHub/PrReviewFlowScaffold.php
@@ -95,6 +95,7 @@ class PrReviewFlowScaffold {
 			'You are reviewing a GitHub pull request. Return findings first, ordered by severity.',
 			'Read the initial pull_review_context packet first, then identify what you still need to know before reviewing.',
 			'Use read-only GitHub tools on demand to inspect specific PR metadata, changed files, base/head file contents, neighboring files, dependency files, or repository tree paths that are necessary to verify a finding.',
+			'Read escalation_policy from the pull_review_context packet. Treat should_escalate=true as a deterministic recommendation for checkout-backed validation; if no checkout execution result is present yet, say that deeper validation is recommended instead of pretending it ran.',
 			'Keep context gathering bounded: fetch only targeted paths, avoid broad repository scans, and stop when you have enough evidence for or against high-confidence findings.',
 			'Only report high-confidence bugs, security risks, behavioral regressions, or missing tests that directly matter for this PR.',
 			'Do not praise the change, summarize obvious edits, or leave generic style feedback.',
@@ -160,9 +161,15 @@ class PrReviewFlowScaffold {
 				'include_checks'          => true,
 				'include_statuses'        => true,
 				'include_homeboy_ci'      => true,
+				'include_escalation_policy' => true,
 				'max_check_runs'          => 30,
 				'include_check_output'    => false,
 				'artifact_name'           => 'homeboy-ci-results',
+				'escalation_policy'       => array(
+					'max_files'         => 20,
+					'max_patch_bytes'   => 100000,
+					'max_total_changes' => 1000,
+				),
 			),
 		);
 	}

--- a/tests/smoke-github-pr-review-context.php
+++ b/tests/smoke-github-pr-review-context.php
@@ -149,6 +149,10 @@ namespace {
 	$assert( 40 === $content['truncation']['max_patch_chars'], 'truncation records configured limit' );
 	$assert( 1 === $content['truncation']['truncated_files'], 'truncation counts omitted patches' );
 	$assert( true === $content['truncation']['truncated'], 'truncation boolean is true when a patch is omitted' );
+	$assert( isset( $content['escalation_policy'] ), 'review context carries escalation_policy by default' );
+	$assert( 'data-machine-code/pr-review-escalation/v1' === $content['escalation_policy']['schema'], 'escalation policy schema is versioned' );
+	$assert( true === $content['escalation_policy']['should_escalate'], 'missing Homeboy context recommends escalation' );
+	$assert( in_array( 'missing_homeboy_artifact', $content['escalation_policy']['reasons'], true ), 'missing Homeboy context reason is explicit' );
 	$assert( ! isset( $content['expanded_context'] ), 'default output omits expanded_context' );
 	$assert( $content === $packet['metadata']['review_context'], 'metadata carries same review context for downstream consumers' );
 
@@ -247,6 +251,30 @@ namespace {
 	$assert( isset( $expanded_content['expanded_context'] ), 'review packet carries expanded_context when provided' );
 	$assert( isset( $expanded_content['changed_files'] ), 'review packet keeps patch changed_files at the top level' );
 	$assert( isset( $expanded_content['expanded_context']['changed_files'][0]['head']['content'] ), 'expanded changed-file content stays under expanded_context' );
+
+	$packet_with_checks = \DataMachineCode\Abilities\GitHubAbilities::normalizePullReviewContext(
+		'Extra-Chill/data-machine-code',
+		$pull,
+		array(
+			array(
+				'filename'  => 'src/internal-review-helper.php',
+				'status'    => 'modified',
+				'additions' => 2,
+				'deletions' => 1,
+				'changes'   => 3,
+				'patch'     => "@@ -1 +1 @@\n-old\n+new\n",
+			),
+		),
+		array(
+			'checks' => array(
+				'homeboy_ci_results' => array( 'workflow' => array( 'head_sha' => 'abc123head' ) ),
+				'check_runs'         => array( 'summary' => array( 'state' => 'success' ) ),
+				'commit_statuses'    => array( 'summary' => array( 'state' => 'success' ) ),
+			),
+		)
+	);
+	$checked_content = json_decode( $packet_with_checks['content'], true );
+	$assert( false === $checked_content['escalation_policy']['should_escalate'], 'passing checks and fresh Homeboy artifact avoid escalation' );
 
 	$mismatch = \DataMachineCode\Abilities\GitHubAbilities::normalizePullReviewContext(
 		'Extra-Chill/data-machine-code',

--- a/tests/smoke-github-pr-review-escalation-policy.php
+++ b/tests/smoke-github-pr-review-escalation-policy.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Pure-PHP smoke for GitHub PR review escalation policy.
+ *
+ * Run: php tests/smoke-github-pr-review-escalation-policy.php
+ */
+
+declare( strict_types=1 );
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', sys_get_temp_dir() . '/dmc-pr-review-escalation-policy/' );
+	}
+
+	require __DIR__ . '/../inc/GitHub/PrReviewEscalationPolicy.php';
+
+	$failures = 0;
+	$total    = 0;
+
+	$assert = function ( bool $cond, string $message ) use ( &$failures, &$total ): void {
+		++$total;
+		if ( $cond ) {
+			echo "  ✓ {$message}\n";
+			return;
+		}
+
+		++$failures;
+		echo "  ✗ {$message}\n";
+	};
+
+	$has_reason = static fn( array $policy, string $reason ): bool => in_array( $reason, $policy['reasons'] ?? array(), true );
+	$pull       = array(
+		'number'   => 112,
+		'head_sha' => 'abc123head',
+	);
+
+	echo "GitHub PR review escalation policy - smoke\n\n";
+
+	$clean = \DataMachineCode\GitHub\PrReviewEscalationPolicy::evaluate(
+		'Extra-Chill/data-machine-code',
+		$pull,
+		array(
+			array(
+				'filename'    => 'inc/GitHub/PrReviewFlowScaffold.php',
+				'changes'     => 10,
+				'patch_bytes' => 300,
+			),
+		),
+		array(
+			'check_runs'         => array( 'summary' => array( 'state' => 'success' ) ),
+			'commit_statuses'    => array( 'summary' => array( 'state' => 'success' ) ),
+			'homeboy_ci_results' => array( 'workflow' => array( 'head_sha' => 'abc123head' ) ),
+		)
+	);
+	$assert( 'data-machine-code/pr-review-escalation/v1' === $clean['schema'], 'schema is versioned' );
+	$assert( 'v1' === $clean['policy_version'], 'policy_version is v1' );
+	$assert( false === $clean['should_escalate'], 'clean PR does not escalate' );
+	$assert( array() === $clean['reasons'], 'clean PR has no reasons' );
+	$assert( 'github_context_only_review_is_sufficient' === $clean['action_recommendation'], 'clean PR recommends GitHub-context-only review' );
+
+	$risky = \DataMachineCode\GitHub\PrReviewEscalationPolicy::evaluate(
+		'Extra-Chill/data-machine-code',
+		$pull,
+		array(
+			array( 'filename' => 'inc/Support/GitHubWebhookValidator.php', 'changes' => 12, 'patch_bytes' => 800 ),
+			array( 'filename' => 'inc/Abilities/GitHubAbilities.php', 'changes' => 20, 'patch_bytes' => 900 ),
+			array( 'filename' => 'inc/migrations/github-webhook-auth.php', 'changes' => 40, 'patch_bytes' => 1000 ),
+			array( 'filename' => 'docs/github-review-flow.md', 'changes' => 8, 'patch_bytes' => 500 ),
+		),
+		array(
+			'errors'      => array( 'homeboy_ci_results' => 'No artifact found.' ),
+			'error_codes' => array( 'homeboy_ci_results' => 'github_homeboy_ci_artifact_not_found' ),
+		)
+	);
+	$assert( true === $risky['should_escalate'], 'risk-path PR escalates' );
+	$assert( $has_reason( $risky, 'missing_homeboy_artifact' ), 'missing Homeboy artifact escalates' );
+	$assert( $has_reason( $risky, 'touches_webhook_auth' ), 'webhook/auth path escalates' );
+	$assert( $has_reason( $risky, 'touches_public_api_surface' ), 'ability/tool/CLI public surface escalates' );
+	$assert( $has_reason( $risky, 'touches_migrations_jobs_queues' ), 'migration/jobs/queue path escalates' );
+	$assert( $has_reason( $risky, 'touches_docs_user_facing_content' ), 'docs/user-facing path escalates' );
+	$assert( 'run_checkout_backed_validation_when_available' === $risky['action_recommendation'], 'risky PR recommends checkout-backed validation' );
+	$assert( 'not_run_issue_111_pending' === $risky['execution_result_source'], 'policy names placeholder execution source while issue 111 is unavailable' );
+
+	$stale = \DataMachineCode\GitHub\PrReviewEscalationPolicy::evaluate(
+		'Extra-Chill/data-machine-code',
+		$pull,
+		array( array( 'filename' => 'README.md', 'changes' => 1, 'patch_bytes' => 50 ) ),
+		array( 'homeboy_ci_results' => array( 'workflow' => array( 'head_sha' => 'oldsha' ) ) )
+	);
+	$assert( $has_reason( $stale, 'stale_homeboy_artifact' ), 'stale Homeboy artifact head SHA escalates' );
+
+	$failing = \DataMachineCode\GitHub\PrReviewEscalationPolicy::evaluate(
+		'Extra-Chill/data-machine-code',
+		$pull,
+		array( array( 'filename' => 'inc/GitHub/PrReviewFlowScaffold.php', 'changes' => 1, 'patch_bytes' => 50 ) ),
+		array(
+			'homeboy_ci_results' => array( 'workflow' => array( 'head_sha' => 'abc123head' ) ),
+			'check_runs'         => array( 'summary' => array( 'state' => 'pending' ) ),
+			'commit_statuses'    => array( 'summary' => array( 'state' => 'failure' ) ),
+		)
+	);
+	$assert( $has_reason( $failing, 'failing_or_unknown_checks' ), 'failing or pending checks/statuses escalate' );
+	$assert( 1 === count( array_keys( $failing['reasons'], 'failing_or_unknown_checks', true ) ), 'check/status reason is de-duplicated' );
+
+	$threshold = \DataMachineCode\GitHub\PrReviewEscalationPolicy::evaluate(
+		'Extra-Chill/data-machine-code',
+		$pull,
+		array(
+			array( 'filename' => 'src/a.php', 'changes' => 60, 'patch_bytes' => 600 ),
+			array( 'filename' => 'src/b.php', 'changes' => 60, 'patch_bytes' => 600 ),
+			array( 'filename' => 'src/c.php', 'changes' => 60, 'patch_bytes' => 600 ),
+		),
+		array( 'homeboy_ci_results' => array( 'workflow' => array( 'head_sha' => 'abc123head' ) ) ),
+		array( 'max_files' => 2, 'max_patch_bytes' => 1000, 'max_total_changes' => 100 )
+	);
+	$assert( $has_reason( $threshold, 'file_count_threshold' ), 'file count threshold escalates' );
+	$assert( $has_reason( $threshold, 'patch_size_threshold' ), 'patch size threshold escalates' );
+	$assert( $has_reason( $threshold, 'change_count_threshold' ), 'total change threshold escalates' );
+	$assert( 3 === $threshold['metrics']['file_count'], 'metrics include file count' );
+	$assert( 1800 === $threshold['metrics']['patch_bytes'], 'metrics include patch bytes' );
+	$assert( 180 === $threshold['metrics']['total_changes'], 'metrics include total changes' );
+
+	$ability_source = file_get_contents( __DIR__ . '/../inc/Abilities/GitHubAbilities.php' );
+	$scaffold_source = file_get_contents( __DIR__ . '/../inc/GitHub/PrReviewFlowScaffold.php' );
+	$assert( str_contains( $ability_source, 'PrReviewEscalationPolicy::evaluate' ), 'review context normalization calls the policy' );
+	$assert( str_contains( $scaffold_source, "'include_escalation_policy'" ), 'scaffold opts into escalation policy output' );
+	$assert( str_contains( $scaffold_source, 'should_escalate=true' ), 'scaffold prompt teaches AI how to handle escalation output' );
+
+	echo "\nAssertions: {$total}, Failures: {$failures}\n";
+	exit( $failures > 0 ? 1 : 0 );
+}

--- a/tests/smoke-github-pr-review-flow-scaffold.php
+++ b/tests/smoke-github-pr-review-flow-scaffold.php
@@ -89,15 +89,18 @@ namespace {
 	$assert( 'review context includes check runs by default', true === $review_config['include_checks'] );
 	$assert( 'review context includes commit statuses by default', true === $review_config['include_statuses'] );
 	$assert( 'review context includes Homeboy CI by default', true === $review_config['include_homeboy_ci'] );
+	$assert( 'review context includes escalation policy by default', true === $review_config['include_escalation_policy'] );
 	$assert( 'review context bounds check runs', 30 === $review_config['max_check_runs'] );
 	$assert( 'review context omits check output by default', false === $review_config['include_check_output'] );
 	$assert( 'review context names Homeboy artifact', 'homeboy-ci-results' === $review_config['artifact_name'] );
+	$assert( 'review context carries escalation thresholds', 20 === $review_config['escalation_policy']['max_files'] && 100000 === $review_config['escalation_policy']['max_patch_bytes'] );
 
 	$ai_step = $steps[2];
 	$prompt  = $ai_step['user_message'];
 	$tools   = $ai_step['enabled_tools'];
 	$assert( 'prompt requires findings-first review', str_contains( $prompt, 'findings first' ) || str_contains( $prompt, 'findings' ) );
 	$assert( 'prompt requires initial context packet read', str_contains( $prompt, 'initial pull_review_context packet' ) );
+	$assert( 'prompt requires escalation policy handling', str_contains( $prompt, 'escalation_policy' ) && str_contains( $prompt, 'checkout-backed validation' ) );
 	$assert( 'prompt requires on-demand context gathering', str_contains( $prompt, 'on demand' ) && str_contains( $prompt, 'specific PR metadata' ) );
 	$assert( 'prompt bounds context gathering', str_contains( $prompt, 'Keep context gathering bounded' ) && str_contains( $prompt, 'targeted paths' ) );
 	$assert( 'prompt rejects praise spam', str_contains( $prompt, 'Do not praise' ) );


### PR DESCRIPTION
## Summary
- Add a deterministic PR review escalation policy that emits `data-machine-code/pr-review-escalation/v1` into `pull_review_context`.
- Surface reasons for checkout-backed validation from Homeboy artifact state, check/status results, risky path categories, and size thresholds.
- Teach the PR review scaffold to read the policy and recommend checkout-backed validation without pretending issue #111's execution primitive has already run.

## Behavior
- `review_context.escalation_policy.should_escalate` is `true` when the PR has missing/stale Homeboy CI, failing/pending checks or statuses, auth/webhook/permission/secrets paths, migration/schema/jobs/queue/action-scheduler paths, public API surfaces, docs/user-facing changes, or configured size threshold breaches.
- The policy returns structured `reasons`, `metrics`, `thresholds`, and a placeholder `execution_result_source: not_run_issue_111_pending` until checkout-backed execution from #111 exists.
- Passing checks plus a fresh Homeboy artifact keep the review on GitHub context only.

## Tests
- `php -l inc/GitHub/PrReviewEscalationPolicy.php && php -l inc/Abilities/GitHubAbilities.php && php -l inc/GitHub/PrReviewFlowScaffold.php`
- `php tests/smoke-github-pr-review-escalation-policy.php`
- `php tests/smoke-github-pr-review-context.php`
- `php tests/smoke-github-pr-review-flow-scaffold.php`
- `php tests/smoke-github-check-status-context.php`
- `php tests/smoke-github-homeboy-ci-results.php`

Closes #112

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the escalation policy helper, threading it into PR review context/scaffold output, and adding focused smoke coverage. Chris remains responsible for review and merge.
