### PR TITLE
fix(workspace): guard worktree creation by disk budget

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -791,6 +791,10 @@ class WorkspaceAbilities {
 								'type'        => 'boolean',
 								'description' => 'After creating the worktree, rebase onto the upstream tip (the branch\'s @{upstream} for existing branches, origin/<base> for new branches off a local base). Default false. On rebase conflicts the rebase is aborted; the worktree stays at its pre-rebase state and `rebase_succeeded: false` is surfaced.',
 							),
+							'force'          => array(
+								'type'        => 'boolean',
+								'description' => 'Explicitly bypass the disk-budget refusal threshold. The disk-budget report still appears in output so the override is visible.',
+							),
 						),
 						'required'   => array( 'repo', 'branch' ),
 					),
@@ -842,6 +846,10 @@ class WorkspaceAbilities {
 							'gate_threshold'            => array(
 								'type'        => 'integer',
 								'description' => 'Echo of the staleness threshold (in commits) that was evaluated. Present whenever the gate ran (i.e. `allow_stale` was false and fetch succeeded).',
+							),
+							'disk_budget'               => array(
+								'type'        => 'object',
+								'description' => 'Pre-create disk-budget report: free bytes/GiB, worktree count, thresholds, status, warnings, and force override state.',
 							),
 							'rebase_attempted'          => array(
 								'type'        => 'boolean',
@@ -1327,6 +1335,7 @@ class WorkspaceAbilities {
 		$allow_stale = array_key_exists( 'allow_stale', $input ) ? (bool) $input['allow_stale'] : false;
 		// Default rebase_base=false; only true when explicitly requested.
 		$rebase_base = array_key_exists( 'rebase_base', $input ) ? (bool) $input['rebase_base'] : false;
+		$force       = ! empty( $input['force'] );
 		return $workspace->worktree_add(
 			$input['repo'] ?? '',
 			$input['branch'] ?? '',
@@ -1334,7 +1343,8 @@ class WorkspaceAbilities {
 			$inject_context,
 			$bootstrap,
 			$allow_stale,
-			$rebase_base
+			$rebase_base,
+			$force
 		);
 	}
 

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1057,8 +1057,9 @@ class WorkspaceCommand extends BaseCommand {
 	 *   `rebase_base=true`.
 	 *
 	 * [--force]
-	 * : Force-remove a worktree even if it is dirty (applies to `remove` and
-	 *   `cleanup`). Does NOT override the unpushed-commits safety in cleanup.
+	 * : For `add`, explicitly bypass the disk-budget refusal threshold. For
+	 *   `remove`, force-remove a worktree even if it is dirty. For `cleanup`,
+	 *   force dirty-worktree removal but not the unpushed-commits safety.
 	 *
 	 * [--dry-run]
 	 * : Preview cleanup candidates without removing anything (cleanup only).
@@ -1179,7 +1180,7 @@ class WorkspaceCommand extends BaseCommand {
 		switch ( $operation ) {
 			case 'add':
 				if ( empty( $args[1] ) || empty( $args[2] ) ) {
-					WP_CLI::error( 'Usage: worktree add <repo> <branch> [--from=<ref>|--base-branch=<branch>] [--skip-context-injection] [--skip-bootstrap] [--allow-stale] [--rebase-base]' );
+					WP_CLI::error( 'Usage: worktree add <repo> <branch> [--from=<ref>|--base-branch=<branch>] [--skip-context-injection] [--skip-bootstrap] [--allow-stale] [--rebase-base] [--force]' );
 					return;
 				}
 				$input['repo']   = $args[1];
@@ -1201,6 +1202,8 @@ class WorkspaceCommand extends BaseCommand {
 				$input['allow_stale'] = ! empty( $assoc_args['allow-stale'] );
 				// --rebase-base auto-rebases onto upstream after creation (default: off).
 				$input['rebase_base'] = ! empty( $assoc_args['rebase-base'] );
+				// --force is an explicit disk-budget override for add.
+				$input['force'] = ! empty( $assoc_args['force'] );
 				break;
 
 			case 'refresh-context':
@@ -1262,6 +1265,12 @@ class WorkspaceCommand extends BaseCommand {
 	 * @param array  $assoc_args CLI assoc args.
 	 */
 	private function renderWorktreeResult( string $operation, array $result, array $assoc_args ): void {
+		if ( 'add' === $operation && 'json' === (string) ( $assoc_args['format'] ?? '' ) ) {
+			$json = wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+			WP_CLI::log( false === $json ? '{}' : $json );
+			return;
+		}
+
 		switch ( $operation ) {
 			case 'list':
 				$worktrees = $result['worktrees'] ?? array();
@@ -1305,6 +1314,16 @@ class WorkspaceCommand extends BaseCommand {
 
 			case 'add':
 				WP_CLI::success( $result['message'] ?? 'Worktree created.' );
+				if ( isset( $result['disk_budget'] ) && is_array( $result['disk_budget'] ) ) {
+					$budget = $result['disk_budget'];
+					WP_CLI::log( \DataMachineCode\Workspace\WorktreeDiskBudget::format_summary( $budget ) );
+					foreach ( (array) ( $budget['warnings'] ?? array() ) as $warning ) {
+						WP_CLI::warning( $warning );
+					}
+					if ( ! empty( $budget['force_override_applied'] ) ) {
+						WP_CLI::warning( 'Disk budget override applied because --force was explicit.' );
+					}
+				}
 				if ( ! empty( $result['handle'] ) ) {
 					WP_CLI::log( sprintf( 'Handle: %s', $result['handle'] ) );
 					WP_CLI::log( sprintf( 'Path:   %s', $result['path'] ?? '-' ) );

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -1047,9 +1047,10 @@ class Workspace {
 	 * @param bool        $bootstrap      Whether to run submodule/package/composer install after creation (default true).
 	 * @param bool        $allow_stale    Bypass the staleness gate (default false).
 	 * @param bool        $rebase_base    Rebase onto upstream after creation (default false).
-	 * @return array{success: bool, handle: string, path: string, branch: string, slug: string, created_branch: bool, message: string, context_injected?: bool, context_files?: string[], context_skip_reason?: string, bootstrap?: array, fetch_failed?: bool, fetch_error?: string, stale_commits_behind?: int, upstream?: string, base_stale_commits_behind?: int, base_upstream?: string, gate_threshold?: int, rebase_attempted?: bool, rebase_succeeded?: bool, rebase_error?: string, rebase_target?: string}|\WP_Error
+	 * @param bool        $force          Bypass the disk-budget refusal threshold (default false).
+	 * @return array{success: bool, handle: string, path: string, branch: string, slug: string, created_branch: bool, message: string, disk_budget?: array, context_injected?: bool, context_files?: string[], context_skip_reason?: string, bootstrap?: array, fetch_failed?: bool, fetch_error?: string, stale_commits_behind?: int, upstream?: string, base_stale_commits_behind?: int, base_upstream?: string, gate_threshold?: int, rebase_attempted?: bool, rebase_succeeded?: bool, rebase_error?: string, rebase_target?: string}|\WP_Error
 	 */
-	public function worktree_add( string $repo, string $branch, ?string $from = null, bool $inject_context = true, bool $bootstrap = true, bool $allow_stale = false, bool $rebase_base = false ): array|\WP_Error {
+	public function worktree_add( string $repo, string $branch, ?string $from = null, bool $inject_context = true, bool $bootstrap = true, bool $allow_stale = false, bool $rebase_base = false, bool $force = false ): array|\WP_Error {
 		$repo   = $this->sanitize_name( $repo );
 		$branch = trim( $branch );
 
@@ -1078,6 +1079,22 @@ class Workspace {
 			return new \WP_Error( 'worktree_exists', sprintf( 'Worktree handle "%s" already exists.', $wt_handle ), array( 'status' => 400 ) );
 		}
 
+		$disk_budget = WorktreeDiskBudget::inspect( $this->workspace_path, WorktreeDiskBudget::thresholds( $repo, $branch ), $force );
+		if ( 'refused' === ( $disk_budget['status'] ?? '' ) ) {
+			return new \WP_Error(
+				'worktree_disk_budget_exceeded',
+				sprintf(
+					"Refusing to create worktree: %s\nRun %s to review cleanup candidates, or retry with --force to override the disk-budget refusal threshold.",
+					implode( ' ', (array) ( $disk_budget['warnings'] ?? array() ) ),
+					$disk_budget['cleanup_dry_run_command']
+				),
+				array(
+					'status'      => 507,
+					'disk_budget' => $disk_budget,
+				)
+			);
+		}
+
 		$response = WorkspaceMutationLock::with_repo(
 			$this->workspace_path,
 			$repo,
@@ -1098,6 +1115,8 @@ class Workspace {
 		if ( is_wp_error( $response ) ) {
 			return $response;
 		}
+
+		$response['disk_budget'] = $disk_budget;
 
 		if ( $bootstrap ) {
 			$response['bootstrap'] = WorktreeBootstrapper::bootstrap( $wt_path );

--- a/inc/Workspace/WorktreeDiskBudget.php
+++ b/inc/Workspace/WorktreeDiskBudget.php
@@ -1,0 +1,235 @@
+<?php
+/**
+ * Worktree Disk Budget
+ *
+ * Cheap pre-create guardrails for workspace worktree growth.
+ *
+ * @package DataMachineCode\Workspace
+ */
+
+namespace DataMachineCode\Workspace;
+
+defined( 'ABSPATH' ) || exit;
+
+final class WorktreeDiskBudget {
+
+	private const BYTES_PER_GIB = 1073741824;
+
+	/**
+	 * Default warning threshold: 20 GiB free.
+	 */
+	private const DEFAULT_WARN_FREE_GIB = 20;
+
+	/**
+	 * Default refusal threshold: 5 GiB free.
+	 */
+	private const DEFAULT_REFUSE_FREE_GIB = 5;
+
+	/**
+	 * Default worktree-count warning threshold.
+	 */
+	private const DEFAULT_WARN_WORKTREE_COUNT = 100;
+
+	/**
+	 * Inspect workspace disk budget without walking file contents.
+	 *
+	 * @param string $workspace_path Workspace root path.
+	 * @param array  $thresholds     Optional threshold override for tests.
+	 * @param bool   $forced         Whether the caller explicitly forced creation.
+	 * @return array<string,mixed>
+	 */
+	public static function inspect( string $workspace_path, array $thresholds = array(), bool $forced = false ): array {
+		$thresholds = self::normalize_thresholds( $thresholds );
+		$free_bytes = is_dir( $workspace_path ) ? disk_free_space( $workspace_path ) : false; // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_disk_free_space
+		$free_bytes = is_float( $free_bytes ) ? (int) $free_bytes : null;
+		$worktrees  = self::count_worktree_like_dirs( $workspace_path );
+
+		return self::evaluate(
+			array(
+				'workspace_path' => $workspace_path,
+				'free_bytes'     => $free_bytes,
+				'worktree_count' => $worktrees,
+			),
+			$thresholds,
+			$forced
+		);
+	}
+
+	/**
+	 * Evaluate disk-budget status from already-measured values.
+	 *
+	 * @param array $metrics    Measured values.
+	 * @param array $thresholds Threshold values.
+	 * @param bool  $forced     Whether the caller explicitly forced creation.
+	 * @return array<string,mixed>
+	 */
+	public static function evaluate( array $metrics, array $thresholds = array(), bool $forced = false ): array {
+		$thresholds = self::normalize_thresholds( $thresholds );
+		$free_bytes = isset( $metrics['free_bytes'] ) && is_numeric( $metrics['free_bytes'] ) ? (int) $metrics['free_bytes'] : null;
+		$count      = isset( $metrics['worktree_count'] ) && is_numeric( $metrics['worktree_count'] ) ? (int) $metrics['worktree_count'] : 0;
+		$warnings   = array();
+		$refused    = false;
+
+		if ( null !== $free_bytes ) {
+			if ( $free_bytes < $thresholds['refuse_free_bytes'] ) {
+				$refused    = ! $forced;
+				$warnings[] = sprintf(
+					'Free disk space is %.1f GiB, below the %.1f GiB refusal threshold.',
+					self::bytes_to_gib( $free_bytes ),
+					self::bytes_to_gib( $thresholds['refuse_free_bytes'] )
+				);
+			} elseif ( $free_bytes < $thresholds['warn_free_bytes'] ) {
+				$warnings[] = sprintf(
+					'Free disk space is %.1f GiB, below the %.1f GiB warning threshold.',
+					self::bytes_to_gib( $free_bytes ),
+					self::bytes_to_gib( $thresholds['warn_free_bytes'] )
+				);
+			}
+		} else {
+			$warnings[] = 'Free disk space could not be measured.';
+		}
+
+		if ( $count > $thresholds['warn_worktree_count'] ) {
+			$warnings[] = sprintf(
+				'Workspace has %d worktree-like directories, above the %d warning threshold.',
+				$count,
+				$thresholds['warn_worktree_count']
+			);
+		}
+
+		$status = $refused ? 'refused' : ( empty( $warnings ) ? 'ok' : 'warning' );
+
+		return array(
+			'workspace_path'          => (string) ( $metrics['workspace_path'] ?? '' ),
+			'free_bytes'              => $free_bytes,
+			'free_gib'                => null === $free_bytes ? null : round( self::bytes_to_gib( $free_bytes ), 2 ),
+			'workspace_size_bytes'    => null,
+			'workspace_size_exact'    => false,
+			'worktree_count'          => $count,
+			'warn_free_bytes'         => $thresholds['warn_free_bytes'],
+			'warn_free_gib'           => round( self::bytes_to_gib( $thresholds['warn_free_bytes'] ), 2 ),
+			'refuse_free_bytes'       => $thresholds['refuse_free_bytes'],
+			'refuse_free_gib'         => round( self::bytes_to_gib( $thresholds['refuse_free_bytes'] ), 2 ),
+			'warn_worktree_count'     => $thresholds['warn_worktree_count'],
+			'forced'                  => $forced,
+			'status'                  => $status,
+			'warnings'                => $warnings,
+			'cleanup_dry_run_command' => 'studio wp datamachine-code workspace worktree cleanup --dry-run',
+			'force_override_required' => $refused,
+			'force_override_applied'  => $forced && ! empty( $warnings ),
+		);
+	}
+
+	/**
+	 * Get filterable thresholds.
+	 *
+	 * @param string $repo   Repository name.
+	 * @param string $branch Branch name.
+	 * @return array<string,int>
+	 */
+	public static function thresholds( string $repo, string $branch ): array {
+		$thresholds = array(
+			'warn_free_bytes'     => self::DEFAULT_WARN_FREE_GIB * self::BYTES_PER_GIB,
+			'refuse_free_bytes'   => self::DEFAULT_REFUSE_FREE_GIB * self::BYTES_PER_GIB,
+			'warn_worktree_count' => self::DEFAULT_WARN_WORKTREE_COUNT,
+		);
+
+		if ( function_exists( 'apply_filters' ) ) {
+			/**
+			 * Filters pre-create worktree disk-budget thresholds.
+			 *
+			 * @param array  $thresholds Default thresholds.
+			 * @param string $repo       Repository name.
+			 * @param string $branch     Branch being materialized.
+			 */
+			// @phpstan-ignore-next-line WordPress accepts context args beyond the filtered value.
+			$thresholds = apply_filters( 'datamachine_worktree_disk_budget_thresholds', $thresholds, $repo, $branch );
+		}
+
+		return self::normalize_thresholds( (array) $thresholds );
+	}
+
+	/**
+	 * Format a short human-readable summary.
+	 *
+	 * @param array $budget Budget report.
+	 * @return string
+	 */
+	public static function format_summary( array $budget ): string {
+		$free = null === ( $budget['free_gib'] ?? null ) ? 'unknown' : sprintf( '%.1f GiB', (float) $budget['free_gib'] );
+		return sprintf(
+			'Disk budget: %s free, %d worktree-like dirs, status=%s.',
+			$free,
+			(int) ( $budget['worktree_count'] ?? 0 ),
+			(string) ( $budget['status'] ?? 'unknown' )
+		);
+	}
+
+	/**
+	 * Normalize threshold inputs.
+	 *
+	 * @param array $thresholds Raw thresholds.
+	 * @return array<string,int>
+	 */
+	private static function normalize_thresholds( array $thresholds ): array {
+		$warn_free   = isset( $thresholds['warn_free_bytes'] ) && is_numeric( $thresholds['warn_free_bytes'] )
+			? max( 0, (int) $thresholds['warn_free_bytes'] )
+			: self::DEFAULT_WARN_FREE_GIB * self::BYTES_PER_GIB;
+		$refuse_free = isset( $thresholds['refuse_free_bytes'] ) && is_numeric( $thresholds['refuse_free_bytes'] )
+			? max( 0, (int) $thresholds['refuse_free_bytes'] )
+			: self::DEFAULT_REFUSE_FREE_GIB * self::BYTES_PER_GIB;
+		$count       = isset( $thresholds['warn_worktree_count'] ) && is_numeric( $thresholds['warn_worktree_count'] )
+			? max( 0, (int) $thresholds['warn_worktree_count'] )
+			: self::DEFAULT_WARN_WORKTREE_COUNT;
+
+		if ( $refuse_free > $warn_free ) {
+			$warn_free = $refuse_free;
+		}
+
+		return array(
+			'warn_free_bytes'     => $warn_free,
+			'refuse_free_bytes'   => $refuse_free,
+			'warn_worktree_count' => $count,
+		);
+	}
+
+	/**
+	 * Count worktree-like directories cheaply without consulting every primary.
+	 *
+	 * @param string $workspace_path Workspace root path.
+	 * @return int
+	 */
+	private static function count_worktree_like_dirs( string $workspace_path ): int {
+		if ( ! is_dir( $workspace_path ) ) {
+			return 0;
+		}
+
+		$entries = scandir( $workspace_path ); // phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.Found,WordPress.WP.AlternativeFunctions.file_system_operations_scandir
+		if ( false === $entries ) {
+			return 0;
+		}
+
+		$count = 0;
+		foreach ( $entries as $entry ) {
+			if ( '.' === $entry || '..' === $entry || ! str_contains( $entry, '@' ) ) {
+				continue;
+			}
+
+			if ( is_dir( $workspace_path . '/' . $entry ) ) {
+				++$count;
+			}
+		}
+
+		return $count;
+	}
+
+	/**
+	 * Convert bytes to GiB.
+	 *
+	 * @param int $bytes Bytes.
+	 * @return float
+	 */
+	private static function bytes_to_gib( int $bytes ): float {
+		return $bytes / self::BYTES_PER_GIB;
+	}
+}

--- a/tests/smoke-worktree-base-branch-cli.php
+++ b/tests/smoke-worktree-base-branch-cli.php
@@ -15,6 +15,14 @@ namespace {
 	class WP_CLI {
 		public static array $logs = array();
 
+		public static function reset_logs(): void {
+			self::$logs = array();
+		}
+
+		public static function get_logs(): array {
+			return self::$logs;
+		}
+
 		public static function error( string $message ): void {
 			throw new RuntimeException( $message );
 		}
@@ -39,6 +47,10 @@ namespace {
 	function wp_get_ability( string $name ) {
 		return $GLOBALS['__abilities'][ $name ] ?? null;
 	}
+
+	function wp_json_encode( $data, int $flags = 0 ) {
+		return json_encode( $data, $flags );
+	}
 }
 
 namespace DataMachine\Cli {
@@ -49,6 +61,7 @@ namespace DataMachine\Cli {
 
 namespace {
 	require_once dirname( __DIR__ ) . '/inc/Cli/Commands/WorkspaceCommand.php';
+	require_once dirname( __DIR__ ) . '/inc/Workspace/WorktreeDiskBudget.php';
 
 	function datamachine_code_assert( bool $condition, string $message ): void {
 		if ( $condition ) {
@@ -71,6 +84,14 @@ namespace {
 				'path'           => '/tmp/worktree',
 				'branch'         => $input['branch'] ?? '',
 				'created_branch' => true,
+				'disk_budget'    => array(
+					'status'                  => 'warning',
+					'free_gib'                => 4.5,
+					'worktree_count'          => 123,
+					'warnings'                => array( 'low disk' ),
+					'force_override_applied'  => ! empty( $input['force'] ),
+					'cleanup_dry_run_command' => 'studio wp datamachine-code workspace worktree cleanup --dry-run',
+				),
 			);
 		}
 	}
@@ -91,6 +112,7 @@ namespace {
 	datamachine_code_assert( 'origin/main' === $ability->last_input['from'], 'main maps to origin/main' );
 	datamachine_code_assert( false === $ability->last_input['bootstrap'], 'skip-bootstrap still forwarded' );
 	datamachine_code_assert( false === $ability->last_input['inject_context'], 'skip-context-injection still forwarded' );
+	datamachine_code_assert( false === $ability->last_input['force'], 'force defaults false for add' );
 
 	echo "\n[2] branch names with slashes still map to origin refs\n";
 	$command->worktree(
@@ -116,6 +138,19 @@ namespace {
 	} catch ( RuntimeException $e ) {
 		datamachine_code_assert( str_contains( $e->getMessage(), 'not both' ), 'ambiguous flags fail clearly' );
 	}
+
+	echo "\n[5] --force is forwarded for add and JSON output keeps disk budget\n";
+	\WP_CLI::reset_logs();
+	$command->worktree(
+		array( 'add', 'data-machine', 'feat/test' ),
+		array( 'force' => true, 'format' => 'json' )
+	);
+	datamachine_code_assert( true === $ability->last_input['force'], 'force forwarded for add' );
+	$logs    = \WP_CLI::get_logs();
+	$decoded = json_decode( $logs[0] ?? '', true );
+	datamachine_code_assert( is_array( $decoded ), 'JSON output decodes' );
+	datamachine_code_assert( 'warning' === ( $decoded['disk_budget']['status'] ?? '' ), 'JSON output includes disk budget status' );
+	datamachine_code_assert( true === ( $decoded['disk_budget']['force_override_applied'] ?? false ), 'JSON output includes explicit force override' );
 
 	echo "\nAll worktree base-branch CLI smoke tests passed.\n";
 }

--- a/tests/smoke-worktree-cleanup-github-cache.php
+++ b/tests/smoke-worktree-cleanup-github-cache.php
@@ -96,6 +96,7 @@ namespace {
 	require __DIR__ . '/../inc/Support/GitRunner.php';
 	require __DIR__ . '/../inc/Support/PathSecurity.php';
 	require __DIR__ . '/../inc/Workspace/WorkspaceMutationLock.php';
+	require __DIR__ . '/../inc/Workspace/WorktreeDiskBudget.php';
 	require __DIR__ . '/../inc/Workspace/WorktreeContextInjector.php';
 	require __DIR__ . '/../inc/Workspace/Workspace.php';
 

--- a/tests/smoke-worktree-cleanup.php
+++ b/tests/smoke-worktree-cleanup.php
@@ -103,6 +103,7 @@ namespace {
 	require __DIR__ . '/../inc/Support/GitRunner.php';
 	require __DIR__ . '/../inc/Support/PathSecurity.php';
 	require __DIR__ . '/../inc/Workspace/WorkspaceMutationLock.php';
+	require __DIR__ . '/../inc/Workspace/WorktreeDiskBudget.php';
 	require __DIR__ . '/../inc/Workspace/WorktreeContextInjector.php';
 	require __DIR__ . '/../inc/Workspace/Workspace.php';
 

--- a/tests/smoke-worktree-disk-budget.php
+++ b/tests/smoke-worktree-disk-budget.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Smoke test for WorktreeDiskBudget.
+ *
+ *   php tests/smoke-worktree-disk-budget.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+require __DIR__ . '/../inc/Workspace/WorktreeDiskBudget.php';
+
+use DataMachineCode\Workspace\WorktreeDiskBudget;
+
+function datamachine_code_budget_assert( bool $condition, string $message ): void {
+	if ( $condition ) {
+		echo "  [PASS] {$message}\n";
+		return;
+	}
+
+	echo "  [FAIL] {$message}\n";
+	exit( 1 );
+}
+
+echo "=== smoke-worktree-disk-budget ===\n";
+
+$gib        = 1073741824;
+$thresholds = array(
+	'warn_free_bytes'     => 20 * $gib,
+	'refuse_free_bytes'   => 5 * $gib,
+	'warn_worktree_count' => 100,
+);
+
+echo "\n[1] healthy workspace passes cleanly\n";
+$budget = WorktreeDiskBudget::evaluate(
+	array(
+		'workspace_path' => '/tmp/workspace',
+		'free_bytes'     => 25 * $gib,
+		'worktree_count' => 10,
+	),
+	$thresholds
+);
+datamachine_code_budget_assert( 'ok' === $budget['status'], 'healthy budget status is ok' );
+datamachine_code_budget_assert( array() === $budget['warnings'], 'healthy budget has no warnings' );
+datamachine_code_budget_assert( false === $budget['workspace_size_exact'], 'workspace size is intentionally not walked' );
+datamachine_code_budget_assert( null === $budget['workspace_size_bytes'], 'workspace size bytes are null when not exact' );
+
+echo "\n[2] low free space warns above refusal threshold\n";
+$budget = WorktreeDiskBudget::evaluate(
+	array(
+		'workspace_path' => '/tmp/workspace',
+		'free_bytes'     => 10 * $gib,
+		'worktree_count' => 10,
+	),
+	$thresholds
+);
+datamachine_code_budget_assert( 'warning' === $budget['status'], 'warning status below 20 GiB' );
+datamachine_code_budget_assert( 1 === count( $budget['warnings'] ), 'warning contains one free-space warning' );
+datamachine_code_budget_assert( false === $budget['force_override_required'], 'warning does not require force' );
+
+echo "\n[3] critically low free space refuses without force\n";
+$budget = WorktreeDiskBudget::evaluate(
+	array(
+		'workspace_path' => '/tmp/workspace',
+		'free_bytes'     => 1 * $gib,
+		'worktree_count' => 10,
+	),
+	$thresholds
+);
+datamachine_code_budget_assert( 'refused' === $budget['status'], 'refused status below 5 GiB' );
+datamachine_code_budget_assert( true === $budget['force_override_required'], 'force required below refusal threshold' );
+datamachine_code_budget_assert( str_contains( $budget['cleanup_dry_run_command'], 'workspace worktree cleanup --dry-run' ), 'cleanup dry-run command is present' );
+
+echo "\n[4] force makes low-space override explicit\n";
+$budget = WorktreeDiskBudget::evaluate(
+	array(
+		'workspace_path' => '/tmp/workspace',
+		'free_bytes'     => 1 * $gib,
+		'worktree_count' => 10,
+	),
+	$thresholds,
+	true
+);
+datamachine_code_budget_assert( 'warning' === $budget['status'], 'forced low-space budget is warning, not refused' );
+datamachine_code_budget_assert( true === $budget['forced'], 'forced flag is recorded' );
+datamachine_code_budget_assert( true === $budget['force_override_applied'], 'force override is visible in output data' );
+
+echo "\n[5] high worktree count warns independently\n";
+$budget = WorktreeDiskBudget::evaluate(
+	array(
+		'workspace_path' => '/tmp/workspace',
+		'free_bytes'     => 25 * $gib,
+		'worktree_count' => 101,
+	),
+	$thresholds
+);
+datamachine_code_budget_assert( 'warning' === $budget['status'], 'high worktree count warns' );
+datamachine_code_budget_assert( str_contains( $budget['warnings'][0], '101 worktree-like directories' ), 'worktree-count warning is descriptive' );
+
+echo "\n[6] inspect counts only worktree-like directories\n";
+$tmp = sys_get_temp_dir() . '/dmc-budget-' . uniqid( '', true );
+mkdir( $tmp );
+mkdir( $tmp . '/repo' );
+mkdir( $tmp . '/repo@feature-one' );
+mkdir( $tmp . '/repo@feature-two' );
+file_put_contents( $tmp . '/repo@not-a-dir', 'file' );
+$budget = WorktreeDiskBudget::inspect( $tmp, $thresholds );
+datamachine_code_budget_assert( 2 === $budget['worktree_count'], 'inspect counts @ directories only' );
+datamachine_code_budget_assert( null !== $budget['free_bytes'], 'inspect reports free bytes' );
+datamachine_code_budget_assert( str_contains( WorktreeDiskBudget::format_summary( $budget ), 'worktree-like dirs' ), 'summary includes worktree count' );
+unlink( $tmp . '/repo@not-a-dir' );
+rmdir( $tmp . '/repo@feature-two' );
+rmdir( $tmp . '/repo@feature-one' );
+rmdir( $tmp . '/repo' );
+rmdir( $tmp );
+
+echo "\nAll worktree disk-budget smoke tests passed.\n";

--- a/tests/smoke-worktree-lifecycle-metadata.php
+++ b/tests/smoke-worktree-lifecycle-metadata.php
@@ -137,6 +137,7 @@ namespace {
 	require __DIR__ . '/../inc/Support/PathSecurity.php';
 	require __DIR__ . '/../inc/Workspace/WorkspaceMutationLock.php';
 	require __DIR__ . '/../inc/Workspace/WorktreeStalenessProbe.php';
+	require __DIR__ . '/../inc/Workspace/WorktreeDiskBudget.php';
 	require __DIR__ . '/../inc/Workspace/WorktreeContextInjector.php';
 	require __DIR__ . '/../inc/Workspace/Workspace.php';
 


### PR DESCRIPTION
## Summary
- Adds a cheap disk-budget gate before `workspace worktree add` creates another checkout.
- Keeps the hard safety check on free filesystem space and reports worktree count without walking the full workspace tree.

## Changes
- Adds `WorktreeDiskBudget` to report free bytes/GiB, worktree-like directory count, thresholds, warnings, force state, and cleanup guidance.
- Refuses worktree creation below 5 GiB free unless `--force` is explicitly passed; warns below 20 GiB free and above 100 worktree-like dirs.
- Exposes `force` and `disk_budget` on the worktree-add ability schema, and includes budget data in `--format=json` output.
- Updates CLI output so human runs see disk-budget warnings and a visible `--force` override message.
- Thresholds are filterable via `datamachine_worktree_disk_budget_thresholds`.

Incident context: on 2026-04-29, the workspace reached 787 worktree-like dirs / ~712.6 GiB and the disk had only 1.1 GiB free. DMC still allowed more worktrees to be created without warning.

## Tests
- `php -l inc/Workspace/WorktreeDiskBudget.php && php -l inc/Workspace/Workspace.php && php -l inc/Abilities/WorkspaceAbilities.php && php -l inc/Cli/Commands/WorkspaceCommand.php && php -l tests/smoke-worktree-disk-budget.php && php -l tests/smoke-worktree-base-branch-cli.php`
- `php tests/smoke-worktree-disk-budget.php`
- `php tests/smoke-worktree-base-branch-cli.php`
- `php tests/smoke-worktree-lifecycle-metadata.php`
- `php tests/smoke-worktree-cleanup.php`
- `php tests/smoke-worktree-cleanup-github-cache.php`
- `homeboy lint data-machine-code --path /Users/chubes/Developer/data-machine-code@fix-worktree-disk-budget-guard --file inc/Workspace/WorktreeDiskBudget.php --summary`

Full `homeboy lint` / `homeboy audit` still report broad pre-existing repository findings unrelated to this change.

Closes #143

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the disk-budget guard, focused smoke coverage, and PR drafting; Chris remains responsible for review and merge.
