### PR TITLE
fix(workspace): expose inventory-only cleanup CLI flag

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1125,32 +1125,37 @@ class WorkspaceCommand extends BaseCommand {
 	 * [--dry-run]
 	 * : Preview cleanup candidates without removing anything (cleanup only).
 	 *
-		 * [--apply-plan=<file>]
-		 * : Apply a previously reviewed cleanup JSON report. The destructive pass
-		 *   revalidates every planned row and removes only exact current matches.
-		 *
-		 * [--skip-github]
-		 * : Skip the GitHub API lookup and rely only on the local `upstream-gone`
-		 *   signal (cleanup only). Faster, but misses merged branches where the
-		 *   remote branch wasn't auto-deleted.
-		 *
-		 * [--older-than=<duration>]
-		 * : Limit cleanup candidates to worktrees with lifecycle `created_at`
-		 *   metadata older than the compact duration (cleanup only, e.g. 7d, 24h).
-		 *   Candidate worktrees without valid `created_at` metadata are skipped.
-		 *
-		 * [--sort=<field>]
-		 * : Sort cleanup candidates by reporting field (cleanup only).
-		 * ---
-		 * options:
-		 *   - size
-		 *   - age
-		 * ---
-		 *
-		 * [--stale]
-		 * : For list, show only worktrees with a stale_reason (old, dirty, or missing metadata).
-		 *
-		 * [--verbose]
+	 * [--apply-plan=<file>]
+	 * : Apply a previously reviewed cleanup JSON report. The destructive pass
+	 *   revalidates every planned row and removes only exact current matches.
+	 *
+	 * [--skip-github]
+	 * : Skip the GitHub API lookup and rely only on the local `upstream-gone`
+	 *   signal (cleanup only). Faster, but misses merged branches where the
+	 *   remote branch wasn't auto-deleted.
+	 *
+	 * [--inventory-only]
+	 * : Build a dry-run review from cheap top-level inventory and explicit
+	 *   lifecycle cleanup signals only (cleanup only). Avoids full git worktree
+	 *   scans, per-worktree status checks, and GitHub lookups.
+	 *
+	 * [--older-than=<duration>]
+	 * : Limit cleanup candidates to worktrees with lifecycle `created_at`
+	 *   metadata older than the compact duration (cleanup only, e.g. 7d, 24h).
+	 *   Candidate worktrees without valid `created_at` metadata are skipped.
+	 *
+	 * [--sort=<field>]
+	 * : Sort cleanup candidates by reporting field (cleanup only).
+	 * ---
+	 * options:
+	 *   - size
+	 *   - age
+	 * ---
+	 *
+	 * [--stale]
+	 * : For list, show only worktrees with a stale_reason (old, dirty, or missing metadata).
+	 *
+	 * [--verbose]
 	 * : Show every cleanup row instead of concise samples (cleanup only).
 	 *
 	 * [--only=<section>]
@@ -1195,14 +1200,14 @@ class WorkspaceCommand extends BaseCommand {
 	 *     wp datamachine workspace worktree cleanup --dry-run --format=json > cleanup-plan.json
 	 *     wp datamachine workspace worktree cleanup --apply-plan=cleanup-plan.json
 	 *
-		 *     # Local-only detection (no GitHub API call)
-		 *     wp datamachine workspace worktree cleanup --skip-github
-		 *
-		 *     # Bounded review on huge workspaces (no per-worktree git probes)
-		 *     wp datamachine workspace worktree cleanup --dry-run --inventory-only --skip-github --format=json
-		 *
-		 *     # Ignore dirty working-tree safety (caution)
-		 *     wp datamachine workspace worktree cleanup --force
+	 *     # Local-only detection (no GitHub API call)
+	 *     wp datamachine workspace worktree cleanup --skip-github
+	 *
+	 *     # Bounded review on huge workspaces (no per-worktree git probes)
+	 *     wp datamachine workspace worktree cleanup --dry-run --inventory-only --skip-github --format=json
+	 *
+	 *     # Ignore dirty working-tree safety (caution)
+	 *     wp datamachine workspace worktree cleanup --force
 	 *
 	 *     # Create a worktree without injecting site-agent context
 	 *     wp datamachine workspace worktree add data-machine fix/foo --skip-context-injection

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -213,6 +213,11 @@ namespace {
 		'datamachine/workspace-worktree-list'    => $list_ability,
 	);
 	$command = new \DataMachineCode\Cli\Commands\WorkspaceCommand();
+	$doc_comment = ( new ReflectionMethod( $command, 'worktree' ) )->getDocComment() ?: '';
+
+	echo "\n[0a] WP-CLI synopsis exposes cleanup flags\n";
+	datamachine_code_cleanup_assert( str_contains( $doc_comment, "\n\t * [--inventory-only]" ), 'worktree synopsis declares --inventory-only at top level' );
+	datamachine_code_cleanup_assert( ! str_contains( $doc_comment, "\n\t\t * [--apply-plan=<file>]" ), 'cleanup flags are not hidden behind nested docblock indentation' );
 
 	echo "\n[0] list stale output exposes disk fields\n";
 	WP_CLI::$logs      = array();


### PR DESCRIPTION
## Summary
- Expose the inventory-only cleanup option in the WP-CLI synopsis so the deployed command accepts the flag.
- Fix nested docblock indentation around cleanup options that hid multiple flags from WP-CLI parsing.
- Add a smoke assertion that inventory-only appears at top level in the command synopsis.

## Tests
- php -l inc/Cli/Commands/WorkspaceCommand.php
- php -l tests/smoke-worktree-cleanup-cli.php
- php tests/smoke-worktree-cleanup-cli.php

Closes #155

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** follow-up diagnosis, patch, and smoke coverage; Chris remains responsible for review and merge decisions.