### PR TITLE
feat(workspace): record worktree lifecycle metadata

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1248,17 +1248,23 @@ class WorkspaceCommand extends BaseCommand {
 				}
 				$items = array_map(
 					fn( $wt ) => array(
-						'handle' => $wt['handle'] ?? '',
-						'repo'   => $wt['repo'] ?? '',
-						'kind'   => ! empty( $wt['is_primary'] ) ? 'primary' : 'worktree',
-						'branch' => $wt['branch'] ?? '-',
-						'head'   => isset( $wt['head'] ) ? substr( (string) $wt['head'], 0, 7 ) : '-',
-						'dirty'  => (int) ( $wt['dirty'] ?? 0 ),
-						'path'   => $wt['path'] ?? '',
+						'handle'     => $wt['handle'] ?? '',
+						'repo'       => $wt['repo'] ?? '',
+						'kind'       => ! empty( $wt['is_primary'] ) ? 'primary' : 'worktree',
+						'branch'     => $wt['branch'] ?? '-',
+						'head'       => isset( $wt['head'] ) ? substr( (string) $wt['head'], 0, 7 ) : '-',
+						'dirty'      => (int) ( $wt['dirty'] ?? 0 ),
+						'created_at' => $wt['created_at'] ?? null,
+						'metadata'   => $wt['metadata'] ?? null,
+						'path'       => $wt['path'] ?? '',
 					),
 					$worktrees
 				);
-				$this->format_items( $items, array( 'handle', 'repo', 'kind', 'branch', 'head', 'dirty', 'path' ), $assoc_args, 'handle' );
+				$fields = array( 'handle', 'repo', 'kind', 'branch', 'head', 'dirty', 'created_at', 'path' );
+				if ( in_array( (string) ( $assoc_args['format'] ?? '' ), array( 'json', 'yaml' ), true ) ) {
+					$fields[] = 'metadata';
+				}
+				$this->format_items( $items, $fields, $assoc_args, 'handle' );
 				return;
 
 			case 'prune':

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -1281,6 +1281,18 @@ class Workspace {
 			}
 		}
 
+		$lifecycle_metadata = WorktreeContextInjector::build_lifecycle_metadata(
+			array(
+				'repo'         => $repo,
+				'branch'      => $branch,
+				'base_ref'    => $created_branch ? $resolved_base : null,
+				'base_source' => $created_branch ? ( null !== $from && '' !== trim( $from ) ? 'requested_ref' : 'default_base' ) : 'existing_local_branch',
+			)
+		);
+		WorktreeContextInjector::store_lifecycle_metadata( $wt_handle, $lifecycle_metadata );
+		$response['created_at'] = $lifecycle_metadata['created_at'] ?? null;
+		$response['metadata']   = WorktreeContextInjector::get_metadata( $wt_handle );
+
 		if ( ! $inject_context ) {
 			$response['context_injected']    = false;
 			$response['context_skip_reason'] = 'inject_context flag disabled';
@@ -1296,6 +1308,7 @@ class Workspace {
 					$response['context_skip_reason'] = 'inject failed: ' . $injection->get_error_message();
 				} else {
 					WorktreeContextInjector::store_metadata( $wt_handle, $payload );
+					$response['metadata'] = WorktreeContextInjector::get_metadata( $wt_handle );
 					$response['context_injected'] = true;
 					$response['context_files']    = $injection['written'];
 					if ( ! empty( $injection['exclude_path'] ) ) {
@@ -1624,6 +1637,8 @@ class Workspace {
 			$repo         = $wt['repo'] ?? '';
 			$branch       = $wt['branch'] ?? '';
 			$wt_path      = $wt['path'] ?? '';
+			$metadata     = $wt['metadata'] ?? null;
+			$created_at   = $wt['created_at'] ?? null;
 			$primary_path = '' !== $repo ? $this->get_primary_path( $repo ) : '';
 
 			if ( ! empty( $wt['external'] ) ) {
@@ -1637,6 +1652,8 @@ class Workspace {
 					'branch'       => $branch,
 					'path'         => $wt_path,
 					'primary_path' => $primary_path,
+					'created_at'  => $created_at,
+					'metadata'    => $metadata,
 				);
 				continue;
 			}
@@ -1665,6 +1682,8 @@ class Workspace {
 					'reason'         => 'missing repo/branch/path',
 					'missing_fields' => $missing_fields,
 					'hint'           => 'Run workspace worktree prune if this is a stale registry entry; inspect manually if the path still exists.',
+					'created_at'     => $created_at,
+					'metadata'       => $metadata,
 				);
 				continue;
 			}
@@ -1677,6 +1696,8 @@ class Workspace {
 					'path'        => $wt_path,
 					'reason_code' => 'protected_branch',
 					'reason'      => sprintf( 'protected branch (%s)', $branch ),
+					'created_at'  => $created_at,
+					'metadata'    => $metadata,
 				);
 				continue;
 			}
@@ -1690,6 +1711,8 @@ class Workspace {
 					'reason_code' => 'dirty_worktree',
 					'reason'      => sprintf( 'working tree dirty (%d files) — pass force=true to override', $dirty_count ),
 					'dirty'       => $dirty_count,
+					'created_at'  => $created_at,
+					'metadata'    => $metadata,
 				);
 				continue;
 			}
@@ -1709,6 +1732,8 @@ class Workspace {
 					'reason_code' => 'unpushed_commits',
 					'reason'      => sprintf( '%d unpushed commit(s) — refusing to delete even with force (push or reset explicitly)', $unpushed ),
 					'unpushed'    => $unpushed,
+					'created_at'  => $created_at,
+					'metadata'    => $metadata,
 				);
 				continue;
 			}
