### PR TITLE
fix(workspace): reduce cleanup GitHub lookups

### DIFF
--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -2019,6 +2019,11 @@ class Workspace {
 			}
 		}
 
+		$local_merged = $this->detect_local_merged_signal( $primary_path, $branch );
+		if ( null !== $local_merged ) {
+			return $local_merged;
+		}
+
 		if ( $skip_github ) {
 			return null;
 		}
@@ -2044,6 +2049,59 @@ class Workspace {
 			'reason' => sprintf( 'PR #%d merged (%s)', $pr['number'], $pr['state'] ),
 			'pr_url' => $pr['html_url'] ?? null,
 		);
+	}
+
+	/**
+	 * Detect branches already contained in the remote default branch using local git refs only.
+	 *
+	 * This catches manually-merged branches before falling through to the GitHub
+	 * API, which keeps GitHub-backed cleanup bounded while avoiding unnecessary
+	 * network calls for branches whose merge state is already locally provable.
+	 *
+	 * @param string $primary_path Path to the primary git checkout.
+	 * @param string $branch       Branch name.
+	 * @return array{signal: string, reason: string}|null
+	 */
+	private function detect_local_merged_signal( string $primary_path, string $branch ): ?array {
+		$default_ref = $this->resolve_remote_default_ref( $primary_path );
+		if ( null === $default_ref ) {
+			return null;
+		}
+
+		$branch_ref = 'refs/heads/' . $branch;
+		$result     = $this->run_git(
+			$primary_path,
+			sprintf( 'rev-list --count %s..%s', escapeshellarg( $default_ref ), escapeshellarg( $branch_ref ) )
+		);
+		if ( is_wp_error( $result ) ) {
+			return null;
+		}
+
+		$unique_commits = (int) trim( (string) ( $result['output'] ?? '' ) );
+		if ( 0 !== $unique_commits ) {
+			return null;
+		}
+
+		return array(
+			'signal' => 'local-merged',
+			'reason' => sprintf( 'branch has no commits outside remote default (%s)', $default_ref ),
+		);
+	}
+
+	/**
+	 * Resolve the remote default branch ref for local cleanup checks.
+	 *
+	 * @param string $primary_path Path to the primary git checkout.
+	 * @return string|null Fully-qualified remote default ref, or null when unavailable.
+	 */
+	private function resolve_remote_default_ref( string $primary_path ): ?string {
+		$result = $this->run_git( $primary_path, 'symbolic-ref --quiet refs/remotes/origin/HEAD' );
+		if ( is_wp_error( $result ) ) {
+			return null;
+		}
+
+		$ref = trim( (string) ( $result['output'] ?? '' ) );
+		return '' === $ref ? null : $ref;
 	}
 
 	/**

--- a/tests/smoke-worktree-cleanup-github-cache.php
+++ b/tests/smoke-worktree-cleanup-github-cache.php
@@ -125,7 +125,24 @@ namespace {
 	};
 
 	$find = new \ReflectionMethod( Workspace::class, 'find_merged_pr_for_branch' );
+	$detect = new \ReflectionMethod( Workspace::class, 'detect_merge_signal' );
 	$workspace = new Workspace();
+	$run = function ( string $command, string $cwd = '' ): string {
+		$full = '' === $cwd ? $command : sprintf( 'cd %s && %s', escapeshellarg( $cwd ), $command );
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
+		exec( $full . ' 2>&1', $output, $code );
+		if ( 0 !== $code ) {
+			throw new \RuntimeException( sprintf( "Command failed (%d): %s\n%s", $code, $full, implode( "\n", $output ) ) );
+		}
+		return implode( "\n", $output );
+	};
+	$rm_rf = function ( string $path ): void {
+		if ( '' === $path || '/' === $path || ! file_exists( $path ) ) {
+			return;
+		}
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
+		exec( sprintf( 'rm -rf %s', escapeshellarg( $path ) ) );
+	};
 
 	$merged_pr = array(
 		'number'    => 42,
@@ -190,6 +207,42 @@ namespace {
 	$disabled = $find->invokeArgs( $workspace, array( 'Extra-Chill/data-machine-code', 'merged-branch', &$cache ) );
 	$assert( null, $disabled, 'no PAT returns no GitHub signal' );
 	$assert( 0, count( GitHubAbilities::$calls ), 'no PAT avoids API call entirely' );
+
+	echo "\n[4] locally merged branches skip GitHub lookup\n";
+	GitHubAbilities::$pat       = 'test-token';
+	GitHubAbilities::$calls     = array();
+	GitHubAbilities::$responses = array( array( 'data' => array( $merged_pr ) ) );
+	$cache = array();
+	$tmp   = sys_get_temp_dir() . '/dmc-cleanup-local-merged-' . bin2hex( random_bytes( 4 ) );
+	mkdir( $tmp, 0755, true );
+
+	try {
+		$run( 'git init -q --initial-branch=main', $tmp );
+		$run( 'git config user.email test@example.test', $tmp );
+		$run( 'git config user.name Test', $tmp );
+		$run( 'git remote add origin https://github.com/Extra-Chill/data-machine-code.git', $tmp );
+		file_put_contents( $tmp . '/README.md', "# Demo\n" );
+		$run( 'git add README.md && git commit -q -m initial', $tmp );
+		$run( 'git checkout -q -b merged-local', $tmp );
+		file_put_contents( $tmp . '/feature.txt', "feature\n" );
+		$run( 'git add feature.txt && git commit -q -m feature', $tmp );
+		$run( 'git checkout -q main && git merge -q --no-ff merged-local -m merge-feature', $tmp );
+		$run( 'git update-ref refs/remotes/origin/main HEAD', $tmp );
+		$run( 'git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main', $tmp );
+
+		$signal = $detect->invokeArgs( $workspace, array( $tmp, 'data-machine-code', 'merged-local', true, &$cache ) );
+		$assert( 'local-merged', $signal['signal'] ?? null, 'local ancestry produces cleanup signal' );
+		$assert( 0, count( GitHubAbilities::$calls ), 'local ancestry signal avoids GitHub API call even with skip_github enabled' );
+
+		$run( 'git checkout -q -b not-merged main', $tmp );
+		file_put_contents( $tmp . '/unmerged.txt', "unmerged\n" );
+		$run( 'git add unmerged.txt && git commit -q -m unmerged', $tmp );
+		$unmerged = $detect->invokeArgs( $workspace, array( $tmp, 'data-machine-code', 'not-merged', false, &$cache ) );
+		$assert( null, $unmerged, 'unmerged local branch falls through to missing GitHub signal' );
+		$assert( 1, count( GitHubAbilities::$calls ), 'unmerged local branch still performs bounded GitHub lookup' );
+	} finally {
+		$rm_rf( $tmp );
+	}
 
 	if ( $failures > 0 ) {
 		echo "\nFAIL: {$failures}/{$total} assertions failed.\n";


### PR DESCRIPTION
## Summary
- Add a local `origin/HEAD` ancestry check before the GitHub cleanup snapshot lookup so branches already contained in the remote default branch avoid API calls entirely.
- Keep the existing bounded per-repo GitHub snapshot cache for branches whose merge state is not locally provable.
- Extend the GitHub cleanup cache smoke to prove locally merged branches skip GitHub, while unmerged branches still fall through to the bounded lookup path.

## Tests
- `php -l inc/Workspace/Workspace.php`
- `php -l tests/smoke-worktree-cleanup-github-cache.php`
- `php tests/smoke-worktree-cleanup-github-cache.php`
- `php tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-worktree-cleanup.php`
- `git diff --check`
- `homeboy lint data-machine-code --path "/Users/chubes/Developer/data-machine-code@perf-cleanup-github-latency" --changed-since origin/main`

Closes #133

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented cleanup GitHub latency improvements; Chris reviewed the direction and owns the final change.