### PR TITLE
fix(workspace): keep hygiene cheap without status scans

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -970,6 +970,10 @@ class WorkspaceAbilities {
 								'type'        => 'boolean',
 								'description' => 'Include best-effort top-level workspace size data. Default true.',
 							),
+							'include_worktree_status' => array(
+								'type'        => 'boolean',
+								'description' => 'Include full per-worktree git status. Default false for huge-workspace safety.',
+							),
 							'size_limit'      => array(
 								'type'        => 'integer',
 								'description' => 'Maximum top-level workspace entries to size. Default 200.',
@@ -986,6 +990,7 @@ class WorkspaceAbilities {
 							'size'                      => array( 'type' => 'object' ),
 							'disk'                      => array( 'type' => 'object' ),
 							'worktrees'                 => array( 'type' => 'object' ),
+							'worktree_status_mode'      => array( 'type' => 'string' ),
 							'top_repos_by_worktrees'    => array( 'type' => 'array' ),
 							'top_repos_by_size'         => array( 'type' => 'array' ),
 							'cleanup'                   => array( 'type' => 'object' ),
@@ -1509,6 +1514,9 @@ class WorkspaceAbilities {
 		}
 		if ( array_key_exists( 'include_sizes', $input ) ) {
 			$opts['include_sizes'] = (bool) $input['include_sizes'];
+		}
+		if ( array_key_exists( 'include_worktree_status', $input ) ) {
+			$opts['include_worktree_status'] = (bool) $input['include_worktree_status'];
 		}
 		if ( isset( $input['size_limit'] ) ) {
 			$opts['size_limit'] = (int) $input['size_limit'];

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -264,6 +264,9 @@ class WorkspaceCommand extends BaseCommand {
 	 * [--skip-sizes]
 	 * : Skip best-effort workspace size collection.
 	 *
+	 * [--include-worktree-status]
+	 * : Include full per-worktree git status. This can be expensive on huge workspaces.
+	 *
 	 * [--size-limit=<count>]
 	 * : Maximum top-level workspace entries to size.
 	 * ---
@@ -285,8 +288,9 @@ class WorkspaceCommand extends BaseCommand {
 		}
 
 		$input = array(
-			'include_cleanup' => empty( $assoc_args['skip-cleanup'] ),
-			'include_sizes'   => empty( $assoc_args['skip-sizes'] ),
+			'include_cleanup'         => empty( $assoc_args['skip-cleanup'] ),
+			'include_sizes'           => empty( $assoc_args['skip-sizes'] ),
+			'include_worktree_status' => ! empty( $assoc_args['include-worktree-status'] ),
 		);
 		if ( isset( $assoc_args['size-limit'] ) ) {
 			$input['size_limit'] = (int) $assoc_args['size-limit'];
@@ -1549,6 +1553,10 @@ class WorkspaceCommand extends BaseCommand {
 				array(
 					'metric' => 'disk_free',
 					'value'  => (string) ( $disk['free_human'] ?? '-' ),
+				),
+				array(
+					'metric' => 'worktree_status_mode',
+					'value'  => (string) ( $report['worktree_status_mode'] ?? '-' ),
 				),
 				array(
 					'metric' => 'worktree_count',

--- a/inc/Tasks/WorkspaceHygieneReportTask.php
+++ b/inc/Tasks/WorkspaceHygieneReportTask.php
@@ -73,9 +73,10 @@ class WorkspaceHygieneReportTask extends SystemTask {
 		$workspace = new Workspace();
 		$result    = $workspace->workspace_hygiene_report(
 			array(
-				'include_cleanup' => array_key_exists( 'include_cleanup', $params ) ? (bool) $params['include_cleanup'] : true,
-				'include_sizes'   => array_key_exists( 'include_sizes', $params ) ? (bool) $params['include_sizes'] : true,
-				'size_limit'      => isset( $params['size_limit'] ) ? (int) $params['size_limit'] : 200,
+				'include_cleanup'         => array_key_exists( 'include_cleanup', $params ) ? (bool) $params['include_cleanup'] : true,
+				'include_sizes'           => array_key_exists( 'include_sizes', $params ) ? (bool) $params['include_sizes'] : true,
+				'include_worktree_status' => array_key_exists( 'include_worktree_status', $params ) ? (bool) $params['include_worktree_status'] : false,
+				'size_limit'              => isset( $params['size_limit'] ) ? (int) $params['size_limit'] : 200,
 			)
 		);
 

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -1579,23 +1579,31 @@ class Workspace {
 	 * collection is best-effort and bounded by a top-level entry limit.
 	 *
 	 * @param array $opts {
-	 *     @type bool $include_cleanup Whether to include a cleanup dry-run. Default true.
-	 *     @type bool $include_sizes   Whether to include best-effort `du` sizes. Default true.
-	 *     @type int  $size_limit      Maximum top-level workspace entries to size. Default 200.
+	 *     @type bool $include_cleanup         Whether to include a cleanup dry-run. Default true.
+	 *     @type bool $include_sizes           Whether to include best-effort `du` sizes. Default true.
+	 *     @type bool $include_worktree_status Whether to include full git worktree status. Default false.
+	 *     @type int  $size_limit              Maximum top-level workspace entries to size. Default 200.
 	 * }
 	 * @return array<string,mixed>|\WP_Error
 	 */
 	public function workspace_hygiene_report( array $opts = array() ): array|\WP_Error {
-		$include_cleanup = array_key_exists( 'include_cleanup', $opts ) ? (bool) $opts['include_cleanup'] : true;
-		$include_sizes   = array_key_exists( 'include_sizes', $opts ) ? (bool) $opts['include_sizes'] : true;
-		$size_limit      = isset( $opts['size_limit'] ) ? max( 0, (int) $opts['size_limit'] ) : self::HYGIENE_DEFAULT_SIZE_LIMIT;
+		$include_cleanup         = array_key_exists( 'include_cleanup', $opts ) ? (bool) $opts['include_cleanup'] : true;
+		$include_sizes           = array_key_exists( 'include_sizes', $opts ) ? (bool) $opts['include_sizes'] : true;
+		$include_worktree_status = array_key_exists( 'include_worktree_status', $opts ) ? (bool) $opts['include_worktree_status'] : false;
+		$size_limit              = isset( $opts['size_limit'] ) ? max( 0, (int) $opts['size_limit'] ) : self::HYGIENE_DEFAULT_SIZE_LIMIT;
 
-		$listing = $this->worktree_list();
-		if ( is_wp_error( $listing ) ) {
-			return $listing;
+		if ( $include_worktree_status ) {
+			$listing = $this->worktree_list();
+			if ( is_wp_error( $listing ) ) {
+				return $listing;
+			}
+			$worktrees            = (array) ( $listing['worktrees'] ?? array() );
+			$worktree_status_mode = 'full_git_status';
+		} else {
+			$worktrees            = $this->build_workspace_inventory_rows();
+			$worktree_status_mode = 'top_level_inventory';
 		}
 
-		$worktrees     = (array) ( $listing['worktrees'] ?? array() );
 		$size_report   = $include_sizes ? $this->build_workspace_size_report( $size_limit ) : $this->empty_workspace_size_report( $size_limit, false );
 		$cleanup       = null;
 		$cleanup_error = null;
@@ -1624,15 +1632,72 @@ class Workspace {
 			'size'                      => $size_report,
 			'disk'                      => $this->build_workspace_disk_report(),
 			'worktrees'                 => $this->summarize_workspace_worktrees( $worktrees, $cleanup ),
+			'worktree_status_mode'      => $worktree_status_mode,
 			'top_repos_by_worktrees'    => $this->top_repos_by_worktree_count( $worktrees, 10 ),
 			'top_repos_by_size'         => $this->top_repos_by_size( (array) ( $size_report['entries'] ?? array() ), 10 ),
 			'cleanup'                   => $this->summarize_workspace_cleanup( $cleanup, $cleanup_error, (array) ( $size_report['entries'] ?? array() ) ),
 			'suggested_cleanup_command' => 'wp datamachine-code workspace worktree cleanup --dry-run --skip-github --format=json',
 			'notes'                     => array_values( array_filter( array(
 				$include_sizes ? (string) ( $size_report['mode_note'] ?? '' ) : 'Size scan disabled by request.',
+				$include_worktree_status ? 'Full worktree status enabled; this may run git status across every worktree.' : 'Worktree status uses cheap top-level inventory; pass --include-worktree-status for full git status.',
 				$include_cleanup ? 'Cleanup summary uses local-only dry-run detection (--skip-github); no GitHub API lookups are required.' : 'Cleanup dry-run disabled by request.',
 			) ) ),
 		);
+	}
+
+	/**
+	 * Build cheap workspace inventory rows from top-level directory names.
+	 *
+	 * This intentionally avoids `git worktree list` and per-worktree `git status`.
+	 * It is the safe default for huge workspaces where hygiene should still be
+	 * able to return a bounded JSON report.
+	 *
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function build_workspace_inventory_rows(): array {
+		if ( '' === $this->workspace_path || ! is_dir( $this->workspace_path ) ) {
+			return array();
+		}
+
+		$entries = scandir( $this->workspace_path );
+		if ( false === $entries ) {
+			return array();
+		}
+
+		$rows = array();
+		foreach ( $entries as $entry ) {
+			if ( '.' === $entry || '..' === $entry ) {
+				continue;
+			}
+
+			$path = $this->workspace_path . '/' . $entry;
+			if ( ! is_dir( $path ) ) {
+				continue;
+			}
+
+			$parsed      = $this->parse_handle( $entry );
+			$is_worktree = ! empty( $parsed['is_worktree'] );
+			$metadata    = $is_worktree ? WorktreeContextInjector::get_metadata( $parsed['dir_name'] ) : null;
+
+			$rows[] = array(
+				'handle'           => $parsed['dir_name'],
+				'repo'             => $parsed['repo'],
+				'is_worktree'      => $is_worktree,
+				'is_primary'       => ! $is_worktree,
+				'external'         => false,
+				'branch_slug'      => $parsed['branch_slug'],
+				'path'             => $path,
+				'dirty'            => 0,
+				'created_at'       => is_array( $metadata ) ? ( $metadata['created_at'] ?? null ) : null,
+				'lifecycle_state'  => is_array( $metadata ) ? ( $metadata['lifecycle_state'] ?? null ) : null,
+				'pr_url'           => is_array( $metadata ) ? ( $metadata['pr_url'] ?? null ) : null,
+				'pr_number'        => is_array( $metadata ) ? ( $metadata['pr_number'] ?? null ) : null,
+				'missing_metadata' => $is_worktree && ! is_array( $metadata ),
+				'metadata'         => $metadata,
+			);
+		}
+
+		return $rows;
 	}
 
 	/**
@@ -1798,6 +1863,10 @@ class Workspace {
 
 			if ( (int) ( $row['dirty'] ?? 0 ) > 0 ) {
 				++$summary['dirty'];
+			}
+
+			if ( ! empty( $row['missing_metadata'] ) ) {
+				++$summary['missing_metadata'];
 			}
 		}
 

--- a/tests/smoke-workspace-hygiene-cli.php
+++ b/tests/smoke-workspace-hygiene-cli.php
@@ -86,6 +86,7 @@ namespace {
 				'missing_metadata'   => 4,
 				'external'           => 7,
 			),
+			'worktree_status_mode'      => 'top_level_inventory',
 			'top_repos_by_worktrees'    => array(
 				array( 'repo' => 'data-machine', 'worktree_count' => 17 ),
 			),
@@ -126,18 +127,24 @@ namespace {
 	echo "\n[1] JSON output is parseable and forwards bounded flags\n";
 	$GLOBALS['__cli_logs'] = array();
 	$command->hygiene( array(), array( 'format' => 'json', 'skip-cleanup' => true, 'skip-sizes' => true, 'size-limit' => '25' ) );
-	datamachine_code_hygiene_assert( array( 'include_cleanup' => false, 'include_sizes' => false, 'size_limit' => 25 ) === $ability->last_input, 'CLI forwards skip flags and size limit' );
+	datamachine_code_hygiene_assert( array( 'include_cleanup' => false, 'include_sizes' => false, 'include_worktree_status' => false, 'size_limit' => 25 ) === $ability->last_input, 'CLI forwards skip flags, status mode, and size limit' );
 	datamachine_code_hygiene_assert( 1 === count( $GLOBALS['__cli_logs'] ), 'JSON path writes one stdout document' );
 	$decoded = json_decode( (string) $GLOBALS['__cli_logs'][0], true );
 	datamachine_code_hygiene_assert( JSON_ERROR_NONE === json_last_error(), 'JSON output parses cleanly' );
 	datamachine_code_hygiene_assert( false === ( $decoded['destructive'] ?? true ), 'JSON report is explicitly non-destructive' );
 	datamachine_code_hygiene_assert( '1.1 GiB' === ( $decoded['disk']['free_human'] ?? '' ), 'JSON report includes free disk space' );
+	datamachine_code_hygiene_assert( 'top_level_inventory' === ( $decoded['worktree_status_mode'] ?? '' ), 'JSON report exposes cheap worktree status mode' );
 
-	echo "\n[2] Human output is summary-first and includes actionable sections\n";
+	echo "\n[2] Full status flag is opt-in\n";
+	$GLOBALS['__cli_logs'] = array();
+	$command->hygiene( array(), array( 'format' => 'json', 'include-worktree-status' => true ) );
+	datamachine_code_hygiene_assert( true === ( $ability->last_input['include_worktree_status'] ?? false ), 'CLI forwards explicit worktree status opt-in' );
+
+	echo "\n[3] Human output is summary-first and includes actionable sections\n";
 	$GLOBALS['__cli_logs'] = array();
 	$command->hygiene( array(), array() );
 	datamachine_code_hygiene_assert( 'Workspace hygiene:' === ( $GLOBALS['__cli_logs'][0] ?? '' ), 'human output starts with report heading' );
-	datamachine_code_hygiene_assert( in_array( 'table:11:metric,value', $GLOBALS['__cli_logs'], true ), 'human output renders summary table' );
+	datamachine_code_hygiene_assert( in_array( 'table:12:metric,value', $GLOBALS['__cli_logs'], true ), 'human output renders summary table' );
 	datamachine_code_hygiene_assert( in_array( 'Top repos by size:', $GLOBALS['__cli_logs'], true ), 'human output renders size leaders' );
 	datamachine_code_hygiene_assert( in_array( 'Top repos by worktree count:', $GLOBALS['__cli_logs'], true ), 'human output renders worktree-count leaders' );
 	datamachine_code_hygiene_assert( in_array( 'Cleanup candidates:', $GLOBALS['__cli_logs'], true ), 'human output renders cleanup candidates' );

--- a/tests/smoke-workspace-hygiene-report.php
+++ b/tests/smoke-workspace-hygiene-report.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Smoke test for bounded workspace hygiene report inventory mode.
+ *
+ *   php tests/smoke-workspace-hygiene-report.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Core\FilesRepository {
+	if ( ! class_exists( __NAMESPACE__ . '\\FilesystemHelper' ) ) {
+		class FilesystemHelper {
+			public static function get() {
+				return null;
+			}
+		}
+	}
+}
+
+namespace {
+	$workspace_root = sys_get_temp_dir() . '/dmc-hygiene-report-' . getmypid() . '-' . bin2hex( random_bytes( 4 ) );
+	mkdir( $workspace_root, 0755, true );
+	mkdir( $workspace_root . '/alpha', 0755, true );
+	mkdir( $workspace_root . '/alpha@feat-one', 0755, true );
+	mkdir( $workspace_root . '/beta@missing-metadata', 0755, true );
+	file_put_contents( $workspace_root . '/not-a-dir.txt', 'ignored' );
+
+	define( 'ABSPATH', __DIR__ . '/' );
+	define( 'DATAMACHINE_WORKSPACE_PATH', $workspace_root );
+
+	$GLOBALS['__dmc_hygiene_metadata'] = array(
+		'alpha@feat-one' => array(
+			'created_at'      => '2026-04-30T00:00:00+00:00',
+			'lifecycle_state' => 'active',
+			'pr_url'          => 'https://github.com/Extra-Chill/data-machine-code/pull/1',
+			'pr_number'       => 1,
+		),
+	);
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			public function __construct( $code = '', $message = '', $data = array() ) {}
+		}
+	}
+
+	function is_wp_error( $value ): bool {
+		return $value instanceof \WP_Error;
+	}
+
+	function get_option( string $name, $default = false ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		return $GLOBALS['__dmc_hygiene_metadata'];
+	}
+
+	require __DIR__ . '/../inc/Workspace/WorktreeContextInjector.php';
+	require __DIR__ . '/../inc/Workspace/Workspace.php';
+
+	function datamachine_code_hygiene_report_assert( bool $condition, string $message ): void {
+		if ( $condition ) {
+			echo "  [PASS] {$message}\n";
+			return;
+		}
+		echo "  [FAIL] {$message}\n";
+		exit( 1 );
+	}
+
+	function datamachine_code_hygiene_report_cleanup( string $path ): void {
+		if ( ! is_dir( $path ) ) {
+			return;
+		}
+		$entries = scandir( $path );
+		if ( false === $entries ) {
+			return;
+		}
+		foreach ( $entries as $entry ) {
+			if ( '.' === $entry || '..' === $entry ) {
+				continue;
+			}
+			$child = $path . '/' . $entry;
+			if ( is_dir( $child ) ) {
+				datamachine_code_hygiene_report_cleanup( $child );
+				continue;
+			}
+			unlink( $child );
+		}
+		rmdir( $path );
+	}
+
+	class Hygiene_Report_Workspace extends \DataMachineCode\Workspace\Workspace {
+		public int $full_listing_calls = 0;
+
+		public function worktree_list( ?string $repo = null, ?string $state = null ): array|\WP_Error { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+			++$this->full_listing_calls;
+			return array(
+				'success'   => true,
+				'worktrees' => array(
+					array(
+						'handle'     => 'alpha',
+						'repo'       => 'alpha',
+						'is_primary' => true,
+						'dirty'      => 0,
+					),
+					array(
+						'handle'      => 'alpha@feat-one',
+						'repo'        => 'alpha',
+						'is_primary'  => false,
+						'is_worktree' => true,
+						'dirty'       => 7,
+					),
+				),
+			);
+		}
+	}
+
+	echo "=== smoke-workspace-hygiene-report ===\n";
+
+	try {
+		$workspace = new Hygiene_Report_Workspace();
+
+		echo "\n[1] Minimal report uses cheap top-level inventory\n";
+		$minimal = $workspace->workspace_hygiene_report(
+			array(
+				'include_cleanup' => false,
+				'include_sizes'   => false,
+			)
+		);
+		datamachine_code_hygiene_report_assert( ! is_wp_error( $minimal ), 'minimal report succeeds' );
+		datamachine_code_hygiene_report_assert( 0 === $workspace->full_listing_calls, 'minimal report does not call full worktree_list' );
+		datamachine_code_hygiene_report_assert( 'top_level_inventory' === ( $minimal['worktree_status_mode'] ?? '' ), 'minimal report declares inventory mode' );
+		datamachine_code_hygiene_report_assert( 1 === (int) ( $minimal['worktrees']['primaries'] ?? 0 ), 'inventory counts primaries' );
+		datamachine_code_hygiene_report_assert( 2 === (int) ( $minimal['worktrees']['worktrees'] ?? 0 ), 'inventory counts worktrees' );
+		datamachine_code_hygiene_report_assert( 1 === (int) ( $minimal['worktrees']['missing_metadata'] ?? 0 ), 'inventory counts missing metadata from registry only' );
+		datamachine_code_hygiene_report_assert( 'alpha' === ( $minimal['top_repos_by_worktrees'][0]['repo'] ?? '' ), 'inventory builds repo count leaders' );
+		datamachine_code_hygiene_report_assert( 1 === (int) ( $minimal['top_repos_by_worktrees'][0]['worktree_count'] ?? 0 ), 'repo count leaders ignore primaries and missing-metadata repo still sorts after alpha' );
+
+		echo "\n[2] Full report remains explicitly available\n";
+		$full = $workspace->workspace_hygiene_report(
+			array(
+				'include_cleanup'         => false,
+				'include_sizes'           => false,
+				'include_worktree_status' => true,
+			)
+		);
+		datamachine_code_hygiene_report_assert( ! is_wp_error( $full ), 'full report succeeds' );
+		datamachine_code_hygiene_report_assert( 1 === $workspace->full_listing_calls, 'full report calls worktree_list once' );
+		datamachine_code_hygiene_report_assert( 'full_git_status' === ( $full['worktree_status_mode'] ?? '' ), 'full report declares git status mode' );
+		datamachine_code_hygiene_report_assert( 1 === (int) ( $full['worktrees']['dirty'] ?? 0 ), 'full report preserves detailed dirty status summary' );
+	} finally {
+		datamachine_code_hygiene_report_cleanup( $workspace_root );
+	}
+
+	echo "\nAll workspace hygiene report smoke tests passed.\n";
+}


### PR DESCRIPTION
## Summary
- Make workspace hygiene use a cheap top-level inventory by default instead of full `worktree_list()` status scans.
- Add `--include-worktree-status` / `include_worktree_status` as the explicit opt-in for the old detailed git status path.
- Add smoke coverage proving minimal hygiene avoids full listing while full status remains available.

## Tests
- `php tests/smoke-workspace-hygiene-report.php`
- `php tests/smoke-workspace-hygiene-cli.php`
- `php tests/smoke-workspace-hygiene-task.php`
- `php tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-worktree-cleanup.php`
- `php -l inc/Workspace/Workspace.php`
- `php -l inc/Cli/Commands/WorkspaceCommand.php`
- `php -l inc/Abilities/WorkspaceAbilities.php`
- `php -l inc/Tasks/WorkspaceHygieneReportTask.php`
- `php -l tests/smoke-workspace-hygiene-report.php`
- `git diff --check`
- `homeboy lint data-machine-code --path /Users/chubes/Developer/data-machine-code@fix-hygiene-huge-workspace --changed-since origin/main`

Closes #153

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation and test drafting; Chris remains responsible for review and merge decisions.
