### PR TITLE
Track worktree finalizer lifecycle metadata

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -905,10 +905,51 @@ class WorkspaceAbilities {
 			);
 
 			wp_register_ability(
+				'datamachine/workspace-worktree-finalize',
+				array(
+					'label'               => 'Finalize Workspace Worktree',
+					'description'         => 'Attach lifecycle metadata to a worktree after a coding-agent session opens a PR, completes, or marks the worktree cleanup-eligible. This metadata is a cleanup signal only; dirty/unpushed safety gates still apply.',
+					'category'            => 'datamachine-code-workspace',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'handle' => array(
+								'type'        => 'string',
+								'description' => 'Worktree handle (`<repo>@<branch-slug>`).',
+							),
+							'state'  => array(
+								'type'        => 'string',
+								'description' => 'Lifecycle state: active, pr_opened, merged, closed, abandoned, cleanup_eligible.',
+							),
+							'pr'     => array(
+								'type'        => 'string',
+								'description' => 'Optional GitHub PR URL or number.',
+							),
+						),
+						'required'   => array( 'handle', 'state' ),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'         => array( 'type' => 'boolean' ),
+							'handle'          => array( 'type' => 'string' ),
+							'path'            => array( 'type' => 'string' ),
+							'lifecycle_state' => array( 'type' => 'string' ),
+							'metadata'        => array( 'type' => 'object' ),
+							'message'         => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'worktreeFinalize' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
 				'datamachine/workspace-worktree-list',
 				array(
 					'label'               => 'List Workspace Worktrees',
-					'description'         => 'List all worktrees in the workspace (optionally filtered by repo).',
+					'description'         => 'List all worktrees in the workspace (optionally filtered by repo and lifecycle state).',
 					'category'            => 'datamachine-code-workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
@@ -916,6 +957,10 @@ class WorkspaceAbilities {
 							'repo' => array(
 								'type'        => 'string',
 								'description' => 'Optional repo name to limit the list.',
+							),
+							'state' => array(
+								'type'        => 'string',
+								'description' => 'Optional lifecycle state filter.',
 							),
 						),
 					),
@@ -939,6 +984,9 @@ class WorkspaceAbilities {
 										'path'        => array( 'type' => 'string' ),
 										'dirty'       => array( 'type' => 'integer' ),
 										'created_at'  => array( 'type' => array( 'string', 'null' ) ),
+										'lifecycle_state' => array( 'type' => array( 'string', 'null' ) ),
+										'pr_url'      => array( 'type' => array( 'string', 'null' ) ),
+										'pr_number'   => array( 'type' => array( 'integer', 'null' ) ),
 										'metadata'    => array( 'type' => array( 'object', 'null' ) ),
 									),
 								),
