### PR TITLE
fix(workspace): add cleanup plan apply workflow

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -1036,6 +1036,10 @@ class WorkspaceAbilities {
 								'type'        => 'boolean',
 								'description' => 'If true, rely solely on the local upstream-gone signal and skip GitHub API lookup.',
 							),
+							'apply_plan'  => array(
+								'type'        => 'object',
+								'description' => 'Decoded cleanup dry-run report to apply after revalidating every candidate.',
+							),
 						),
 					),
 					'output_schema'       => array(
@@ -1394,6 +1398,7 @@ class WorkspaceAbilities {
 				'dry_run'     => ! empty( $input['dry_run'] ),
 				'force'       => ! empty( $input['force'] ),
 				'skip_github' => ! empty( $input['skip_github'] ),
+				'apply_plan'  => isset( $input['apply_plan'] ) && is_array( $input['apply_plan'] ) ? $input['apply_plan'] : null,
 			)
 		);
 	}

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1063,6 +1063,10 @@ class WorkspaceCommand extends BaseCommand {
 	 * [--dry-run]
 	 * : Preview cleanup candidates without removing anything (cleanup only).
 	 *
+	 * [--apply-plan=<file>]
+	 * : Apply a previously reviewed cleanup JSON report. The destructive pass
+	 *   revalidates every planned row and removes only exact current matches.
+	 *
 	 * [--skip-github]
 	 * : Skip the GitHub API lookup and rely only on the local `upstream-gone`
 	 *   signal (cleanup only). Faster, but misses merged branches where the
@@ -1108,6 +1112,10 @@ class WorkspaceCommand extends BaseCommand {
 	 *
 	 *     # Remove all merged worktrees
 	 *     wp datamachine workspace worktree cleanup
+	 *
+	 *     # Review a plan, then apply only those rows after revalidation
+	 *     wp datamachine workspace worktree cleanup --dry-run --format=json > cleanup-plan.json
+	 *     wp datamachine workspace worktree cleanup --apply-plan=cleanup-plan.json
 	 *
 	 *     # Local-only detection (no GitHub API call)
 	 *     wp datamachine workspace worktree cleanup --skip-github
@@ -1218,6 +1226,13 @@ class WorkspaceCommand extends BaseCommand {
 				$input['dry_run']     = ! empty( $assoc_args['dry-run'] );
 				$input['force']       = ! empty( $assoc_args['force'] );
 				$input['skip_github'] = ! empty( $assoc_args['skip-github'] );
+				if ( ! empty( $assoc_args['apply-plan'] ) ) {
+					if ( ! empty( $assoc_args['force'] ) ) {
+						WP_CLI::error( 'Do not combine --apply-plan with --force. Plan application always revalidates and refuses dirty worktrees.' );
+						return;
+					}
+					$input['apply_plan'] = $this->read_worktree_cleanup_plan( (string) $assoc_args['apply-plan'] );
+				}
 				break;
 		}
 
@@ -1460,6 +1475,38 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 		WP_CLI::success( sprintf( 'Removed %d worktree(s); %d skipped.', count( $result['removed'] ?? array() ), count( $result['skipped'] ?? array() ) ) );
+	}
+
+	/**
+	 * Read and decode a cleanup plan file for --apply-plan.
+	 *
+	 * @param string $path Plan file path.
+	 * @return array
+	 */
+	private function read_worktree_cleanup_plan( string $path ): array {
+		if ( '' === trim( $path ) ) {
+			WP_CLI::error( '--apply-plan requires a file path.' );
+			return array();
+		}
+
+		if ( ! is_readable( $path ) ) {
+			WP_CLI::error( sprintf( 'Cleanup plan is not readable: %s', $path ) );
+			return array();
+		}
+
+		$raw = file_get_contents( $path );
+		if ( false === $raw ) {
+			WP_CLI::error( sprintf( 'Failed to read cleanup plan: %s', $path ) );
+			return array();
+		}
+
+		$decoded = json_decode( $raw, true );
+		if ( JSON_ERROR_NONE !== json_last_error() || ! is_array( $decoded ) ) {
+			WP_CLI::error( sprintf( 'Cleanup plan must be a JSON object: %s', json_last_error_msg() ) );
+			return array();
+		}
+
+		return $decoded;
 	}
 
 	/**

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -1613,6 +1613,19 @@ class Workspace {
 		$dry_run     = ! empty( $opts['dry_run'] );
 		$force       = ! empty( $opts['force'] );
 		$skip_github = ! empty( $opts['skip_github'] );
+		$apply_plan  = isset( $opts['apply_plan'] ) && is_array( $opts['apply_plan'] ) ? $opts['apply_plan'] : null;
+
+		$planned_candidates = null;
+		if ( null !== $apply_plan ) {
+			$planned_candidates = $this->extract_worktree_cleanup_plan_candidates( $apply_plan );
+			if ( is_wp_error( $planned_candidates ) ) {
+				return $planned_candidates;
+			}
+
+			// Applying a stale plan must never use the dirty override. The current
+			// workspace state is re-evaluated below and dirty rows stay skipped.
+			$force = false;
+		}
 
 		$listing = $this->worktree_list();
 		if ( is_wp_error( $listing ) ) {
@@ -1802,6 +1815,12 @@ class Workspace {
 			);
 		}
 
+		if ( null !== $planned_candidates ) {
+			$scoped     = $this->scope_worktree_cleanup_to_plan( $planned_candidates, $candidates, $skipped );
+			$candidates = $scoped['candidates'];
+			$skipped    = $scoped['skipped'];
+		}
+
 		$summary = $this->build_worktree_cleanup_summary( $candidates, array(), $skipped );
 
 		if ( $dry_run ) {
@@ -1894,6 +1913,115 @@ class Workspace {
 			'skipped'              => count( $skipped ),
 			'skipped_by_reason'    => $skipped_by_reason,
 			'candidates_by_signal' => $candidates_by_signal,
+		);
+	}
+
+	/**
+	 * Extract cleanup candidates from a dry-run JSON report.
+	 *
+	 * @param array $plan Decoded cleanup report.
+	 * @return array<int,array>|\WP_Error
+	 */
+	private function extract_worktree_cleanup_plan_candidates( array $plan ): array|\WP_Error {
+		$candidates = $plan['candidates'] ?? null;
+		if ( ! is_array( $candidates ) ) {
+			return new \WP_Error( 'invalid_cleanup_plan', 'Cleanup plan must contain a candidates array.', array( 'status' => 400 ) );
+		}
+
+		$required = array( 'handle', 'repo', 'branch', 'path', 'signal' );
+		foreach ( $candidates as $index => $row ) {
+			if ( ! is_array( $row ) ) {
+				return new \WP_Error( 'invalid_cleanup_plan', sprintf( 'Cleanup plan candidate #%d is not an object.', (int) $index ), array( 'status' => 400 ) );
+			}
+			foreach ( $required as $field ) {
+				if ( '' === trim( (string) ( $row[ $field ] ?? '' ) ) ) {
+					return new \WP_Error( 'invalid_cleanup_plan', sprintf( 'Cleanup plan candidate #%d is missing %s.', (int) $index, $field ), array( 'status' => 400 ) );
+				}
+			}
+		}
+
+		return array_values( $candidates );
+	}
+
+	/**
+	 * Restrict a freshly-evaluated cleanup report to a reviewed plan.
+	 *
+	 * The destructive pass still re-runs every cleanup gate. Only rows that are
+	 * current safe candidates and exactly match the reviewed handle/path/branch/
+	 * signal are removed; anything that drifted is reported as skipped.
+	 *
+	 * @param array<int,array> $planned_candidates Candidate rows from the plan file.
+	 * @param array<int,array> $current_candidates Freshly detected safe candidates.
+	 * @param array<int,array> $current_skipped    Freshly detected skipped rows.
+	 * @return array{candidates: array<int,array>, skipped: array<int,array>}
+	 */
+	private function scope_worktree_cleanup_to_plan( array $planned_candidates, array $current_candidates, array $current_skipped ): array {
+		$current_by_handle = array();
+		foreach ( $current_candidates as $row ) {
+			$handle = (string) ( $row['handle'] ?? '' );
+			if ( '' !== $handle ) {
+				$current_by_handle[ $handle ] = $row;
+			}
+		}
+
+		$skipped_by_handle = array();
+		foreach ( $current_skipped as $row ) {
+			$handle = (string) ( $row['handle'] ?? '' );
+			if ( '' !== $handle && ! isset( $skipped_by_handle[ $handle ] ) ) {
+				$skipped_by_handle[ $handle ] = $row;
+			}
+		}
+
+		$scoped_candidates = array();
+		$scoped_skipped    = array();
+
+		foreach ( $planned_candidates as $plan_row ) {
+			$handle = (string) ( $plan_row['handle'] ?? '' );
+			$current = $current_by_handle[ $handle ] ?? null;
+
+			if ( null === $current ) {
+				$skip = $skipped_by_handle[ $handle ] ?? array(
+					'handle'      => $handle,
+					'repo'        => (string) ( $plan_row['repo'] ?? '' ),
+					'branch'      => (string) ( $plan_row['branch'] ?? '' ),
+					'path'        => (string) ( $plan_row['path'] ?? '' ),
+					'reason_code' => 'plan_not_current',
+					'reason'      => 'planned cleanup row is no longer present in the current worktree list',
+				);
+				$skip['planned_signal'] = (string) ( $plan_row['signal'] ?? '' );
+				$scoped_skipped[]       = $skip;
+				continue;
+			}
+
+			$mismatches = array();
+			foreach ( array( 'repo', 'branch', 'path', 'signal' ) as $field ) {
+				$planned = (string) ( $plan_row[ $field ] ?? '' );
+				$actual  = (string) ( $current[ $field ] ?? '' );
+				if ( $planned !== $actual ) {
+					$mismatches[] = sprintf( '%s planned=%s current=%s', $field, $planned, $actual );
+				}
+			}
+
+			if ( array() !== $mismatches ) {
+				$scoped_skipped[] = array(
+					'handle'         => $handle,
+					'repo'           => (string) ( $current['repo'] ?? $plan_row['repo'] ?? '' ),
+					'branch'         => (string) ( $current['branch'] ?? $plan_row['branch'] ?? '' ),
+					'path'           => (string) ( $current['path'] ?? $plan_row['path'] ?? '' ),
+					'reason_code'    => 'plan_mismatch',
+					'reason'         => 'planned cleanup row no longer matches current state: ' . implode( '; ', $mismatches ),
+					'planned_signal' => (string) ( $plan_row['signal'] ?? '' ),
+					'current_signal' => (string) ( $current['signal'] ?? '' ),
+				);
+				continue;
+			}
+
+			$scoped_candidates[] = $current;
+		}
+
+		return array(
+			'candidates' => $scoped_candidates,
+			'skipped'    => $scoped_skipped,
 		);
 	}
 

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -155,6 +155,23 @@ namespace {
 	datamachine_code_cleanup_assert( str_contains( $decoded['skipped'][11]['hint'] ?? '', 'workspace worktree prune' ), 'JSON missing_metadata includes remediation hint' );
 	datamachine_code_cleanup_assert( 10 === (int) ( $decoded['summary']['skipped_by_reason']['no_merge_signal'] ?? 0 ), 'JSON summary includes reason counts' );
 
+	echo "\n[1b] --apply-plan decodes JSON and forbids force\n";
+	$plan_file = sys_get_temp_dir() . '/dmc-cleanup-plan-' . bin2hex( random_bytes( 3 ) ) . '.json';
+	file_put_contents( $plan_file, wp_json_encode( datamachine_code_cleanup_report() ) );
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->worktree( array( 'cleanup' ), array( 'apply-plan' => $plan_file, 'skip-github' => true, 'format' => 'json' ) );
+	datamachine_code_cleanup_assert( false === ( $ability->last_input['dry_run'] ?? null ), '--apply-plan does not imply dry-run' );
+	datamachine_code_cleanup_assert( false === ( $ability->last_input['force'] ?? null ), '--apply-plan forwards force=false' );
+	datamachine_code_cleanup_assert( 'repo@merged' === ( $ability->last_input['apply_plan']['candidates'][0]['handle'] ?? '' ), '--apply-plan forwards decoded plan' );
+	try {
+		$command->worktree( array( 'cleanup' ), array( 'apply-plan' => $plan_file, 'force' => true ) );
+		datamachine_code_cleanup_assert( false, '--apply-plan --force throws' );
+	} catch ( RuntimeException $e ) {
+		datamachine_code_cleanup_assert( str_contains( $e->getMessage(), 'Do not combine --apply-plan with --force' ), '--apply-plan --force is rejected' );
+	}
+	unlink( $plan_file );
+
 	echo "\n[2] default output is concise and summary-first\n";
 	WP_CLI::$logs      = array();
 	WP_CLI::$successes = array();

--- a/tests/smoke-worktree-cleanup.php
+++ b/tests/smoke-worktree-cleanup.php
@@ -189,7 +189,7 @@ namespace {
 	$run( 'git push -u origin main', $primary );
 
 	// Helper: make a branch on the remote too so "upstream" tracking exists.
-	$make_branch = function ( string $branch, string $content ) use ( $primary, $run, $remote ) {
+	$make_branch = function ( string $branch, string $content ) use ( $primary, $run ) {
 		$run( sprintf( 'git checkout -b %s', escapeshellarg( $branch ) ), $primary );
 		file_put_contents( $primary . '/' . str_replace( '/', '-', $branch ) . '.txt', $content );
 		$run( sprintf( 'git add . && git commit -m %s', escapeshellarg( 'work on ' . $branch ) ), $primary );
@@ -199,6 +199,7 @@ namespace {
 
 	// Branches that have branches on the remote.
 	$make_branch( 'merged-autodelete', 'a' );   // → simulate remote delete below
+	$make_branch( 'merged-stale-plan', 'a2' );  // → candidate in plan, dirty before apply
 	$make_branch( 'merged-live-remote', 'b' );  // → simulate via PR-merged (stubbed → none)
 	$make_branch( 'unmerged-feature', 'c' );    // still active
 	$make_branch( 'dirty-branch', 'd' );        // will be dirty in worktree
@@ -210,6 +211,7 @@ namespace {
 	//   - canonical path for the unmerged one
 	//   - canonical path for dirty
 	$run( sprintf( 'git worktree add %s merged-autodelete', escapeshellarg( $tmp . '/demo@merged-autodelete' ) ), $primary );
+	$run( sprintf( 'git worktree add %s merged-stale-plan', escapeshellarg( $tmp . '/demo@merged-stale-plan' ) ), $primary );
 	$run( sprintf( 'git worktree add %s merged-live-remote', escapeshellarg( $tmp . '/demo-legacy-merged' ) ), $primary );
 	$run( sprintf( 'git worktree add %s unmerged-feature', escapeshellarg( $tmp . '/demo@unmerged-feature' ) ), $primary );
 	$run( sprintf( 'git worktree add %s dirty-branch', escapeshellarg( $tmp . '/demo@dirty-branch' ) ), $primary );
@@ -239,6 +241,7 @@ namespace {
 	// origin. But our origin IS the bare repo — so we need to update the
 	// bare ref directly.)
 	$run( sprintf( 'git --git-dir=%s update-ref -d refs/heads/merged-autodelete', escapeshellarg( $remote ) ) );
+	$run( sprintf( 'git --git-dir=%s update-ref -d refs/heads/merged-stale-plan', escapeshellarg( $remote ) ) );
 
 	// -------------------------------------------------------------------------
 	// Dry-run assertions
@@ -283,7 +286,7 @@ namespace {
 	$assert( 'external_worktree', $external_row['reason_code'] ?? '', 'external worktree exposes stable reason code' );
 	$assert( true, str_contains( $external_row['hint'] ?? '', 'outside the DMC workspace' ), 'external worktree includes remediation hint' );
 
-	$assert( 1, (int) ( $plan['summary']['would_remove'] ?? 0 ), 'summary counts cleanup candidates' );
+	$assert( 2, (int) ( $plan['summary']['would_remove'] ?? 0 ), 'summary counts cleanup candidates' );
 	$assert( 1, (int) ( $plan['summary']['skipped_by_reason']['dirty_worktree'] ?? 0 ), 'summary counts dirty skips by reason' );
 	$assert( true, isset( $plan['summary']['skipped_by_reason']['no_merge_signal'] ), 'summary includes no_merge_signal bucket' );
 
@@ -314,6 +317,24 @@ namespace {
 	$assert( array( 'repo', 'branch', 'path' ), $missing_row['missing_fields'] ?? array(), 'missing metadata lists missing fields' );
 	$assert( true, str_contains( $missing_row['hint'] ?? '', 'workspace worktree prune' ), 'missing metadata includes prune remediation hint' );
 
+	$scope_reflection = new \ReflectionMethod( \DataMachineCode\Workspace\Workspace::class, 'scope_worktree_cleanup_to_plan' );
+	$scoped_mismatch  = $scope_reflection->invoke(
+		$ws,
+		array(
+			array(
+				'handle' => 'demo@merged-autodelete',
+				'repo'   => 'demo',
+				'branch' => 'merged-autodelete',
+				'path'   => $tmp . '/demo@merged-autodelete',
+				'signal' => 'pr-merged',
+			),
+		),
+		$plan['candidates'] ?? array(),
+		$plan['skipped'] ?? array()
+	);
+	$assert( 0, count( $scoped_mismatch['candidates'] ?? array() ), 'plan mismatch does not leave a removable candidate' );
+	$assert( 'plan_mismatch', $scoped_mismatch['skipped'][0]['reason_code'] ?? '', 'plan mismatch reports a stable reason code' );
+
 	// External worktrees are reported with routing metadata, but never owned by cleanup.
 	$external_skips = array_filter( $plan['skipped'] ?? array(), fn( $s ) => ( $s['path'] ?? '' ) === $external_real );
 	$assert( 1, count( $external_skips ), 'external worktree skipped with exactly one entry' );
@@ -338,11 +359,16 @@ namespace {
 	// Execute
 	// -------------------------------------------------------------------------
 
-	echo "\nExecuting cleanup\n";
+	// The reviewed plan still contains this row, but the worktree changes before
+	// apply. Plan application must re-run the dirty gate and leave it in place.
+	file_put_contents( $tmp . '/demo@merged-stale-plan/late-dirty.txt', 'changed after plan' );
+
+	echo "\nExecuting cleanup from reviewed plan\n";
 	$result = $ws->worktree_cleanup_merged(
 		array(
 			'dry_run'     => false,
 			'skip_github' => true,
+			'apply_plan'  => $plan,
 		)
 	);
 
@@ -351,6 +377,10 @@ namespace {
 
 	// The merged-autodelete candidate should be in removed[].
 	$assert_contains( $result['removed'] ?? array(), 'demo@merged-autodelete', 'canonical merged worktree was actually removed' );
+
+	$stale_skips = array_values( array_filter( $result['skipped'] ?? array(), fn( $s ) => ( $s['handle'] ?? '' ) === 'demo@merged-stale-plan' ) );
+	$assert( 1, count( $stale_skips ), 'stale plan row is skipped after revalidation' );
+	$assert( 'dirty_worktree', $stale_skips[0]['reason_code'] ?? '', 'stale plan row reuses dirty safety gate' );
 
 	// Directory should be gone from disk.
 	$assert( false, is_dir( $tmp . '/demo@merged-autodelete' ), 'merged worktree directory no longer exists on disk' );
@@ -361,6 +391,7 @@ namespace {
 	// Protected branches: unmerged/dirty worktrees survive.
 	$assert( true, is_dir( $tmp . '/demo@unmerged-feature' ), 'unmerged worktree survives cleanup' );
 	$assert( true, is_dir( $tmp . '/demo@dirty-branch' ), 'dirty worktree survives cleanup' );
+	$assert( true, is_dir( $tmp . '/demo@merged-stale-plan' ), 'dirty stale-plan worktree survives cleanup' );
 	$assert( true, is_dir( $tmp . '-external/demo-external' ), 'external worktree survives cleanup' );
 
 	// The local branch for the removed worktree should be gone.


### PR DESCRIPTION
## Summary
- Add `workspace worktree cleanup --apply-plan=<file>` so operators can apply a reviewed dry-run JSON report instead of re-running destructive cleanup against every current candidate.
- Revalidate each planned row against the current workspace state before removal, requiring exact repo/branch/path/signal matches and preserving dirty/unpushed/external/missing-metadata safety gates.
- Cover CLI plan decoding, force rejection, plan mismatch, and stale-plan dirty revalidation in focused smokes.

## Tests
- `php -l inc/Workspace/Workspace.php`
- `php -l inc/Cli/Commands/WorkspaceCommand.php`
- `php -l inc/Abilities/WorkspaceAbilities.php`
- `php -l tests/smoke-worktree-cleanup.php`
- `php -l tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-worktree-cleanup.php`
- `git diff --check`

Closes #131

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the cleanup plan/apply workflow; Chris reviewed the direction and owns the final change.