### PR TITLE
fix(workspace): add inventory-only cleanup review

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -1149,6 +1149,10 @@ class WorkspaceAbilities {
 								'type'        => 'boolean',
 								'description' => 'If true, rely solely on the local upstream-gone signal and skip GitHub API lookup.',
 							),
+							'inventory_only' => array(
+								'type'        => 'boolean',
+								'description' => 'If true, build a dry-run review from cheap top-level inventory and explicit lifecycle cleanup signals only. Avoids full git worktree/status scans and GitHub lookups.',
+							),
 							'apply_plan'  => array(
 								'type'        => 'object',
 								'description' => 'Decoded cleanup dry-run report to apply after revalidating every candidate.',
@@ -1554,15 +1558,16 @@ class WorkspaceAbilities {
 	/**
 	 * Remove merged worktrees across all primary checkouts.
 	 *
-	 * @param array $input Input parameters (dry_run, force, skip_github, apply_plan, older_than, sort).
+	 * @param array $input Input parameters (dry_run, force, skip_github, inventory_only, apply_plan, older_than, sort).
 	 * @return array
 	 */
 	public static function worktreeCleanup( array $input ): array|\WP_Error {
 		$workspace = new Workspace();
 		$opts      = array(
-			'dry_run'     => ! empty( $input['dry_run'] ),
-			'force'       => ! empty( $input['force'] ),
-			'skip_github' => ! empty( $input['skip_github'] ),
+			'dry_run'        => ! empty( $input['dry_run'] ),
+			'force'          => ! empty( $input['force'] ),
+			'skip_github'    => ! empty( $input['skip_github'] ),
+			'inventory_only' => ! empty( $input['inventory_only'] ),
 		);
 		if ( isset( $input['apply_plan'] ) && is_array( $input['apply_plan'] ) ) {
 			$opts['apply_plan'] = $input['apply_plan'];

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1195,11 +1195,14 @@ class WorkspaceCommand extends BaseCommand {
 	 *     wp datamachine workspace worktree cleanup --dry-run --format=json > cleanup-plan.json
 	 *     wp datamachine workspace worktree cleanup --apply-plan=cleanup-plan.json
 	 *
-	 *     # Local-only detection (no GitHub API call)
-	 *     wp datamachine workspace worktree cleanup --skip-github
-	 *
-	 *     # Ignore dirty working-tree safety (caution)
-	 *     wp datamachine workspace worktree cleanup --force
+		 *     # Local-only detection (no GitHub API call)
+		 *     wp datamachine workspace worktree cleanup --skip-github
+		 *
+		 *     # Bounded review on huge workspaces (no per-worktree git probes)
+		 *     wp datamachine workspace worktree cleanup --dry-run --inventory-only --skip-github --format=json
+		 *
+		 *     # Ignore dirty working-tree safety (caution)
+		 *     wp datamachine workspace worktree cleanup --force
 	 *
 	 *     # Create a worktree without injecting site-agent context
 	 *     wp datamachine workspace worktree add data-machine fix/foo --skip-context-injection
@@ -1336,9 +1339,10 @@ class WorkspaceCommand extends BaseCommand {
 				break;
 
 			case 'cleanup':
-				$input['dry_run']     = ! empty( $assoc_args['dry-run'] );
-				$input['force']       = ! empty( $assoc_args['force'] );
-				$input['skip_github'] = ! empty( $assoc_args['skip-github'] );
+				$input['dry_run']        = ! empty( $assoc_args['dry-run'] );
+				$input['force']          = ! empty( $assoc_args['force'] );
+				$input['skip_github']    = ! empty( $assoc_args['skip-github'] );
+				$input['inventory_only'] = ! empty( $assoc_args['inventory-only'] );
 				if ( ! empty( $assoc_args['apply-plan'] ) ) {
 					if ( ! empty( $assoc_args['force'] ) ) {
 						WP_CLI::error( 'Do not combine --apply-plan with --force. Plan application always revalidates and refuses dirty worktrees.' );

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -1611,9 +1611,10 @@ class Workspace {
 		if ( $include_cleanup ) {
 			$cleanup = $this->worktree_cleanup_merged(
 				array(
-					'dry_run'     => true,
-					'force'       => false,
-					'skip_github' => true,
+					'dry_run'        => true,
+					'force'          => false,
+					'skip_github'    => true,
+					'inventory_only' => true,
 				)
 			);
 			if ( $cleanup instanceof \WP_Error ) {
@@ -1636,11 +1637,11 @@ class Workspace {
 			'top_repos_by_worktrees'    => $this->top_repos_by_worktree_count( $worktrees, 10 ),
 			'top_repos_by_size'         => $this->top_repos_by_size( (array) ( $size_report['entries'] ?? array() ), 10 ),
 			'cleanup'                   => $this->summarize_workspace_cleanup( $cleanup, $cleanup_error, (array) ( $size_report['entries'] ?? array() ) ),
-			'suggested_cleanup_command' => 'wp datamachine-code workspace worktree cleanup --dry-run --skip-github --format=json',
+			'suggested_cleanup_command' => 'wp datamachine-code workspace worktree cleanup --dry-run --inventory-only --skip-github --format=json',
 			'notes'                     => array_values( array_filter( array(
 				$include_sizes ? (string) ( $size_report['mode_note'] ?? '' ) : 'Size scan disabled by request.',
 				$include_worktree_status ? 'Full worktree status enabled; this may run git status across every worktree.' : 'Worktree status uses cheap top-level inventory; pass --include-worktree-status for full git status.',
-				$include_cleanup ? 'Cleanup summary uses local-only dry-run detection (--skip-github); no GitHub API lookups are required.' : 'Cleanup dry-run disabled by request.',
+				$include_cleanup ? 'Cleanup summary uses inventory-only dry-run detection (--inventory-only --skip-github); no per-worktree git probes or GitHub API lookups are required.' : 'Cleanup dry-run disabled by request.',
 			) ) ),
 		);
 	}
@@ -1920,6 +1921,7 @@ class Workspace {
 			'included'             => true,
 			'dry_run'              => true,
 			'skip_github'          => true,
+			'inventory_only'       => ! empty( $cleanup['inventory_only'] ),
 			'summary'              => $cleanup['summary'] ?? array(),
 			'biggest_candidates'   => array_slice( $candidates, 0, 10 ),
 			'skipped_by_reason'    => $cleanup['summary']['skipped_by_reason'] ?? array(),
@@ -2145,15 +2147,27 @@ class Workspace {
 	 * }|\WP_Error
 	 */
 	public function worktree_cleanup_merged( array $opts = array() ): array|\WP_Error {
-		$dry_run     = ! empty( $opts['dry_run'] );
-		$force       = ! empty( $opts['force'] );
-		$skip_github = ! empty( $opts['skip_github'] );
-		$apply_plan  = isset( $opts['apply_plan'] ) && is_array( $opts['apply_plan'] ) ? $opts['apply_plan'] : null;
-		$older_than  = isset( $opts['older_than'] ) ? trim( (string) $opts['older_than'] ) : '';
-		$sort        = isset( $opts['sort'] ) ? trim( (string) $opts['sort'] ) : '';
+		$dry_run        = ! empty( $opts['dry_run'] );
+		$force          = ! empty( $opts['force'] );
+		$skip_github    = ! empty( $opts['skip_github'] );
+		$inventory_only = ! empty( $opts['inventory_only'] );
+		$apply_plan     = isset( $opts['apply_plan'] ) && is_array( $opts['apply_plan'] ) ? $opts['apply_plan'] : null;
+		$older_than     = isset( $opts['older_than'] ) ? trim( (string) $opts['older_than'] ) : '';
+		$sort           = isset( $opts['sort'] ) ? trim( (string) $opts['sort'] ) : '';
 
 		if ( '' !== $sort && ! in_array( $sort, array( 'size', 'age' ), true ) ) {
 			return new \WP_Error( 'invalid_cleanup_sort', 'Invalid cleanup sort. Use size or age.', array( 'status' => 400 ) );
+		}
+
+		if ( $inventory_only ) {
+			if ( ! $dry_run ) {
+				return new \WP_Error( 'inventory_cleanup_requires_dry_run', 'Inventory-only cleanup is review-only. Pass --dry-run, then run full cleanup to apply a reviewed plan.', array( 'status' => 400 ) );
+			}
+			if ( null !== $apply_plan ) {
+				return new \WP_Error( 'inventory_cleanup_apply_plan_unsupported', 'Inventory-only cleanup cannot apply a plan because it intentionally skips full safety revalidation.', array( 'status' => 400 ) );
+			}
+
+			return $this->worktree_cleanup_inventory_only( $older_than, $sort );
 		}
 
 		$planned_candidates = null;
@@ -2510,6 +2524,147 @@ class Workspace {
 			'removed'    => $removed,
 			'skipped'    => $skipped,
 			'summary'    => $this->build_worktree_cleanup_summary( $candidates, $removed, $skipped, $age_filter ),
+		);
+	}
+
+	/**
+	 * Build a bounded cleanup review from top-level inventory only.
+	 *
+	 * This mode is deliberately dry-run-only. It avoids git worktree discovery,
+	 * per-worktree status, unpushed-commit checks, fetches, and GitHub lookups.
+	 * Only explicit lifecycle cleanup signals become candidates; every ambiguous
+	 * worktree is skipped with stable reason codes for review.
+	 *
+	 * @param string $older_than Optional age filter duration.
+	 * @param string $sort       Optional candidate sort.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private function worktree_cleanup_inventory_only( string $older_than, string $sort ): array|\WP_Error {
+		$age_filter = null;
+		if ( '' !== $older_than ) {
+			$duration_seconds = $this->parse_worktree_cleanup_duration( $older_than );
+			if ( is_wp_error( $duration_seconds ) ) {
+				return $duration_seconds;
+			}
+
+			$threshold_ts = time() - $duration_seconds;
+			$age_filter   = array(
+				'type'             => 'older_than',
+				'older_than'       => $older_than,
+				'duration_seconds' => $duration_seconds,
+				'threshold'        => gmdate( 'c', $threshold_ts ),
+				'threshold_unix'   => $threshold_ts,
+				'excluded'         => 0,
+				'unknown_age'      => 0,
+			);
+		}
+
+		$candidates = array();
+		$skipped    = array();
+
+		foreach ( $this->build_workspace_inventory_rows() as $wt ) {
+			if ( ! empty( $wt['is_primary'] ) ) {
+				continue;
+			}
+
+			$handle       = (string) ( $wt['handle'] ?? '?' );
+			$repo         = (string) ( $wt['repo'] ?? '' );
+			$branch       = (string) ( $wt['branch_slug'] ?? '' );
+			$path         = (string) ( $wt['path'] ?? '' );
+			$metadata     = $wt['metadata'] ?? null;
+			$created_at   = $wt['created_at'] ?? null;
+			$base_row     = array(
+				'handle'     => $handle,
+				'repo'       => $repo,
+				'branch'     => $branch,
+				'path'       => $path,
+				'created_at' => $created_at,
+				'metadata'   => $metadata,
+			);
+
+			if ( ! is_array( $metadata ) ) {
+				$skipped[] = array_merge( $base_row, array(
+					'reason_code' => 'requires_full_scan',
+					'reason'      => 'inventory row has no lifecycle metadata; cleanup safety requires a full scan',
+					'hint'        => 'Run workspace worktree cleanup --dry-run without --inventory-only when you are ready for full git safety probes.',
+				) );
+				continue;
+			}
+
+			if ( WorktreeContextInjector::STATE_CLEANUP_ELIGIBLE !== ( $metadata['lifecycle_state'] ?? null ) ) {
+				$skipped[] = array_merge( $base_row, array(
+					'reason_code' => 'no_inventory_cleanup_signal',
+					'reason'      => 'no explicit inventory cleanup signal — leaving in place',
+					'hint'        => 'Mark the worktree cleanup-eligible after review, or run full cleanup to detect merge signals.',
+				) );
+				continue;
+			}
+
+			if ( null !== $age_filter ) {
+				$created_ts = is_string( $created_at ) && '' !== $created_at ? strtotime( $created_at ) : false;
+				if ( false === $created_ts ) {
+					++$age_filter['unknown_age'];
+					$skipped[] = array_merge( $base_row, array(
+						'reason_code' => 'unknown_age',
+						'reason'      => 'missing or invalid created_at metadata - age filter cannot decide safely',
+						'age_filter'  => array(
+							'type'       => 'older_than',
+							'older_than' => $age_filter['older_than'],
+							'threshold'  => $age_filter['threshold'],
+							'decision'   => 'unknown_age',
+						),
+					) );
+					continue;
+				}
+
+				if ( $created_ts > $age_filter['threshold_unix'] ) {
+					++$age_filter['excluded'];
+					$skipped[] = array_merge( $base_row, array(
+						'reason_code' => 'age_filter',
+						'reason'      => sprintf( 'created_at %s is newer than --older-than=%s threshold %s', $created_at, $age_filter['older_than'], $age_filter['threshold'] ),
+						'age_filter'  => array(
+							'type'        => 'older_than',
+							'older_than'  => $age_filter['older_than'],
+							'threshold'   => $age_filter['threshold'],
+							'created_at'  => $created_at,
+							'age_seconds' => time() - $created_ts,
+							'decision'    => 'excluded',
+						),
+					) );
+					continue;
+				}
+			}
+
+			$candidate = array_merge( $base_row, array(
+				'dirty'       => 0,
+				'signal'      => 'cleanup_eligible',
+				'reason_code' => 'cleanup_eligible',
+				'reason'      => 'worktree explicitly marked cleanup_eligible',
+				'pr_url'      => $metadata['pr_url'] ?? null,
+			) );
+			if ( null !== $age_filter && is_string( $created_at ) && '' !== $created_at ) {
+				$candidate['age_filter'] = array(
+					'type'        => 'older_than',
+					'older_than'  => $age_filter['older_than'],
+					'threshold'   => $age_filter['threshold'],
+					'created_at'  => $created_at,
+					'age_seconds' => time() - (int) strtotime( $created_at ),
+					'decision'    => 'included',
+				);
+			}
+
+			$candidates[] = $candidate;
+		}
+
+		$candidates = $this->sort_worktree_cleanup_rows( $candidates, $sort );
+		return array(
+			'success'        => true,
+			'dry_run'        => true,
+			'inventory_only' => true,
+			'candidates'     => $candidates,
+			'removed'        => array(),
+			'skipped'        => $skipped,
+			'summary'        => $this->build_worktree_cleanup_summary( $candidates, array(), $skipped, $age_filter ),
 		);
 	}
 

--- a/tests/smoke-workspace-hygiene-cli.php
+++ b/tests/smoke-workspace-hygiene-cli.php
@@ -97,13 +97,14 @@ namespace {
 				'included'           => true,
 				'dry_run'            => true,
 				'skip_github'        => true,
+				'inventory_only'     => true,
 				'summary'            => array( 'would_remove' => 9 ),
 				'biggest_candidates' => array(
 					array( 'handle' => 'data-machine@merged', 'branch' => 'merged', 'signal' => 'upstream-gone' ),
 				),
 			),
-			'suggested_cleanup_command' => 'wp datamachine-code workspace worktree cleanup --dry-run --skip-github --format=json',
-			'notes'                     => array( 'Cleanup summary uses local-only dry-run detection (--skip-github); no GitHub API lookups are required.' ),
+			'suggested_cleanup_command' => 'wp datamachine-code workspace worktree cleanup --dry-run --inventory-only --skip-github --format=json',
+			'notes'                     => array( 'Cleanup summary uses inventory-only dry-run detection (--inventory-only --skip-github); no per-worktree git probes or GitHub API lookups are required.' ),
 		);
 	}
 

--- a/tests/smoke-workspace-hygiene-report.php
+++ b/tests/smoke-workspace-hygiene-report.php
@@ -25,6 +25,7 @@ namespace {
 	mkdir( $workspace_root . '/alpha', 0755, true );
 	mkdir( $workspace_root . '/alpha@feat-one', 0755, true );
 	mkdir( $workspace_root . '/beta@missing-metadata', 0755, true );
+	mkdir( $workspace_root . '/gamma@eligible', 0755, true );
 	file_put_contents( $workspace_root . '/not-a-dir.txt', 'ignored' );
 
 	define( 'ABSPATH', __DIR__ . '/' );
@@ -36,6 +37,12 @@ namespace {
 			'lifecycle_state' => 'active',
 			'pr_url'          => 'https://github.com/Extra-Chill/data-machine-code/pull/1',
 			'pr_number'       => 1,
+		),
+		'gamma@eligible' => array(
+			'created_at'      => '2026-04-01T00:00:00+00:00',
+			'lifecycle_state' => 'cleanup_eligible',
+			'pr_url'          => 'https://github.com/Extra-Chill/data-machine-code/pull/2',
+			'pr_number'       => 2,
 		),
 	);
 
@@ -129,10 +136,24 @@ namespace {
 		datamachine_code_hygiene_report_assert( 0 === $workspace->full_listing_calls, 'minimal report does not call full worktree_list' );
 		datamachine_code_hygiene_report_assert( 'top_level_inventory' === ( $minimal['worktree_status_mode'] ?? '' ), 'minimal report declares inventory mode' );
 		datamachine_code_hygiene_report_assert( 1 === (int) ( $minimal['worktrees']['primaries'] ?? 0 ), 'inventory counts primaries' );
-		datamachine_code_hygiene_report_assert( 2 === (int) ( $minimal['worktrees']['worktrees'] ?? 0 ), 'inventory counts worktrees' );
+		datamachine_code_hygiene_report_assert( 3 === (int) ( $minimal['worktrees']['worktrees'] ?? 0 ), 'inventory counts worktrees' );
 		datamachine_code_hygiene_report_assert( 1 === (int) ( $minimal['worktrees']['missing_metadata'] ?? 0 ), 'inventory counts missing metadata from registry only' );
 		datamachine_code_hygiene_report_assert( 'alpha' === ( $minimal['top_repos_by_worktrees'][0]['repo'] ?? '' ), 'inventory builds repo count leaders' );
 		datamachine_code_hygiene_report_assert( 1 === (int) ( $minimal['top_repos_by_worktrees'][0]['worktree_count'] ?? 0 ), 'repo count leaders ignore primaries and missing-metadata repo still sorts after alpha' );
+
+		echo "\n[1b] Default cleanup summary uses inventory-only review\n";
+		$with_cleanup = $workspace->workspace_hygiene_report(
+			array(
+				'include_sizes' => false,
+			)
+		);
+		datamachine_code_hygiene_report_assert( ! is_wp_error( $with_cleanup ), 'inventory cleanup hygiene report succeeds' );
+		datamachine_code_hygiene_report_assert( 0 === $workspace->full_listing_calls, 'inventory cleanup does not call full worktree_list' );
+		datamachine_code_hygiene_report_assert( str_contains( $with_cleanup['suggested_cleanup_command'] ?? '', '--inventory-only' ), 'suggested cleanup command uses inventory-only review' );
+		datamachine_code_hygiene_report_assert( true === ( $with_cleanup['cleanup']['inventory_only'] ?? false ), 'cleanup report declares inventory_only mode' );
+		datamachine_code_hygiene_report_assert( 1 === (int) ( $with_cleanup['cleanup']['summary']['would_remove'] ?? 0 ), 'inventory cleanup counts explicit cleanup signal' );
+		datamachine_code_hygiene_report_assert( 1 === (int) ( $with_cleanup['cleanup']['summary']['skipped_by_reason']['no_inventory_cleanup_signal'] ?? 0 ), 'inventory cleanup skips active metadata with stable reason' );
+		datamachine_code_hygiene_report_assert( 1 === (int) ( $with_cleanup['cleanup']['summary']['skipped_by_reason']['requires_full_scan'] ?? 0 ), 'inventory cleanup skips missing metadata with full-scan reason' );
 
 		echo "\n[2] Full report remains explicitly available\n";
 		$full = $workspace->workspace_hygiene_report(

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -224,7 +224,7 @@ namespace {
 	WP_CLI::$logs      = array();
 	WP_CLI::$successes = array();
 	$command->worktree( array( 'cleanup' ), array( 'dry-run' => true, 'skip-github' => true, 'format' => 'json' ) );
-	datamachine_code_cleanup_assert( array( 'dry_run' => true, 'force' => false, 'skip_github' => true ) === $ability->last_input, 'cleanup flags forwarded to ability' );
+	datamachine_code_cleanup_assert( array( 'dry_run' => true, 'force' => false, 'skip_github' => true, 'inventory_only' => false ) === $ability->last_input, 'cleanup flags forwarded to ability' );
 	datamachine_code_cleanup_assert( 1 === count( WP_CLI::$logs ), 'JSON path writes exactly one stdout log entry' );
 	datamachine_code_cleanup_assert( array() === WP_CLI::$successes, 'JSON path emits no success suffix' );
 	$decoded = json_decode( WP_CLI::$logs[0], true );
@@ -295,7 +295,7 @@ namespace {
 	WP_CLI::$logs      = array();
 	WP_CLI::$successes = array();
 	$command->worktree( array( 'cleanup' ), array( 'dry-run' => true, 'skip-github' => true, 'older-than' => '7d' ) );
-	datamachine_code_cleanup_assert( array( 'dry_run' => true, 'force' => false, 'skip_github' => true, 'older_than' => '7d' ) === $ability->last_input, 'older-than forwards to cleanup ability as older_than' );
+	datamachine_code_cleanup_assert( array( 'dry_run' => true, 'force' => false, 'skip_github' => true, 'inventory_only' => false, 'older_than' => '7d' ) === $ability->last_input, 'older-than forwards to cleanup ability as older_than' );
 	datamachine_code_cleanup_assert( in_array( 'table:10:metric,count', WP_CLI::$logs, true ), 'age filter and disk summary rows are rendered' );
 
 	WP_CLI::$logs      = array();
@@ -310,6 +310,12 @@ namespace {
 	WP_CLI::$successes = array();
 	$command->worktree( array( 'cleanup' ), array( 'dry-run' => true, 'skip-github' => true, 'sort' => 'size', 'format' => 'json' ) );
 	datamachine_code_cleanup_assert( 'size' === ( $ability->last_input['sort'] ?? null ), '--sort forwards to cleanup ability' );
+
+	echo "\n[8] --inventory-only forwards bounded cleanup review flag\n";
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->worktree( array( 'cleanup' ), array( 'dry-run' => true, 'inventory-only' => true, 'skip-github' => true, 'format' => 'json' ) );
+	datamachine_code_cleanup_assert( true === ( $ability->last_input['inventory_only'] ?? null ), '--inventory-only forwards to cleanup ability' );
 
 	echo "\nAll worktree cleanup CLI smoke tests passed.\n";
 }

--- a/tests/smoke-worktree-cleanup.php
+++ b/tests/smoke-worktree-cleanup.php
@@ -159,6 +159,15 @@ namespace {
 		echo "    haystack: " . implode( ', ', array_map( fn( $i ) => is_array( $i ) ? ( $i['handle'] ?? '?' ) : $i, $haystack ) ) . "\n";
 	};
 
+	class Cleanup_Inventory_Workspace extends \DataMachineCode\Workspace\Workspace {
+		public int $full_listing_calls = 0;
+
+		public function worktree_list( ?string $repo = null, ?string $state = null ): array|\WP_Error { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+			++$this->full_listing_calls;
+			return parent::worktree_list( $repo, $state );
+		}
+	}
+
 	$run = function ( string $cmd, string $cwd = '' ) {
 		$full = '' === $cwd ? $cmd : sprintf( 'cd %s && %s', escapeshellarg( $cwd ), $cmd );
 		exec( $full . ' 2>&1', $out, $rc );
@@ -264,6 +273,25 @@ namespace {
 			'timestamp'  => '2026-04-25T00:00:00+00:00',
 		)
 	);
+	mkdir( $tmp . '/demo@inventory-cleanup-eligible', 0755, true );
+	mkdir( $tmp . '/demo@inventory-active', 0755, true );
+	mkdir( $tmp . '/demo@inventory-missing-metadata', 0755, true );
+	\DataMachineCode\Workspace\WorktreeContextInjector::store_lifecycle_metadata(
+		'demo@inventory-cleanup-eligible',
+		array(
+			'created_at'      => '2026-04-01T00:00:00+00:00',
+			'lifecycle_state' => \DataMachineCode\Workspace\WorktreeContextInjector::STATE_CLEANUP_ELIGIBLE,
+			'pr_url'          => 'https://github.com/acme/demo/pull/42',
+			'pr_number'       => 42,
+		)
+	);
+	\DataMachineCode\Workspace\WorktreeContextInjector::store_lifecycle_metadata(
+		'demo@inventory-active',
+		array(
+			'created_at'      => '2026-04-01T00:00:00+00:00',
+			'lifecycle_state' => \DataMachineCode\Workspace\WorktreeContextInjector::STATE_ACTIVE,
+		)
+	);
 
 	// Simulate "remote deleted the merged-* branches" — classic
 	// GitHub auto-delete-on-merge scenario. After a fetch --prune, the
@@ -335,6 +363,27 @@ namespace {
 	$assert( true, (int) ( $plan['summary']['total_size_bytes'] ?? 0 ) > 0, 'summary reports total worktree size bytes' );
 	$assert( true, (int) ( $plan['summary']['artifact_size_bytes'] ?? 0 ) > 0, 'summary reports artifact size bytes' );
 	$assert( true, ! empty( $plan['summary']['top_by_size'] ), 'summary reports top worktrees by size' );
+
+	echo "\nInventory-only dry-run scenario\n";
+	$inventory_ws   = new Cleanup_Inventory_Workspace();
+	$inventory_plan = $inventory_ws->worktree_cleanup_merged(
+		array(
+			'dry_run'        => true,
+			'skip_github'    => true,
+			'inventory_only' => true,
+		)
+	);
+	$assert( true, ! is_wp_error( $inventory_plan ) && ( $inventory_plan['success'] ?? false ), 'inventory-only dry_run returns success' );
+	$assert( true, $inventory_plan['inventory_only'] ?? false, 'inventory-only flag echoes back true' );
+	$assert( 0, $inventory_ws->full_listing_calls, 'inventory-only cleanup does not call full worktree_list' );
+	$assert_contains( $inventory_plan['candidates'] ?? array(), 'demo@inventory-cleanup-eligible', 'inventory-only flags explicit cleanup_eligible worktree' );
+	$assert( 1, count( $inventory_plan['candidates'] ?? array() ), 'inventory-only only returns explicit cheap cleanup signals as candidates' );
+	$inventory_active = array_values( array_filter( $inventory_plan['skipped'] ?? array(), fn( $s ) => ( $s['handle'] ?? '' ) === 'demo@inventory-active' ) )[0] ?? array();
+	$assert( 'no_inventory_cleanup_signal', $inventory_active['reason_code'] ?? '', 'inventory-only active metadata uses stable ambiguous reason' );
+	$inventory_missing = array_values( array_filter( $inventory_plan['skipped'] ?? array(), fn( $s ) => ( $s['handle'] ?? '' ) === 'demo@inventory-missing-metadata' ) )[0] ?? array();
+	$assert( 'requires_full_scan', $inventory_missing['reason_code'] ?? '', 'inventory-only missing metadata requires full scan' );
+	$inventory_apply = $inventory_ws->worktree_cleanup_merged( array( 'inventory_only' => true ) );
+	$assert( true, is_wp_error( $inventory_apply ), 'inventory-only cleanup refuses non-dry-run apply path' );
 
 	$size_plan = $ws->worktree_cleanup_merged(
 		array(


### PR DESCRIPTION
## Summary
- Add `--inventory-only` cleanup dry-run mode for huge workspaces, using top-level handle inventory plus explicit lifecycle cleanup signals instead of full worktree scans.
- Keep full cleanup behaviour available by default, while making hygiene suggest and use the safe bounded review command.
- Cover inventory-only candidates, ambiguous skip reasons, CLI forwarding, and hygiene’s no-full-scan behaviour in smokes.

## Tests
- `php -l inc/Workspace/Workspace.php && php -l inc/Cli/Commands/WorkspaceCommand.php && php -l inc/Abilities/WorkspaceAbilities.php && php -l tests/smoke-worktree-cleanup.php && php -l tests/smoke-worktree-cleanup-cli.php && php -l tests/smoke-workspace-hygiene-report.php && php -l tests/smoke-workspace-hygiene-cli.php`
- `php tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-worktree-cleanup.php`
- `php tests/smoke-workspace-hygiene-report.php`
- `php tests/smoke-workspace-hygiene-cli.php`
- `homeboy lint data-machine-code --path /Users/chubes/Developer/data-machine-code@fix-cleanup-huge-workspace --changed-since origin/main` *(reported no files changed since origin/main because changes were uncommitted at the time; PHP syntax + focused smokes above are the meaningful checks)*
- `homeboy audit data-machine-code --path /Users/chubes/Developer/data-machine-code@fix-cleanup-huge-workspace --changed-since origin/main` *(reported no files scanned for the same reason)*

Closes #155

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation and test drafting; Chris remains responsible for review and merge decisions.
