### PR TITLE
fix(workspace): cache cleanup GitHub lookups

### DIFF
--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -2390,14 +2390,14 @@ class GitHubAbilities {
 	// HTTP Helpers
 	// -------------------------------------------------------------------------
 
-	public static function apiGet( string $url, array $query_params, string $pat ): array|\WP_Error {
+	public static function apiGet( string $url, array $query_params, string $pat, int $timeout = 30 ): array|\WP_Error {
 		if ( ! empty( $query_params ) ) {
 			$url = add_query_arg( $query_params, $url );
 		}
 
 		$response = wp_remote_get( $url, array(
 			'headers' => self::getHeaders( $pat ),
-			'timeout' => 30,
+			'timeout' => $timeout,
 		) );
 
 		return self::parseResponse( $response );

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -27,6 +27,16 @@ class Workspace {
 	const MAX_READ_SIZE = 1048576;
 
 	/**
+	 * Bound GitHub cleanup checks so one slow repo cannot stall cleanup.
+	 */
+	private const CLEANUP_GITHUB_TIMEOUT = 5;
+
+	/**
+	 * Closed PR pages to inspect per repo during cleanup.
+	 */
+	private const CLEANUP_GITHUB_MAX_PAGES = 3;
+
+	/**
 	 * @var string Resolved workspace path.
 	 */
 	private string $workspace_path;
@@ -1600,6 +1610,7 @@ class Workspace {
 		$protected_branches = array( 'main', 'master', 'trunk', 'develop', 'HEAD' );
 		$candidates         = array();
 		$skipped            = array();
+		$github_cache       = array();
 
 		// Fetch + prune each primary once up-front so upstream-gone signals are fresh.
 		$fetched = array();
@@ -1673,11 +1684,19 @@ class Workspace {
 				$fetched[ $repo ] = true;
 			}
 
-			$signal = $this->detect_merge_signal( $primary_path, $repo, $branch, $skip_github );
+			$signal = $this->detect_merge_signal( $primary_path, $repo, $branch, $skip_github, $github_cache );
 			if ( null === $signal ) {
 				$skipped[] = array(
 					'handle' => $wt['handle'] ?? '?',
 					'reason' => 'no merge signal — leaving in place',
+				);
+				continue;
+			}
+
+			if ( 'github-unknown' === ( $signal['signal'] ?? '' ) ) {
+				$skipped[] = array(
+					'handle' => $wt['handle'] ?? '?',
+					'reason' => $signal['reason'],
 				);
 				continue;
 			}
@@ -1849,9 +1868,10 @@ class Workspace {
 	 * @param string $repo         Primary repo directory name.
 	 * @param string $branch       Branch name.
 	 * @param bool   $skip_github  If true, skip GitHub API lookup.
+	 * @param array  $github_cache Run-local cache for GitHub repo lookups.
 	 * @return array{signal: string, reason: string, pr_url?: string}|null
 	 */
-	private function detect_merge_signal( string $primary_path, string $repo, string $branch, bool $skip_github ): ?array {
+	private function detect_merge_signal( string $primary_path, string $repo, string $branch, bool $skip_github, array &$github_cache = array() ): ?array {
 		$ref    = 'refs/heads/' . $branch;
 		$format = '%(upstream:track)';
 		$result = $this->run_git( $primary_path, sprintf( 'for-each-ref --format=%s %s', escapeshellarg( $format ), escapeshellarg( $ref ) ) );
@@ -1875,7 +1895,13 @@ class Workspace {
 			return null;
 		}
 
-		$pr = $this->find_merged_pr_for_branch( $gh_slug, $branch );
+		$pr = $this->find_merged_pr_for_branch( $gh_slug, $branch, $github_cache );
+		if ( is_wp_error( $pr ) ) {
+			return array(
+				'signal' => 'github-unknown',
+				'reason' => 'unknown_github_state — ' . $pr->get_error_message(),
+			);
+		}
 		if ( null === $pr ) {
 			return null;
 		}
@@ -1902,56 +1928,115 @@ class Workspace {
 	}
 
 	/**
-	 * Look up a merged PR for a branch via the GitHub API.
+	 * Look up a merged PR for a branch via a cached GitHub API snapshot.
 	 *
-	 * Queries `GET /repos/{slug}/pulls?state=closed&head={owner}:{branch}`
-	 * and returns the first entry whose `merged_at` is non-null.
+	 * Cleanup may inspect hundreds of worktrees for the same repo. Querying
+	 * GitHub once per branch does not scale, so each repo gets one bounded
+	 * closed-PR snapshot per cleanup run and branch lookups read that cache.
 	 *
-	 * @param string $slug   owner/repo.
-	 * @param string $branch Branch name.
-	 * @return array|null PR data or null.
+	 * @param string $slug         owner/repo.
+	 * @param string $branch       Branch name.
+	 * @param array  $github_cache Run-local cache keyed by owner/repo.
+	 * @return array|null|\WP_Error PR data, null when no PR matched, or lookup failure.
 	 */
-	private function find_merged_pr_for_branch( string $slug, string $branch ): ?array {
+	private function find_merged_pr_for_branch( string $slug, string $branch, array &$github_cache = array() ): array|\WP_Error|null {
+		$lookup = $this->get_cleanup_github_lookup( $slug, $github_cache );
+		if ( is_wp_error( $lookup ) ) {
+			return $lookup;
+		}
+
+		if ( null === $lookup ) {
+			return null;
+		}
+
+		return $lookup[ $branch ] ?? null;
+	}
+
+	/**
+	 * Load and cache merged same-repo PRs for a GitHub repo.
+	 *
+	 * @param string $slug         owner/repo.
+	 * @param array  $github_cache Run-local cache keyed by owner/repo.
+	 * @return array<string,array>|null|\WP_Error Branch-name map, null when GitHub is unavailable, or lookup failure.
+	 */
+	private function get_cleanup_github_lookup( string $slug, array &$github_cache ): array|\WP_Error|null {
+		if ( array_key_exists( $slug, $github_cache ) ) {
+			return $github_cache[ $slug ];
+		}
+
 		if ( ! class_exists( '\DataMachineCode\Abilities\GitHubAbilities' ) ) {
+			$github_cache[ $slug ] = null;
 			return null;
 		}
 
 		$pat = \DataMachineCode\Abilities\GitHubAbilities::getPat();
 		if ( empty( $pat ) ) {
+			$github_cache[ $slug ] = null;
 			return null;
 		}
 
-		$owner = explode( '/', $slug )[0];
-		if ( '' === $owner ) {
+		$parts = explode( '/', $slug, 2 );
+		$owner = $parts[0] ?? '';
+		if ( '' === $owner || empty( $parts[1] ) ) {
+			$github_cache[ $slug ] = null;
 			return null;
 		}
 
-		$response = \DataMachineCode\Abilities\GitHubAbilities::apiGet(
-			GitHubRemote::apiUrl( $slug, 'pulls' ),
-			array(
-				'state'    => 'closed',
-				'head'     => $owner . ':' . $branch,
-				'per_page' => 5,
-			),
-			$pat
-		);
+		$merged = array();
+		$url    = GitHubRemote::apiUrl( $slug, 'pulls' );
 
-		if ( is_wp_error( $response ) ) {
-			return null;
-		}
+		for ( $page = 1; $page <= self::CLEANUP_GITHUB_MAX_PAGES; $page++ ) {
+			$response = \DataMachineCode\Abilities\GitHubAbilities::apiGet(
+				$url,
+				array(
+					'state'     => 'closed',
+					'sort'      => 'updated',
+					'direction' => 'desc',
+					'per_page'  => 100,
+					'page'      => $page,
+				),
+				$pat,
+				self::CLEANUP_GITHUB_TIMEOUT
+			);
 
-		foreach ( (array) ( $response['data'] ?? array() ) as $pr ) {
-			if ( ! empty( $pr['merged_at'] ) ) {
-				return array(
+			if ( is_wp_error( $response ) ) {
+				$error                 = new \WP_Error(
+					'github_cleanup_lookup_failed',
+					sprintf( 'GitHub cleanup lookup failed for %s: %s', $slug, $response->get_error_message() ),
+					$response->get_error_data()
+				);
+				$github_cache[ $slug ] = $error;
+				return $error;
+			}
+
+			$items = (array) ( $response['data'] ?? array() );
+			foreach ( $items as $pr ) {
+				if ( empty( $pr['merged_at'] ) ) {
+					continue;
+				}
+
+				$head      = is_array( $pr['head'] ?? null ) ? $pr['head'] : array();
+				$head_repo = is_array( $head['repo'] ?? null ) ? (string) ( $head['repo']['full_name'] ?? '' ) : '';
+				$head_ref  = (string) ( $head['ref'] ?? '' );
+				if ( $head_repo !== $slug || '' === $head_ref ) {
+					continue;
+				}
+
+				$merged[ $head_ref ] = array(
 					'number'    => (int) ( $pr['number'] ?? 0 ),
 					'state'     => (string) ( $pr['state'] ?? 'closed' ),
 					'merged_at' => (string) $pr['merged_at'],
 					'html_url'  => (string) ( $pr['html_url'] ?? '' ),
 				);
 			}
+
+			if ( count( $items ) < 100 ) {
+				break;
+			}
 		}
 
-		return null;
+		$github_cache[ $slug ] = $merged;
+		return $merged;
 	}
 
 	/**

--- a/tests/smoke-worktree-cleanup-github-cache.php
+++ b/tests/smoke-worktree-cleanup-github-cache.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * Smoke test for GitHub-backed worktree cleanup lookup caching.
+ *
+ * Run: php tests/smoke-worktree-cleanup-github-cache.php
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Core\FilesRepository {
+	if ( ! class_exists( __NAMESPACE__ . '\\FilesystemHelper' ) ) {
+		class FilesystemHelper {
+			public static function get() {
+				return null;
+			}
+		}
+	}
+}
+
+namespace DataMachineCode\Abilities {
+	class GitHubAbilities {
+		public static string $pat = 'test-token';
+		public static array $calls = array();
+		public static array $responses = array();
+
+		public static function getPat(): string {
+			return self::$pat;
+		}
+
+		public static function apiGet( string $url, array $params, string $pat, int $timeout = 30 ) {
+			self::$calls[] = array(
+				'url'     => $url,
+				'params'  => $params,
+				'pat'     => $pat,
+				'timeout' => $timeout,
+			);
+
+			$response = array_shift( self::$responses );
+			return null === $response ? array( 'data' => array() ) : $response;
+		}
+	}
+}
+
+namespace {
+	use DataMachineCode\Abilities\GitHubAbilities;
+	use DataMachineCode\Workspace\Workspace;
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			public string $code;
+			public string $message;
+			public array $data;
+			public function __construct( $code = '', $message = '', $data = array() ) {
+				$this->code    = (string) $code;
+				$this->message = (string) $message;
+				$this->data    = (array) $data;
+			}
+			public function get_error_message(): string {
+				return $this->message;
+			}
+			public function get_error_data(): array {
+				return $this->data;
+			}
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $thing ): bool {
+			return $thing instanceof \WP_Error;
+		}
+	}
+
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( string $hook_name, $value ) {
+			return $value;
+		}
+	}
+
+	if ( ! function_exists( 'get_option' ) ) {
+		function get_option( string $name, $default = false ) {
+			return $default;
+		}
+	}
+
+	if ( ! function_exists( 'size_format' ) ) {
+		function size_format( $bytes ): string {
+			return (string) $bytes;
+		}
+	}
+
+	require __DIR__ . '/../inc/Support/GitHubRemote.php';
+	require __DIR__ . '/../inc/Support/GitRunner.php';
+	require __DIR__ . '/../inc/Support/PathSecurity.php';
+	require __DIR__ . '/../inc/Workspace/WorkspaceMutationLock.php';
+	require __DIR__ . '/../inc/Workspace/WorktreeContextInjector.php';
+	require __DIR__ . '/../inc/Workspace/Workspace.php';
+
+	$failures = 0;
+	$total    = 0;
+
+	$assert = function ( $expected, $actual, string $message ) use ( &$failures, &$total ): void {
+		$total++;
+		if ( $expected === $actual ) {
+			echo "  ✓ {$message}\n";
+			return;
+		}
+		$failures++;
+		echo "  ✗ {$message}\n";
+		echo '    expected: ' . var_export( $expected, true ) . "\n";
+		echo '    actual:   ' . var_export( $actual, true ) . "\n";
+	};
+
+	$assert_true = function ( bool $condition, string $message ) use ( &$failures, &$total ): void {
+		$total++;
+		if ( $condition ) {
+			echo "  ✓ {$message}\n";
+			return;
+		}
+		$failures++;
+		echo "  ✗ {$message}\n";
+	};
+
+	$find = new \ReflectionMethod( Workspace::class, 'find_merged_pr_for_branch' );
+	$workspace = new Workspace();
+
+	$merged_pr = array(
+		'number'    => 42,
+		'state'     => 'closed',
+		'merged_at' => '2026-04-28T00:00:00Z',
+		'html_url'  => 'https://github.com/Extra-Chill/data-machine-code/pull/42',
+		'head'      => array(
+			'ref'  => 'merged-branch',
+			'repo' => array( 'full_name' => 'Extra-Chill/data-machine-code' ),
+		),
+	);
+	$fork_pr = array(
+		'number'    => 43,
+		'state'     => 'closed',
+		'merged_at' => '2026-04-28T00:00:00Z',
+		'html_url'  => 'https://github.com/fork/data-machine-code/pull/43',
+		'head'      => array(
+			'ref'  => 'fork-branch',
+			'repo' => array( 'full_name' => 'someone/data-machine-code' ),
+		),
+	);
+
+	echo "=== smoke-worktree-cleanup-github-cache ===\n";
+
+	echo "\n[1] one repo lookup is cached across branch checks\n";
+	GitHubAbilities::$pat       = 'test-token';
+	GitHubAbilities::$calls     = array();
+	GitHubAbilities::$responses = array( array( 'data' => array( $merged_pr, $fork_pr ) ) );
+	$cache = array();
+
+	$hit  = $find->invokeArgs( $workspace, array( 'Extra-Chill/data-machine-code', 'merged-branch', &$cache ) );
+	$miss = $find->invokeArgs( $workspace, array( 'Extra-Chill/data-machine-code', 'missing-branch', &$cache ) );
+	$fork = $find->invokeArgs( $workspace, array( 'Extra-Chill/data-machine-code', 'fork-branch', &$cache ) );
+
+	$assert( 42, $hit['number'] ?? null, 'merged same-repo branch is found' );
+	$assert( null, $miss, 'missing branch returns null' );
+	$assert( null, $fork, 'fork branch with same ref is ignored' );
+	$assert( 1, count( GitHubAbilities::$calls ), 'GitHub API called once for three branch checks' );
+	$assert( 5, GitHubAbilities::$calls[0]['timeout'] ?? null, 'GitHub lookup uses bounded timeout' );
+	$assert( 'closed', GitHubAbilities::$calls[0]['params']['state'] ?? null, 'lookup lists closed PRs' );
+	$assert( false, array_key_exists( 'head', GitHubAbilities::$calls[0]['params'] ?? array() ), 'lookup is repo-level, not branch-specific' );
+
+	echo "\n[2] lookup failures are cached and returned as per-repo errors\n";
+	GitHubAbilities::$calls     = array();
+	GitHubAbilities::$responses = array( new \WP_Error( 'github_request_failed', 'timeout after 5 seconds' ) );
+	$cache = array();
+
+	$error_a = $find->invokeArgs( $workspace, array( 'Extra-Chill/data-machine-code', 'a', &$cache ) );
+	$error_b = $find->invokeArgs( $workspace, array( 'Extra-Chill/data-machine-code', 'b', &$cache ) );
+
+	$assert_true( is_wp_error( $error_a ), 'first failed lookup returns WP_Error' );
+	$assert_true( is_wp_error( $error_b ), 'cached failed lookup returns WP_Error' );
+	$assert( 1, count( GitHubAbilities::$calls ), 'failed GitHub lookup is cached' );
+	$assert_true( str_contains( $error_a->get_error_message(), 'GitHub cleanup lookup failed' ), 'error message names cleanup lookup' );
+
+	echo "\n[3] missing GitHub credentials skip API calls\n";
+	GitHubAbilities::$pat       = '';
+	GitHubAbilities::$calls     = array();
+	GitHubAbilities::$responses = array( array( 'data' => array( $merged_pr ) ) );
+	$cache = array();
+
+	$disabled = $find->invokeArgs( $workspace, array( 'Extra-Chill/data-machine-code', 'merged-branch', &$cache ) );
+	$assert( null, $disabled, 'no PAT returns no GitHub signal' );
+	$assert( 0, count( GitHubAbilities::$calls ), 'no PAT avoids API call entirely' );
+
+	if ( $failures > 0 ) {
+		echo "\nFAIL: {$failures}/{$total} assertions failed.\n";
+		exit( 1 );
+	}
+
+	echo "\nPASS: {$total} assertions passed.\n";
+}


### PR DESCRIPTION
## Summary
- Make GitHub-backed worktree cleanup scale by replacing per-branch PR queries with a bounded per-repo merged-PR cache.
- Degrade GitHub lookup failures into per-worktree `unknown_github_state` skips instead of blocking the whole cleanup report.

## Changes
- Added a per-run GitHub cleanup cache keyed by `owner/repo`.
- Changed cleanup PR detection to fetch up to 3 pages of recently closed PRs per repo, with a 5-second timeout per page.
- Kept cheap local safety checks first; GitHub is only consulted after protected/dirty/unpushed/missing-primary checks pass.
- Added optional timeout support to `GitHubAbilities::apiGet()` without changing existing callers.
- Added a smoke test covering cache reuse, same-repo merged PR filtering, timeout propagation, failure caching, and no-PAT short-circuiting.

## Tests
- `php tests/smoke-worktree-cleanup-github-cache.php`
  - PASS: 13 assertions passed.
- `php tests/smoke-worktree-cleanup.php`
  - PASS: 20/20 passed.
- `php -l inc/Workspace/Workspace.php && php -l inc/Abilities/GitHubAbilities.php && php -l tests/smoke-worktree-cleanup-github-cache.php`
  - PASS: no syntax errors.
- `homeboy lint data-machine-code --path "/Users/chubes/Developer/data-machine-code@fix-worktree-cleanup-scale" --changed-since origin/main`
  - PASS: no changed-file findings reported.
- `homeboy lint data-machine-code --path "/Users/chubes/Developer/data-machine-code@fix-worktree-cleanup-scale"`
  - BLOCKED/FAILED: reports existing unrelated lint findings across `WorktreeContextInjector.php`, `WorkspaceMutationLock.php`, `GitHubCredentialResolver.php`, `WorkspaceCommand.php`, `Workspace.php`, and `WorktreeBootstrapper.php`; touched-line syntax and focused smokes pass.
- `homeboy test data-machine-code --path "/Users/chubes/Developer/data-machine-code@fix-worktree-cleanup-scale"`
  - BLOCKED/FAILED: initially failed because the `--skip-bootstrap` worktree lacked `vendor/autoload.php`; after `composer install`, the Playground runner loaded the plugin but failed with `NO_TEST_FILES` because this repo currently has smoke scripts rather than PHPUnit `*Test.php` files.

Closes #116

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implementing the cleanup scaling fix, tests, and PR description; Chris remains responsible for review.