@@ -1723,6 +1748,8 @@ class Workspace {
 					'reason_code' => 'missing_metadata',
 					'reason'      => 'primary checkout missing',
 					'hint'        => 'Run workspace worktree prune if this is a stale registry entry; inspect manually if the path still exists.',
+					'created_at'  => $created_at,
+					'metadata'    => $metadata,
 				);
 				continue;
 			}
@@ -1741,14 +1768,22 @@ class Workspace {
 					'path'        => $wt_path,
 					'reason_code' => 'no_merge_signal',
 					'reason'      => 'no merge signal — leaving in place',
+					'created_at'  => $created_at,
+					'metadata'    => $metadata,
 				);
 				continue;
 			}
 
 			if ( 'github-unknown' === ( $signal['signal'] ?? '' ) ) {
 				$skipped[] = array(
-					'handle' => $wt['handle'] ?? '?',
-					'reason' => $signal['reason'],
+					'handle'      => $handle,
+					'repo'        => $repo,
+					'branch'      => $branch,
+					'path'        => $wt_path,
+					'reason_code' => 'github_unknown',
+					'reason'      => $signal['reason'],
+					'created_at'  => $created_at,
+					'metadata'    => $metadata,
 				);
 				continue;
 			}
@@ -1763,6 +1798,8 @@ class Workspace {
 				'reason_code' => $signal['signal'],
 				'reason'      => $signal['reason'],
 				'pr_url'      => $signal['pr_url'] ?? null,
+				'created_at'  => $created_at,
+				'metadata'    => $metadata,
 			);
 		}
 
@@ -1806,6 +1843,8 @@ class Workspace {
 					'path'        => $cand['path'] ?? '',
 					'reason_code' => 'remove_failed',
 					'reason'      => 'remove failed: ' . $remove->get_error_message(),
+					'created_at'  => $cand['created_at'] ?? null,
+					'metadata'    => $cand['metadata'] ?? null,
 				);
 				continue;
 			}

--- a/inc/Workspace/WorktreeContextInjector.php
+++ b/inc/Workspace/WorktreeContextInjector.php
@@ -14,9 +14,9 @@
  * worktree's `info/exclude` file, so the tracked `.gitignore` is never touched
  * and other worktrees / the primary checkout are unaffected.
  *
- * Per-worktree metadata (`created_from_site`) is persisted in the
- * `datamachine_worktree_metadata` site option so later `refresh-context`
- * calls can resolve back to the originating site.
+ * Per-worktree lifecycle metadata is persisted in the
+ * `datamachine_worktree_metadata` site option so later list, cleanup, and
+ * `refresh-context` calls can reason about where a worktree came from.
  *
  * Cross-machine federation is explicitly out of scope: the originating site
  * is always the site invoking this code; if that site is not reachable