@@ -1350,6 +1398,21 @@ class WorkspaceAbilities {
 	}
 
 	/**
+	 * Attach lifecycle metadata to a worktree.
+	 *
+	 * @param array $input Input parameters with handle, state, optional pr.
+	 * @return array|\WP_Error
+	 */
+	public static function worktreeFinalize( array $input ): array|\WP_Error {
+		$workspace = new Workspace();
+		return $workspace->worktree_finalize(
+			$input['handle'] ?? '',
+			$input['state'] ?? '',
+			isset( $input['pr'] ) ? (string) $input['pr'] : null
+		);
+	}
+
+	/**
 	 * List worktrees in the workspace.
 	 *
 	 * @param array $input Input parameters with optional 'repo'.
@@ -1360,7 +1423,10 @@ class WorkspaceAbilities {
 		$repo      = isset( $input['repo'] ) && '' !== trim( (string) $input['repo'] )
 			? (string) $input['repo']
 			: null;
-		return $workspace->worktree_list( $repo );
+		$state     = isset( $input['state'] ) && '' !== trim( (string) $input['state'] )
+			? (string) $input['state']
+			: null;
+		return $workspace->worktree_list( $repo, $state );
 	}
 
 	/**

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1143,13 +1143,17 @@ class WorkspaceCommand extends BaseCommand {
 	 *     # Re-read the originating site's agent memory into an existing worktree
 	 *     wp datamachine workspace worktree refresh-context data-machine@fix-foo
 	 *
+	 *     # Attach PR/finalizer metadata to a worktree
+	 *     wp datamachine workspace worktree finalize data-machine@fix-foo --pr=https://github.com/org/repo/pull/123
+	 *     wp datamachine workspace worktree mark-cleanup-eligible data-machine@fix-foo
+	 *
 	 * @subcommand worktree
 	 */
 	public function worktree( array $args, array $assoc_args ): void {
 		$operation = $args[0] ?? '';
 
 		if ( '' === $operation ) {
-			WP_CLI::error( 'Usage: wp datamachine workspace worktree <add|list|remove|prune|cleanup|refresh-context> [<repo>] [<branch>] [--flags]' );
+			WP_CLI::error( 'Usage: wp datamachine workspace worktree <add|list|remove|prune|cleanup|refresh-context|finalize|mark-cleanup-eligible> [<repo>] [<branch>] [--flags]' );
 			return;
 		}
 
@@ -1160,6 +1164,8 @@ class WorkspaceCommand extends BaseCommand {
 			'prune'           => 'datamachine/workspace-worktree-prune',
 			'cleanup'         => 'datamachine/workspace-worktree-cleanup',
 			'refresh-context' => 'datamachine/workspace-worktree-refresh-context',
+			'finalize'        => 'datamachine/workspace-worktree-finalize',
+			'mark-cleanup-eligible' => 'datamachine/workspace-worktree-finalize',
 			default           => '',
 		};
 
@@ -1211,9 +1217,36 @@ class WorkspaceCommand extends BaseCommand {
 				$input['handle'] = (string) $args[1];
 				break;
 
+			case 'finalize':
+				if ( empty( $args[1] ) ) {
+					WP_CLI::error( 'Usage: worktree finalize <handle> [--pr=<url-or-number>] [--state=<state>]' );
+					return;
+				}
+				$input['handle'] = (string) $args[1];
+				$input['state']  = isset( $assoc_args['state'] ) && '' !== trim( (string) $assoc_args['state'] ) ? (string) $assoc_args['state'] : ( isset( $assoc_args['pr'] ) ? 'pr_opened' : 'active' );
+				if ( isset( $assoc_args['pr'] ) && '' !== trim( (string) $assoc_args['pr'] ) ) {
+					$input['pr'] = (string) $assoc_args['pr'];
+				}
+				break;
+
+			case 'mark-cleanup-eligible':
+				if ( empty( $args[1] ) ) {
+					WP_CLI::error( 'Usage: worktree mark-cleanup-eligible <handle> [--pr=<url-or-number>]' );
+					return;
+				}
+				$input['handle'] = (string) $args[1];
+				$input['state']  = 'cleanup_eligible';
+				if ( isset( $assoc_args['pr'] ) && '' !== trim( (string) $assoc_args['pr'] ) ) {
+					$input['pr'] = (string) $assoc_args['pr'];
+				}
+				break;
+
 			case 'list':
 				if ( ! empty( $args[1] ) ) {
 					$input['repo'] = $args[1];
+				}
+				if ( isset( $assoc_args['state'] ) && '' !== trim( (string) $assoc_args['state'] ) ) {
+					$input['state'] = (string) $assoc_args['state'];
 				}
 				break;
 
@@ -1278,12 +1311,14 @@ class WorkspaceCommand extends BaseCommand {
 						'head'       => isset( $wt['head'] ) ? substr( (string) $wt['head'], 0, 7 ) : '-',
 						'dirty'      => (int) ( $wt['dirty'] ?? 0 ),
 						'created_at' => $wt['created_at'] ?? null,
+						'state'      => $wt['lifecycle_state'] ?? null,
+						'pr'         => $wt['pr_url'] ?? null,
 						'metadata'   => $wt['metadata'] ?? null,
 						'path'       => $wt['path'] ?? '',
 					),
 					$worktrees
 				);
-				$fields = array( 'handle', 'repo', 'kind', 'branch', 'head', 'dirty', 'created_at', 'path' );
+				$fields = array( 'handle', 'repo', 'kind', 'branch', 'head', 'dirty', 'state', 'created_at', 'pr', 'path' );
 				if ( in_array( (string) ( $assoc_args['format'] ?? '' ), array( 'json', 'yaml' ), true ) ) {
 					$fields[] = 'metadata';
 				}
@@ -1351,6 +1386,16 @@ class WorkspaceCommand extends BaseCommand {
 				}
 				if ( ! empty( $result['metadata']['site_url'] ) ) {
 					WP_CLI::log( sprintf( 'Originating site: %s', $result['metadata']['site_url'] ) );
+				}
+				return;
+
+			case 'finalize':
+			case 'mark-cleanup-eligible':
+				WP_CLI::success( $result['message'] ?? 'Worktree finalized.' );
+				WP_CLI::log( sprintf( 'Handle: %s', $result['handle'] ?? '-' ) );
+				WP_CLI::log( sprintf( 'State:  %s', $result['lifecycle_state'] ?? '-' ) );
+				if ( ! empty( $result['metadata']['pr_url'] ) ) {
+					WP_CLI::log( sprintf( 'PR:     %s', $result['metadata']['pr_url'] ) );
 				}
 				return;
 

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -1282,6 +1282,8 @@ class Workspace {
 
 		$lifecycle_metadata = WorktreeContextInjector::build_lifecycle_metadata(
 			array(
+				'handle'      => $wt_handle,
+				'path'        => $wt_path,
 				'repo'        => $repo,
 				'branch'      => $branch,
 				'base_ref'    => $created_branch ? $resolved_base : null,
@@ -1318,6 +1320,52 @@ class Workspace {
 		}
 
 		return $response;
+	}
+
+	/**
+	 * Attach lifecycle finalizer metadata to a worktree record.
+	 *
+	 * @param string      $handle Workspace worktree handle.
+	 * @param string      $state  Lifecycle state.
+	 * @param string|null $pr     Optional PR URL or number.
+	 * @return array{success: bool, handle: string, path: string, lifecycle_state: string, metadata: array, message: string}|\WP_Error
+	 */
+	public function worktree_finalize( string $handle, string $state, ?string $pr = null ): array|\WP_Error {
+		$parsed = $this->parse_handle( $handle );
+		if ( ! $parsed['is_worktree'] ) {
+			return new \WP_Error( 'not_a_worktree', sprintf( 'Handle "%s" is a primary checkout, not a worktree.', $handle ), array( 'status' => 400 ) );
+		}
+
+		$normalized_state = WorktreeContextInjector::normalize_state( $state );
+		if ( null === $normalized_state ) {
+			return new \WP_Error( 'invalid_lifecycle_state', sprintf( 'Invalid lifecycle state "%s". Valid states: %s.', $state, implode( ', ', WorktreeContextInjector::VALID_STATES ) ), array( 'status' => 400 ) );
+		}
+
+		$wt_path = $this->workspace_path . '/' . $parsed['dir_name'];
+		if ( ! is_dir( $wt_path ) ) {
+			return new \WP_Error( 'worktree_not_found', sprintf( 'Worktree "%s" does not exist on disk.', $parsed['dir_name'] ), array( 'status' => 404 ) );
+		}
+
+		$metadata = WorktreeContextInjector::build_finalizer_metadata( $normalized_state, $pr );
+		$metadata = array_merge(
+			array(
+				'handle' => $parsed['dir_name'],
+				'path'   => $wt_path,
+				'repo'   => $parsed['repo'],
+			),
+			$metadata
+		);
+		WorktreeContextInjector::store_lifecycle_metadata( $parsed['dir_name'], $metadata );
+
+		$stored = WorktreeContextInjector::get_metadata( $parsed['dir_name'] ) ?? array();
+		return array(
+			'success'         => true,
+			'handle'          => $parsed['dir_name'],
+			'path'            => $wt_path,
+			'lifecycle_state' => (string) ( $stored['lifecycle_state'] ?? $normalized_state ),
+			'metadata'        => $stored,
+			'message'         => sprintf( 'Worktree "%s" marked %s.', $parsed['dir_name'], (string) ( $stored['lifecycle_state'] ?? $normalized_state ) ),
+		);
 	}
 
 	/**
@@ -1385,7 +1433,15 @@ class Workspace {
 	 * @param string|null $repo Optional repo filter (only this primary's worktrees).
 	 * @return array{success: bool, worktrees: array}|\WP_Error
 	 */
-	public function worktree_list( ?string $repo = null ): array|\WP_Error {
+	public function worktree_list( ?string $repo = null, ?string $state = null ): array|\WP_Error {
+		if ( null !== $state && '' !== trim( $state ) ) {
+			$state = WorktreeContextInjector::normalize_state( (string) $state );
+			if ( null === $state ) {
+				return new \WP_Error( 'invalid_lifecycle_state', sprintf( 'Invalid lifecycle state. Valid states: %s.', implode( ', ', WorktreeContextInjector::VALID_STATES ) ), array( 'status' => 400 ) );
+			}
+		} else {
+			$state = null;
+		}
 		if ( ! is_dir( $this->workspace_path ) ) {
 			return array(
 				'success'   => true,
@@ -1449,6 +1505,11 @@ class Workspace {
 					: count( array_filter( array_map( 'trim', explode( "\n", $dirty_result['output'] ?? '' ) ) ) );
 				$metadata     = ( ! $is_primary && $inside_ws ) ? WorktreeContextInjector::get_metadata( $relative ) : null;
 
+				$lifecycle_state = is_array( $metadata ) ? ( $metadata['lifecycle_state'] ?? null ) : null;
+				if ( null !== $state && $lifecycle_state !== $state ) {
+					continue;
+				}
+
 				$worktrees[] = array(
 					'handle'      => $handle,
 					'repo'        => $primary,
@@ -1461,6 +1522,9 @@ class Workspace {
 					'path'        => $wt['path'],
 					'dirty'       => $dirty_files,
 					'created_at'  => is_array( $metadata ) ? ( $metadata['created_at'] ?? null ) : null,
+					'lifecycle_state' => $lifecycle_state,
+					'pr_url'      => is_array( $metadata ) ? ( $metadata['pr_url'] ?? null ) : null,
+					'pr_number'   => is_array( $metadata ) ? ( $metadata['pr_number'] ?? null ) : null,
 					'metadata'    => $metadata,
 				);
 			}
@@ -1792,7 +1856,18 @@ class Workspace {
 				$fetched[ $repo ] = true;
 			}
 
-			$signal = $this->detect_merge_signal( $primary_path, $repo, $branch, $skip_github, $github_cache );
+			$signal = null;
+			if ( is_array( $metadata ) && WorktreeContextInjector::STATE_CLEANUP_ELIGIBLE === ( $metadata['lifecycle_state'] ?? null ) ) {
+				$signal = array(
+					'signal' => 'cleanup_eligible',
+					'reason' => 'worktree explicitly marked cleanup_eligible',
+				);
+				if ( ! empty( $metadata['pr_url'] ) ) {
+					$signal['pr_url'] = (string) $metadata['pr_url'];
+				}
+			} else {
+				$signal = $this->detect_merge_signal( $primary_path, $repo, $branch, $skip_github, $github_cache );
+			}
 			if ( null === $signal ) {
 				$skipped[] = array(
 					'handle'      => $handle,

--- a/inc/Workspace/WorktreeContextInjector.php
+++ b/inc/Workspace/WorktreeContextInjector.php
@@ -34,6 +34,28 @@ defined( 'ABSPATH' ) || exit;
 class WorktreeContextInjector {
 
 	/**
+	 * Lifecycle states stored on worktree metadata records.
+	 */
+	public const STATE_ACTIVE = 'active';
+	public const STATE_PR_OPENED = 'pr_opened';
+	public const STATE_MERGED = 'merged';
+	public const STATE_CLOSED = 'closed';
+	public const STATE_ABANDONED = 'abandoned';
+	public const STATE_CLEANUP_ELIGIBLE = 'cleanup_eligible';
+
+	/**
+	 * Valid worktree lifecycle state values.
+	 */
+	public const VALID_STATES = array(
+		self::STATE_ACTIVE,
+		self::STATE_PR_OPENED,
+		self::STATE_MERGED,
+		self::STATE_CLOSED,
+		self::STATE_ABANDONED,
+		self::STATE_CLEANUP_ELIGIBLE,
+	);
+
+	/**
 	 * Site option key used to persist per-worktree metadata.
 	 *
 	 * Shape: array<string, array<string,mixed>> keyed by workspace handle.
@@ -70,13 +92,18 @@ class WorktreeContextInjector {
 		$site_name = function_exists( 'get_bloginfo' ) ? (string) get_bloginfo( 'name' ) : '';
 		$user      = self::resolve_origin_user();
 		$agent     = self::resolve_origin_agent();
+		$session   = self::resolve_origin_session();
 
 		$metadata = array(
 			'created_at'       => gmdate( 'c' ),
+			'lifecycle_state'  => self::STATE_ACTIVE,
+			'handle'           => isset( $args['handle'] ) && '' !== (string) $args['handle'] ? (string) $args['handle'] : null,
+			'path'             => isset( $args['path'] ) && '' !== (string) $args['path'] ? (string) $args['path'] : null,
 			'origin_site'      => '' !== $site_name ? $site_name : ( '' !== $site_url ? $site_url : null ),
 			'origin_site_url'  => '' !== $site_url ? $site_url : null,
 			'origin_site_name' => '' !== $site_name ? $site_name : null,
 			'origin_agent'     => $agent,
+			'origin_session'   => $session,
 			'origin_user'      => $user,
 			'base_ref'         => isset( $args['base_ref'] ) && '' !== (string) $args['base_ref'] ? (string) $args['base_ref'] : null,
 			'base_source'      => isset( $args['base_source'] ) && '' !== (string) $args['base_source'] ? (string) $args['base_source'] : null,
@@ -90,6 +117,70 @@ class WorktreeContextInjector {
 		$metadata['agent_slug'] = is_string( $agent ) ? $agent : '';
 
 		return array_filter( $metadata, fn( $value ) => null !== $value );
+	}
+
+	/**
+	 * Validate a lifecycle state string.
+	 *
+	 * @param string $state Raw lifecycle state.
+	 * @return string|null Normalized state, or null when invalid.
+	 */
+	public static function normalize_state( string $state ): ?string {
+		$state = strtolower( trim( $state ) );
+		return in_array( $state, self::VALID_STATES, true ) ? $state : null;
+	}
+
+	/**
+	 * Build metadata fields for finalizing a worktree lifecycle.
+	 *
+	 * @param string      $state Lifecycle state.
+	 * @param string|null $pr    Optional PR URL or number.
+	 * @return array<string,mixed>
+	 */
+	public static function build_finalizer_metadata( string $state, ?string $pr = null ): array {
+		$normalized = self::normalize_state( $state );
+		if ( null === $normalized ) {
+			$normalized = self::STATE_ACTIVE;
+		}
+
+		$metadata = array(
+			'lifecycle_state' => $normalized,
+			'finalized_at'    => gmdate( 'c' ),
+		);
+
+		$pr_metadata = self::parse_pr_reference( $pr );
+		if ( ! empty( $pr_metadata ) ) {
+			$metadata = array_merge( $metadata, $pr_metadata );
+		}
+
+		return $metadata;
+	}
+
+	/**
+	 * Parse a GitHub PR reference into stable metadata fields.
+	 *
+	 * @param string|null $pr PR URL or number.
+	 * @return array<string,mixed>
+	 */
+	public static function parse_pr_reference( ?string $pr ): array {
+		$pr = trim( (string) $pr );
+		if ( '' === $pr ) {
+			return array();
+		}
+
+		$metadata = array( 'pr_ref' => $pr );
+		if ( preg_match( '~^https?://github\.com/([^/]+)/([^/]+)/pull/(\d+)(?:[/?#].*)?$~', $pr, $matches ) ) {
+			$metadata['pr_url']    = sprintf( 'https://github.com/%s/%s/pull/%d', $matches[1], $matches[2], (int) $matches[3] );
+			$metadata['pr_number'] = (int) $matches[3];
+			$metadata['pr_repo']   = $matches[1] . '/' . $matches[2];
+			return $metadata;
+		}
+
+		if ( preg_match( '/^#?(\d+)$/', $pr, $matches ) ) {
+			$metadata['pr_number'] = (int) $matches[1];
+		}
+
+		return $metadata;
 	}
 
 	/**
@@ -421,6 +512,42 @@ class WorktreeContextInjector {
 		} catch ( \Throwable $e ) {
 			return null;
 		}
+	}
+
+	/**
+	 * Resolve non-sensitive runtime/session hints from the creating process.
+	 *
+	 * @return array<string,mixed>|null
+	 */
+	private static function resolve_origin_session(): ?array {
+		$session = array();
+
+		$opencode_run_id = getenv( 'OPENCODE_RUN_ID' );
+		if ( is_string( $opencode_run_id ) && '' !== trim( $opencode_run_id ) ) {
+			$session['opencode_run_id'] = trim( $opencode_run_id );
+		}
+
+		$opencode_pid = getenv( 'OPENCODE_PID' );
+		if ( is_string( $opencode_pid ) && ctype_digit( $opencode_pid ) ) {
+			$session['opencode_pid'] = (int) $opencode_pid;
+		}
+
+		$kimaki_session_id = getenv( 'KIMAKI_SESSION_ID' );
+		if ( is_string( $kimaki_session_id ) && '' !== trim( $kimaki_session_id ) ) {
+			$session['kimaki_session_id'] = trim( $kimaki_session_id );
+		}
+
+		$kimaki_thread_id = getenv( 'KIMAKI_THREAD_ID' );
+		if ( is_string( $kimaki_thread_id ) && '' !== trim( $kimaki_thread_id ) ) {
+			$session['kimaki_thread_id'] = trim( $kimaki_thread_id );
+		}
+
+		$kimaki_thread_url = getenv( 'KIMAKI_THREAD_URL' );
+		if ( is_string( $kimaki_thread_url ) && preg_match( '#^https?://#', $kimaki_thread_url ) ) {
+			$session['kimaki_thread_url'] = trim( $kimaki_thread_url );
+		}
+
+		return empty( $session ) ? null : $session;
 	}
 
 	/**

--- a/tests/smoke-worktree-cleanup.php
+++ b/tests/smoke-worktree-cleanup.php
@@ -350,7 +350,7 @@ namespace {
 	$assert( true, is_wp_error( $invalid_age_plan ), 'invalid older_than duration returns WP_Error' );
 
 	class Missing_Metadata_Workspace extends \DataMachineCode\Workspace\Workspace {
-		public function worktree_list( ?string $repo = null ): array|\WP_Error { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+		public function worktree_list( ?string $repo = null, ?string $state = null ): array|\WP_Error { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 			return array(
 				'success'   => true,
 				'worktrees' => array(

--- a/tests/smoke-worktree-finalizer-cli.php
+++ b/tests/smoke-worktree-finalizer-cli.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Smoke test for worktree finalizer CLI routing.
+ *
+ * Run: php tests/smoke-worktree-finalizer-cli.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ );
+	}
+
+	class WP_CLI {
+		public static array $logs = array();
+		public static array $successes = array();
+
+		public static function error( string $message ): void {
+			throw new RuntimeException( $message );
+		}
+
+		public static function success( string $message ): void {
+			self::$successes[] = $message;
+		}
+
+		public static function log( string $message ): void {
+			self::$logs[] = $message;
+		}
+
+		public static function warning( string $message ): void {
+			self::$logs[] = 'warning: ' . $message;
+		}
+	}
+
+	function is_wp_error( $value ): bool {
+		return false;
+	}
+
+	function wp_get_ability( string $name ) {
+		return $GLOBALS['__abilities'][ $name ] ?? null;
+	}
+}
+
+namespace DataMachine\Cli {
+	class BaseCommand {
+		protected function format_items( array $items, array $fields, array $assoc_args, string $default_sort = '' ): void {
+			\WP_CLI::log( 'table:' . count( $items ) . ':' . implode( ',', $fields ) );
+		}
+	}
+}
+
+namespace {
+	require_once dirname( __DIR__ ) . '/inc/Cli/Commands/WorkspaceCommand.php';
+
+	function datamachine_code_finalizer_assert( bool $condition, string $message ): void {
+		if ( $condition ) {
+			echo "  [PASS] {$message}\n";
+			return;
+		}
+		echo "  [FAIL] {$message}\n";
+		exit( 1 );
+	}
+
+	class FakeWorktreeFinalizeAbility {
+		public array $last_input = array();
+
+		public function execute( array $input ): array {
+			$this->last_input = $input;
+			return array(
+				'success'         => true,
+				'handle'          => $input['handle'],
+				'path'            => '/workspace/' . $input['handle'],
+				'lifecycle_state' => $input['state'],
+				'metadata'        => array(
+					'lifecycle_state' => $input['state'],
+					'pr_url'          => $input['pr'] ?? null,
+				),
+				'message'         => 'finalized',
+			);
+		}
+	}
+
+	class FakeWorktreeListAbility {
+		public array $last_input = array();
+
+		public function execute( array $input ): array {
+			$this->last_input = $input;
+			return array(
+				'success'   => true,
+				'worktrees' => array(
+					array(
+						'handle'          => 'repo@feature',
+						'repo'            => 'repo',
+						'is_primary'      => false,
+						'branch'          => 'feature',
+						'head'            => 'abcdef123',
+						'dirty'           => 0,
+						'lifecycle_state' => 'cleanup_eligible',
+						'created_at'      => '2026-04-29T00:00:00+00:00',
+						'pr_url'          => 'https://github.com/acme/repo/pull/7',
+						'path'            => '/workspace/repo@feature',
+						'metadata'        => array( 'lifecycle_state' => 'cleanup_eligible' ),
+					),
+				),
+			);
+		}
+	}
+
+	echo "=== smoke-worktree-finalizer-cli ===\n";
+
+	$finalize = new FakeWorktreeFinalizeAbility();
+	$list     = new FakeWorktreeListAbility();
+	$GLOBALS['__abilities'] = array(
+		'datamachine/workspace-worktree-finalize' => $finalize,
+		'datamachine/workspace-worktree-list'     => $list,
+	);
+	$command = new \DataMachineCode\Cli\Commands\WorkspaceCommand();
+
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->worktree( array( 'finalize', 'repo@feature' ), array( 'pr' => 'https://github.com/acme/repo/pull/7' ) );
+	datamachine_code_finalizer_assert( array( 'handle' => 'repo@feature', 'state' => 'pr_opened', 'pr' => 'https://github.com/acme/repo/pull/7' ) === $finalize->last_input, 'finalize defaults PR-bearing records to pr_opened' );
+	datamachine_code_finalizer_assert( in_array( 'State:  pr_opened', WP_CLI::$logs, true ), 'finalize output prints lifecycle state' );
+	datamachine_code_finalizer_assert( in_array( 'PR:     https://github.com/acme/repo/pull/7', WP_CLI::$logs, true ), 'finalize output prints PR URL' );
+
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->worktree( array( 'mark-cleanup-eligible', 'repo@feature' ), array() );
+	datamachine_code_finalizer_assert( array( 'handle' => 'repo@feature', 'state' => 'cleanup_eligible' ) === $finalize->last_input, 'mark-cleanup-eligible routes to cleanup_eligible state' );
+
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->worktree( array( 'list' ), array( 'state' => 'cleanup_eligible' ) );
+	datamachine_code_finalizer_assert( array( 'state' => 'cleanup_eligible' ) === $list->last_input, 'list forwards lifecycle state filter' );
+	datamachine_code_finalizer_assert( in_array( 'table:1:handle,repo,kind,branch,head,dirty,state,created_at,pr,path', WP_CLI::$logs, true ), 'list human table exposes state and PR columns' );
+
+	echo "\nAll worktree finalizer CLI smoke tests passed.\n";
+}

--- a/tests/smoke-worktree-lifecycle-metadata.php
+++ b/tests/smoke-worktree-lifecycle-metadata.php
@@ -191,6 +191,8 @@ namespace {
 	file_put_contents( $primary . '/README.md', "# Demo\n" );
 	$run( 'git add README.md', $primary );
 	$run( 'git commit -m initial', $primary );
+	putenv( 'OPENCODE_RUN_ID=smoke-run-123' );
+	putenv( 'OPENCODE_PID=12345' );
 
 	$ws     = new \DataMachineCode\Workspace\Workspace();
 	$result = $ws->worktree_add( 'demo', 'feature/metadata', 'HEAD', false, false, true, false );
@@ -203,12 +205,33 @@ namespace {
 	$assert( 42, $metadata['origin_user']['id'] ?? null, 'origin user id is recorded without sensitive fields' );
 	$assert( 'HEAD', $metadata['base_ref'] ?? null, 'base ref is recorded' );
 	$assert( 'requested_ref', $metadata['base_source'] ?? null, 'base source is recorded' );
+	$assert( 'active', $metadata['lifecycle_state'] ?? null, 'new worktree lifecycle state defaults to active' );
+	$assert( 'demo@feature-metadata', $metadata['handle'] ?? null, 'worktree handle is recorded' );
+	$assert( DATAMACHINE_WORKSPACE_PATH . '/demo@feature-metadata', $metadata['path'] ?? null, 'worktree path is recorded' );
+	$assert( true, isset( $metadata['origin_session'] ) && is_array( $metadata['origin_session'] ), 'origin session metadata is recorded when runtime env is available' );
 
 	$list  = $ws->worktree_list( 'demo' );
 	$items = array_values( array_filter( $list['worktrees'] ?? array(), fn( $wt ) => ( $wt['handle'] ?? '' ) === 'demo@feature-metadata' ) );
 	$item  = $items[0] ?? array();
 	$assert( $metadata['created_at'] ?? null, $item['created_at'] ?? null, 'list data exposes created_at metadata' );
 	$assert( 'Origin Site', $item['metadata']['origin_site'] ?? null, 'list data exposes nested lifecycle metadata' );
+	$assert( 'active', $item['lifecycle_state'] ?? null, 'list data exposes lifecycle state' );
+
+	$finalized = $ws->worktree_finalize( 'demo@feature-metadata', 'pr_opened', 'https://github.com/acme/demo/pull/123' );
+	$assert( true, ! is_wp_error( $finalized ) && ( $finalized['success'] ?? false ), 'worktree_finalize succeeds with PR URL' );
+	$assert( 'pr_opened', $finalized['lifecycle_state'] ?? null, 'finalizer stores pr_opened state' );
+	$assert( 123, $finalized['metadata']['pr_number'] ?? null, 'finalizer extracts PR number' );
+	$assert( 'https://github.com/acme/demo/pull/123', $finalized['metadata']['pr_url'] ?? null, 'finalizer stores normalized PR URL' );
+
+	$filtered = $ws->worktree_list( 'demo', 'pr_opened' );
+	$filtered_items = array_values( array_filter( $filtered['worktrees'] ?? array(), fn( $wt ) => ( $wt['handle'] ?? '' ) === 'demo@feature-metadata' ) );
+	$assert( 1, count( $filtered_items ), 'worktree_list can filter by lifecycle state' );
+
+	$invalid_state = $ws->worktree_finalize( 'demo@feature-metadata', 'donezo' );
+	$assert( true, is_wp_error( $invalid_state ), 'invalid finalizer state returns WP_Error' );
+
+	$eligible = $ws->worktree_finalize( 'demo@feature-metadata', 'cleanup_eligible' );
+	$assert( true, ! is_wp_error( $eligible ) && ( $eligible['success'] ?? false ), 'worktree can be marked cleanup_eligible' );
 
 	$result_old = $ws->worktree_add( 'demo', 'feature/old-record', 'HEAD', false, false, true, false );
 	$assert( true, ! is_wp_error( $result_old ) && ( $result_old['success'] ?? false ), 'second worktree_add succeeds' );
@@ -229,8 +252,12 @@ namespace {
 		)
 	);
 	$assert( true, ! is_wp_error( $plan ) && ( $plan['success'] ?? false ), 'cleanup dry-run succeeds with mixed metadata records' );
+	$eligible_candidates = array_values( array_filter( $plan['candidates'] ?? array(), fn( $cand ) => ( $cand['handle'] ?? '' ) === 'demo@feature-metadata' ) );
+	$assert( 1, count( $eligible_candidates ), 'cleanup dry-run treats cleanup_eligible metadata as a candidate signal' );
+	$assert( 'cleanup_eligible', $eligible_candidates[0]['signal'] ?? null, 'cleanup_eligible candidate exposes stable signal' );
 	$feature_skip = array_values( array_filter( $plan['skipped'] ?? array(), fn( $skip ) => ( $skip['handle'] ?? '' ) === 'demo@feature-metadata' ) );
-	$assert( 'Origin Site', $feature_skip[0]['metadata']['origin_site'] ?? null, 'cleanup dry-run exposes metadata on skipped worktree records' );
+	$old_skip = array_values( array_filter( $plan['skipped'] ?? array(), fn( $skip ) => ( $skip['handle'] ?? '' ) === 'demo@feature-old-record' ) );
+	$assert( null, $old_skip[0]['metadata'] ?? null, 'cleanup dry-run tolerates worktrees with missing metadata' );
 
 	if ( $failures > 0 ) {
 		echo "\n{$failures} failure(s) across {$assertions} assertion(s).\n";


### PR DESCRIPTION
## Summary
- Track lifecycle/finalizer metadata on workspace worktrees so completed coding-agent session work can become cleanup-eligible after PR completion.
- Add a narrow finalizer CLI/ability surface without weakening dirty or unpushed worktree cleanup safety gates.

## Changes
- Adds lifecycle states (`active`, `pr_opened`, `merged`, `closed`, `abandoned`, `cleanup_eligible`) to persisted worktree metadata.
- Records non-sensitive origin/session hints, handle, path, repo, branch, and PR metadata on the existing `datamachine_worktree_metadata` option.
- Adds `workspace worktree finalize <handle> --pr=<url-or-number> [--state=<state>]`, `workspace worktree mark-cleanup-eligible <handle>`, and `workspace worktree list --state=<state>`.
- Treats `cleanup_eligible` metadata as a cleanup signal only after the existing dirty/unpushed safety gates pass.
- Exposes lifecycle state and PR columns in worktree list output and preserves full metadata in JSON/YAML output.

The 2026-04-29 disk incident happened because many completed coding-session worktrees never had an end-of-life signal. This gives DMC a durable signal that a worktree has served its purpose.

## Tests
- `php -l inc/Workspace/WorktreeContextInjector.php && php -l inc/Workspace/Workspace.php && php -l inc/Abilities/WorkspaceAbilities.php && php -l inc/Cli/Commands/WorkspaceCommand.php && php -l tests/smoke-worktree-lifecycle-metadata.php && php -l tests/smoke-worktree-finalizer-cli.php`
- `php tests/smoke-worktree-lifecycle-metadata.php`
- `php tests/smoke-worktree-finalizer-cli.php`
- `php tests/smoke-worktree-cleanup.php`
- `php tests/smoke-worktree-cleanup-cli.php`
- `git diff --check`
- `homeboy lint data-machine-code --path /Users/chubes/Developer/data-machine-code@feat-worktree-session-finalizer` reports the existing broad smoke/PHPStan drift (627 findings across unrelated tests); focused smokes above pass.

Closes #147

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the lifecycle/finalizer metadata changes, focused smoke coverage, and PR description. Chris remains responsible for review and merge.
