### PR TITLE
feat(memory): document disk projection boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ Workspace git policies are configured via the `datamachine_workspace_git_policie
 
 DMC extends core base classes (`BaseTool`, `SystemTask`, `BaseCommand`, `FetchHandler`) and registers its capabilities through standard Data Machine hooks (`datamachine_tools`, `datamachine_tasks`, `MemoryFileRegistry`, `SectionRegistry`, Abilities API). Its difference from the handler-adding siblings is **what it changes about the install**, not what API it uses to register things.
 
+Memory and guideline disk projection follows the same boundary: Data Machine owns logical memory semantics and storage backends; DMC owns local runtime/file projection when explicit update events and writable disk are available. See [Memory Disk Projection](docs/memory-disk-projection.md).
+
 ### Capability detection
 
 Other plugins gate disk-side or shell-using behavior on DMC's presence rather than on platform sniffing:

--- a/docs/memory-disk-projection.md
+++ b/docs/memory-disk-projection.md
@@ -1,0 +1,53 @@
+# Memory Disk Projection
+
+Data Machine Code owns **local runtime/file projection** for coding agents. Data Machine owns **logical agent memory**, memory storage backends, and prompt injection.
+
+This boundary matters because external coding agents need files on disk, while WordPress-hosted agents may use disk, `wp_guideline`, or another store behind Data Machine's memory interfaces.
+
+## Boundary
+
+```text
+Data Machine memory/guideline store
+        |
+        | explicit update/delete events
+        v
+Data Machine Code projection
+        |
+        v
+local files for coding-agent runtimes
+```
+
+DMC should not decide what `MEMORY.md`, `SOUL.md`, `USER.md`, or guideline records mean. It should only project already-resolved records to safe local file paths when a writable local runtime exists.
+
+## Guardrails
+
+- `wp_guideline` is optional. It is not guaranteed in WordPress core today.
+- Guideline-backed projection must feature-detect `post_type_exists( 'wp_guideline' )` and `taxonomy_exists( 'wp_guideline_type' )`, or rely on an explicit producer contract/polyfill.
+- Disk projection is one-way until a separate sync-back design exists.
+- Data Machine core should not learn about OpenCode, Claude Code, or Kimaki.
+- DMC should not subscribe to inferred low-level writes. It should consume explicit Data Machine memory/guideline events.
+
+## Current Safe Slice
+
+`DataMachineCode\MemoryDiskProjection` provides:
+
+- environment gating via `is_available()`;
+- optional Guidelines substrate detection via `has_guideline_substrate()`;
+- a named list of expected future Data Machine event hooks;
+- path normalization/resolution helpers that reject absolute paths, traversal, empty paths, and NUL bytes.
+
+It does not register a live sync loop because Data Machine does not currently emit memory/guideline update events.
+
+## Upstream Dependency
+
+DMC can implement live projection after Data Machine provides explicit events such as:
+
+```php
+do_action( 'datamachine_agent_memory_updated', $scope, $content, $metadata );
+do_action( 'datamachine_agent_memory_deleted', $scope );
+do_action( 'datamachine_guideline_updated', $post_id, $type );
+```
+
+The event payload should identify the logical memory four-tuple `(layer, user_id, agent_id, filename)` or a guideline record type. DMC can then map records to local runtime files without owning storage semantics.
+
+Tracked upstream: https://github.com/Extra-Chill/data-machine/issues/1522

--- a/inc/MemoryDiskProjection.php
+++ b/inc/MemoryDiskProjection.php
@@ -19,8 +19,8 @@ class MemoryDiskProjection {
 	public const GUIDELINE_POST_TYPE = 'wp_guideline';
 	public const GUIDELINE_TAXONOMY  = 'wp_guideline_type';
 
-	public const HOOK_MEMORY_UPDATED   = 'datamachine_agent_memory_updated';
-	public const HOOK_MEMORY_DELETED   = 'datamachine_agent_memory_deleted';
+	public const HOOK_MEMORY_UPDATED    = 'datamachine_agent_memory_updated';
+	public const HOOK_MEMORY_DELETED    = 'datamachine_agent_memory_deleted';
 	public const HOOK_GUIDELINE_UPDATED = 'datamachine_guideline_updated';
 
 	/**

--- a/inc/MemoryDiskProjection.php
+++ b/inc/MemoryDiskProjection.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Memory Disk Projection helpers.
+ *
+ * DMC owns local runtime/file projection for coding agents. Data Machine owns
+ * memory semantics and storage backends. This helper intentionally stops at
+ * capability checks and path contracts until Data Machine emits explicit
+ * memory/guideline change events.
+ *
+ * @package DataMachineCode
+ */
+
+namespace DataMachineCode;
+
+defined( 'ABSPATH' ) || exit;
+
+class MemoryDiskProjection {
+
+	public const GUIDELINE_POST_TYPE = 'wp_guideline';
+	public const GUIDELINE_TAXONOMY  = 'wp_guideline_type';
+
+	public const HOOK_MEMORY_UPDATED   = 'datamachine_agent_memory_updated';
+	public const HOOK_MEMORY_DELETED   = 'datamachine_agent_memory_deleted';
+	public const HOOK_GUIDELINE_UPDATED = 'datamachine_guideline_updated';
+
+	/**
+	 * Whether DMC can write projection files for a co-located coding runtime.
+	 */
+	public static function is_available(): bool {
+		return Environment::is_available() && Environment::has_writable_fs();
+	}
+
+	/**
+	 * Whether the optional WordPress Guidelines substrate is present.
+	 *
+	 * `wp_guideline` is not guaranteed in WordPress core. It may come from
+	 * Gutenberg, a future core merge, or an explicit plugin/polyfill.
+	 */
+	public static function has_guideline_substrate(): bool {
+		return function_exists( 'post_type_exists' )
+			&& function_exists( 'taxonomy_exists' )
+			&& post_type_exists( self::GUIDELINE_POST_TYPE )
+			&& taxonomy_exists( self::GUIDELINE_TAXONOMY );
+	}
+
+	/**
+	 * Future Data Machine events DMC expects before live projection is safe.
+	 *
+	 * @return array<string,string>
+	 */
+	public static function expected_event_hooks(): array {
+		return array(
+			'memory_updated'    => self::HOOK_MEMORY_UPDATED,
+			'memory_deleted'    => self::HOOK_MEMORY_DELETED,
+			'guideline_updated' => self::HOOK_GUIDELINE_UPDATED,
+		);
+	}
+
+	/**
+	 * Normalize a relative projection path.
+	 *
+	 * Projection paths are always relative to the WordPress site root. Absolute
+	 * paths, parent-directory traversal, empty paths, and NUL bytes are rejected.
+	 */
+	public static function normalize_relative_path( string $relative_path ): ?string {
+		if ( str_contains( $relative_path, "\0" ) ) {
+			return null;
+		}
+
+		$relative_path = str_replace( '\\', '/', trim( $relative_path ) );
+		if ( '' === $relative_path || str_starts_with( $relative_path, '/' ) ) {
+			return null;
+		}
+
+		$relative_path = preg_replace( '#/+#', '/', $relative_path );
+		$relative_path = null === $relative_path ? '' : $relative_path;
+		while ( str_starts_with( $relative_path, './' ) ) {
+			$relative_path = substr( $relative_path, 2 );
+		}
+
+		if ( '' === $relative_path ) {
+			return null;
+		}
+
+		$parts = explode( '/', $relative_path );
+		foreach ( $parts as $part ) {
+			if ( '' === $part || '.' === $part || '..' === $part ) {
+				return null;
+			}
+		}
+
+		return implode( '/', $parts );
+	}
+
+	/**
+	 * Resolve a safe absolute projection path below the site root.
+	 */
+	public static function resolve_site_projection_path( string $site_root, string $relative_path ): ?string {
+		$relative_path = self::normalize_relative_path( $relative_path );
+		$site_root     = rtrim( str_replace( '\\', '/', trim( $site_root ) ), '/' );
+
+		if ( null === $relative_path || '' === $site_root ) {
+			return null;
+		}
+
+		return $site_root . '/' . $relative_path;
+	}
+}

--- a/tests/smoke-memory-disk-projection.php
+++ b/tests/smoke-memory-disk-projection.php
@@ -53,9 +53,9 @@ $assert(
 );
 
 $hooks = MemoryDiskProjection::expected_event_hooks();
-$assert( 'memory update hook named', 'datamachine_agent_memory_updated' === ( $hooks['memory_updated'] ?? '' ) );
-$assert( 'memory delete hook named', 'datamachine_agent_memory_deleted' === ( $hooks['memory_deleted'] ?? '' ) );
-$assert( 'guideline update hook named', 'datamachine_guideline_updated' === ( $hooks['guideline_updated'] ?? '' ) );
+$assert( 'memory update hook named', MemoryDiskProjection::HOOK_MEMORY_UPDATED === ( $hooks['memory_updated'] ?? '' ) );
+$assert( 'memory delete hook named', MemoryDiskProjection::HOOK_MEMORY_DELETED === ( $hooks['memory_deleted'] ?? '' ) );
+$assert( 'guideline update hook named', MemoryDiskProjection::HOOK_GUIDELINE_UPDATED === ( $hooks['guideline_updated'] ?? '' ) );
 
 $assert( 'guideline substrate absent without WP helpers', false === MemoryDiskProjection::has_guideline_substrate() );
 

--- a/tests/smoke-memory-disk-projection.php
+++ b/tests/smoke-memory-disk-projection.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Pure-PHP smoke test for memory disk projection helpers.
+ *
+ * Run: php tests/smoke-memory-disk-projection.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+declare( strict_types=1 );
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+if ( ! defined( 'WP_CONTENT_DIR' ) ) {
+	define( 'WP_CONTENT_DIR', sys_get_temp_dir() );
+}
+
+require __DIR__ . '/../inc/Environment.php';
+require __DIR__ . '/../inc/MemoryDiskProjection.php';
+
+use DataMachineCode\MemoryDiskProjection;
+
+$failures = array();
+$assert   = function ( string $label, bool $cond ) use ( &$failures ): void {
+	if ( $cond ) {
+		echo "  [PASS] {$label}\n";
+		return;
+	}
+	$failures[] = $label;
+	echo "  [FAIL] {$label}\n";
+};
+
+echo "Memory disk projection helper -- smoke\n";
+
+$assert( 'relative path kept', 'MEMORY.md' === MemoryDiskProjection::normalize_relative_path( 'MEMORY.md' ) );
+$assert( 'nested relative path kept', 'contexts/code.md' === MemoryDiskProjection::normalize_relative_path( 'contexts//code.md' ) );
+$assert( 'leading dot slash trimmed', 'AGENTS.md' === MemoryDiskProjection::normalize_relative_path( './AGENTS.md' ) );
+$assert( 'absolute path rejected', null === MemoryDiskProjection::normalize_relative_path( '/tmp/MEMORY.md' ) );
+$assert( 'parent traversal rejected', null === MemoryDiskProjection::normalize_relative_path( '../MEMORY.md' ) );
+$assert( 'nested parent traversal rejected', null === MemoryDiskProjection::normalize_relative_path( 'contexts/../MEMORY.md' ) );
+$assert( 'empty path rejected', null === MemoryDiskProjection::normalize_relative_path( '' ) );
+$assert( 'nul byte rejected', null === MemoryDiskProjection::normalize_relative_path( "MEMORY.md\0" ) );
+
+$assert(
+	'safe site path resolved',
+	'/wordpress/AGENTS.md' === MemoryDiskProjection::resolve_site_projection_path( '/wordpress/', 'AGENTS.md' )
+);
+$assert(
+	'unsafe site path rejected',
+	null === MemoryDiskProjection::resolve_site_projection_path( '/wordpress', '../../etc/passwd' )
+);
+
+$hooks = MemoryDiskProjection::expected_event_hooks();
+$assert( 'memory update hook named', 'datamachine_agent_memory_updated' === ( $hooks['memory_updated'] ?? '' ) );
+$assert( 'memory delete hook named', 'datamachine_agent_memory_deleted' === ( $hooks['memory_deleted'] ?? '' ) );
+$assert( 'guideline update hook named', 'datamachine_guideline_updated' === ( $hooks['guideline_updated'] ?? '' ) );
+
+$assert( 'guideline substrate absent without WP helpers', false === MemoryDiskProjection::has_guideline_substrate() );
+
+if ( ! empty( $failures ) ) {
+	echo "\nFAIL: " . count( $failures ) . " assertion(s)\n";
+	foreach ( $failures as $failure ) {
+		echo "  - {$failure}\n";
+	}
+	exit( 1 );
+}
+
+echo "\nOK\n";
+exit( 0 );


### PR DESCRIPTION
## Summary

- Document the DMC/Data Machine boundary for memory and guideline disk projection.
- Add `DataMachineCode\MemoryDiskProjection` as a small capability/path contract helper for future projection work.
- Add a pure-PHP smoke test for projection path safety, optional Guidelines detection, and expected upstream event names.

## Guardrail

- `wp_guideline` is optional and not guaranteed in WordPress core today.
- Guideline-specific projection must feature-detect `post_type_exists( 'wp_guideline' )` and `taxonomy_exists( 'wp_guideline_type' )`, or rely on an explicit producer contract/polyfill.

## Boundary

- DMC provides file projection/runtime integration only.
- Data Machine remains the owner of memory semantics, storage backends, and update/delete decisions.
- This PR intentionally does not register a live sync loop because Data Machine does not yet emit explicit memory/guideline update events.

## Upstream dependency

- Filed Extra-Chill/data-machine#1522 for explicit memory/guideline change events that DMC can consume later.

## Tests

- `php tests/smoke-memory-disk-projection.php`
- `php -l inc/MemoryDiskProjection.php`
- `php -l tests/smoke-memory-disk-projection.php`
- `homeboy lint data-machine-code --path /Users/chubes/Developer/data-machine-code@feat-memory-disk-projection --changed-since origin/main`
- `homeboy audit data-machine-code --path /Users/chubes/Developer/data-machine-code@feat-memory-disk-projection --changed-since origin/main`

Refs #137

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Source-level research, drafting the projection boundary docs, implementing the helper/smoke test, and validating the branch. Chris supplied the architectural guardrails in the issue prompt.
