### PR TITLE
fix(workspace): stabilize cleanup report contract

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -1046,6 +1046,7 @@ class WorkspaceAbilities {
 							'candidates' => array( 'type' => 'array' ),
 							'removed'    => array( 'type' => 'array' ),
 							'skipped'    => array( 'type' => 'array' ),
+							'summary'    => array( 'type' => 'object' ),
 						),
 					),
 					'execute_callback'    => array( self::class, 'worktreeCleanup' ),

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1068,8 +1068,16 @@ class WorkspaceCommand extends BaseCommand {
 	 *   signal (cleanup only). Faster, but misses merged branches where the
 	 *   remote branch wasn't auto-deleted.
 	 *
+	 * [--verbose]
+	 * : Show every cleanup row instead of concise samples (cleanup only).
+	 *
+	 * [--only=<section>]
+	 * : Limit cleanup rows to one section or reason code. Supported values:
+	 *   candidates, removed, no_merge_signal, dirty_worktree,
+	 *   unpushed_commits, missing_metadata, external_worktree.
+	 *
 	 * [--format=<format>]
-	 * : Output format for list (table, json, csv, yaml).
+	 * : Output format for list and cleanup (table, json, csv, yaml).
 	 *
 	 * ## EXAMPLES
 	 *
@@ -1263,49 +1271,7 @@ class WorkspaceCommand extends BaseCommand {
 				return;
 
 			case 'cleanup':
-				$candidates = $result['candidates'] ?? array();
-				$removed    = $result['removed'] ?? array();
-				$skipped    = $result['skipped'] ?? array();
-				$dry_run    = ! empty( $result['dry_run'] );
-
-				if ( empty( $candidates ) && empty( $skipped ) ) {
-					WP_CLI::log( 'No worktrees found.' );
-					return;
-				}
-
-				if ( ! empty( $candidates ) ) {
-					WP_CLI::log( $dry_run ? 'Would remove:' : 'Removed:' );
-					$rows = array_map(
-						fn( $c ) => array(
-							'handle' => $c['handle'] ?? '',
-							'branch' => $c['branch'] ?? '',
-							'signal' => $c['signal'] ?? '',
-							'reason' => $c['reason'] ?? '',
-						),
-						$candidates
-					);
-					$this->format_items( $rows, array( 'handle', 'branch', 'signal', 'reason' ), $assoc_args, 'handle' );
-				}
-
-				if ( ! empty( $skipped ) ) {
-					WP_CLI::log( '' );
-					WP_CLI::log( 'Skipped:' );
-					$rows = array_map(
-						fn( $s ) => array(
-							'handle' => $s['handle'] ?? '',
-							'reason' => $s['reason'] ?? '',
-						),
-						$skipped
-					);
-					$this->format_items( $rows, array( 'handle', 'reason' ), $assoc_args, 'handle' );
-				}
-
-				if ( $dry_run ) {
-					WP_CLI::log( '' );
-					WP_CLI::success( sprintf( '%d worktree(s) would be removed. Re-run without --dry-run to apply.', count( $candidates ) ) );
-				} else {
-					WP_CLI::success( sprintf( 'Removed %d worktree(s); %d skipped.', count( $removed ), count( $skipped ) ) );
-				}
+				$this->render_worktree_cleanup_result( $result, $assoc_args );
 				return;
 
 			case 'add':
@@ -1364,6 +1330,175 @@ class WorkspaceCommand extends BaseCommand {
 				WP_CLI::success( $result['message'] ?? 'Worktree operation complete.' );
 				return;
 		}
+	}
+
+	/**
+	 * Render cleanup output with a machine-safe JSON contract and concise tables.
+	 *
+	 * @param array $result     Cleanup ability result.
+	 * @param array $assoc_args CLI assoc args.
+	 * @return void
+	 */
+	private function render_worktree_cleanup_result( array $result, array $assoc_args ): void {
+		$format = isset( $assoc_args['format'] ) ? (string) $assoc_args['format'] : 'table';
+		$only   = isset( $assoc_args['only'] ) ? (string) $assoc_args['only'] : '';
+		$report = $this->filter_worktree_cleanup_report( $result, $only );
+
+		if ( 'json' === $format ) {
+			$json = wp_json_encode( $report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+			WP_CLI::log( false === $json ? '{}' : $json );
+			return;
+		}
+
+		$candidates = $report['candidates'] ?? array();
+		$removed    = $report['removed'] ?? array();
+		$skipped    = $report['skipped'] ?? array();
+		$summary    = $report['summary'] ?? array();
+		$dry_run    = ! empty( $report['dry_run'] );
+		$verbose    = ! empty( $assoc_args['verbose'] );
+		$limit      = $verbose ? PHP_INT_MAX : 10;
+
+		if ( empty( $candidates ) && empty( $removed ) && empty( $skipped ) ) {
+			WP_CLI::log( 'No worktrees found.' );
+			return;
+		}
+
+		WP_CLI::log( 'Summary:' );
+		$summary_rows = array(
+			array(
+				'metric' => 'would_remove',
+				'count'  => (int) ( $summary['would_remove'] ?? count( $candidates ) ),
+			),
+			array(
+				'metric' => 'removed',
+				'count'  => (int) ( $summary['removed'] ?? count( $removed ) ),
+			),
+			array(
+				'metric' => 'skipped',
+				'count'  => (int) ( $summary['skipped'] ?? count( $skipped ) ),
+			),
+		);
+		foreach ( (array) ( $summary['skipped_by_reason'] ?? array() ) as $reason_code => $count ) {
+			$summary_rows[] = array(
+				'metric' => 'skipped:' . $reason_code,
+				'count'  => (int) $count,
+			);
+		}
+		$this->format_items( $summary_rows, array( 'metric', 'count' ), array( 'format' => 'table' ), 'metric' );
+
+		if ( '' !== $only ) {
+			WP_CLI::log( sprintf( 'Filter: %s', $only ) );
+		}
+
+		if ( ! empty( $candidates ) && ( '' === $only || 'candidates' === $only ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( $dry_run ? 'Would remove:' : 'Candidates:' );
+			$candidate_rows = array_map(
+				fn( $c ) => array(
+					'handle' => $c['handle'] ?? '',
+					'branch' => $c['branch'] ?? '',
+					'signal' => $c['signal'] ?? '',
+					'reason' => $c['reason'] ?? '',
+				),
+				array_slice( $candidates, 0, $limit )
+			);
+			$this->format_items( $candidate_rows, array( 'handle', 'branch', 'signal', 'reason' ), array( 'format' => 'table' ), 'handle' );
+			$this->render_cleanup_truncation_hint( count( $candidates ), $limit, 'candidate rows' );
+		}
+
+		if ( ! empty( $removed ) && ( '' === $only || 'removed' === $only ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( 'Removed:' );
+			$removed_rows = array_map(
+				fn( $c ) => array(
+					'handle' => $c['handle'] ?? '',
+					'branch' => $c['branch'] ?? '',
+					'signal' => $c['signal'] ?? '',
+					'reason' => $c['reason'] ?? '',
+				),
+				array_slice( $removed, 0, $limit )
+			);
+			$this->format_items( $removed_rows, array( 'handle', 'branch', 'signal', 'reason' ), array( 'format' => 'table' ), 'handle' );
+			$this->render_cleanup_truncation_hint( count( $removed ), $limit, 'removed rows' );
+		}
+
+		if ( ! empty( $skipped ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( 'Skipped:' );
+			$skipped_rows = array_map(
+				fn( $s ) => array(
+					'handle'      => $s['handle'] ?? '',
+					'reason_code' => $s['reason_code'] ?? '',
+					'reason'      => $s['reason'] ?? '',
+					'missing'     => implode( ',', (array) ( $s['missing_fields'] ?? array() ) ),
+					'hint'        => $s['hint'] ?? '',
+				),
+				array_slice( $skipped, 0, $limit )
+			);
+			$this->format_items( $skipped_rows, array( 'handle', 'reason_code', 'reason', 'missing', 'hint' ), array( 'format' => 'table' ), 'handle' );
+			$this->render_cleanup_truncation_hint( count( $skipped ), $limit, 'skipped rows' );
+		}
+
+		WP_CLI::log( '' );
+		if ( $dry_run ) {
+			WP_CLI::success( sprintf( '%d worktree(s) would be removed. Re-run without --dry-run to apply.', count( $result['candidates'] ?? array() ) ) );
+			return;
+		}
+		WP_CLI::success( sprintf( 'Removed %d worktree(s); %d skipped.', count( $result['removed'] ?? array() ), count( $result['skipped'] ?? array() ) ) );
+	}
+
+	/**
+	 * Filter cleanup row arrays for --only without changing summary counts.
+	 *
+	 * @param array  $report Cleanup report.
+	 * @param string $only   Section or reason-code filter.
+	 * @return array
+	 */
+	private function filter_worktree_cleanup_report( array $report, string $only ): array {
+		if ( '' === $only ) {
+			return $report;
+		}
+
+		$aliases = array(
+			'dirty'            => 'dirty_worktree',
+			'unpushed'         => 'unpushed_commits',
+			'missing-metadata' => 'missing_metadata',
+			'external'         => 'external_worktree',
+		);
+		$only    = $aliases[ $only ] ?? $only;
+
+		if ( 'candidates' !== $only ) {
+			$report['candidates'] = array();
+		}
+		if ( 'removed' !== $only ) {
+			$report['removed'] = array();
+		}
+
+		if ( ! in_array( $only, array( 'candidates', 'removed' ), true ) ) {
+			$report['skipped'] = array_values( array_filter(
+				(array) ( $report['skipped'] ?? array() ),
+				fn( $row ) => (string) ( $row['reason_code'] ?? '' ) === $only
+			) );
+		} else {
+			$report['skipped'] = array();
+		}
+
+		return $report;
+	}
+
+	/**
+	 * Print a concise-output truncation hint.
+	 *
+	 * @param int    $total Total rows.
+	 * @param int    $limit Rendered row limit.
+	 * @param string $label Row label.
+	 * @return void
+	 */
+	private function render_cleanup_truncation_hint( int $total, int $limit, string $label ): void {
+		if ( $total <= $limit ) {
+			return;
+		}
+		WP_CLI::log( sprintf( 'Showing %d of %d %s. Re-run with --verbose for all rows or --only=<reason_code> to filter.', $limit, $total, $label ) );
 	}
 
 	/**

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -1608,39 +1608,74 @@ class Workspace {
 			if ( ! empty( $wt['is_primary'] ) ) {
 				continue;
 			}
+
+			$handle  = $wt['handle'] ?? '?';
+			$repo    = $wt['repo'] ?? '';
+			$branch  = $wt['branch'] ?? '';
+			$wt_path = $wt['path'] ?? '';
+
 			if ( ! empty( $wt['external'] ) ) {
 				$skipped[] = array(
-					'handle' => $wt['handle'] ?? '?',
-					'reason' => 'external worktree (outside workspace)',
+					'handle'      => $handle,
+					'repo'        => $repo,
+					'branch'      => $branch,
+					'path'        => $wt_path,
+					'reason_code' => 'external_worktree',
+					'reason'      => 'external worktree (outside workspace)',
+					'hint'        => 'Inspect manually; cleanup never removes worktrees outside the DMC workspace.',
 				);
 				continue;
 			}
 
-			$repo        = $wt['repo'] ?? '';
-			$branch      = $wt['branch'] ?? '';
-			$wt_path     = $wt['path'] ?? '';
 			$dirty_count = (int) ( $wt['dirty'] ?? 0 );
 
 			if ( '' === $repo || '' === $branch || '' === $wt_path ) {
+				$missing_fields = array();
+				foreach (
+					array(
+						'repo'   => $repo,
+						'branch' => $branch,
+						'path'   => $wt_path,
+					) as $field => $value
+				) {
+					if ( '' === $value ) {
+						$missing_fields[] = $field;
+					}
+				}
 				$skipped[] = array(
-					'handle' => $wt['handle'] ?? '?',
-					'reason' => 'missing repo/branch/path',
+					'handle'         => $handle,
+					'repo'           => $repo,
+					'branch'         => $branch,
+					'path'           => $wt_path,
+					'reason_code'    => 'missing_metadata',
+					'reason'         => 'missing repo/branch/path',
+					'missing_fields' => $missing_fields,
+					'hint'           => 'Run workspace worktree prune if this is a stale registry entry; inspect manually if the path still exists.',
 				);
 				continue;
 			}
 
 			if ( in_array( $branch, $protected_branches, true ) ) {
 				$skipped[] = array(
-					'handle' => $wt['handle'] ?? '?',
-					'reason' => sprintf( 'protected branch (%s)', $branch ),
+					'handle'      => $handle,
+					'repo'        => $repo,
+					'branch'      => $branch,
+					'path'        => $wt_path,
+					'reason_code' => 'protected_branch',
+					'reason'      => sprintf( 'protected branch (%s)', $branch ),
 				);
 				continue;
 			}
 
 			if ( $dirty_count > 0 && ! $force ) {
 				$skipped[] = array(
-					'handle' => $wt['handle'] ?? '?',
-					'reason' => sprintf( 'working tree dirty (%d files) — pass force=true to override', $dirty_count ),
+					'handle'      => $handle,
+					'repo'        => $repo,
+					'branch'      => $branch,
+					'path'        => $wt_path,
+					'reason_code' => 'dirty_worktree',
+					'reason'      => sprintf( 'working tree dirty (%d files) — pass force=true to override', $dirty_count ),
+					'dirty'       => $dirty_count,
 				);
 				continue;
 			}
@@ -1653,8 +1688,13 @@ class Workspace {
 			$unpushed = $this->count_unpushed_commits( $wt_path );
 			if ( $unpushed > 0 ) {
 				$skipped[] = array(
-					'handle' => $wt['handle'] ?? '?',
-					'reason' => sprintf( '%d unpushed commit(s) — refusing to delete even with force (push or reset explicitly)', $unpushed ),
+					'handle'      => $handle,
+					'repo'        => $repo,
+					'branch'      => $branch,
+					'path'        => $wt_path,
+					'reason_code' => 'unpushed_commits',
+					'reason'      => sprintf( '%d unpushed commit(s) — refusing to delete even with force (push or reset explicitly)', $unpushed ),
+					'unpushed'    => $unpushed,
 				);
 				continue;
 			}
@@ -1662,8 +1702,13 @@ class Workspace {
 			$primary_path = $this->get_primary_path( $repo );
 			if ( ! is_dir( $primary_path . '/.git' ) ) {
 				$skipped[] = array(
-					'handle' => $wt['handle'] ?? '?',
-					'reason' => 'primary checkout missing',
+					'handle'      => $handle,
+					'repo'        => $repo,
+					'branch'      => $branch,
+					'path'        => $wt_path,
+					'reason_code' => 'missing_metadata',
+					'reason'      => 'primary checkout missing',
+					'hint'        => 'Run workspace worktree prune if this is a stale registry entry; inspect manually if the path still exists.',
 				);
 				continue;
 			}
@@ -1676,23 +1721,30 @@ class Workspace {
 			$signal = $this->detect_merge_signal( $primary_path, $repo, $branch, $skip_github );
 			if ( null === $signal ) {
 				$skipped[] = array(
-					'handle' => $wt['handle'] ?? '?',
-					'reason' => 'no merge signal — leaving in place',
+					'handle'      => $handle,
+					'repo'        => $repo,
+					'branch'      => $branch,
+					'path'        => $wt_path,
+					'reason_code' => 'no_merge_signal',
+					'reason'      => 'no merge signal — leaving in place',
 				);
 				continue;
 			}
 
 			$candidates[] = array(
-				'handle' => $wt['handle'],
-				'repo'   => $repo,
-				'branch' => $branch,
-				'path'   => $wt_path,
-				'dirty'  => $dirty_count,
-				'signal' => $signal['signal'],
-				'reason' => $signal['reason'],
-				'pr_url' => $signal['pr_url'] ?? null,
+				'handle'      => $wt['handle'],
+				'repo'        => $repo,
+				'branch'      => $branch,
+				'path'        => $wt_path,
+				'dirty'       => $dirty_count,
+				'signal'      => $signal['signal'],
+				'reason_code' => $signal['signal'],
+				'reason'      => $signal['reason'],
+				'pr_url'      => $signal['pr_url'] ?? null,
 			);
 		}
+
+		$summary = $this->build_worktree_cleanup_summary( $candidates, array(), $skipped );
 
 		if ( $dry_run ) {
 			return array(
@@ -1701,6 +1753,7 @@ class Workspace {
 				'candidates' => $candidates,
 				'removed'    => array(),
 				'skipped'    => $skipped,
+				'summary'    => $summary,
 			);
 		}
 
@@ -1725,8 +1778,12 @@ class Workspace {
 			);
 			if ( is_wp_error( $remove ) ) {
 				$skipped[] = array(
-					'handle' => $cand['handle'],
-					'reason' => 'remove failed: ' . $remove->get_error_message(),
+					'handle'      => $cand['handle'],
+					'repo'        => $cand['repo'] ?? '',
+					'branch'      => $cand['branch'] ?? '',
+					'path'        => $cand['path'] ?? '',
+					'reason_code' => 'remove_failed',
+					'reason'      => 'remove failed: ' . $remove->get_error_message(),
 				);
 				continue;
 			}
@@ -1742,6 +1799,41 @@ class Workspace {
 			'candidates' => $candidates,
 			'removed'    => $removed,
 			'skipped'    => $skipped,
+			'summary'    => $this->build_worktree_cleanup_summary( $candidates, $removed, $skipped ),
+		);
+	}
+
+	/**
+	 * Build stable cleanup counts for CLI and automation consumers.
+	 *
+	 * @param array<int,array> $candidates Candidate rows.
+	 * @param array<int,array> $removed    Removed rows.
+	 * @param array<int,array> $skipped    Skipped rows.
+	 * @return array<string,mixed>
+	 */
+	private function build_worktree_cleanup_summary( array $candidates, array $removed, array $skipped ): array {
+		$skipped_by_reason    = array();
+		$candidates_by_signal = array();
+
+		foreach ( $skipped as $row ) {
+			$code = (string) ( $row['reason_code'] ?? 'unknown' );
+			$skipped_by_reason[ $code ] = ( $skipped_by_reason[ $code ] ?? 0 ) + 1;
+		}
+
+		foreach ( $candidates as $row ) {
+			$signal = (string) ( $row['signal'] ?? $row['reason_code'] ?? 'unknown' );
+			$candidates_by_signal[ $signal ] = ( $candidates_by_signal[ $signal ] ?? 0 ) + 1;
+		}
+
+		ksort( $skipped_by_reason );
+		ksort( $candidates_by_signal );
+
+		return array(
+			'would_remove'         => count( $candidates ),
+			'removed'              => count( $removed ),
+			'skipped'              => count( $skipped ),
+			'skipped_by_reason'    => $skipped_by_reason,
+			'candidates_by_signal' => $candidates_by_signal,
 		);
 	}
 

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Smoke test for workspace worktree cleanup CLI report rendering.
+ *
+ *   php tests/smoke-worktree-cleanup-cli.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ );
+	}
+
+	class WP_CLI {
+		public static array $logs = array();
+		public static array $successes = array();
+
+		public static function error( string $message ): void {
+			throw new RuntimeException( $message );
+		}
+
+		public static function success( string $message ): void {
+			self::$successes[] = $message;
+		}
+
+		public static function log( string $message ): void {
+			self::$logs[] = $message;
+		}
+
+		public static function warning( string $message ): void {
+			self::$logs[] = 'warning: ' . $message;
+		}
+	}
+
+	function is_wp_error( $value ): bool {
+		return false;
+	}
+
+	function wp_get_ability( string $name ) {
+		return $GLOBALS['__abilities'][ $name ] ?? null;
+	}
+
+	function wp_json_encode( $data, int $flags = 0 ) {
+		return json_encode( $data, $flags );
+	}
+}
+
+namespace DataMachine\Cli {
+	class BaseCommand {
+		protected function format_items( array $items, array $fields, array $assoc_args, string $default_sort = '' ): void {
+			\WP_CLI::log( 'table:' . count( $items ) . ':' . implode( ',', $fields ) );
+		}
+	}
+}
+
+namespace {
+	require_once dirname( __DIR__ ) . '/inc/Cli/Commands/WorkspaceCommand.php';
+
+	function datamachine_code_cleanup_assert( bool $condition, string $message ): void {
+		if ( $condition ) {
+			echo "  [PASS] {$message}\n";
+			return;
+		}
+		echo "  [FAIL] {$message}\n";
+		exit( 1 );
+	}
+
+	function datamachine_code_cleanup_report(): array {
+		$skipped = array();
+		for ( $i = 1; $i <= 11; $i++ ) {
+			$skipped[] = array(
+				'handle'      => 'repo@feature-' . $i,
+				'repo'        => 'repo',
+				'branch'      => 'feature-' . $i,
+				'path'        => '/workspace/repo@feature-' . $i,
+				'reason_code' => 1 === $i ? 'dirty_worktree' : 'no_merge_signal',
+				'reason'      => 1 === $i ? 'working tree dirty (1 files) - pass force=true to override' : 'no merge signal - leaving in place',
+			);
+		}
+
+		$skipped[] = array(
+			'handle'         => 'broken@metadata',
+			'repo'           => '',
+			'branch'         => '',
+			'path'           => '',
+			'reason_code'    => 'missing_metadata',
+			'reason'         => 'missing repo/branch/path',
+			'missing_fields' => array( 'repo', 'branch', 'path' ),
+			'hint'           => 'Run workspace worktree prune if this is a stale registry entry; inspect manually if the path still exists.',
+		);
+
+		return array(
+			'success'    => true,
+			'dry_run'    => true,
+			'candidates' => array(
+				array(
+					'handle'      => 'repo@merged',
+					'repo'        => 'repo',
+					'branch'      => 'merged',
+					'path'        => '/workspace/repo@merged',
+					'signal'      => 'upstream-gone',
+					'reason_code' => 'upstream-gone',
+					'reason'      => 'remote branch deleted (likely merged + auto-deleted)',
+				),
+			),
+			'removed'    => array(),
+			'skipped'    => $skipped,
+			'summary'    => array(
+				'would_remove'         => 1,
+				'removed'              => 0,
+				'skipped'              => count( $skipped ),
+				'skipped_by_reason'    => array(
+					'dirty_worktree'   => 1,
+					'missing_metadata' => 1,
+					'no_merge_signal'  => 10,
+				),
+				'candidates_by_signal' => array(
+					'upstream-gone' => 1,
+				),
+			),
+		);
+	}
+
+	class FakeCleanupAbility {
+		public array $last_input = array();
+
+		public function execute( array $input ): array {
+			$this->last_input = $input;
+			return datamachine_code_cleanup_report();
+		}
+	}
+
+	echo "=== smoke-worktree-cleanup-cli ===\n";
+
+	$ability = new FakeCleanupAbility();
+	$GLOBALS['__abilities'] = array(
+		'datamachine/workspace-worktree-cleanup' => $ability,
+	);
+	$command = new \DataMachineCode\Cli\Commands\WorkspaceCommand();
+
+	echo "\n[1] JSON output is one parseable document\n";
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->worktree( array( 'cleanup' ), array( 'dry-run' => true, 'skip-github' => true, 'format' => 'json' ) );
+	datamachine_code_cleanup_assert( array( 'dry_run' => true, 'force' => false, 'skip_github' => true ) === $ability->last_input, 'cleanup flags forwarded to ability' );
+	datamachine_code_cleanup_assert( 1 === count( WP_CLI::$logs ), 'JSON path writes exactly one stdout log entry' );
+	datamachine_code_cleanup_assert( array() === WP_CLI::$successes, 'JSON path emits no success suffix' );
+	$decoded = json_decode( WP_CLI::$logs[0], true );
+	datamachine_code_cleanup_assert( JSON_ERROR_NONE === json_last_error(), 'JSON output parses cleanly' );
+	datamachine_code_cleanup_assert( 'dirty_worktree' === ( $decoded['skipped'][0]['reason_code'] ?? '' ), 'JSON rows include stable reason code' );
+	datamachine_code_cleanup_assert( array( 'repo', 'branch', 'path' ) === ( $decoded['skipped'][11]['missing_fields'] ?? array() ), 'JSON missing_metadata includes missing fields' );
+	datamachine_code_cleanup_assert( str_contains( $decoded['skipped'][11]['hint'] ?? '', 'workspace worktree prune' ), 'JSON missing_metadata includes remediation hint' );
+	datamachine_code_cleanup_assert( 10 === (int) ( $decoded['summary']['skipped_by_reason']['no_merge_signal'] ?? 0 ), 'JSON summary includes reason counts' );
+
+	echo "\n[2] default output is concise and summary-first\n";
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->worktree( array( 'cleanup' ), array( 'dry-run' => true, 'skip-github' => true ) );
+	datamachine_code_cleanup_assert( 'Summary:' === ( WP_CLI::$logs[0] ?? '' ), 'human output starts with summary' );
+	datamachine_code_cleanup_assert( in_array( 'Showing 10 of 12 skipped rows. Re-run with --verbose for all rows or --only=<reason_code> to filter.', WP_CLI::$logs, true ), 'human output truncates skipped rows with hint' );
+	datamachine_code_cleanup_assert( 1 === count( WP_CLI::$successes ), 'human output keeps success suffix' );
+
+	echo "\n[3] --only filters rows while keeping full summary\n";
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->worktree( array( 'cleanup' ), array( 'dry-run' => true, 'only' => 'missing-metadata', 'format' => 'json' ) );
+	$filtered = json_decode( WP_CLI::$logs[0], true );
+	datamachine_code_cleanup_assert( array() === ( $filtered['candidates'] ?? null ), '--only reason hides candidates' );
+	datamachine_code_cleanup_assert( 1 === count( $filtered['skipped'] ?? array() ), '--only reason keeps matching skipped rows only' );
+	datamachine_code_cleanup_assert( 'missing_metadata' === ( $filtered['skipped'][0]['reason_code'] ?? '' ), '--only alias resolves to reason code' );
+	datamachine_code_cleanup_assert( 12 === (int) ( $filtered['summary']['skipped'] ?? 0 ), '--only leaves summary counts unfiltered' );
+
+	echo "\nAll worktree cleanup CLI smoke tests passed.\n";
+}

--- a/tests/smoke-worktree-cleanup.php
+++ b/tests/smoke-worktree-cleanup.php
@@ -120,6 +120,9 @@ namespace {
 		if ( is_dir( $tmp ) ) {
 			exec( 'rm -rf ' . escapeshellarg( $tmp ) );
 		}
+		if ( is_dir( $tmp . '-external' ) ) {
+			exec( 'rm -rf ' . escapeshellarg( $tmp . '-external' ) );
+		}
 	} );
 
 	define( 'DATAMACHINE_WORKSPACE_PATH', realpath( $tmp ) ?: $tmp );
@@ -198,6 +201,7 @@ namespace {
 	$make_branch( 'merged-live-remote', 'b' );  // → simulate via PR-merged (stubbed → none)
 	$make_branch( 'unmerged-feature', 'c' );    // still active
 	$make_branch( 'dirty-branch', 'd' );        // will be dirty in worktree
+	$make_branch( 'external-branch', 'e' );     // outside workspace, should never be removed
 
 	// Create worktrees at various paths:
 	//   - canonical slug path (demo@merged-autodelete)
@@ -208,6 +212,8 @@ namespace {
 	$run( sprintf( 'git worktree add %s merged-live-remote', escapeshellarg( $tmp . '/demo-legacy-merged' ) ), $primary );
 	$run( sprintf( 'git worktree add %s unmerged-feature', escapeshellarg( $tmp . '/demo@unmerged-feature' ) ), $primary );
 	$run( sprintf( 'git worktree add %s dirty-branch', escapeshellarg( $tmp . '/demo@dirty-branch' ) ), $primary );
+	mkdir( $tmp . '-external', 0755, true );
+	$run( sprintf( 'git worktree add %s external-branch', escapeshellarg( $tmp . '-external/demo-external' ) ), $primary );
 
 	// Dirty the dirty worktree.
 	file_put_contents( $tmp . '/demo@dirty-branch/scratch.txt', 'dirty' );
@@ -259,12 +265,52 @@ namespace {
 	// dirty-branch should be skipped (reason: dirty)
 	$dirty_skips = array_filter( $plan['skipped'] ?? array(), fn( $s ) => ( $s['handle'] ?? '' ) === 'demo@dirty-branch' );
 	$assert( 1, count( $dirty_skips ), 'dirty worktree skipped with exactly one entry' );
-	$dirty_reason = array_values( $dirty_skips )[0]['reason'] ?? '';
+	$dirty_row = array_values( $dirty_skips )[0] ?? array();
+	$dirty_reason = $dirty_row['reason'] ?? '';
 	$assert( true, str_contains( $dirty_reason, 'dirty' ), 'dirty skip reason mentions dirty' );
+	$assert( 'dirty_worktree', $dirty_row['reason_code'] ?? '', 'dirty skip exposes stable reason code' );
 
 	// unmerged-feature should be skipped (no merge signal)
 	$unmerged = array_filter( $plan['skipped'] ?? array(), fn( $s ) => ( $s['handle'] ?? '' ) === 'demo@unmerged-feature' );
 	$assert( 1, count( $unmerged ), 'unmerged worktree skipped with exactly one entry' );
+	$unmerged_row = array_values( $unmerged )[0] ?? array();
+	$assert( 'no_merge_signal', $unmerged_row['reason_code'] ?? '', 'unmerged skip exposes stable reason code' );
+
+	$external_rows = array_values( array_filter( $plan['skipped'] ?? array(), fn( $s ) => ( $s['reason_code'] ?? '' ) === 'external_worktree' ) );
+	$external_row  = $external_rows[0] ?? array();
+	$assert( 'external_worktree', $external_row['reason_code'] ?? '', 'external worktree exposes stable reason code' );
+	$assert( true, str_contains( $external_row['hint'] ?? '', 'outside the DMC workspace' ), 'external worktree includes remediation hint' );
+
+	$assert( 1, (int) ( $plan['summary']['would_remove'] ?? 0 ), 'summary counts cleanup candidates' );
+	$assert( 1, (int) ( $plan['summary']['skipped_by_reason']['dirty_worktree'] ?? 0 ), 'summary counts dirty skips by reason' );
+	$assert( true, isset( $plan['summary']['skipped_by_reason']['no_merge_signal'] ), 'summary includes no_merge_signal bucket' );
+
+	class Missing_Metadata_Workspace extends \DataMachineCode\Workspace\Workspace {
+		public function worktree_list( ?string $repo = null ): array|\WP_Error { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+			return array(
+				'success'   => true,
+				'worktrees' => array(
+					array(
+						'handle' => 'broken@metadata',
+						'repo'   => '',
+						'branch' => '',
+						'path'   => '',
+					),
+				),
+			);
+		}
+	}
+
+	$missing_plan = ( new Missing_Metadata_Workspace() )->worktree_cleanup_merged(
+		array(
+			'dry_run'     => true,
+			'skip_github' => true,
+		)
+	);
+	$missing_row = $missing_plan['skipped'][0] ?? array();
+	$assert( 'missing_metadata', $missing_row['reason_code'] ?? '', 'missing metadata exposes stable reason code' );
+	$assert( array( 'repo', 'branch', 'path' ), $missing_row['missing_fields'] ?? array(), 'missing metadata lists missing fields' );
+	$assert( true, str_contains( $missing_row['hint'] ?? '', 'workspace worktree prune' ), 'missing metadata includes prune remediation hint' );
 
 	// Primary itself should NEVER show up as a candidate.
 	foreach ( $plan['candidates'] ?? array() as $c ) {
@@ -302,6 +348,7 @@ namespace {
 	// Protected branches: unmerged/dirty worktrees survive.
 	$assert( true, is_dir( $tmp . '/demo@unmerged-feature' ), 'unmerged worktree survives cleanup' );
 	$assert( true, is_dir( $tmp . '/demo@dirty-branch' ), 'dirty worktree survives cleanup' );
+	$assert( true, is_dir( $tmp . '-external/demo-external' ), 'external worktree survives cleanup' );
 
 	// The local branch for the removed worktree should be gone.
 	$branch_check = $run( 'git for-each-ref --format="%(refname:short)" refs/heads/merged-autodelete', $primary );


### PR DESCRIPTION
## Summary
- Makes worktree cleanup JSON output a single parseable document for automation.
- Adds stable cleanup reason codes, summary counts, concise default output, and reason filtering.
- Explains missing metadata rows with missing field details and remediation guidance.

## Changes
- Adds `summary` to cleanup reports with candidate and skipped reason counts.
- Adds `reason_code` metadata for cleanup decisions including `no_merge_signal`, `dirty_worktree`, `unpushed_commits`, `missing_metadata`, and `external_worktree`.
- Adds cleanup CLI `--verbose` and `--only=<reason>` handling while keeping JSON output free of human prefixes/suffixes.
- Extends cleanup smoke coverage and adds a CLI renderer smoke for the JSON-only contract.

## Tests
- `php tests/smoke-worktree-cleanup.php`
- `php tests/smoke-worktree-cleanup-cli.php`
- `php -l inc/Workspace/Workspace.php && php -l inc/Cli/Commands/WorkspaceCommand.php && php -l tests/smoke-worktree-cleanup.php && php -l tests/smoke-worktree-cleanup-cli.php`

Closes #117
Closes #118
Closes #120

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implementing the cleanup report contract, tests, and PR description; Chris remains responsible for review.