@@ -36,13 +36,8 @@ class WorktreeContextInjector {
 	/**
 	 * Site option key used to persist per-worktree metadata.
 	 *
-	 * Shape: array<string, array{
-	 *   site_url: string,
-	 *   site_name: string,
-	 *   agent_slug: string,
-	 *   abspath: string,
-	 *   created_at: string,
-	 * }> keyed by workspace handle.
+	 * Shape: array<string, array<string,mixed>> keyed by workspace handle.
+	 * Older records may contain only the original context-injection fields.
 	 */
 	public const METADATA_OPTION = 'datamachine_worktree_metadata';
 
@@ -63,6 +58,39 @@ class WorktreeContextInjector {
 	 * Site-provided sections that should be visible before long memory snapshots.
 	 */
 	private const PRIORITY_RULE_SECTIONS = array( 'Minion Session Routing' );
+
+	/**
+	 * Build best-effort lifecycle metadata for a newly-created worktree.
+	 *
+	 * @param array $args Worktree creation context.
+	 * @return array<string,mixed>
+	 */
+	public static function build_lifecycle_metadata( array $args = array() ): array {
+		$site_url  = function_exists( 'home_url' ) ? (string) home_url() : '';
+		$site_name = function_exists( 'get_bloginfo' ) ? (string) get_bloginfo( 'name' ) : '';
+		$user      = self::resolve_origin_user();
+		$agent     = self::resolve_origin_agent();
+
+		$metadata = array(
+			'created_at'       => gmdate( 'c' ),
+			'origin_site'      => '' !== $site_name ? $site_name : ( '' !== $site_url ? $site_url : null ),
+			'origin_site_url'  => '' !== $site_url ? $site_url : null,
+			'origin_site_name' => '' !== $site_name ? $site_name : null,
+			'origin_agent'     => $agent,
+			'origin_user'      => $user,
+			'base_ref'         => isset( $args['base_ref'] ) && '' !== (string) $args['base_ref'] ? (string) $args['base_ref'] : null,
+			'base_source'      => isset( $args['base_source'] ) && '' !== (string) $args['base_source'] ? (string) $args['base_source'] : null,
+			'branch'           => isset( $args['branch'] ) && '' !== (string) $args['branch'] ? (string) $args['branch'] : null,
+			'repo'             => isset( $args['repo'] ) && '' !== (string) $args['repo'] ? (string) $args['repo'] : null,
+		);
+
+		// Preserve the original context metadata field names for existing callers.
+		$metadata['site_url']   = $metadata['origin_site_url'] ?? '';
+		$metadata['site_name']  = $metadata['origin_site_name'] ?? '';
+		$metadata['agent_slug'] = is_string( $agent ) ? $agent : '';
+
+		return array_filter( $metadata, fn( $value ) => null !== $value );
+	}
 
 	/**
 	 * Build a payload capturing the originating site's agent context.
@@ -305,12 +333,12 @@ class WorktreeContextInjector {
 	}
 
 	/**
-	 * Persist `created_from_site` metadata for a worktree handle.
+	 * Persist lifecycle metadata for a worktree handle.
 	 *
-	 * @param string $handle  Workspace handle.
-	 * @param array  $payload Payload from {@see self::build_payload()}.
+	 * @param string $handle   Workspace handle.
+	 * @param array  $metadata Metadata fields.
 	 */
-	public static function store_metadata( string $handle, array $payload ): void {
+	public static function store_lifecycle_metadata( string $handle, array $metadata ): void {
 		if ( ! function_exists( 'get_option' ) || ! function_exists( 'update_option' ) ) {
 			return;
 		}
@@ -320,15 +348,79 @@ class WorktreeContextInjector {
 			$all = array();
 		}
 
-		$all[ $handle ] = array(
-			'site_url'   => (string) ( $payload['site_url'] ?? '' ),
-			'site_name'  => (string) ( $payload['site_name'] ?? '' ),
-			'agent_slug' => (string) ( $payload['agent_slug'] ?? '' ),
-			'abspath'    => (string) ( $payload['abspath'] ?? '' ),
-			'created_at' => (string) ( $payload['timestamp'] ?? gmdate( 'c' ) ),
-		);
+		$existing       = isset( $all[ $handle ] ) && is_array( $all[ $handle ] ) ? $all[ $handle ] : array();
+		$all[ $handle ] = array_merge( $existing, $metadata );
 
 		update_option( self::METADATA_OPTION, $all, false );
+	}
+
+	/**
+	 * Persist context-injection metadata for a worktree handle.
+	 *
+	 * @param string $handle  Workspace handle.
+	 * @param array  $payload Payload from {@see self::build_payload()}.
+	 */
+	public static function store_metadata( string $handle, array $payload ): void {
+		self::store_lifecycle_metadata( $handle, array(
+			'site_url'         => (string) ( $payload['site_url'] ?? '' ),
+			'site_name'        => (string) ( $payload['site_name'] ?? '' ),
+			'agent_slug'       => (string) ( $payload['agent_slug'] ?? '' ),
+			'origin_site'      => '' !== (string) ( $payload['site_name'] ?? '' ) ? (string) $payload['site_name'] : (string) ( $payload['site_url'] ?? '' ),
+			'origin_site_url'  => (string) ( $payload['site_url'] ?? '' ),
+			'origin_site_name' => (string) ( $payload['site_name'] ?? '' ),
+			'origin_agent'     => (string) ( $payload['agent_slug'] ?? '' ),
+			'abspath'          => (string) ( $payload['abspath'] ?? '' ),
+			'created_at'       => (string) ( $payload['timestamp'] ?? gmdate( 'c' ) ),
+		) );
+	}
+
+	/**
+	 * Resolve a non-sensitive current user summary.
+	 *
+	 * @return array{id:int,login:string,display_name:string}|null
+	 */
+	private static function resolve_origin_user(): ?array {
+		if ( ! function_exists( 'get_current_user_id' ) ) {
+			return null;
+		}
+		$user_id = (int) get_current_user_id();
+		if ( $user_id <= 0 ) {
+			return null;
+		}
+
+		$summary = array(
+			'id'           => $user_id,
+			'login'        => '',
+			'display_name' => '',
+		);
+
+		if ( function_exists( 'get_userdata' ) ) {
+			$user = get_userdata( $user_id );
+			if ( is_object( $user ) ) {
+				$summary['login']        = (string) ( $user->user_login ?? '' );
+				$summary['display_name'] = (string) ( $user->display_name ?? '' );
+			}
+		}
+
+		return $summary;
+	}
+
+	/**
+	 * Resolve the active Data Machine agent slug when available.
+	 */
+	private static function resolve_origin_agent(): ?string {
+		if ( ! class_exists( '\DataMachine\Core\FilesRepository\DirectoryManager' ) ) {
+			return null;
+		}
+
+		try {
+			$dm         = new \DataMachine\Core\FilesRepository\DirectoryManager();
+			$user_id    = method_exists( $dm, 'get_effective_user_id' ) ? $dm->get_effective_user_id( 0 ) : 0;
+			$agent_slug = method_exists( $dm, 'resolve_agent_slug' ) ? $dm->resolve_agent_slug( array( 'user_id' => $user_id ) ) : '';
+			return '' !== (string) $agent_slug ? (string) $agent_slug : null;
+		} catch ( \Throwable $e ) {
+			return null;
+		}
 	}
 
 	/**

--- a/tests/smoke-worktree-lifecycle-metadata.php
+++ b/tests/smoke-worktree-lifecycle-metadata.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ * Smoke test for DMC worktree lifecycle metadata.
+ *
+ * Run: php tests/smoke-worktree-lifecycle-metadata.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Core\FilesRepository {
+	if ( ! class_exists( __NAMESPACE__ . '\FilesystemHelper' ) ) {
+		class FilesystemHelper {
+			public static function get() {
+				return null;
+			}
+		}
+	}
+
+	if ( ! class_exists( __NAMESPACE__ . '\DirectoryManager' ) ) {
+		class DirectoryManager {
+			public function get_effective_user_id( int $fallback ): int {
+				return 7;
+			}
+
+			public function resolve_agent_slug( array $args ): string {
+				return 'agent-one';
+			}
+		}
+	}
+}
+
+namespace DataMachineCode\Abilities {
+	if ( ! class_exists( __NAMESPACE__ . '\GitHubAbilities' ) ) {
+		class GitHubAbilities {
+			public static function getPat(): string {
+				return '';
+			}
+
+			public static function apiGet( string $url, array $params, string $pat ) {
+				return array( 'data' => array() );
+			}
+		}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			public string $code;
+			public string $message;
+			public array $data;
+
+			public function __construct( $code = '', $message = '', $data = array() ) {
+				$this->code    = (string) $code;
+				$this->message = (string) $message;
+				$this->data    = (array) $data;
+			}
+
+			public function get_error_message(): string {
+				return $this->message;
+			}
+
+			public function get_error_data() {
+				return $this->data;
+			}
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $thing ): bool {
+			return $thing instanceof \WP_Error;
+		}
+	}
+
+	if ( ! function_exists( 'wp_mkdir_p' ) ) {
+		function wp_mkdir_p( string $path ): bool {
+			return is_dir( $path ) || mkdir( $path, 0755, true );
+		}
+	}
+
+	if ( ! function_exists( 'get_option' ) ) {
+		function get_option( string $name, $default = false ) {
+			global $datamachine_code_test_options;
+			return $datamachine_code_test_options[ $name ] ?? $default;
+		}
+	}
+
+	if ( ! function_exists( 'update_option' ) ) {
+		function update_option( string $name, $value, $autoload = null ): bool {
+			global $datamachine_code_test_options;
+			$datamachine_code_test_options[ $name ] = $value;
+			return true;
+		}
+	}
+
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( string $hook_name, $value ) {
+			return $value;
+		}
+	}
+
+	if ( ! function_exists( 'home_url' ) ) {
+		function home_url(): string {
+			return 'https://origin.example.test';
+		}
+	}
+
+	if ( ! function_exists( 'get_bloginfo' ) ) {
+		function get_bloginfo( string $show ): string {
+			return 'Origin Site';
+		}
+	}
+
+	if ( ! function_exists( 'get_current_user_id' ) ) {
+		function get_current_user_id(): int {
+			return 42;
+		}
+	}
+
+	if ( ! function_exists( 'get_userdata' ) ) {
+		function get_userdata( int $user_id ): object {
+			return (object) array(
+				'user_login'   => 'chris',
+				'display_name' => 'Chris',
+			);
+		}
+	}
+
+	require __DIR__ . '/../inc/Support/GitHubRemote.php';
+	require __DIR__ . '/../inc/Support/GitRunner.php';
+	require __DIR__ . '/../inc/Support/PathSecurity.php';
+	require __DIR__ . '/../inc/Workspace/WorkspaceMutationLock.php';
+	require __DIR__ . '/../inc/Workspace/WorktreeStalenessProbe.php';
+	require __DIR__ . '/../inc/Workspace/WorktreeContextInjector.php';
+	require __DIR__ . '/../inc/Workspace/Workspace.php';
+
+	exec( 'git --version 2>&1', $_git_version, $git_exit );
+	if ( 0 !== $git_exit ) {
+		echo "SKIP: git not available\n";
+		exit( 0 );
+	}
+
+	$assertions = 0;
+	$failures   = 0;
+
+	$assert = function ( $expected, $actual, string $message ) use ( &$assertions, &$failures ): void {
+		++$assertions;
+		if ( $expected === $actual ) {
+			echo "  [PASS] {$message}\n";
+			return;
+		}
+		++$failures;
+		echo "  [FAIL] {$message}\n";
+		echo '         expected: ' . var_export( $expected, true ) . "\n";
+		echo '         actual:   ' . var_export( $actual, true ) . "\n";
+	};
+
+	$run = function ( string $command, ?string $cwd = null ) use ( &$assert ): string {
+		$full = null === $cwd ? $command : sprintf( 'cd %s && %s', escapeshellarg( $cwd ), $command );
+		exec( $full . ' 2>&1', $output, $code );
+		$stdout = trim( implode( "\n", $output ) );
+		$assert( 0, $code, 'command succeeds: ' . $command . ( '' !== $stdout ? "\n{$stdout}" : '' ) );
+		return $stdout;
+	};
+
+	echo "=== smoke-worktree-lifecycle-metadata ===\n";
+
+	$tmp = sys_get_temp_dir() . '/dmc-worktree-metadata-' . bin2hex( random_bytes( 4 ) );
+	mkdir( $tmp, 0755, true );
+	$tmp = (string) realpath( $tmp );
+	register_shutdown_function( function () use ( $tmp ): void {
+		if ( is_dir( $tmp ) ) {
+			exec( 'rm -rf ' . escapeshellarg( $tmp ) . ' 2>&1' );
+		}
+	} );
+
+	define( 'DATAMACHINE_WORKSPACE_PATH', $tmp . '/workspace' );
+	mkdir( DATAMACHINE_WORKSPACE_PATH, 0755, true );
+	$primary = DATAMACHINE_WORKSPACE_PATH . '/demo';
+	mkdir( $primary, 0755, true );
+
+	$run( 'git init', $primary );
+	$run( 'git config user.email test@example.test', $primary );
+	$run( 'git config user.name Test', $primary );
+	file_put_contents( $primary . '/README.md', "# Demo\n" );
+	$run( 'git add README.md', $primary );
+	$run( 'git commit -m initial', $primary );
+
+	$ws     = new \DataMachineCode\Workspace\Workspace();
+	$result = $ws->worktree_add( 'demo', 'feature/metadata', 'HEAD', false, false, true, false );
+	$assert( true, ! is_wp_error( $result ) && ( $result['success'] ?? false ), 'worktree_add succeeds without context injection' );
+
+	$metadata = \DataMachineCode\Workspace\WorktreeContextInjector::get_metadata( 'demo@feature-metadata' );
+	$assert( true, is_array( $metadata ), 'lifecycle metadata recorded at add time' );
+	$assert( 'Origin Site', $metadata['origin_site'] ?? null, 'origin site is recorded' );
+	$assert( 'agent-one', $metadata['origin_agent'] ?? null, 'origin agent is recorded' );
+	$assert( 42, $metadata['origin_user']['id'] ?? null, 'origin user id is recorded without sensitive fields' );
+	$assert( 'HEAD', $metadata['base_ref'] ?? null, 'base ref is recorded' );
+	$assert( 'requested_ref', $metadata['base_source'] ?? null, 'base source is recorded' );
+
+	$list  = $ws->worktree_list( 'demo' );
+	$items = array_values( array_filter( $list['worktrees'] ?? array(), fn( $wt ) => ( $wt['handle'] ?? '' ) === 'demo@feature-metadata' ) );
+	$item  = $items[0] ?? array();
+	$assert( $metadata['created_at'] ?? null, $item['created_at'] ?? null, 'list data exposes created_at metadata' );
+	$assert( 'Origin Site', $item['metadata']['origin_site'] ?? null, 'list data exposes nested lifecycle metadata' );
+
+	$result_old = $ws->worktree_add( 'demo', 'feature/old-record', 'HEAD', false, false, true, false );
+	$assert( true, ! is_wp_error( $result_old ) && ( $result_old['success'] ?? false ), 'second worktree_add succeeds' );
+	$all_metadata = get_option( \DataMachineCode\Workspace\WorktreeContextInjector::METADATA_OPTION, array() );
+	unset( $all_metadata['demo@feature-old-record'] );
+	update_option( \DataMachineCode\Workspace\WorktreeContextInjector::METADATA_OPTION, $all_metadata, false );
+
+	$list_old  = $ws->worktree_list( 'demo' );
+	$old_items = array_values( array_filter( $list_old['worktrees'] ?? array(), fn( $wt ) => ( $wt['handle'] ?? '' ) === 'demo@feature-old-record' ) );
+	$old_item  = $old_items[0] ?? array();
+	$assert( true, isset( $old_item['handle'] ), 'old worktree with missing metadata still lists' );
+	$assert( null, $old_item['metadata'] ?? null, 'old worktree missing metadata degrades to null' );
+
+	$plan = $ws->worktree_cleanup_merged(
+		array(
+			'dry_run'     => true,
+			'skip_github' => true,
+		)
+	);
+	$assert( true, ! is_wp_error( $plan ) && ( $plan['success'] ?? false ), 'cleanup dry-run succeeds with mixed metadata records' );
+	$feature_skip = array_values( array_filter( $plan['skipped'] ?? array(), fn( $skip ) => ( $skip['handle'] ?? '' ) === 'demo@feature-metadata' ) );
+	$assert( 'Origin Site', $feature_skip[0]['metadata']['origin_site'] ?? null, 'cleanup dry-run exposes metadata on skipped worktree records' );
+
+	if ( $failures > 0 ) {
+		echo "\n{$failures} failure(s) across {$assertions} assertion(s).\n";
+		exit( 1 );
+	}
+
+	echo "\nAll {$assertions} worktree lifecycle metadata assertions passed.\n";
+}


### PR DESCRIPTION
## Summary
- Records best-effort lifecycle metadata for DMC-created worktrees so cleanup/list views can distinguish parked work from abandoned agent work.
- Exposes created_at and nested metadata through worktree list and cleanup dry-run data, while allowing old worktrees with no metadata to degrade to null.

## Changes
- Adds lifecycle metadata capture at worktree add time, independent of context injection success.
- Merges context-injection metadata into the same metadata record for compatibility with existing refresh-context behavior.
- Threads metadata into worktree list results, cleanup candidates, and cleanup skipped records; JSON/YAML CLI output includes the nested metadata object.

## Tests
- php -l inc/Cli/Commands/WorkspaceCommand.php
- php -l inc/Workspace/WorktreeContextInjector.php
- php -l inc/Workspace/Workspace.php
- php tests/smoke-worktree-lifecycle-metadata.php — 19 assertions passed
- php tests/smoke-worktree-context-injection.php — passed
- php tests/smoke-worktree-cleanup.php — 20/20 passed

Closes #121

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implementing worktree lifecycle metadata, tests, and PR description; Chris remains responsible for review.