### PR TITLE
feat(workspace): add cleanup age filter

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -1040,6 +1040,10 @@ class WorkspaceAbilities {
 								'type'        => 'object',
 								'description' => 'Decoded cleanup dry-run report to apply after revalidating every candidate.',
 							),
+							'older_than'  => array(
+								'type'        => 'string',
+								'description' => 'Optional candidate age filter such as 7d, 24h, 30m, or 60s. Uses lifecycle created_at metadata only.',
+							),
 						),
 					),
 					'output_schema'       => array(
@@ -1388,19 +1392,24 @@ class WorkspaceAbilities {
 	/**
 	 * Remove merged worktrees across all primary checkouts.
 	 *
-	 * @param array $input Input parameters (dry_run, force, skip_github).
+	 * @param array $input Input parameters (dry_run, force, skip_github, apply_plan, older_than).
 	 * @return array
 	 */
 	public static function worktreeCleanup( array $input ): array|\WP_Error {
 		$workspace = new Workspace();
-		return $workspace->worktree_cleanup_merged(
-			array(
-				'dry_run'     => ! empty( $input['dry_run'] ),
-				'force'       => ! empty( $input['force'] ),
-				'skip_github' => ! empty( $input['skip_github'] ),
-				'apply_plan'  => isset( $input['apply_plan'] ) && is_array( $input['apply_plan'] ) ? $input['apply_plan'] : null,
-			)
+		$opts      = array(
+			'dry_run'     => ! empty( $input['dry_run'] ),
+			'force'       => ! empty( $input['force'] ),
+			'skip_github' => ! empty( $input['skip_github'] ),
 		);
+		if ( isset( $input['apply_plan'] ) && is_array( $input['apply_plan'] ) ) {
+			$opts['apply_plan'] = $input['apply_plan'];
+		}
+		if ( isset( $input['older_than'] ) && '' !== trim( (string) $input['older_than'] ) ) {
+			$opts['older_than'] = trim( (string) $input['older_than'] );
+		}
+
+		return $workspace->worktree_cleanup_merged( $opts );
 	}
 
 	/**

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1072,13 +1072,18 @@ class WorkspaceCommand extends BaseCommand {
 	 *   signal (cleanup only). Faster, but misses merged branches where the
 	 *   remote branch wasn't auto-deleted.
 	 *
+	 * [--older-than=<duration>]
+	 * : Limit cleanup candidates to worktrees with lifecycle `created_at`
+	 *   metadata older than the compact duration (cleanup only, e.g. 7d, 24h).
+	 *   Candidate worktrees without valid `created_at` metadata are skipped.
+	 *
 	 * [--verbose]
 	 * : Show every cleanup row instead of concise samples (cleanup only).
 	 *
 	 * [--only=<section>]
 	 * : Limit cleanup rows to one section or reason code. Supported values:
 	 *   candidates, would-remove, would_remove, removed, no_merge_signal, dirty_worktree,
-	 *   unpushed_commits, missing_metadata, external_worktree.
+	 *   unpushed_commits, missing_metadata, external_worktree, age_filter, unknown_age.
 	 *
 	 * [--format=<format>]
 	 * : Output format for list and cleanup (table, json, csv, yaml).
@@ -1232,6 +1237,9 @@ class WorkspaceCommand extends BaseCommand {
 						return;
 					}
 					$input['apply_plan'] = $this->read_worktree_cleanup_plan( (string) $assoc_args['apply-plan'] );
+				}
+				if ( isset( $assoc_args['older-than'] ) && '' !== trim( (string) $assoc_args['older-than'] ) ) {
+					$input['older_than'] = trim( (string) $assoc_args['older-than'] );
 				}
 				break;
 		}
@@ -1405,6 +1413,16 @@ class WorkspaceCommand extends BaseCommand {
 				'count'  => (int) $count,
 			);
 		}
+		if ( isset( $summary['age_filter'] ) && is_array( $summary['age_filter'] ) ) {
+			$summary_rows[] = array(
+				'metric' => 'age_filter:excluded',
+				'count'  => (int) ( $summary['age_filter']['excluded'] ?? 0 ),
+			);
+			$summary_rows[] = array(
+				'metric' => 'age_filter:unknown_age',
+				'count'  => (int) ( $summary['age_filter']['unknown_age'] ?? 0 ),
+			);
+		}
 		$this->format_items( $summary_rows, array( 'metric', 'count' ), array( 'format' => 'table' ), 'metric' );
 
 		if ( '' !== $only ) {
@@ -1424,7 +1442,7 @@ class WorkspaceCommand extends BaseCommand {
 				),
 				array_slice( $candidates, 0, $limit )
 			);
-			$fields = $verbose ? array( 'handle', 'branch', 'signal', 'reason' ) : array( 'handle', 'branch', 'signal', 'reason_code' );
+			$fields         = $verbose ? array( 'handle', 'branch', 'signal', 'reason' ) : array( 'handle', 'branch', 'signal', 'reason_code' );
 			$this->format_items( $candidate_rows, $fields, array( 'format' => 'table' ), 'handle' );
 			$this->render_cleanup_truncation_hint( count( $candidates ), $limit, 'candidate rows' );
 		}
@@ -1442,7 +1460,7 @@ class WorkspaceCommand extends BaseCommand {
 				),
 				array_slice( $removed, 0, $limit )
 			);
-			$fields = $verbose ? array( 'handle', 'branch', 'signal', 'reason' ) : array( 'handle', 'branch', 'signal', 'reason_code' );
+			$fields       = $verbose ? array( 'handle', 'branch', 'signal', 'reason' ) : array( 'handle', 'branch', 'signal', 'reason_code' );
 			$this->format_items( $removed_rows, $fields, array( 'format' => 'table' ), 'handle' );
 			$this->render_cleanup_truncation_hint( count( $removed ), $limit, 'removed rows' );
 		}
@@ -1464,7 +1482,7 @@ class WorkspaceCommand extends BaseCommand {
 				),
 				array_slice( $skipped, 0, $limit )
 			);
-			$fields = $verbose ? array( 'handle', 'reason_code', 'reason', 'repo', 'branch', 'path', 'primary_path', 'missing', 'hint' ) : array( 'handle', 'reason_code', 'reason' );
+			$fields       = $verbose ? array( 'handle', 'reason_code', 'reason', 'repo', 'branch', 'path', 'primary_path', 'missing', 'hint' ) : array( 'handle', 'reason_code', 'reason' );
 			$this->format_items( $skipped_rows, $fields, array( 'format' => 'table' ), 'handle' );
 			$this->render_cleanup_truncation_hint( count( $skipped ), $limit, 'skipped rows' );
 		}

--- a/inc/Tasks/WorktreeCleanupTask.php
+++ b/inc/Tasks/WorktreeCleanupTask.php
@@ -103,6 +103,8 @@ class WorktreeCleanupTask extends SystemTask {
 	 *   - `force` (bool)        — override dirty-worktree safety. Default: false.
 	 *                             Does NOT override the unpushed-commits safety.
 	 *   - `skip_github` (bool)  — only use local `upstream-gone` signal. Default: false.
+	 *   - `older_than` (string) — optional age filter such as 7d or 24h. Uses
+	 *                             lifecycle created_at metadata only.
 	 *
 	 * Opt-out:
 	 *   Apply the `datamachine_code_worktree_cleanup_enabled` filter with
@@ -140,6 +142,9 @@ class WorktreeCleanupTask extends SystemTask {
 			'force'       => ! empty( $params['force'] ),
 			'skip_github' => ! empty( $params['skip_github'] ),
 		);
+		if ( isset( $params['older_than'] ) && '' !== trim( (string) $params['older_than'] ) ) {
+			$opts['older_than'] = trim( (string) $params['older_than'] );
+		}
 
 		$workspace = new Workspace();
 		$result    = $workspace->worktree_cleanup_merged( $opts );

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -635,7 +635,7 @@ class Workspace {
 	 *
 	 * Tracked paths are removed via `git rm` so the deletion lands in the
 	 * working tree and the index in one shot. Untracked paths fall back to a
-	 * filesystem unlink (file) or a recursive directory removal (directory,
+	 * filesystem wp_delete_file( file ) or a recursive directory removal (directory,
 	 * only when $recursive is true). Sensitive-path, traversal, allowlist,
 	 * and primary-mutation gates mirror `git_add`.
 	 *
@@ -1600,6 +1600,7 @@ class Workspace {
 	 *     @type bool $dry_run If true, return the plan without removing anything.
 	 *     @type bool $force   If true, ignore dirty working-tree safety.
 	 *     @type bool $skip_github If true, only use upstream-gone signal (no API calls).
+	 *     @type string $older_than Optional duration such as 7d, 24h, or 30m. Candidates newer than this are skipped.
 	 * }
 	 * @return array{
 	 *     success: bool,
@@ -1614,6 +1615,7 @@ class Workspace {
 		$force       = ! empty( $opts['force'] );
 		$skip_github = ! empty( $opts['skip_github'] );
 		$apply_plan  = isset( $opts['apply_plan'] ) && is_array( $opts['apply_plan'] ) ? $opts['apply_plan'] : null;
+		$older_than  = isset( $opts['older_than'] ) ? trim( (string) $opts['older_than'] ) : '';
 
 		$planned_candidates = null;
 		if ( null !== $apply_plan ) {
@@ -1625,6 +1627,25 @@ class Workspace {
 			// Applying a stale plan must never use the dirty override. The current
 			// workspace state is re-evaluated below and dirty rows stay skipped.
 			$force = false;
+		}
+
+		$age_filter = null;
+		if ( '' !== $older_than ) {
+			$duration_seconds = $this->parse_worktree_cleanup_duration( $older_than );
+			if ( is_wp_error( $duration_seconds ) ) {
+				return $duration_seconds;
+			}
+
+			$threshold_ts = time() - $duration_seconds;
+			$age_filter   = array(
+				'type'             => 'older_than',
+				'older_than'       => $older_than,
+				'duration_seconds' => $duration_seconds,
+				'threshold'        => gmdate( 'c', $threshold_ts ),
+				'threshold_unix'   => $threshold_ts,
+				'excluded'         => 0,
+				'unknown_age'      => 0,
+			);
 		}
 
 		$listing = $this->worktree_list();
@@ -1800,7 +1821,59 @@ class Workspace {
 				continue;
 			}
 
-			$candidates[] = array(
+			$age_decision = null;
+			if ( null !== $age_filter ) {
+				$created_ts = is_string( $created_at ) && '' !== $created_at ? strtotime( $created_at ) : false;
+				if ( false === $created_ts ) {
+					++$age_filter['unknown_age'];
+					$skipped[] = array(
+						'handle'      => $handle,
+						'repo'        => $repo,
+						'branch'      => $branch,
+						'path'        => $wt_path,
+						'reason_code' => 'unknown_age',
+						'reason'      => 'missing or invalid created_at metadata - age filter cannot decide safely',
+						'created_at'  => $created_at,
+						'metadata'    => $metadata,
+						'age_filter'  => array(
+							'type'       => 'older_than',
+							'older_than' => $age_filter['older_than'],
+							'threshold'  => $age_filter['threshold'],
+							'decision'   => 'unknown_age',
+						),
+					);
+					continue;
+				}
+
+				$age_seconds  = time() - $created_ts;
+				$age_decision = array(
+					'type'        => 'older_than',
+					'older_than'  => $age_filter['older_than'],
+					'threshold'   => $age_filter['threshold'],
+					'created_at'  => $created_at,
+					'age_seconds' => $age_seconds,
+				);
+
+				if ( $created_ts > $age_filter['threshold_unix'] ) {
+					++$age_filter['excluded'];
+					$skipped[] = array(
+						'handle'      => $handle,
+						'repo'        => $repo,
+						'branch'      => $branch,
+						'path'        => $wt_path,
+						'reason_code' => 'age_filter',
+						'reason'      => sprintf( 'created_at %s is newer than --older-than=%s threshold %s', $created_at, $age_filter['older_than'], $age_filter['threshold'] ),
+						'created_at'  => $created_at,
+						'metadata'    => $metadata,
+						'age_filter'  => array_merge( $age_decision, array( 'decision' => 'excluded' ) ),
+					);
+					continue;
+				}
+
+				$age_decision['decision'] = 'included';
+			}
+
+			$candidate = array(
 				'handle'      => $wt['handle'],
 				'repo'        => $repo,
 				'branch'      => $branch,
@@ -1813,6 +1886,10 @@ class Workspace {
 				'created_at'  => $created_at,
 				'metadata'    => $metadata,
 			);
+			if ( null !== $age_decision ) {
+				$candidate['age_filter'] = $age_decision;
+			}
+			$candidates[] = $candidate;
 		}
 
 		if ( null !== $planned_candidates ) {
@@ -1821,7 +1898,7 @@ class Workspace {
 			$skipped    = $scoped['skipped'];
 		}
 
-		$summary = $this->build_worktree_cleanup_summary( $candidates, array(), $skipped );
+		$summary = $this->build_worktree_cleanup_summary( $candidates, array(), $skipped, $age_filter );
 
 		if ( $dry_run ) {
 			return array(
@@ -1878,7 +1955,7 @@ class Workspace {
 			'candidates' => $candidates,
 			'removed'    => $removed,
 			'skipped'    => $skipped,
-			'summary'    => $this->build_worktree_cleanup_summary( $candidates, $removed, $skipped ),
+			'summary'    => $this->build_worktree_cleanup_summary( $candidates, $removed, $skipped, $age_filter ),
 		);
 	}
 
@@ -1890,7 +1967,7 @@ class Workspace {
 	 * @param array<int,array> $skipped    Skipped rows.
 	 * @return array<string,mixed>
 	 */
-	private function build_worktree_cleanup_summary( array $candidates, array $removed, array $skipped ): array {
+	private function build_worktree_cleanup_summary( array $candidates, array $removed, array $skipped, ?array $age_filter = null ): array {
 		$skipped_by_reason    = array();
 		$candidates_by_signal = array();
 
@@ -1907,13 +1984,47 @@ class Workspace {
 		ksort( $skipped_by_reason );
 		ksort( $candidates_by_signal );
 
-		return array(
+		$summary = array(
 			'would_remove'         => count( $candidates ),
 			'removed'              => count( $removed ),
 			'skipped'              => count( $skipped ),
 			'skipped_by_reason'    => $skipped_by_reason,
 			'candidates_by_signal' => $candidates_by_signal,
 		);
+
+		if ( null !== $age_filter ) {
+			unset( $age_filter['threshold_unix'] );
+			$summary['age_filter'] = $age_filter;
+		}
+
+		return $summary;
+	}
+
+	/**
+	 * Parse a compact cleanup age duration.
+	 *
+	 * @param string $duration Duration like 7d, 24h, 30m, or 60s.
+	 * @return int|\WP_Error Seconds on success.
+	 */
+	private function parse_worktree_cleanup_duration( string $duration ): int|\WP_Error {
+		if ( ! preg_match( '/^(\d+)([smhdw])$/', trim( $duration ), $matches ) ) {
+			return new \WP_Error( 'invalid_cleanup_age_filter', 'Invalid --older-than duration. Use a compact value like 7d, 24h, 30m, or 60s.', array( 'status' => 400 ) );
+		}
+
+		$value = (int) $matches[1];
+		if ( $value <= 0 ) {
+			return new \WP_Error( 'invalid_cleanup_age_filter', 'Invalid --older-than duration. Duration must be greater than zero.', array( 'status' => 400 ) );
+		}
+
+		$unit_seconds = array(
+			's' => 1,
+			'm' => 60,
+			'h' => 3600,
+			'd' => 86400,
+			'w' => 604800,
+		);
+
+		return $value * $unit_seconds[ $matches[2] ];
 	}
 
 	/**

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -129,7 +129,18 @@ namespace {
 
 		public function execute( array $input ): array {
 			$this->last_input = $input;
-			return datamachine_code_cleanup_report();
+			$report = datamachine_code_cleanup_report();
+			if ( isset( $input['older_than'] ) ) {
+				$report['summary']['age_filter'] = array(
+					'type'             => 'older_than',
+					'older_than'       => $input['older_than'],
+					'duration_seconds' => 604800,
+					'threshold'        => '2026-04-21T00:00:00+00:00',
+					'excluded'         => 2,
+					'unknown_age'      => 1,
+				);
+			}
+			return $report;
 		}
 	}
 
@@ -210,6 +221,20 @@ namespace {
 		datamachine_code_cleanup_assert( array() === ( $filtered['skipped'] ?? null ), "--only={$alias} hides skipped" );
 		datamachine_code_cleanup_assert( 1 === (int) ( $filtered['summary']['would_remove'] ?? 0 ), "--only={$alias} keeps summary counts" );
 	}
+
+	echo "\n[6] --older-than forwards and renders age summary\n";
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->worktree( array( 'cleanup' ), array( 'dry-run' => true, 'skip-github' => true, 'older-than' => '7d' ) );
+	datamachine_code_cleanup_assert( array( 'dry_run' => true, 'force' => false, 'skip_github' => true, 'older_than' => '7d' ) === $ability->last_input, 'older-than forwards to cleanup ability as older_than' );
+	datamachine_code_cleanup_assert( in_array( 'table:8:metric,count', WP_CLI::$logs, true ), 'age filter summary adds two summary rows' );
+
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->worktree( array( 'cleanup' ), array( 'dry-run' => true, 'skip-github' => true, 'older-than' => '7d', 'format' => 'json' ) );
+	$older_than_json = json_decode( WP_CLI::$logs[0], true );
+	datamachine_code_cleanup_assert( '7d' === ( $older_than_json['summary']['age_filter']['older_than'] ?? '' ), 'JSON summary exposes older_than filter value' );
+	datamachine_code_cleanup_assert( 2 === (int) ( $older_than_json['summary']['age_filter']['excluded'] ?? 0 ), 'JSON summary exposes age-filter excluded count' );
 
 	echo "\nAll worktree cleanup CLI smoke tests passed.\n";
 }

--- a/tests/smoke-worktree-cleanup.php
+++ b/tests/smoke-worktree-cleanup.php
@@ -73,9 +73,9 @@ namespace {
 	}
 
 	if ( ! function_exists( 'get_option' ) ) {
-		function get_option( string $name, $default = false ) {
+		function get_option( string $name, $default_value = false ) {
 			global $datamachine_code_test_options;
-			return $datamachine_code_test_options[ $name ] ?? $default;
+			return $datamachine_code_test_options[ $name ] ?? $default_value;
 		}
 	}
 
@@ -125,7 +125,7 @@ namespace {
 		}
 	} );
 
-	define( 'DATAMACHINE_WORKSPACE_PATH', realpath( $tmp ) ?: $tmp );
+	define( 'DATAMACHINE_WORKSPACE_PATH', realpath( $tmp ) ? realpath( $tmp ) : $tmp );
 
 	$failures = 0;
 	$total    = 0;
@@ -180,7 +180,7 @@ namespace {
 	// Primary checkout: clone + initial commit on main + push.
 	$primary = $tmp . '/demo';
 	$run( sprintf( 'git clone %s %s', escapeshellarg( $remote ), escapeshellarg( $primary ) ) );
-	$primary_real = realpath( $primary ) ?: $primary;
+	$primary_real = realpath( $primary ) ? realpath( $primary ) : $primary;
 	$run( 'git config user.email test@example.com', $primary );
 	$run( 'git config user.name test', $primary );
 	file_put_contents( $primary . '/README.md', "demo\n" );
@@ -200,10 +200,12 @@ namespace {
 	// Branches that have branches on the remote.
 	$make_branch( 'merged-autodelete', 'a' );   // → simulate remote delete below
 	$make_branch( 'merged-stale-plan', 'a2' );  // → candidate in plan, dirty before apply
-	$make_branch( 'merged-live-remote', 'b' );  // → simulate via PR-merged (stubbed → none)
-	$make_branch( 'unmerged-feature', 'c' );    // still active
-	$make_branch( 'dirty-branch', 'd' );        // will be dirty in worktree
-	$make_branch( 'external-branch', 'e' );     // outside workspace, should never be removed
+	$make_branch( 'merged-recent', 'b' );       // → merged, but too new for age-filtered cleanup
+	$make_branch( 'merged-unknown-age', 'c' );  // → merged, but missing created_at metadata
+	$make_branch( 'merged-live-remote', 'd' );  // → simulate via PR-merged (stubbed → none)
+	$make_branch( 'unmerged-feature', 'e' );    // still active
+	$make_branch( 'dirty-branch', 'f' );        // will be dirty in worktree
+	$make_branch( 'external-branch', 'g' );     // outside workspace, should never be removed
 
 	// Create worktrees at various paths:
 	//   - canonical slug path (demo@merged-autodelete)
@@ -212,15 +214,39 @@ namespace {
 	//   - canonical path for dirty
 	$run( sprintf( 'git worktree add %s merged-autodelete', escapeshellarg( $tmp . '/demo@merged-autodelete' ) ), $primary );
 	$run( sprintf( 'git worktree add %s merged-stale-plan', escapeshellarg( $tmp . '/demo@merged-stale-plan' ) ), $primary );
+	$run( sprintf( 'git worktree add %s merged-recent', escapeshellarg( $tmp . '/demo@merged-recent' ) ), $primary );
+	$run( sprintf( 'git worktree add %s merged-unknown-age', escapeshellarg( $tmp . '/demo@merged-unknown-age' ) ), $primary );
 	$run( sprintf( 'git worktree add %s merged-live-remote', escapeshellarg( $tmp . '/demo-legacy-merged' ) ), $primary );
 	$run( sprintf( 'git worktree add %s unmerged-feature', escapeshellarg( $tmp . '/demo@unmerged-feature' ) ), $primary );
 	$run( sprintf( 'git worktree add %s dirty-branch', escapeshellarg( $tmp . '/demo@dirty-branch' ) ), $primary );
 	mkdir( $tmp . '-external', 0755, true );
 	$run( sprintf( 'git worktree add %s external-branch', escapeshellarg( $tmp . '-external/demo-external' ) ), $primary );
-	$external_real = realpath( $tmp . '-external/demo-external' ) ?: $tmp . '-external/demo-external';
+	$external_real = realpath( $tmp . '-external/demo-external' ) ? realpath( $tmp . '-external/demo-external' ) : $tmp . '-external/demo-external';
 
 	// Dirty the dirty worktree.
 	file_put_contents( $tmp . '/demo@dirty-branch/scratch.txt', 'dirty' );
+
+	\DataMachineCode\Workspace\WorktreeContextInjector::store_metadata(
+		'demo@merged-autodelete',
+		array(
+			'site_url'   => 'http://example.test',
+			'site_name'  => 'Example',
+			'agent_slug' => 'agent-one',
+			'abspath'    => '/example',
+			'timestamp'  => gmdate( 'c', time() - 14 * 86400 ),
+		)
+	);
+
+	\DataMachineCode\Workspace\WorktreeContextInjector::store_metadata(
+		'demo@merged-recent',
+		array(
+			'site_url'   => 'http://example.test',
+			'site_name'  => 'Example',
+			'agent_slug' => 'agent-one',
+			'abspath'    => '/example',
+			'timestamp'  => gmdate( 'c', time() - 3600 ),
+		)
+	);
 
 	\DataMachineCode\Workspace\WorktreeContextInjector::store_metadata(
 		'demo@unmerged-feature',
@@ -233,7 +259,7 @@ namespace {
 		)
 	);
 
-	// Simulate "remote deleted the merged-autodelete branch" — classic
+	// Simulate "remote deleted the merged-* branches" — classic
 	// GitHub auto-delete-on-merge scenario. After a fetch --prune, the
 	// local branch's upstream tracking ref will be "gone".
 	$run( sprintf( 'git -C %s push origin --delete merged-autodelete', escapeshellarg( $remote ) ) );
@@ -242,6 +268,8 @@ namespace {
 	// bare ref directly.)
 	$run( sprintf( 'git --git-dir=%s update-ref -d refs/heads/merged-autodelete', escapeshellarg( $remote ) ) );
 	$run( sprintf( 'git --git-dir=%s update-ref -d refs/heads/merged-stale-plan', escapeshellarg( $remote ) ) );
+	$run( sprintf( 'git --git-dir=%s update-ref -d refs/heads/merged-recent', escapeshellarg( $remote ) ) );
+	$run( sprintf( 'git --git-dir=%s update-ref -d refs/heads/merged-unknown-age', escapeshellarg( $remote ) ) );
 
 	// -------------------------------------------------------------------------
 	// Dry-run assertions
@@ -266,6 +294,8 @@ namespace {
 	$assert( 'agent-one', $metadata_item['metadata']['agent_slug'] ?? null, 'worktree list exposes agent metadata for agent runtime' );
 
 	$assert_contains( $plan['candidates'] ?? array(), 'demo@merged-autodelete', 'canonical merged worktree flagged prunable' );
+	$assert_contains( $plan['candidates'] ?? array(), 'demo@merged-recent', 'recent merged worktree is still prunable without age filter' );
+	$assert_contains( $plan['candidates'] ?? array(), 'demo@merged-unknown-age', 'merged worktree without age metadata is still prunable without age filter' );
 
 	// dirty-branch should be skipped (reason: dirty)
 	$dirty_skips = array_filter( $plan['skipped'] ?? array(), fn( $s ) => ( $s['handle'] ?? '' ) === 'demo@dirty-branch' );
@@ -286,9 +316,38 @@ namespace {
 	$assert( 'external_worktree', $external_row['reason_code'] ?? '', 'external worktree exposes stable reason code' );
 	$assert( true, str_contains( $external_row['hint'] ?? '', 'outside the DMC workspace' ), 'external worktree includes remediation hint' );
 
-	$assert( 2, (int) ( $plan['summary']['would_remove'] ?? 0 ), 'summary counts cleanup candidates' );
+	$assert( 4, (int) ( $plan['summary']['would_remove'] ?? 0 ), 'summary counts cleanup candidates' );
 	$assert( 1, (int) ( $plan['summary']['skipped_by_reason']['dirty_worktree'] ?? 0 ), 'summary counts dirty skips by reason' );
 	$assert( true, isset( $plan['summary']['skipped_by_reason']['no_merge_signal'] ), 'summary includes no_merge_signal bucket' );
+
+	$age_plan = $ws->worktree_cleanup_merged(
+		array(
+			'dry_run'     => true,
+			'skip_github' => true,
+			'older_than'  => '7d',
+		)
+	);
+	$assert( true, ! is_wp_error( $age_plan ) && ( $age_plan['success'] ?? false ), 'age-filtered dry_run returns success' );
+	$assert( 1, (int) ( $age_plan['summary']['would_remove'] ?? 0 ), 'older_than keeps only old cleanup candidate' );
+	$assert( 1, (int) ( $age_plan['summary']['age_filter']['excluded'] ?? 0 ), 'age filter summary counts newer candidate exclusion' );
+	$assert( 2, (int) ( $age_plan['summary']['age_filter']['unknown_age'] ?? 0 ), 'age filter summary counts unknown-age candidate exclusions' );
+	$assert_contains( $age_plan['candidates'] ?? array(), 'demo@merged-autodelete', 'older_than keeps old merged worktree' );
+	$recent_age_rows = array_values( array_filter( $age_plan['skipped'] ?? array(), fn( $s ) => ( $s['handle'] ?? '' ) === 'demo@merged-recent' ) );
+	$assert( 'age_filter', $recent_age_rows[0]['reason_code'] ?? '', 'newer merged worktree is skipped by age_filter' );
+	$assert( 'excluded', $recent_age_rows[0]['age_filter']['decision'] ?? '', 'age-filter skip row exposes excluded decision' );
+	$unknown_age_rows = array_values( array_filter( $age_plan['skipped'] ?? array(), fn( $s ) => ( $s['handle'] ?? '' ) === 'demo@merged-unknown-age' ) );
+	$assert( 'unknown_age', $unknown_age_rows[0]['reason_code'] ?? '', 'missing created_at candidate is skipped as unknown_age when age filter is active' );
+	$assert( 'unknown_age', $unknown_age_rows[0]['age_filter']['decision'] ?? '', 'unknown-age skip row exposes age-filter decision' );
+	$old_age_rows = array_values( array_filter( $age_plan['candidates'] ?? array(), fn( $s ) => ( $s['handle'] ?? '' ) === 'demo@merged-autodelete' ) );
+	$assert( 'included', $old_age_rows[0]['age_filter']['decision'] ?? '', 'kept candidate exposes included age-filter decision' );
+	$invalid_age_plan = $ws->worktree_cleanup_merged(
+		array(
+			'dry_run'     => true,
+			'skip_github' => true,
+			'older_than'  => 'soon',
+		)
+	);
+	$assert( true, is_wp_error( $invalid_age_plan ), 'invalid older_than duration returns WP_Error' );
 
 	class Missing_Metadata_Workspace extends \DataMachineCode\Workspace\Workspace {
 		public function worktree_list( ?string $repo = null ): array|\WP_Error { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
@@ -377,6 +436,8 @@ namespace {
 
 	// The merged-autodelete candidate should be in removed[].
 	$assert_contains( $result['removed'] ?? array(), 'demo@merged-autodelete', 'canonical merged worktree was actually removed' );
+	$assert_contains( $result['removed'] ?? array(), 'demo@merged-recent', 'recent merged worktree was actually removed without age filter' );
+	$assert_contains( $result['removed'] ?? array(), 'demo@merged-unknown-age', 'unknown-age merged worktree was actually removed without age filter' );
 
 	$stale_skips = array_values( array_filter( $result['skipped'] ?? array(), fn( $s ) => ( $s['handle'] ?? '' ) === 'demo@merged-stale-plan' ) );
 	$assert( 1, count( $stale_skips ), 'stale plan row is skipped after revalidation' );
@@ -384,6 +445,8 @@ namespace {
 
 	// Directory should be gone from disk.
 	$assert( false, is_dir( $tmp . '/demo@merged-autodelete' ), 'merged worktree directory no longer exists on disk' );
+	$assert( false, is_dir( $tmp . '/demo@merged-recent' ), 'recent merged worktree directory no longer exists on disk' );
+	$assert( false, is_dir( $tmp . '/demo@merged-unknown-age' ), 'unknown-age merged worktree directory no longer exists on disk' );
 
 	// Primary survives.
 	$assert( true, is_dir( $primary . '/.git' ), 'primary .git survives cleanup' );


### PR DESCRIPTION
## Summary
- Add `--older-than=<duration>` support to workspace worktree cleanup so routine maintenance can remove only otherwise-safe candidates older than lifecycle `created_at` metadata.
- Skip candidate worktrees with missing or invalid age metadata as `unknown_age`, and expose stable age-filter decisions in summary and JSON output.

## Tests
- `php -l inc/Workspace/Workspace.php && php -l inc/Cli/Commands/WorkspaceCommand.php && php -l inc/Abilities/WorkspaceAbilities.php && php tests/smoke-worktree-cleanup.php && php tests/smoke-worktree-cleanup-cli.php`
- `homeboy lint data-machine-code --path "/Users/chubes/Developer/data-machine-code@feat-cleanup-age-filters" --changed-since origin/main`

Closes #132

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented cleanup age filtering; Chris reviewed the direction and owns the final change.
