### PR TITLE
fix(workspace): route external cleanup skips

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1427,15 +1427,19 @@ class WorkspaceCommand extends BaseCommand {
 			WP_CLI::log( 'Skipped:' );
 			$skipped_rows = array_map(
 				fn( $s ) => array(
-					'handle'      => $s['handle'] ?? '',
-					'reason_code' => $s['reason_code'] ?? '',
-					'reason'      => $s['reason'] ?? '',
-					'missing'     => implode( ',', (array) ( $s['missing_fields'] ?? array() ) ),
-					'hint'        => $s['hint'] ?? '',
+					'handle'       => $s['handle'] ?? '',
+					'reason_code'  => $s['reason_code'] ?? '',
+					'reason'       => $s['reason'] ?? '',
+					'repo'         => $s['repo'] ?? '',
+					'branch'       => $s['branch'] ?? '',
+					'path'         => $s['path'] ?? '',
+					'primary_path' => $s['primary_path'] ?? '',
+					'missing'      => implode( ',', (array) ( $s['missing_fields'] ?? array() ) ),
+					'hint'         => $s['hint'] ?? '',
 				),
 				array_slice( $skipped, 0, $limit )
 			);
-			$this->format_items( $skipped_rows, array( 'handle', 'reason_code', 'reason', 'missing', 'hint' ), array( 'format' => 'table' ), 'handle' );
+			$this->format_items( $skipped_rows, array( 'handle', 'reason_code', 'reason', 'repo', 'branch', 'path', 'primary_path', 'missing', 'hint' ), array( 'format' => 'table' ), 'handle' );
 			$this->render_cleanup_truncation_hint( count( $skipped ), $limit, 'skipped rows' );
 		}
 

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -1620,20 +1620,23 @@ class Workspace {
 				continue;
 			}
 
-			$handle  = $wt['handle'] ?? '?';
-			$repo    = $wt['repo'] ?? '';
-			$branch  = $wt['branch'] ?? '';
-			$wt_path = $wt['path'] ?? '';
+			$handle       = $wt['handle'] ?? '?';
+			$repo         = $wt['repo'] ?? '';
+			$branch       = $wt['branch'] ?? '';
+			$wt_path      = $wt['path'] ?? '';
+			$primary_path = '' !== $repo ? $this->get_primary_path( $repo ) : '';
 
 			if ( ! empty( $wt['external'] ) ) {
 				$skipped[] = array(
-					'handle'      => $handle,
-					'repo'        => $repo,
-					'branch'      => $branch,
-					'path'        => $wt_path,
-					'reason_code' => 'external_worktree',
-					'reason'      => 'external worktree (outside workspace)',
-					'hint'        => 'Inspect manually; cleanup never removes worktrees outside the DMC workspace.',
+					'handle'       => $handle,
+					'reason_code'  => 'external_worktree',
+					'reason'       => 'external worktree (outside workspace)',
+					'hint'         => 'External worktree outside the DMC workspace; remove with the owning tool or inspect with git worktree list from the primary repo.',
+					'repo'         => $repo,
+					'owning_repo'  => $repo,
+					'branch'       => $branch,
+					'path'         => $wt_path,
+					'primary_path' => $primary_path,
 				);
 				continue;
 			}

--- a/tests/smoke-worktree-cleanup.php
+++ b/tests/smoke-worktree-cleanup.php
@@ -180,6 +180,7 @@ namespace {
 	// Primary checkout: clone + initial commit on main + push.
 	$primary = $tmp . '/demo';
 	$run( sprintf( 'git clone %s %s', escapeshellarg( $remote ), escapeshellarg( $primary ) ) );
+	$primary_real = realpath( $primary ) ?: $primary;
 	$run( 'git config user.email test@example.com', $primary );
 	$run( 'git config user.name test', $primary );
 	file_put_contents( $primary . '/README.md', "demo\n" );
@@ -214,6 +215,7 @@ namespace {
 	$run( sprintf( 'git worktree add %s dirty-branch', escapeshellarg( $tmp . '/demo@dirty-branch' ) ), $primary );
 	mkdir( $tmp . '-external', 0755, true );
 	$run( sprintf( 'git worktree add %s external-branch', escapeshellarg( $tmp . '-external/demo-external' ) ), $primary );
+	$external_real = realpath( $tmp . '-external/demo-external' ) ?: $tmp . '-external/demo-external';
 
 	// Dirty the dirty worktree.
 	file_put_contents( $tmp . '/demo@dirty-branch/scratch.txt', 'dirty' );
@@ -311,6 +313,17 @@ namespace {
 	$assert( 'missing_metadata', $missing_row['reason_code'] ?? '', 'missing metadata exposes stable reason code' );
 	$assert( array( 'repo', 'branch', 'path' ), $missing_row['missing_fields'] ?? array(), 'missing metadata lists missing fields' );
 	$assert( true, str_contains( $missing_row['hint'] ?? '', 'workspace worktree prune' ), 'missing metadata includes prune remediation hint' );
+
+	// External worktrees are reported with routing metadata, but never owned by cleanup.
+	$external_skips = array_filter( $plan['skipped'] ?? array(), fn( $s ) => ( $s['path'] ?? '' ) === $external_real );
+	$assert( 1, count( $external_skips ), 'external worktree skipped with exactly one entry' );
+	$external_skip = array_values( $external_skips )[0] ?? array();
+	$assert( 'external_worktree', $external_skip['reason_code'] ?? '', 'external skip has stable reason_code' );
+	$assert( 'demo', $external_skip['repo'] ?? '', 'external skip includes owning repo' );
+	$assert( 'demo', $external_skip['owning_repo'] ?? '', 'external skip includes owning_repo alias' );
+	$assert( 'external-branch', $external_skip['branch'] ?? '', 'external skip includes branch' );
+	$assert( $primary_real, $external_skip['primary_path'] ?? '', 'external skip includes primary repo path' );
+	$assert( true, str_contains( $external_skip['hint'] ?? '', 'owning tool' ), 'external skip includes remediation hint' );
 
 	// Primary itself should NEVER show up as a candidate.
 	foreach ( $plan['candidates'] ?? array() as $c ) {


### PR DESCRIPTION
## Summary
- Adds stable external-worktree cleanup routing metadata without deleting paths outside the DMC workspace.
- Surfaces remediation details so operators and JSON consumers can route external skips safely.

## Changes
- Adds `reason_code: external_worktree`, owning repo, branch, path, primary repo path, and a remediation hint to external cleanup skip rows.
- Includes the new skip metadata in CLI cleanup output.
- Extends the worktree cleanup smoke with an external worktree fixture outside the DMC workspace root.

## Tests
- `php tests/smoke-worktree-cleanup.php`

Closes #119

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implementing external-worktree cleanup routing, tests, and PR description; Chris remains responsible for review.