### PR TITLE
fix(workspace): polish worktree cleanup UX

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1073,7 +1073,7 @@ class WorkspaceCommand extends BaseCommand {
 	 *
 	 * [--only=<section>]
 	 * : Limit cleanup rows to one section or reason code. Supported values:
-	 *   candidates, removed, no_merge_signal, dirty_worktree,
+	 *   candidates, would-remove, would_remove, removed, no_merge_signal, dirty_worktree,
 	 *   unpushed_commits, missing_metadata, external_worktree.
 	 *
 	 * [--format=<format>]
@@ -1347,7 +1347,7 @@ class WorkspaceCommand extends BaseCommand {
 	 */
 	private function render_worktree_cleanup_result( array $result, array $assoc_args ): void {
 		$format = isset( $assoc_args['format'] ) ? (string) $assoc_args['format'] : 'table';
-		$only   = isset( $assoc_args['only'] ) ? (string) $assoc_args['only'] : '';
+		$only   = isset( $assoc_args['only'] ) ? $this->normalize_worktree_cleanup_only( (string) $assoc_args['only'] ) : '';
 		$report = $this->filter_worktree_cleanup_report( $result, $only );
 
 		if ( 'json' === $format ) {
@@ -1401,14 +1401,16 @@ class WorkspaceCommand extends BaseCommand {
 			WP_CLI::log( $dry_run ? 'Would remove:' : 'Candidates:' );
 			$candidate_rows = array_map(
 				fn( $c ) => array(
-					'handle' => $c['handle'] ?? '',
-					'branch' => $c['branch'] ?? '',
-					'signal' => $c['signal'] ?? '',
-					'reason' => $c['reason'] ?? '',
+					'handle'      => $c['handle'] ?? '',
+					'branch'      => $c['branch'] ?? '',
+					'signal'      => $c['signal'] ?? '',
+					'reason_code' => $c['reason_code'] ?? ( $c['signal'] ?? '' ),
+					'reason'      => $c['reason'] ?? '',
 				),
 				array_slice( $candidates, 0, $limit )
 			);
-			$this->format_items( $candidate_rows, array( 'handle', 'branch', 'signal', 'reason' ), array( 'format' => 'table' ), 'handle' );
+			$fields = $verbose ? array( 'handle', 'branch', 'signal', 'reason' ) : array( 'handle', 'branch', 'signal', 'reason_code' );
+			$this->format_items( $candidate_rows, $fields, array( 'format' => 'table' ), 'handle' );
 			$this->render_cleanup_truncation_hint( count( $candidates ), $limit, 'candidate rows' );
 		}
 
@@ -1417,14 +1419,16 @@ class WorkspaceCommand extends BaseCommand {
 			WP_CLI::log( 'Removed:' );
 			$removed_rows = array_map(
 				fn( $c ) => array(
-					'handle' => $c['handle'] ?? '',
-					'branch' => $c['branch'] ?? '',
-					'signal' => $c['signal'] ?? '',
-					'reason' => $c['reason'] ?? '',
+					'handle'      => $c['handle'] ?? '',
+					'branch'      => $c['branch'] ?? '',
+					'signal'      => $c['signal'] ?? '',
+					'reason_code' => $c['reason_code'] ?? ( $c['signal'] ?? '' ),
+					'reason'      => $c['reason'] ?? '',
 				),
 				array_slice( $removed, 0, $limit )
 			);
-			$this->format_items( $removed_rows, array( 'handle', 'branch', 'signal', 'reason' ), array( 'format' => 'table' ), 'handle' );
+			$fields = $verbose ? array( 'handle', 'branch', 'signal', 'reason' ) : array( 'handle', 'branch', 'signal', 'reason_code' );
+			$this->format_items( $removed_rows, $fields, array( 'format' => 'table' ), 'handle' );
 			$this->render_cleanup_truncation_hint( count( $removed ), $limit, 'removed rows' );
 		}
 
@@ -1435,7 +1439,7 @@ class WorkspaceCommand extends BaseCommand {
 				fn( $s ) => array(
 					'handle'       => $s['handle'] ?? '',
 					'reason_code'  => $s['reason_code'] ?? '',
-					'reason'       => $s['reason'] ?? '',
+					'reason'       => $verbose ? ( $s['reason'] ?? '' ) : $this->shorten_cleanup_reason( (string) ( $s['reason'] ?? '' ) ),
 					'repo'         => $s['repo'] ?? '',
 					'branch'       => $s['branch'] ?? '',
 					'path'         => $s['path'] ?? '',
@@ -1445,7 +1449,8 @@ class WorkspaceCommand extends BaseCommand {
 				),
 				array_slice( $skipped, 0, $limit )
 			);
-			$this->format_items( $skipped_rows, array( 'handle', 'reason_code', 'reason', 'repo', 'branch', 'path', 'primary_path', 'missing', 'hint' ), array( 'format' => 'table' ), 'handle' );
+			$fields = $verbose ? array( 'handle', 'reason_code', 'reason', 'repo', 'branch', 'path', 'primary_path', 'missing', 'hint' ) : array( 'handle', 'reason_code', 'reason' );
+			$this->format_items( $skipped_rows, $fields, array( 'format' => 'table' ), 'handle' );
 			$this->render_cleanup_truncation_hint( count( $skipped ), $limit, 'skipped rows' );
 		}
 
@@ -1465,17 +1470,11 @@ class WorkspaceCommand extends BaseCommand {
 	 * @return array
 	 */
 	private function filter_worktree_cleanup_report( array $report, string $only ): array {
+		$only = $this->normalize_worktree_cleanup_only( $only );
+
 		if ( '' === $only ) {
 			return $report;
 		}
-
-		$aliases = array(
-			'dirty'            => 'dirty_worktree',
-			'unpushed'         => 'unpushed_commits',
-			'missing-metadata' => 'missing_metadata',
-			'external'         => 'external_worktree',
-		);
-		$only    = $aliases[ $only ] ?? $only;
 
 		if ( 'candidates' !== $only ) {
 			$report['candidates'] = array();
@@ -1494,6 +1493,39 @@ class WorkspaceCommand extends BaseCommand {
 		}
 
 		return $report;
+	}
+
+	/**
+	 * Normalize cleanup section/reason aliases used by --only.
+	 *
+	 * @param string $only Raw CLI filter value.
+	 * @return string Normalized filter value.
+	 */
+	private function normalize_worktree_cleanup_only( string $only ): string {
+		$aliases = array(
+			'would-remove'     => 'candidates',
+			'would_remove'     => 'candidates',
+			'dirty'            => 'dirty_worktree',
+			'unpushed'         => 'unpushed_commits',
+			'missing-metadata' => 'missing_metadata',
+			'external'         => 'external_worktree',
+		);
+
+		return $aliases[ $only ] ?? $only;
+	}
+
+	/**
+	 * Shorten cleanup reasons for compact human tables.
+	 *
+	 * @param string $reason Full reason text.
+	 * @return string Shortened reason text.
+	 */
+	private function shorten_cleanup_reason( string $reason ): string {
+		if ( strlen( $reason ) <= 72 ) {
+			return $reason;
+		}
+
+		return rtrim( substr( $reason, 0, 69 ) ) . '...';
 	}
 
 	/**

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -160,10 +160,19 @@ namespace {
 	WP_CLI::$successes = array();
 	$command->worktree( array( 'cleanup' ), array( 'dry-run' => true, 'skip-github' => true ) );
 	datamachine_code_cleanup_assert( 'Summary:' === ( WP_CLI::$logs[0] ?? '' ), 'human output starts with summary' );
+	datamachine_code_cleanup_assert( in_array( 'table:1:handle,branch,signal,reason_code', WP_CLI::$logs, true ), 'default candidate table uses compact fields' );
+	datamachine_code_cleanup_assert( in_array( 'table:10:handle,reason_code,reason', WP_CLI::$logs, true ), 'default skipped table omits path and hint fields' );
 	datamachine_code_cleanup_assert( in_array( 'Showing 10 of 12 skipped rows. Re-run with --verbose for all rows or --only=<reason_code> to filter.', WP_CLI::$logs, true ), 'human output truncates skipped rows with hint' );
 	datamachine_code_cleanup_assert( 1 === count( WP_CLI::$successes ), 'human output keeps success suffix' );
 
-	echo "\n[3] --only filters rows while keeping full summary\n";
+	echo "\n[3] verbose output keeps detailed human fields\n";
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->worktree( array( 'cleanup' ), array( 'dry-run' => true, 'skip-github' => true, 'verbose' => true ) );
+	datamachine_code_cleanup_assert( in_array( 'table:1:handle,branch,signal,reason', WP_CLI::$logs, true ), 'verbose candidate table keeps full reason field' );
+	datamachine_code_cleanup_assert( in_array( 'table:12:handle,reason_code,reason,repo,branch,path,primary_path,missing,hint', WP_CLI::$logs, true ), 'verbose skipped table keeps diagnostic fields' );
+
+	echo "\n[4] --only filters rows while keeping full summary\n";
 	WP_CLI::$logs      = array();
 	WP_CLI::$successes = array();
 	$command->worktree( array( 'cleanup' ), array( 'dry-run' => true, 'only' => 'missing-metadata', 'format' => 'json' ) );
@@ -172,6 +181,18 @@ namespace {
 	datamachine_code_cleanup_assert( 1 === count( $filtered['skipped'] ?? array() ), '--only reason keeps matching skipped rows only' );
 	datamachine_code_cleanup_assert( 'missing_metadata' === ( $filtered['skipped'][0]['reason_code'] ?? '' ), '--only alias resolves to reason code' );
 	datamachine_code_cleanup_assert( 12 === (int) ( $filtered['summary']['skipped'] ?? 0 ), '--only leaves summary counts unfiltered' );
+
+	echo "\n[5] --only aliases resolve candidate section\n";
+	foreach ( array( 'candidates', 'would-remove', 'would_remove' ) as $alias ) {
+		WP_CLI::$logs      = array();
+		WP_CLI::$successes = array();
+		$command->worktree( array( 'cleanup' ), array( 'dry-run' => true, 'only' => $alias, 'format' => 'json' ) );
+		$filtered = json_decode( WP_CLI::$logs[0], true );
+		datamachine_code_cleanup_assert( 1 === count( $filtered['candidates'] ?? array() ), "--only={$alias} keeps candidates" );
+		datamachine_code_cleanup_assert( array() === ( $filtered['removed'] ?? null ), "--only={$alias} hides removed" );
+		datamachine_code_cleanup_assert( array() === ( $filtered['skipped'] ?? null ), "--only={$alias} hides skipped" );
+		datamachine_code_cleanup_assert( 1 === (int) ( $filtered['summary']['would_remove'] ?? 0 ), "--only={$alias} keeps summary counts" );
+	}
 
 	echo "\nAll worktree cleanup CLI smoke tests passed.\n";
 }


### PR DESCRIPTION
## Summary
- Add `--only=would-remove` and `--only=would_remove` aliases for the cleanup candidate table.
- Compact the default human cleanup tables while keeping verbose output and machine-readable report shapes intact.

## Tests
- `php -l inc/Cli/Commands/WorkspaceCommand.php`
- `php -l tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-worktree-cleanup.php`
- `php tests/smoke-worktree-cleanup-github-cache.php`

Closes #128

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the cleanup UX alias/table polish; Chris reviewed the direction and owns the final change.