### PR TITLE
feat(github): add workflow_run PR review trigger

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -66,6 +66,7 @@ add_action( 'plugins_loaded', 'datamachine_code_bootstrap', 20 );
  */
 add_filter( 'datamachine_webhook_verifier_modes', function ( array $modes ): array {
 	$modes['github_pull_request'] = \DataMachineCode\Support\GitHubWebhookValidator::class;
+	$modes['github_workflow_run'] = \DataMachineCode\Support\GitHubWebhookValidator::class;
 	return $modes;
 } );
 

--- a/inc/Cli/Commands/GitHubCommand.php
+++ b/inc/Cli/Commands/GitHubCommand.php
@@ -558,11 +558,26 @@ class GitHubCommand extends BaseCommand {
 	 *   - dry_run
 	 * ---
 	 *
-	 * [--actions=<actions>]
-	 * : Comma-separated GitHub pull_request actions.
-	 * ---
-	 * default: opened,reopened,synchronize,ready_for_review
-	 * ---
+		 * [--actions=<actions>]
+		 * : Comma-separated GitHub webhook actions. Defaults depend on --trigger.
+		 * ---
+		 * default: opened,reopened,synchronize,ready_for_review for pull_request; completed for workflow_run
+		 * ---
+		 *
+		 * [--trigger=<trigger>]
+		 * : GitHub webhook event to review from.
+		 * ---
+		 * default: pull_request
+		 * options:
+		 *   - pull_request
+		 *   - workflow_run
+		 * ---
+		 *
+		 * [--workflow-names=<names>]
+		 * : Comma-separated workflow_run.name allow-list, for example Homeboy CI.
+		 *
+		 * [--workflow-paths=<paths>]
+		 * : Comma-separated workflow_run.path allow-list, for example .github/workflows/homeboy.yml.
 	 *
 	 * [--mode=<mode>]
 	 * : create action mode. `scaffold` preserves the historical JSON-only output; `install` creates the Data Machine pipeline/flow.
@@ -625,15 +640,18 @@ class GitHubCommand extends BaseCommand {
 		}
 
 		$options = array(
-			'repo'         => $repo,
-			'agent'        => $assoc_args['agent'] ?? '',
-			'name'         => $assoc_args['name'] ?? 'GitHub PR review',
-			'comment_mode' => $assoc_args['comment-mode'] ?? 'managed',
-			'actions'      => $assoc_args['actions'] ?? PrReviewFlowScaffold::DEFAULT_ACTIONS,
-			'secret_id'    => $assoc_args['secret-id'] ?? 'github_webhook',
-			'secret'       => $assoc_args['secret'] ?? '',
-			'allow_drafts' => ! empty( $assoc_args['allow-drafts'] ),
-			'force'        => ! empty( $assoc_args['force'] ),
+			'repo'           => $repo,
+			'agent'          => $assoc_args['agent'] ?? '',
+			'name'           => $assoc_args['name'] ?? 'GitHub PR review',
+			'comment_mode'   => $assoc_args['comment-mode'] ?? 'managed',
+			'trigger'        => $assoc_args['trigger'] ?? 'pull_request',
+			'actions'        => $assoc_args['actions'] ?? null,
+			'workflow_names' => $assoc_args['workflow-names'] ?? '',
+			'workflow_paths' => $assoc_args['workflow-paths'] ?? '',
+			'secret_id'      => $assoc_args['secret-id'] ?? 'github_webhook',
+			'secret'         => $assoc_args['secret'] ?? '',
+			'allow_drafts'   => ! empty( $assoc_args['allow-drafts'] ),
+			'force'          => ! empty( $assoc_args['force'] ),
 		);
 
 		$mode = 'install' === $action ? 'install' : (string) ( $assoc_args['mode'] ?? 'scaffold' );

--- a/inc/GitHub/PrReviewFlowInstaller.php
+++ b/inc/GitHub/PrReviewFlowInstaller.php
@@ -27,17 +27,18 @@ class PrReviewFlowInstaller {
 	public static function install( array $args ): array|\WP_Error {
 		$definition = PrReviewFlowScaffold::build( $args );
 		$repo       = (string) ( $definition['repo'] ?? '' );
+		$trigger    = (string) ( $definition['webhook']['event'] ?? 'pull_request' );
 		if ( '' === $repo ) {
 			return new \WP_Error( 'missing_repo', 'Repository is required.' );
 		}
 
 		$force = ! empty( $args['force'] );
 		if ( ! $force ) {
-			$existing = self::findExistingInstall( $repo );
+			$existing = self::findExistingInstallForTrigger( $repo, $trigger );
 			if ( $existing ) {
 				return new \WP_Error(
 					'github_pr_review_flow_exists',
-					sprintf( 'A GitHub PR review flow already exists for %s (flow_id=%d). Pass --force to create another one.', $repo, (int) $existing['flow_id'] ),
+					sprintf( 'A GitHub PR review flow already exists for %s with trigger %s (flow_id=%d). Pass --force to create another one.', $repo, $trigger, (int) $existing['flow_id'] ),
 					array( 'existing' => $existing )
 				);
 			}
@@ -61,7 +62,7 @@ class PrReviewFlowInstaller {
 			'workflow'      => $definition['workflow'] ?? array(),
 			'flow_config'   => array(
 				'flow_name'         => $name,
-				'scheduling_config' => self::buildSchedulingConfig( $repo, $actions, $definition ),
+				'scheduling_config' => self::buildSchedulingConfig( $repo, $actions, $trigger, $definition ),
 			),
 		);
 
@@ -74,7 +75,7 @@ class PrReviewFlowInstaller {
 			return new \WP_Error( 'create_pipeline_failed', (string) ( $created['error'] ?? 'Failed to create Data Machine pipeline/flow.' ), $created );
 		}
 
-		$webhook = self::enableWebhook( (int) $created['flow_id'], $repo, $actions, $args );
+		$webhook = self::enableWebhook( (int) $created['flow_id'], $repo, $actions, $trigger, $definition, $args );
 		if ( is_wp_error( $webhook ) ) {
 			return $webhook;
 		}
@@ -89,13 +90,13 @@ class PrReviewFlowInstaller {
 			'flow_name'       => (string) $created['flow_name'],
 			'flow_step_ids'   => $created['flow_step_ids'] ?? array(),
 			'webhook_url'     => (string) ( $webhook['webhook_url'] ?? '' ),
-			'webhook_event'   => 'pull_request',
+			'webhook_event'   => $trigger,
 			'webhook_actions' => array_values( (array) $actions ),
 			'webhook_auth'    => array(
-				'mode'         => 'github_pull_request',
+				'mode'         => self::verifierModeForTrigger( $trigger ),
 				'secret_ids'   => $webhook['secret_ids'] ?? array(),
 				'secret'       => $webhook['secret'] ?? null,
-				'instructions' => 'Configure the GitHub repository webhook for pull_request events, use the webhook_url, and set the secret shown here or stored under the listed secret id.',
+				'instructions' => sprintf( 'Configure the GitHub repository webhook for %s events, use the webhook_url, and set the secret shown here or stored under the listed secret id.', $trigger ),
 			),
 			'scaffold_schema' => (string) ( $definition['schema'] ?? '' ),
 		);
@@ -106,16 +107,17 @@ class PrReviewFlowInstaller {
 	 * @param array<string,mixed> $definition
 	 * @return array<string,mixed>
 	 */
-	private static function buildSchedulingConfig( string $repo, array $actions, array $definition ): array {
+	private static function buildSchedulingConfig( string $repo, array $actions, string $trigger, array $definition ): array {
 		$config = array(
 			'interval'        => 'manual',
-			'webhook_event'   => 'pull_request',
+			'webhook_event'   => $trigger,
 			'webhook_actions' => array_values( $actions ),
 		);
 
 		$config[ self::SCHEDULING_MARKER_KEY ] = array(
-			'schema' => (string) ( $definition['schema'] ?? '' ),
-			'repo'   => $repo,
+			'schema'  => (string) ( $definition['schema'] ?? '' ),
+			'repo'    => $repo,
+			'trigger' => $trigger,
 		);
 
 		return $config;
@@ -126,24 +128,34 @@ class PrReviewFlowInstaller {
 	 * @param array<string,mixed> $args
 	 * @return array<string,mixed>|\WP_Error
 	 */
-	private static function enableWebhook( int $flow_id, string $repo, array $actions, array $args ): array|\WP_Error {
+	private static function enableWebhook( int $flow_id, string $repo, array $actions, string $trigger, array $definition, array $args ): array|\WP_Error {
 		$enable_webhook = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'datamachine/webhook-trigger-enable' ) : null;
 		if ( ! $enable_webhook ) {
 			return new \WP_Error( 'webhook_enable_missing', 'Data Machine webhook-trigger-enable ability is not available.' );
 		}
 
-		$secret = isset( $args['secret'] ) ? (string) $args['secret'] : '';
-		$input  = array(
+		$secret           = isset( $args['secret'] ) ? (string) $args['secret'] : '';
+		$webhook          = is_array( $definition['webhook'] ?? null ) ? $definition['webhook'] : array();
+		$filters          = is_array( $webhook['workflow_filters'] ?? null ) ? $webhook['workflow_filters'] : array();
+		$template_options = array(
+			'mode'            => self::verifierModeForTrigger( $trigger ),
+			'repo'            => $repo,
+			'allowed_repos'   => array( $repo ),
+			'allowed_actions' => array_values( $actions ),
+			'allow_drafts'    => ! empty( $args['allow_drafts'] ),
+		);
+
+		if ( 'workflow_run' === $trigger ) {
+			$template_options['workflow_names'] = array_values( (array) ( $filters['names'] ?? array() ) );
+			$template_options['workflow_paths'] = array_values( (array) ( $filters['paths'] ?? array() ) );
+		}
+
+		$input = array(
 			'flow_id'         => $flow_id,
 			'auth_mode'       => 'hmac',
 			'template'        => GitHubWebhookValidator::buildVerifierConfig(
 				'',
-				array(
-					'repo'            => $repo,
-					'allowed_repos'   => array( $repo ),
-					'allowed_actions' => array_values( $actions ),
-					'allow_drafts'    => ! empty( $args['allow_drafts'] ),
-				)
+				$template_options
 			),
 			'secret_id'       => self::sanitizeSecretId( (string) ( $args['secret_id'] ?? 'github_webhook' ) ),
 			'generate_secret' => '' === $secret,
@@ -166,6 +178,10 @@ class PrReviewFlowInstaller {
 	private static function sanitizeSecretId( string $secret_id ): string {
 		$secret_id = function_exists( 'sanitize_key' ) ? sanitize_key( $secret_id ) : strtolower( preg_replace( '/[^a-z0-9_\-]/i', '', $secret_id ) );
 		return '' !== $secret_id ? $secret_id : 'github_webhook';
+	}
+
+	private static function verifierModeForTrigger( string $trigger ): string {
+		return 'workflow_run' === $trigger ? 'github_workflow_run' : 'github_pull_request';
 	}
 
 	/**
@@ -198,7 +214,7 @@ class PrReviewFlowInstaller {
 	/**
 	 * @return array<string,mixed>|null
 	 */
-	private static function findExistingInstall( string $repo ): ?array {
+	private static function findExistingInstallForTrigger( string $repo, string $trigger ): ?array {
 		if ( ! class_exists( '\\DataMachine\\Core\\Database\\Flows\\Flows' ) ) {
 			return null;
 		}
@@ -211,9 +227,10 @@ class PrReviewFlowInstaller {
 			$flows      = $flows_repo->get_all_flows_summary( $per_page, $offset );
 			$flow_count = count( $flows );
 			foreach ( $flows as $flow ) {
-				$config = is_array( $flow['scheduling_config'] ?? null ) ? $flow['scheduling_config'] : array();
-				$marker = is_array( $config[ self::SCHEDULING_MARKER_KEY ] ?? null ) ? $config[ self::SCHEDULING_MARKER_KEY ] : array();
-				if ( strtolower( $repo ) === strtolower( (string) ( $marker['repo'] ?? '' ) ) ) {
+				$config         = is_array( $flow['scheduling_config'] ?? null ) ? $flow['scheduling_config'] : array();
+				$marker         = is_array( $config[ self::SCHEDULING_MARKER_KEY ] ?? null ) ? $config[ self::SCHEDULING_MARKER_KEY ] : array();
+				$marker_trigger = (string) ( $marker['trigger'] ?? 'pull_request' );
+				if ( strtolower( $repo ) === strtolower( (string) ( $marker['repo'] ?? '' ) ) && $trigger === $marker_trigger ) {
 					return array(
 						'flow_id'     => (int) $flow['flow_id'],
 						'flow_name'   => (string) $flow['flow_name'],

--- a/inc/GitHub/PrReviewFlowScaffold.php
+++ b/inc/GitHub/PrReviewFlowScaffold.php
@@ -14,7 +14,8 @@ defined( 'ABSPATH' ) || exit;
  */
 class PrReviewFlowScaffold {
 
-	public const DEFAULT_ACTIONS = array( 'opened', 'reopened', 'synchronize', 'ready_for_review' );
+	public const DEFAULT_ACTIONS              = array( 'opened', 'reopened', 'synchronize', 'ready_for_review' );
+	public const DEFAULT_WORKFLOW_RUN_ACTIONS = array( 'completed' );
 
 	/**
 	 * Build the scaffold definition.
@@ -27,17 +28,20 @@ class PrReviewFlowScaffold {
 		$name         = self::clean_string( $args['name'] ?? 'GitHub PR review' );
 		$agent        = self::clean_string( $args['agent'] ?? '' );
 		$comment_mode = self::normalize_comment_mode( $args['comment_mode'] ?? 'managed' );
+		$trigger      = self::normalize_trigger( $args['trigger'] ?? 'pull_request' );
 
-		$actions = $args['actions'] ?? self::DEFAULT_ACTIONS;
+		$actions = $args['actions'] ?? self::default_actions_for_trigger( $trigger );
 		if ( is_string( $actions ) ) {
 			$actions = array_filter( array_map( 'trim', explode( ',', $actions ) ) );
 		}
-		$actions = array_values( array_unique( array_filter( array_map( 'sanitize_key', is_array( $actions ) ? $actions : self::DEFAULT_ACTIONS ) ) ) );
+		$actions = array_values( array_unique( array_filter( array_map( 'sanitize_key', is_array( $actions ) ? $actions : self::default_actions_for_trigger( $trigger ) ) ) ) );
 		if ( empty( $actions ) ) {
-			$actions = self::DEFAULT_ACTIONS;
+			$actions = self::default_actions_for_trigger( $trigger );
 		}
 
-		$dedupe_key = '{repository.full_name}#{pull_request.number}@{pull_request.head.sha}';
+		$dedupe_key     = self::dedupe_key_for_trigger( $trigger );
+		$workflow_names = self::string_list( $args['workflow_names'] ?? $args['workflow-name'] ?? array() );
+		$workflow_paths = self::string_list( $args['workflow_paths'] ?? $args['workflow-path'] ?? array() );
 
 		return array(
 			'schema'       => 'data-machine-code/github-pr-review-flow-scaffold/v1',
@@ -54,23 +58,22 @@ class PrReviewFlowScaffold {
 				'The AI review step can call github_repo_review_profile once for bounded repository rules and architecture context before making findings.',
 			),
 			'webhook'      => array(
-				'provider'      => 'github',
-				'event'         => 'pull_request',
-				'actions'       => $actions,
-				'dedupe_key'    => $dedupe_key,
-				'auth_mode'     => 'hmac',
-				'preset_hint'   => 'github',
-				'payload_paths' => array(
-					'repo'        => 'repository.full_name',
-					'pull_number' => 'pull_request.number',
-					'action'      => 'action',
-					'head_sha'    => 'pull_request.head.sha',
+				'provider'         => 'github',
+				'event'            => $trigger,
+				'actions'          => $actions,
+				'dedupe_key'       => $dedupe_key,
+				'auth_mode'        => 'hmac',
+				'preset_hint'      => 'github',
+				'payload_paths'    => self::payload_paths_for_trigger( $trigger ),
+				'workflow_filters' => array(
+					'names' => $workflow_names,
+					'paths' => $workflow_paths,
 				),
 			),
 			'workflow'     => array(
 				'type'  => 'pipeline_template',
 				'steps' => array(
-					self::webhook_payload_step( $dedupe_key ),
+					self::webhook_payload_step( $dedupe_key, $trigger ),
 					self::pull_review_context_step( $repo ),
 					self::ai_review_step( $comment_mode ),
 				),
@@ -81,7 +84,7 @@ class PrReviewFlowScaffold {
 				'scheduling_config' => array(
 					'interval'        => 'manual',
 					'webhook_enabled' => true,
-					'webhook_event'   => 'pull_request',
+					'webhook_event'   => $trigger,
 					'webhook_actions' => $actions,
 				),
 			),
@@ -114,24 +117,20 @@ class PrReviewFlowScaffold {
 	 * @param string $dedupe_key Dedupe key template.
 	 * @return array<string,mixed>
 	 */
-	private static function webhook_payload_step( string $dedupe_key ): array {
+	private static function webhook_payload_step( string $dedupe_key, string $trigger ): array {
+		$workflow_run = 'workflow_run' === $trigger;
 		return array(
-			'id'             => 'github_pull_request_payload',
+			'id'             => $workflow_run ? 'github_workflow_run_payload' : 'github_pull_request_payload',
 			'type'           => 'fetch',
-			'label'          => 'GitHub pull request webhook payload',
+			'label'          => $workflow_run ? 'GitHub workflow run webhook payload' : 'GitHub pull request webhook payload',
 			'handler_slug'   => 'webhook_payload',
 			'handler_config' => array(
-				'source_type'              => 'github_pull_request_webhook',
-				'title_path'               => 'pull_request.title',
-				'content_path'             => 'pull_request.body',
+				'source_type'              => $workflow_run ? 'github_workflow_run_webhook' : 'github_pull_request_webhook',
+				'title_path'               => $workflow_run ? 'workflow_run.display_title' : 'pull_request.title',
+				'content_path'             => $workflow_run ? 'workflow_run.html_url' : 'pull_request.body',
 				'item_identifier_template' => $dedupe_key,
 				'ignore_missing_paths'     => false,
-				'metadata'                 => array(
-					'repo'        => 'repository.full_name',
-					'pull_number' => 'pull_request.number',
-					'action'      => 'action',
-					'head_sha'    => 'pull_request.head.sha',
-				),
+				'metadata'                 => self::payload_paths_for_trigger( $trigger ),
 			),
 		);
 	}
@@ -220,6 +219,69 @@ class PrReviewFlowScaffold {
 			? sanitize_key( (string) $mode )
 			: strtolower( preg_replace( '/[^a-z0-9_\-]/i', '', (string) $mode ) );
 		return in_array( $mode, array( 'managed', 'append', 'dry_run' ), true ) ? $mode : 'managed';
+	}
+
+	/**
+	 * Normalize trigger mode.
+	 *
+	 * @param mixed $trigger Raw trigger mode.
+	 */
+	private static function normalize_trigger( mixed $trigger ): string {
+		$trigger = function_exists( 'sanitize_key' )
+			? sanitize_key( (string) $trigger )
+			: strtolower( preg_replace( '/[^a-z0-9_\-]/i', '', (string) $trigger ) );
+		return in_array( $trigger, array( 'pull_request', 'workflow_run' ), true ) ? $trigger : 'pull_request';
+	}
+
+	/**
+	 * @return array<int,string>
+	 */
+	private static function default_actions_for_trigger( string $trigger ): array {
+		return 'workflow_run' === $trigger ? self::DEFAULT_WORKFLOW_RUN_ACTIONS : self::DEFAULT_ACTIONS;
+	}
+
+	/**
+	 * Build the existing processed-items dedupe template for a trigger.
+	 */
+	private static function dedupe_key_for_trigger( string $trigger ): string {
+		return 'workflow_run' === $trigger
+			? '{repository.full_name}#{workflow_run.pull_requests.0.number}@{workflow_run.head_sha}'
+			: '{repository.full_name}#{pull_request.number}@{pull_request.head.sha}';
+	}
+
+	/**
+	 * @return array<string,string>
+	 */
+	private static function payload_paths_for_trigger( string $trigger ): array {
+		if ( 'workflow_run' === $trigger ) {
+			return array(
+				'repo'            => 'repository.full_name',
+				'pull_number'     => 'workflow_run.pull_requests.0.number',
+				'action'          => 'action',
+				'head_sha'        => 'workflow_run.head_sha',
+				'workflow_run_id' => 'workflow_run.id',
+				'workflow_name'   => 'workflow_run.name',
+				'conclusion'      => 'workflow_run.conclusion',
+			);
+		}
+
+		return array(
+			'repo'        => 'repository.full_name',
+			'pull_number' => 'pull_request.number',
+			'action'      => 'action',
+			'head_sha'    => 'pull_request.head.sha',
+		);
+	}
+
+	/**
+	 * @param mixed $value Raw list value.
+	 * @return array<int,string>
+	 */
+	private static function string_list( mixed $value ): array {
+		if ( is_string( $value ) ) {
+			$value = array_map( 'trim', explode( ',', $value ) );
+		}
+		return array_values( array_filter( array_map( 'strval', (array) $value ) ) );
 	}
 
 	/**

--- a/inc/Support/GitHubWebhookValidator.php
+++ b/inc/Support/GitHubWebhookValidator.php
@@ -16,13 +16,16 @@ defined( 'ABSPATH' ) || exit;
  */
 class GitHubWebhookValidator {
 
-	const DEFAULT_ALLOWED_ACTIONS = array( 'opened', 'reopened', 'synchronize', 'ready_for_review' );
+	const DEFAULT_ALLOWED_ACTIONS              = array( 'opened', 'reopened', 'synchronize', 'ready_for_review' );
+	const DEFAULT_WORKFLOW_RUN_ALLOWED_ACTIONS = array( 'completed' );
 
 	const WRONG_EVENT       = 'github_wrong_event';
 	const DISALLOWED_ACTION = 'github_disallowed_action';
 	const REPO_MISMATCH     = 'github_repo_mismatch';
 	const DRAFT_SKIPPED     = 'github_draft_skipped';
 	const MALFORMED_PAYLOAD = 'github_malformed_payload';
+	const WORKFLOW_MISMATCH = 'github_workflow_mismatch';
+	const NO_PULL_REQUEST   = 'github_workflow_run_no_pull_request';
 
 	/**
 	 * Verify a GitHub pull_request webhook.
@@ -85,14 +88,29 @@ class GitHubWebhookValidator {
 			return WebhookVerificationResult::fail( WebhookVerificationResult::BAD_SIGNATURE, 'signature mismatch' );
 		}
 
-		$event = trim( (string) ( $headers['x-github-event'] ?? '' ) );
-		if ( 'pull_request' !== $event ) {
-			return WebhookVerificationResult::fail( self::WRONG_EVENT, 'event is not pull_request' );
-		}
-
 		$payload = json_decode( $raw_body, true );
 		if ( ! is_array( $payload ) ) {
 			return WebhookVerificationResult::fail( self::MALFORMED_PAYLOAD, 'payload is not valid JSON' );
+		}
+
+		$mode = (string) ( $config['mode'] ?? 'github_pull_request' );
+		return 'github_workflow_run' === $mode
+			? self::verifyWorkflowRunPayload( $payload, $headers, $config, $matched_secret_id )
+			: self::verifyPullRequestPayload( $payload, $headers, $config, $matched_secret_id );
+	}
+
+	/**
+	 * Verify a pull_request payload after HMAC validation.
+	 *
+	 * @param array<string,mixed> $payload Payload body.
+	 * @param array<string,string> $headers Lower-cased request headers.
+	 * @param array<string,mixed> $config Verifier config.
+	 * @param string $matched_secret_id Matched secret id.
+	 */
+	private static function verifyPullRequestPayload( array $payload, array $headers, array $config, string $matched_secret_id ): WebhookVerificationResult {
+		$event = trim( (string) ( $headers['x-github-event'] ?? '' ) );
+		if ( 'pull_request' !== $event ) {
+			return WebhookVerificationResult::fail( self::WRONG_EVENT, 'event is not pull_request' );
 		}
 
 		$action = (string) ( $payload['action'] ?? '' );
@@ -125,23 +143,87 @@ class GitHubWebhookValidator {
 	}
 
 	/**
+	 * Verify a workflow_run payload after HMAC validation.
+	 *
+	 * @param array<string,mixed> $payload Payload body.
+	 * @param array<string,string> $headers Lower-cased request headers.
+	 * @param array<string,mixed> $config Verifier config.
+	 * @param string $matched_secret_id Matched secret id.
+	 */
+	private static function verifyWorkflowRunPayload( array $payload, array $headers, array $config, string $matched_secret_id ): WebhookVerificationResult {
+		$event = trim( (string) ( $headers['x-github-event'] ?? '' ) );
+		if ( 'workflow_run' !== $event ) {
+			return WebhookVerificationResult::fail( self::WRONG_EVENT, 'event is not workflow_run' );
+		}
+
+		$action = (string) ( $payload['action'] ?? '' );
+		if ( '' === $action ) {
+			return WebhookVerificationResult::fail( self::MALFORMED_PAYLOAD, 'payload action missing' );
+		}
+
+		$allowed_actions = self::allowedActions( $config );
+		if ( ! in_array( $action, $allowed_actions, true ) ) {
+			return WebhookVerificationResult::fail( self::DISALLOWED_ACTION, 'action=' . $action );
+		}
+
+		$repo = (string) ( $payload['repository']['full_name'] ?? '' );
+		if ( '' === $repo ) {
+			return WebhookVerificationResult::fail( self::MALFORMED_PAYLOAD, 'repository.full_name missing' );
+		}
+
+		$allowed_repos = self::allowedRepos( $config );
+		if ( ! empty( $allowed_repos ) && ! in_array( strtolower( $repo ), $allowed_repos, true ) ) {
+			return WebhookVerificationResult::fail( self::REPO_MISMATCH, 'repo=' . $repo );
+		}
+
+		$workflow_run = is_array( $payload['workflow_run'] ?? null ) ? $payload['workflow_run'] : array();
+		if ( empty( $workflow_run ) ) {
+			return WebhookVerificationResult::fail( self::MALFORMED_PAYLOAD, 'workflow_run missing' );
+		}
+
+		$workflow_name   = (string) ( $workflow_run['name'] ?? '' );
+		$workflow_path   = (string) ( $workflow_run['path'] ?? '' );
+		$allowed_names   = self::stringList( $config['workflow_names'] ?? $config['allowed_workflow_names'] ?? array() );
+		$allowed_paths   = self::stringList( $config['workflow_paths'] ?? $config['allowed_workflow_paths'] ?? array() );
+		$normalized_name = strtolower( $workflow_name );
+		$normalized_path = strtolower( $workflow_path );
+
+		if ( ! empty( $allowed_names ) && ! in_array( $normalized_name, array_map( 'strtolower', $allowed_names ), true ) ) {
+			return WebhookVerificationResult::fail( self::WORKFLOW_MISMATCH, 'workflow=' . $workflow_name );
+		}
+
+		if ( ! empty( $allowed_paths ) && ! in_array( $normalized_path, array_map( 'strtolower', $allowed_paths ), true ) ) {
+			return WebhookVerificationResult::fail( self::WORKFLOW_MISMATCH, 'workflow_path=' . $workflow_path );
+		}
+
+		$pull_requests = is_array( $workflow_run['pull_requests'] ?? null ) ? $workflow_run['pull_requests'] : array();
+		if ( empty( $pull_requests ) || ! is_array( $pull_requests[0] ?? null ) || empty( $pull_requests[0]['number'] ) ) {
+			return WebhookVerificationResult::fail( self::NO_PULL_REQUEST, 'workflow_run.pull_requests is empty' );
+		}
+
+		return WebhookVerificationResult::ok( $matched_secret_id );
+	}
+
+	/**
 	 * Build a Data Machine webhook verifier config for GitHub PR review flows.
 	 *
 	 * @param string $secret  Webhook secret from GitHub.
-	 * @param array  $options Optional allowed_actions, repo, allowed_repos, allow_drafts.
+	 * @param array  $options Optional mode, allowed_actions, repo, allowed_repos, allow_drafts, workflow filters.
 	 * @return array
 	 */
 	public static function buildVerifierConfig( string $secret, array $options = array() ): array {
 		$config = array_merge(
 			array(
-				'mode'            => 'github_pull_request',
+				'mode'            => (string) ( $options['mode'] ?? 'github_pull_request' ),
 				'secrets'         => array(
 					array(
 						'id'    => 'github_webhook',
 						'value' => $secret,
 					),
 				),
-				'allowed_actions' => self::DEFAULT_ALLOWED_ACTIONS,
+				'allowed_actions' => 'github_workflow_run' === ( $options['mode'] ?? '' )
+					? self::DEFAULT_WORKFLOW_RUN_ALLOWED_ACTIONS
+					: self::DEFAULT_ALLOWED_ACTIONS,
 				'allow_drafts'    => false,
 			),
 			$options
@@ -201,12 +283,24 @@ class GitHubWebhookValidator {
 	 * @return array<int,string>
 	 */
 	private static function allowedActions( array $config ): array {
-		$actions = $config['allowed_actions'] ?? self::DEFAULT_ALLOWED_ACTIONS;
+		$default = 'github_workflow_run' === ( $config['mode'] ?? '' ) ? self::DEFAULT_WORKFLOW_RUN_ALLOWED_ACTIONS : self::DEFAULT_ALLOWED_ACTIONS;
+		$actions = $config['allowed_actions'] ?? $default;
 		if ( is_string( $actions ) ) {
 			$actions = array_map( 'trim', explode( ',', $actions ) );
 		}
 		$actions = array_values( array_filter( array_map( 'strval', (array) $actions ) ) );
-		return ! empty( $actions ) ? $actions : self::DEFAULT_ALLOWED_ACTIONS;
+		return ! empty( $actions ) ? $actions : $default;
+	}
+
+	/**
+	 * @param mixed $value Raw list value.
+	 * @return array<int,string>
+	 */
+	private static function stringList( mixed $value ): array {
+		if ( is_string( $value ) ) {
+			$value = array_map( 'trim', explode( ',', $value ) );
+		}
+		return array_values( array_filter( array_map( 'strval', (array) $value ) ) );
 	}
 
 	/**

--- a/tests/smoke-github-pr-review-flow-installer.php
+++ b/tests/smoke-github-pr-review-flow-installer.php
@@ -134,6 +134,27 @@ namespace {
 	$assert( ! isset( $webhook_input['template']['secrets'] ), 'template does not carry raw secret storage' );
 	$assert( true === ( $webhook_input['generate_secret'] ?? null ), 'installer generates secret by default' );
 	$assert( 'github_pr_review' === ( $webhook_input['secret_id'] ?? '' ), 'installer passes requested secret id' );
+	$assert( 'pull_request' === ( $result['webhook_event'] ?? '' ), 'default installer result keeps pull_request event' );
+	$assert( 'pull_request' === ( $create_input['flow_config']['scheduling_config']['data_machine_code_github_pr_review']['trigger'] ?? '' ), 'flow marker records default trigger' );
+
+	Flows::$summary_rows = array();
+	$workflow_result = PrReviewFlowInstaller::install( array(
+		'repo'           => 'Extra-Chill/data-machine-code',
+		'trigger'        => 'workflow_run',
+		'workflow_names' => 'Homeboy CI',
+		'workflow_paths' => '.github/workflows/homeboy.yml',
+	) );
+	$workflow_create_input  = $GLOBALS['dmc_test_create_pipeline']->last_input;
+	$workflow_webhook_input = $GLOBALS['dmc_test_webhook_enable']->last_input;
+	$assert( ! is_wp_error( $workflow_result ), 'workflow_run installer succeeds through same public abilities' );
+	$assert( 'workflow_run' === ( $workflow_result['webhook_event'] ?? '' ), 'workflow_run installer result carries event' );
+	$assert( array( 'completed' ) === ( $workflow_result['webhook_actions'] ?? array() ), 'workflow_run installer defaults action to completed' );
+	$assert( 'workflow_run' === ( $workflow_create_input['flow_config']['scheduling_config']['webhook_event'] ?? '' ), 'workflow_run scheduling config carries event' );
+	$assert( 'workflow_run' === ( $workflow_create_input['flow_config']['scheduling_config']['data_machine_code_github_pr_review']['trigger'] ?? '' ), 'workflow_run marker records trigger' );
+	$assert( 'github_workflow_run' === ( $workflow_webhook_input['template']['mode'] ?? '' ), 'workflow_run webhook template uses workflow_run verifier mode' );
+	$assert( array( 'completed' ) === ( $workflow_webhook_input['template']['allowed_actions'] ?? array() ), 'workflow_run verifier scopes completed action' );
+	$assert( array( 'Homeboy CI' ) === ( $workflow_webhook_input['template']['workflow_names'] ?? array() ), 'workflow_run verifier carries workflow name filter' );
+	$assert( array( '.github/workflows/homeboy.yml' ) === ( $workflow_webhook_input['template']['workflow_paths'] ?? array() ), 'workflow_run verifier carries workflow path filter' );
 
 	Flows::$summary_rows = array(
 		array(
@@ -147,6 +168,8 @@ namespace {
 	);
 	$existing = PrReviewFlowInstaller::install( array( 'repo' => 'Extra-Chill/data-machine-code' ) );
 	$assert( is_wp_error( $existing ) && 'github_pr_review_flow_exists' === $existing->get_error_code(), 'existing repo install fails clearly' );
+	$workflow_not_blocked = PrReviewFlowInstaller::install( array( 'repo' => 'Extra-Chill/data-machine-code', 'trigger' => 'workflow_run' ) );
+	$assert( ! is_wp_error( $workflow_not_blocked ), 'legacy pull_request install marker does not block workflow_run install' );
 
 	$forced = PrReviewFlowInstaller::install( array( 'repo' => 'Extra-Chill/data-machine-code', 'force' => true ) );
 	$assert( ! is_wp_error( $forced ), '--force bypasses existing install guard' );

--- a/tests/smoke-github-pr-review-flow-scaffold.php
+++ b/tests/smoke-github-pr-review-flow-scaffold.php
@@ -139,6 +139,8 @@ namespace {
 	$assert( 'CLI exposes review-flow subcommand', str_contains( $command_source, '@subcommand review-flow' ) );
 	$assert( 'CLI calls scaffold builder', str_contains( $command_source, 'PrReviewFlowScaffold::build' ) );
 	$assert( 'CLI exposes review-flow installer', str_contains( $command_source, 'PrReviewFlowInstaller::install' ) );
+	$assert( 'CLI exposes workflow_run trigger option', str_contains( $command_source, '--trigger=<trigger>' ) && str_contains( $command_source, 'workflow_run' ) );
+	$assert( 'CLI exposes workflow filter options', str_contains( $command_source, '--workflow-names=<names>' ) && str_contains( $command_source, '--workflow-paths=<paths>' ) );
 
 	if ( ! empty( $failures ) ) {
 		echo "\nFAIL: " . count( $failures ) . " assertion(s) failed out of {$total}\n";

--- a/tests/smoke-github-webhook-validator.php
+++ b/tests/smoke-github-webhook-validator.php
@@ -65,7 +65,7 @@ namespace {
 	};
 
 	$secret = 'test-webhook-secret';
-	$body   = json_encode(
+	$body   = (string) json_encode(
 		array(
 			'action'       => 'opened',
 			'repository'   => array( 'full_name' => 'Extra-Chill/data-machine-code' ),
@@ -169,13 +169,14 @@ namespace {
 	$assert( $draft_allowed->ok, 'draft PR behavior can be explicitly enabled' );
 
 	foreach ( array( $missing, $invalid, $wrong_event, $closed, $repo_mismatch, $draft ) as $result ) {
-		$encoded = json_encode( $result );
+		$encoded = (string) json_encode( $result );
 		$assert( false === strpos( $encoded, $secret ), 'errors do not leak secret' );
 		$assert( false === strpos( $encoded, $signature ), 'errors do not leak full signature' );
 	}
 
-	$plugin_source = file_get_contents( __DIR__ . '/../data-machine-code.php' );
+	$plugin_source = (string) file_get_contents( __DIR__ . '/../data-machine-code.php' );
 	$assert( str_contains( $plugin_source, "'github_pull_request'" ), 'plugin registers github_pull_request verifier mode' );
+	$assert( str_contains( $plugin_source, "'github_workflow_run'" ), 'plugin registers github_workflow_run verifier mode' );
 
 	echo "\n{$passes} passed, {$failures} failed\n";
 	if ( $failures > 0 ) {

--- a/tests/smoke-github-workflow-run-review-trigger.php
+++ b/tests/smoke-github-workflow-run-review-trigger.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Pure-PHP smoke for GitHub workflow_run review trigger support.
+ *
+ * Run: php tests/smoke-github-workflow-run-review-trigger.php
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Api {
+	if ( ! class_exists( __NAMESPACE__ . '\\WebhookVerificationResult' ) ) {
+		class WebhookVerificationResult {
+			const OK                = 'ok';
+			const BAD_SIGNATURE     = 'bad_signature';
+			const MISSING_SIGNATURE = 'missing_signature';
+			const NO_ACTIVE_SECRET  = 'no_active_secret';
+			const PAYLOAD_TOO_LARGE = 'payload_too_large';
+
+			public function __construct( public bool $ok, public string $reason, public ?string $secret_id = null, public ?string $detail = null ) {}
+
+			public static function ok( ?string $secret_id = null, ?int $timestamp = null, ?int $skew = null ): self {
+				unset( $timestamp, $skew );
+				return new self( true, self::OK, $secret_id );
+			}
+
+			public static function fail( string $reason, ?string $detail = null, ?int $timestamp = null, ?int $skew = null ): self {
+				unset( $timestamp, $skew );
+				return new self( false, $reason, null, $detail );
+			}
+		}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', sys_get_temp_dir() . '/dmc-github-workflow-run-review-trigger/' );
+	}
+
+	if ( ! function_exists( 'sanitize_text_field' ) ) {
+		function sanitize_text_field( $value ): string { return trim( (string) $value ); }
+	}
+
+	if ( ! function_exists( 'sanitize_key' ) ) {
+		function sanitize_key( $value ): string { return strtolower( preg_replace( '/[^a-z0-9_\-]/i', '', (string) $value ) ); }
+	}
+
+	require __DIR__ . '/../inc/Support/GitHubWebhookValidator.php';
+	require __DIR__ . '/../inc/GitHub/PrReviewFlowScaffold.php';
+
+	use DataMachineCode\GitHub\PrReviewFlowScaffold;
+	use DataMachineCode\Support\GitHubWebhookValidator;
+
+	$failures = array();
+	$total    = 0;
+	$assert   = function ( string $label, bool $condition ) use ( &$failures, &$total ): void {
+		++$total;
+		if ( $condition ) {
+			echo "  ok {$label}\n";
+			return;
+		}
+
+		$failures[] = $label;
+		echo "  fail {$label}\n";
+	};
+
+	$secret  = 'workflow-run-secret';
+	$payload = array(
+		'action'       => 'completed',
+		'repository'   => array( 'full_name' => 'Extra-Chill/data-machine-code' ),
+		'workflow_run' => array(
+			'id'            => 987654,
+			'name'          => 'Homeboy CI',
+			'path'          => '.github/workflows/homeboy.yml',
+			'head_sha'      => 'abc123def456',
+			'conclusion'    => 'success',
+			'display_title' => 'PR checks',
+			'html_url'      => 'https://github.com/Extra-Chill/data-machine-code/actions/runs/987654',
+			'pull_requests' => array(
+				array( 'number' => 139 ),
+			),
+		),
+	);
+	$headers = function ( string $request_body, string $event = 'workflow_run' ) use ( $secret ): array {
+		return array(
+			'X-Hub-Signature-256' => 'sha256=' . hash_hmac( 'sha256', $request_body, $secret ),
+			'X-GitHub-Event'       => $event,
+		);
+	};
+	$config  = GitHubWebhookValidator::buildVerifierConfig(
+		$secret,
+		array(
+			'mode'           => 'github_workflow_run',
+			'repo'           => 'Extra-Chill/data-machine-code',
+			'workflow_names' => array( 'Homeboy CI' ),
+			'workflow_paths' => array( '.github/workflows/homeboy.yml' ),
+		)
+	);
+	$verify  = function ( array $request_payload, array $override = array(), string $event = 'workflow_run' ) use ( $config, $headers ) {
+		$request_body = (string) json_encode( $request_payload );
+		return GitHubWebhookValidator::verify(
+			$request_body,
+			$headers( $request_body, $event ),
+			array(),
+			array(),
+			'https://example.test/wp-json/datamachine/v1/trigger/4',
+			array_merge( $config, $override ),
+			1700000000
+		);
+	};
+
+	echo "GitHub workflow_run review trigger - smoke\n";
+
+	$valid = $verify( $payload );
+	$assert( 'valid workflow_run.completed payload passes', $valid->ok );
+	$assert( 'valid workflow_run carries secret id only', 'github_webhook' === $valid->secret_id );
+
+	$wrong_action = $payload;
+	$wrong_action['action'] = 'requested';
+	$wrong_action_result = $verify( $wrong_action );
+	$assert( 'wrong workflow_run action is rejected clearly', ! $wrong_action_result->ok && GitHubWebhookValidator::DISALLOWED_ACTION === $wrong_action_result->reason && str_contains( (string) $wrong_action_result->detail, 'requested' ) );
+
+	$wrong_repo = $payload;
+	$wrong_repo['repository']['full_name'] = 'Extra-Chill/data-machine';
+	$wrong_repo_result = $verify( $wrong_repo );
+	$assert( 'wrong repo is rejected', ! $wrong_repo_result->ok && GitHubWebhookValidator::REPO_MISMATCH === $wrong_repo_result->reason );
+
+	$wrong_workflow = $payload;
+	$wrong_workflow['workflow_run']['name'] = 'Other CI';
+	$wrong_workflow_result = $verify( $wrong_workflow );
+	$assert( 'workflow name filter rejects non-matching workflow', ! $wrong_workflow_result->ok && GitHubWebhookValidator::WORKFLOW_MISMATCH === $wrong_workflow_result->reason );
+
+	$no_pr = $payload;
+	$no_pr['workflow_run']['pull_requests'] = array();
+	$no_pr_result = $verify( $no_pr );
+	$assert( 'workflow_run without associated PR returns clear no-op reason', ! $no_pr_result->ok && GitHubWebhookValidator::NO_PULL_REQUEST === $no_pr_result->reason );
+
+	$wrong_event = $verify( $payload, array(), 'pull_request' );
+	$assert( 'wrong GitHub event is rejected', ! $wrong_event->ok && GitHubWebhookValidator::WRONG_EVENT === $wrong_event->reason );
+
+	$definition = PrReviewFlowScaffold::build(
+		array(
+			'repo'           => 'Extra-Chill/data-machine-code',
+			'trigger'        => 'workflow_run',
+			'workflow_names' => 'Homeboy CI',
+			'workflow_paths' => '.github/workflows/homeboy.yml',
+		)
+	);
+	$webhook = $definition['webhook'];
+	$payload_config = $definition['workflow']['steps'][0]['handler_config'];
+	$review_config = $definition['workflow']['steps'][1]['handler_config'];
+
+	$assert( 'scaffold event is workflow_run', 'workflow_run' === $webhook['event'] );
+	$assert( 'scaffold default action is completed', array( 'completed' ) === $webhook['actions'] );
+	$assert( 'scaffold dedupe remains repo plus PR number plus head SHA', '{repository.full_name}#{workflow_run.pull_requests.0.number}@{workflow_run.head_sha}' === $webhook['dedupe_key'] );
+	$assert( 'scaffold maps repo metadata path', 'repository.full_name' === $webhook['payload_paths']['repo'] );
+	$assert( 'scaffold maps workflow_run PR number metadata path', 'workflow_run.pull_requests.0.number' === $webhook['payload_paths']['pull_number'] );
+	$assert( 'scaffold maps workflow_run head SHA metadata path', 'workflow_run.head_sha' === $webhook['payload_paths']['head_sha'] );
+	$assert( 'scaffold maps workflow run id metadata path', 'workflow_run.id' === $webhook['payload_paths']['workflow_run_id'] );
+	$assert( 'scaffold maps workflow name metadata path', 'workflow_run.name' === $webhook['payload_paths']['workflow_name'] );
+	$assert( 'scaffold maps conclusion metadata path', 'workflow_run.conclusion' === $webhook['payload_paths']['conclusion'] );
+	$assert( 'scaffold records workflow filters', array( 'Homeboy CI' ) === $webhook['workflow_filters']['names'] && array( '.github/workflows/homeboy.yml' ) === $webhook['workflow_filters']['paths'] );
+	$assert( 'webhook payload source type is workflow_run specific', 'github_workflow_run_webhook' === $payload_config['source_type'] );
+	$assert( 'webhook payload metadata mirrors workflow_run payload paths', $webhook['payload_paths'] === $payload_config['metadata'] );
+	$assert( 'pull review context still uses existing webhook-derived placeholders', '{{metadata.pull_number}}' === $review_config['pull_number'] && '{{metadata.head_sha}}' === $review_config['head_sha'] );
+	$assert( 'import hint carries workflow_run event and completed action', 'workflow_run' === $definition['import_hint']['scheduling_config']['webhook_event'] && array( 'completed' ) === $definition['import_hint']['scheduling_config']['webhook_actions'] );
+
+	$plugin_source = (string) file_get_contents( __DIR__ . '/../data-machine-code.php' );
+	$assert( 'plugin registers github_workflow_run verifier mode', str_contains( $plugin_source, "'github_workflow_run'" ) );
+
+	if ( ! empty( $failures ) ) {
+		echo "\nFAIL: " . count( $failures ) . " assertion(s) failed out of {$total}\n";
+		foreach ( $failures as $failure ) {
+			echo "  - {$failure}\n";
+		}
+		exit( 1 );
+	}
+
+	echo "\nOK ({$total} assertions)\n";
+	exit( 0 );
+}


### PR DESCRIPTION
## Summary
- Adds a `github_workflow_run` verifier mode for GitHub `workflow_run.completed` webhooks, including HMAC validation, repo allow-listing, action filtering, optional workflow name/path filters, and a clear no-PR skip reason.
- Extends the PR review flow scaffold/install path with `--trigger=workflow_run` while keeping the existing `pull_request` trigger behavior unchanged.
- Maps workflow-run metadata into the existing `webhook_payload` fetch step so the existing `pull_review_context` fetch, Homeboy artifact lookup, processed-items dedupe, AI review step, and managed comment upsert continue to do the runtime work.

## Existing Webhook Infra Reused
- Reuses Data Machine's existing webhook trigger route, verifier mode registration, webhook payload fetch handler, and processed-items dedupe.
- Does not add a new webhook route, scheduler, or DMC-specific webhook execution path.

## Trigger Behavior
- Default workflow-run action allow-list is `completed`.
- Review metadata paths include repo, pull number, head SHA, workflow run ID, workflow name, and conclusion.
- Workflow runs without `workflow_run.pull_requests.0.number` fail verification with `github_workflow_run_no_pull_request`, so branch-only workflow runs do not start review flows.
- Workflow name/path filters can scope installs to Homeboy CI or a specific workflow file.

## Tests
- `php -l inc/Support/GitHubWebhookValidator.php && php -l inc/GitHub/PrReviewFlowScaffold.php && php -l inc/GitHub/PrReviewFlowInstaller.php && php -l inc/Cli/Commands/GitHubCommand.php && php -l data-machine-code.php && php -l tests/smoke-github-workflow-run-review-trigger.php`
- `php tests/smoke-github-workflow-run-review-trigger.php`
- `php tests/smoke-github-webhook-validator.php`
- `php tests/smoke-github-pr-review-flow-scaffold.php`
- `php tests/smoke-github-pr-review-flow-installer.php`
- `homeboy lint data-machine-code --path /Users/chubes/Developer/data-machine-code@feat-github-workflow-run-review-trigger --changed-only --summary` failed on existing PHPStan noise in `data-machine-code.php`, `GitHubCommand.php`, and `PrReviewFlowInstaller.php`; changed-file PHPCS passed.

Closes #139

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the workflow_run verifier/scaffold support and focused smoke coverage; Chris remains responsible for review and merge.
