### PR TITLE
feat(workspace): reconcile legacy worktree metadata

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -1183,6 +1183,43 @@ class WorkspaceAbilities {
 					'meta'                => array( 'show_in_rest' => false ),
 				)
 			);
+
+			wp_register_ability(
+				'datamachine/workspace-worktree-reconcile-metadata',
+				array(
+					'label'               => 'Reconcile Legacy Worktree Metadata',
+					'description'         => 'Build or apply a reviewed, non-destructive lifecycle metadata backfill plan for legacy workspace worktrees. Never removes worktrees and never infers cleanup eligibility.',
+					'category'            => 'datamachine-code-workspace',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'dry_run'    => array(
+								'type'        => 'boolean',
+								'description' => 'If true, return a review plan without writing metadata.',
+							),
+							'apply_plan' => array(
+								'type'        => 'object',
+								'description' => 'Decoded dry-run plan to apply after exact handle/path/repo/branch revalidation.',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'   => array( 'type' => 'boolean' ),
+							'dry_run'   => array( 'type' => 'boolean' ),
+							'applied'   => array( 'type' => 'boolean' ),
+							'proposals' => array( 'type' => 'array' ),
+							'written'   => array( 'type' => 'array' ),
+							'skipped'   => array( 'type' => 'array' ),
+							'summary'   => array( 'type' => 'object' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'worktreeReconcileMetadata' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
 		};
 
 		if ( doing_action( 'wp_abilities_api_init' ) ) {
@@ -1580,6 +1617,24 @@ class WorkspaceAbilities {
 		}
 
 		return $workspace->worktree_cleanup_merged( $opts );
+	}
+
+	/**
+	 * Reconcile legacy worktree lifecycle metadata.
+	 *
+	 * @param array $input Input parameters (dry_run, apply_plan).
+	 * @return array
+	 */
+	public static function worktreeReconcileMetadata( array $input ): array|\WP_Error {
+		$workspace = new Workspace();
+		$opts      = array(
+			'dry_run' => ! empty( $input['dry_run'] ),
+		);
+		if ( isset( $input['apply_plan'] ) && is_array( $input['apply_plan'] ) ) {
+			$opts['apply_plan'] = $input['apply_plan'];
+		}
+
+		return $workspace->worktree_reconcile_metadata( $opts );
 	}
 
 	/**

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1062,7 +1062,7 @@ class WorkspaceCommand extends BaseCommand {
 	 * ## OPTIONS
 	 *
 	 * <operation>
-	 * : Worktree operation: add, list, remove, prune, cleanup, refresh-context.
+	 * : Worktree operation: add, list, remove, prune, cleanup, reconcile-metadata, refresh-context.
 	 *
 	 * [<repo>]
 	 * : Primary repo name (required for add and remove). For refresh-context,
@@ -1128,6 +1128,7 @@ class WorkspaceCommand extends BaseCommand {
 	 * [--apply-plan=<file>]
 	 * : Apply a previously reviewed cleanup JSON report. The destructive pass
 	 *   revalidates every planned row and removes only exact current matches.
+	 *   For reconcile-metadata, applies a reviewed non-destructive metadata plan.
 	 *
 	 * [--skip-github]
 	 * : Skip the GitHub API lookup and rely only on the local `upstream-gone`
@@ -1205,6 +1206,8 @@ class WorkspaceCommand extends BaseCommand {
 	 *
 	 *     # Bounded review on huge workspaces (no per-worktree git probes)
 	 *     wp datamachine workspace worktree cleanup --dry-run --inventory-only --skip-github --format=json
+	 *     wp datamachine workspace worktree reconcile-metadata --dry-run --format=json > reconcile-plan.json
+	 *     wp datamachine workspace worktree reconcile-metadata --apply-plan=reconcile-plan.json
 	 *
 	 *     # Ignore dirty working-tree safety (caution)
 	 *     wp datamachine workspace worktree cleanup --force
@@ -1234,7 +1237,7 @@ class WorkspaceCommand extends BaseCommand {
 		$operation = $args[0] ?? '';
 
 		if ( '' === $operation ) {
-			WP_CLI::error( 'Usage: wp datamachine workspace worktree <add|list|remove|prune|cleanup|refresh-context|finalize|mark-cleanup-eligible> [<repo>] [<branch>] [--flags]' );
+			WP_CLI::error( 'Usage: wp datamachine workspace worktree <add|list|remove|prune|cleanup|reconcile-metadata|refresh-context|finalize|mark-cleanup-eligible> [<repo>] [<branch>] [--flags]' );
 			return;
 		}
 
@@ -1244,6 +1247,7 @@ class WorkspaceCommand extends BaseCommand {
 			'remove'          => 'datamachine/workspace-worktree-remove',
 			'prune'           => 'datamachine/workspace-worktree-prune',
 			'cleanup'         => 'datamachine/workspace-worktree-cleanup',
+			'reconcile-metadata' => 'datamachine/workspace-worktree-reconcile-metadata',
 			'refresh-context' => 'datamachine/workspace-worktree-refresh-context',
 			'finalize'        => 'datamachine/workspace-worktree-finalize',
 			'mark-cleanup-eligible' => 'datamachine/workspace-worktree-finalize',
@@ -1362,6 +1366,13 @@ class WorkspaceCommand extends BaseCommand {
 					$input['sort'] = trim( (string) $assoc_args['sort'] );
 				}
 				break;
+
+			case 'reconcile-metadata':
+				$input['dry_run'] = ! empty( $assoc_args['dry-run'] );
+				if ( ! empty( $assoc_args['apply-plan'] ) ) {
+					$input['apply_plan'] = $this->read_worktree_json_plan( (string) $assoc_args['apply-plan'], 'metadata reconciliation' );
+				}
+				break;
 		}
 
 		$result = $ability->execute( $input );
@@ -1439,6 +1450,10 @@ class WorkspaceCommand extends BaseCommand {
 
 			case 'cleanup':
 				$this->render_worktree_cleanup_result( $result, $assoc_args );
+				return;
+
+			case 'reconcile-metadata':
+				$this->render_worktree_metadata_reconciliation_result( $result, $assoc_args );
 				return;
 
 			case 'add':
@@ -1819,31 +1834,154 @@ class WorkspaceCommand extends BaseCommand {
 	}
 
 	/**
+	 * Render metadata reconciliation output.
+	 *
+	 * @param array $result     Reconciliation ability result.
+	 * @param array $assoc_args CLI assoc args.
+	 * @return void
+	 */
+	private function render_worktree_metadata_reconciliation_result( array $result, array $assoc_args ): void {
+		$format = isset( $assoc_args['format'] ) ? (string) $assoc_args['format'] : 'table';
+		if ( 'json' === $format ) {
+			$json = wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+			WP_CLI::log( false === $json ? '{}' : $json );
+			return;
+		}
+
+		$summary   = (array) ( $result['summary'] ?? array() );
+		$proposals = (array) ( $result['proposals'] ?? array() );
+		$written   = (array) ( $result['written'] ?? array() );
+		$skipped   = (array) ( $result['skipped'] ?? array() );
+		$verbose   = ! empty( $assoc_args['verbose'] );
+		$limit     = $verbose ? PHP_INT_MAX : 10;
+
+		WP_CLI::log( 'Summary:' );
+		$summary_rows = array(
+			array(
+				'metric' => 'inspected',
+				'count'  => (int) ( $summary['inspected'] ?? 0 ),
+			),
+			array(
+				'metric' => 'proposed',
+				'count'  => (int) ( $summary['proposed'] ?? count( $proposals ) ),
+			),
+			array(
+				'metric' => 'written',
+				'count'  => (int) ( $summary['written'] ?? count( $written ) ),
+			),
+			array(
+				'metric' => 'skipped',
+				'count'  => (int) ( $summary['skipped'] ?? count( $skipped ) ),
+			),
+		);
+		foreach ( (array) ( $summary['skipped_by_reason'] ?? array() ) as $reason_code => $count ) {
+			$summary_rows[] = array(
+				'metric' => 'skipped:' . $reason_code,
+				'count'  => (int) $count,
+			);
+		}
+		foreach ( (array) ( $summary['proposed_by_state'] ?? array() ) as $state => $count ) {
+			$summary_rows[] = array(
+				'metric' => 'state:' . $state,
+				'count'  => (int) $count,
+			);
+		}
+		$this->format_items( $summary_rows, array( 'metric', 'count' ), array( 'format' => 'table' ), 'metric' );
+
+		if ( ! empty( $proposals ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( ! empty( $result['dry_run'] ) ? 'Would write metadata:' : 'Reviewed proposals:' );
+			$proposal_rows = array_map(
+				fn( $row ) => array(
+					'handle'   => $row['handle'] ?? '',
+					'branch'   => $row['branch'] ?? '',
+					'state'    => $row['proposed_metadata']['lifecycle_state'] ?? '',
+					'missing'  => implode( ',', (array) ( $row['missing_fields'] ?? array() ) ),
+					'dirty'    => (int) ( $row['dirty'] ?? 0 ),
+					'unpushed' => (int) ( $row['unpushed'] ?? 0 ),
+				),
+				array_slice( $proposals, 0, $limit )
+			);
+			$this->format_items( $proposal_rows, array( 'handle', 'branch', 'state', 'missing', 'dirty', 'unpushed' ), array( 'format' => 'table' ), 'handle' );
+			$this->render_cleanup_truncation_hint( count( $proposals ), $limit, 'proposal rows' );
+		}
+
+		if ( ! empty( $written ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( 'Written:' );
+			$written_rows = array_map(
+				fn( $row ) => array(
+					'handle' => $row['handle'] ?? '',
+					'branch' => $row['branch'] ?? '',
+					'state'  => $row['metadata']['lifecycle_state'] ?? '',
+				),
+				array_slice( $written, 0, $limit )
+			);
+			$this->format_items( $written_rows, array( 'handle', 'branch', 'state' ), array( 'format' => 'table' ), 'handle' );
+			$this->render_cleanup_truncation_hint( count( $written ), $limit, 'written rows' );
+		}
+
+		if ( ! empty( $skipped ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( 'Skipped:' );
+			$skipped_rows = array_map(
+				fn( $row ) => array(
+					'handle'      => $row['handle'] ?? '',
+					'reason_code' => $row['reason_code'] ?? '',
+					'reason'      => $verbose ? ( $row['reason'] ?? '' ) : $this->shorten_cleanup_reason( (string) ( $row['reason'] ?? '' ) ),
+				),
+				array_slice( $skipped, 0, $limit )
+			);
+			$this->format_items( $skipped_rows, array( 'handle', 'reason_code', 'reason' ), array( 'format' => 'table' ), 'handle' );
+			$this->render_cleanup_truncation_hint( count( $skipped ), $limit, 'skipped rows' );
+		}
+
+		WP_CLI::log( '' );
+		if ( ! empty( $result['dry_run'] ) ) {
+			WP_CLI::success( sprintf( '%d metadata reconciliation proposal(s). Review JSON, then apply with --apply-plan.', count( $proposals ) ) );
+			return;
+		}
+		WP_CLI::success( sprintf( 'Wrote metadata for %d worktree(s); %d skipped.', count( $written ), count( $skipped ) ) );
+	}
+
+	/**
 	 * Read and decode a cleanup plan file for --apply-plan.
 	 *
 	 * @param string $path Plan file path.
 	 * @return array
 	 */
 	private function read_worktree_cleanup_plan( string $path ): array {
+		return $this->read_worktree_json_plan( $path, 'cleanup' );
+	}
+
+	/**
+	 * Read and decode a JSON plan file for --apply-plan.
+	 *
+	 * @param string $path Plan file path.
+	 * @param string $label Human label for errors.
+	 * @return array
+	 */
+	private function read_worktree_json_plan( string $path, string $label ): array {
 		if ( '' === trim( $path ) ) {
 			WP_CLI::error( '--apply-plan requires a file path.' );
 			return array();
 		}
 
 		if ( ! is_readable( $path ) ) {
-			WP_CLI::error( sprintf( 'Cleanup plan is not readable: %s', $path ) );
+			WP_CLI::error( sprintf( '%s plan is not readable: %s', ucfirst( $label ), $path ) );
 			return array();
 		}
 
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		$raw = file_get_contents( $path );
 		if ( false === $raw ) {
-			WP_CLI::error( sprintf( 'Failed to read cleanup plan: %s', $path ) );
+			WP_CLI::error( sprintf( 'Failed to read %s plan: %s', $label, $path ) );
 			return array();
 		}
 
 		$decoded = json_decode( $raw, true );
 		if ( JSON_ERROR_NONE !== json_last_error() || ! is_array( $decoded ) ) {
-			WP_CLI::error( sprintf( 'Cleanup plan must be a JSON object: %s', json_last_error_msg() ) );
+			WP_CLI::error( sprintf( '%s plan must be a JSON object: %s', ucfirst( $label ), json_last_error_msg() ) );
 			return array();
 		}
 

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -2202,7 +2202,7 @@ class Workspace {
 		}
 
 		$listing = $this->worktree_list();
-		if ( is_wp_error( $listing ) ) {
+		if ( $listing instanceof \WP_Error ) {
 			return $listing;
 		}
 
@@ -2524,6 +2524,400 @@ class Workspace {
 			'removed'    => $removed,
 			'skipped'    => $skipped,
 			'summary'    => $this->build_worktree_cleanup_summary( $candidates, $removed, $skipped, $age_filter ),
+		);
+	}
+
+	/**
+	 * Reconcile lifecycle metadata for legacy worktrees without removing anything.
+	 *
+	 * Dry-runs build a reviewed plan from the current full git worktree listing.
+	 * Applying a plan revalidates handle/path/repo/branch before writing metadata.
+	 *
+	 * @param array $opts Options: dry_run bool, apply_plan array.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function worktree_reconcile_metadata( array $opts = array() ): array|\WP_Error {
+		$dry_run    = ! empty( $opts['dry_run'] );
+		$apply_plan = isset( $opts['apply_plan'] ) && is_array( $opts['apply_plan'] ) ? $opts['apply_plan'] : null;
+
+		if ( null !== $apply_plan ) {
+			return $this->apply_worktree_metadata_reconciliation_plan( $apply_plan );
+		}
+
+		if ( ! $dry_run ) {
+			return new \WP_Error( 'metadata_reconcile_requires_review', 'Metadata reconciliation is dry-run-first. Pass --dry-run to write a review plan, then --apply-plan=<file> after review.', array( 'status' => 400 ) );
+		}
+
+		$listing = $this->worktree_list();
+		if ( is_wp_error( $listing ) ) {
+			return $listing;
+		}
+
+		$proposals = array();
+		$skipped   = array();
+
+		foreach ( (array) ( $listing['worktrees'] ?? array() ) as $wt ) {
+			if ( ! empty( $wt['is_primary'] ) ) {
+				continue;
+			}
+
+			$proposal = $this->build_worktree_metadata_reconciliation_row( $wt );
+			if ( isset( $proposal['proposal'] ) ) {
+				$proposals[] = $proposal['proposal'];
+			} elseif ( isset( $proposal['skip'] ) ) {
+				$skipped[] = $proposal['skip'];
+			}
+		}
+
+		return array(
+			'success'        => true,
+			'dry_run'        => true,
+			'applied'        => false,
+			'generated_at'   => gmdate( 'c' ),
+			'workspace_path' => $this->workspace_path,
+			'proposals'      => $proposals,
+			'written'        => array(),
+			'skipped'        => $skipped,
+			'summary'        => $this->build_worktree_metadata_reconciliation_summary( count( (array) ( $listing['worktrees'] ?? array() ) ), $proposals, array(), $skipped ),
+		);
+	}
+
+	/**
+	 * Build one metadata reconciliation row for a current worktree listing row.
+	 *
+	 * @param array<string,mixed> $wt Worktree list row.
+	 * @return array{proposal?:array<string,mixed>,skip?:array<string,mixed>}
+	 */
+	private function build_worktree_metadata_reconciliation_row( array $wt ): array {
+		$handle   = (string) ( $wt['handle'] ?? '' );
+		$repo     = (string) ( $wt['repo'] ?? '' );
+		$branch   = (string) ( $wt['branch'] ?? '' );
+		$path     = (string) ( $wt['path'] ?? '' );
+		$metadata = is_array( $wt['metadata'] ?? null ) ? (array) $wt['metadata'] : array();
+
+		$base_row = array(
+			'handle'   => $handle,
+			'repo'     => $repo,
+			'branch'   => $branch,
+			'path'     => $path,
+			'metadata' => array() === $metadata ? null : $metadata,
+		);
+
+		if ( ! empty( $wt['external'] ) ) {
+			return array(
+				'skip' => array_merge(
+					$base_row,
+					array(
+						'reason_code' => 'external_worktree',
+						'reason'      => 'external worktree outside the DMC workspace',
+					)
+				),
+			);
+		}
+
+		$missing = array_values( array_filter( array(
+			'' === $handle ? 'handle' : '',
+			'' === $repo ? 'repo' : '',
+			'' === $branch ? 'branch' : '',
+			'' === $path ? 'path' : '',
+		) ) );
+		if ( array() !== $missing ) {
+			return array(
+				'skip' => array_merge(
+					$base_row,
+					array(
+						'reason_code'    => 'missing_identity',
+						'reason'         => 'current worktree row is missing required identity fields',
+						'missing_fields' => $missing,
+					)
+				),
+			);
+		}
+
+		$parsed = $this->parse_handle( $handle );
+		if ( empty( $parsed['is_worktree'] ) || $parsed['repo'] !== $repo ) {
+			return array(
+				'skip' => array_merge(
+					$base_row,
+					array(
+						'reason_code' => 'noncanonical_handle',
+						'reason'      => 'worktree is not represented by a canonical <repo>@<slug> workspace handle',
+					)
+				),
+			);
+		}
+
+		$proposed   = $metadata;
+		$source_map = array();
+		$this->set_reconciled_metadata_field( $proposed, $source_map, 'handle', $handle, 'filesystem' );
+		$this->set_reconciled_metadata_field( $proposed, $source_map, 'repo', $repo, 'filesystem' );
+		$this->set_reconciled_metadata_field( $proposed, $source_map, 'branch', $branch, 'git' );
+		$this->set_reconciled_metadata_field( $proposed, $source_map, 'path', $path, 'git' );
+
+		$created_source = '';
+		$created_at     = '';
+		foreach ( array( 'created_at', 'timestamp' ) as $key ) {
+			if ( ! empty( $metadata[ $key ] ) && false !== strtotime( (string) $metadata[ $key ] ) ) {
+				$created_at     = gmdate( 'c', (int) strtotime( (string) $metadata[ $key ] ) );
+				$created_source = 'metadata';
+				break;
+			}
+		}
+		if ( '' === $created_at ) {
+			$mtime = file_exists( $path ) ? filemtime( $path ) : false;
+			if ( false !== $mtime ) {
+				$created_at     = gmdate( 'c', (int) $mtime );
+				$created_source = 'filesystem';
+			}
+		}
+		if ( '' !== $created_at ) {
+			$this->set_reconciled_metadata_field( $proposed, $source_map, 'created_at', $created_at, $created_source );
+		}
+
+		$existing_state = isset( $metadata['lifecycle_state'] ) ? WorktreeContextInjector::normalize_state( (string) $metadata['lifecycle_state'] ) : null;
+		if ( null !== $existing_state ) {
+			$this->set_reconciled_metadata_field( $proposed, $source_map, 'lifecycle_state', $existing_state, 'metadata' );
+		} else {
+			$this->set_reconciled_metadata_field( $proposed, $source_map, 'lifecycle_state', WorktreeContextInjector::STATE_ACTIVE, 'operator_plan' );
+		}
+
+		$missing_after = array_values( array_filter( array(
+			empty( $proposed['created_at'] ) ? 'created_at' : '',
+			empty( $proposed['lifecycle_state'] ) ? 'lifecycle_state' : '',
+		) ) );
+		if ( array() !== $missing_after ) {
+			return array(
+				'skip' => array_merge(
+					$base_row,
+					array(
+						'reason_code'    => 'insufficient_signal',
+						'reason'         => 'not enough stable metadata could be inferred safely',
+						'missing_fields' => $missing_after,
+					)
+				),
+			);
+		}
+
+		$metadata_missing = array();
+		foreach ( array( 'handle', 'repo', 'branch', 'path', 'created_at', 'lifecycle_state' ) as $field ) {
+			if ( ! array_key_exists( $field, $metadata ) || '' === (string) $metadata[ $field ] ) {
+				$metadata_missing[] = $field;
+			}
+		}
+
+		if ( array() === $metadata_missing ) {
+			return array();
+		}
+
+		return array(
+			'proposal' => array_merge(
+				$base_row,
+				array(
+					'reason_code'       => 'metadata_backfill',
+					'reason'            => 'legacy worktree metadata can be backfilled without changing cleanup eligibility',
+					'dirty'             => (int) ( $wt['dirty'] ?? 0 ),
+					'unpushed'          => $this->count_unpushed_commits( $path ),
+					'missing_fields'    => $metadata_missing,
+					'proposed_metadata' => $proposed,
+					'source_map'        => $source_map,
+				)
+			),
+		);
+	}
+
+	/**
+	 * Set a reconciled metadata field and record its source.
+	 *
+	 * @param array<string,mixed> $metadata Metadata under construction.
+	 * @param array<string,string> $source_map Field source map.
+	 * @param string $field Field name.
+	 * @param mixed  $value Field value.
+	 * @param string $source Source label.
+	 */
+	private function set_reconciled_metadata_field( array &$metadata, array &$source_map, string $field, mixed $value, string $source ): void {
+		if ( null === $value || '' === (string) $value ) {
+			return;
+		}
+		$metadata[ $field ]    = $value;
+		$source_map[ $field ]  = $source;
+	}
+
+	/**
+	 * Apply a reviewed metadata reconciliation plan after exact revalidation.
+	 *
+	 * @param array<string,mixed> $plan Dry-run plan.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private function apply_worktree_metadata_reconciliation_plan( array $plan ): array|\WP_Error {
+		$planned = $this->extract_worktree_metadata_reconciliation_plan( $plan );
+		if ( $planned instanceof \WP_Error ) {
+			return $planned;
+		}
+
+		$listing = $this->worktree_list();
+		if ( $listing instanceof \WP_Error ) {
+			return $listing;
+		}
+
+		$current_by_handle = array();
+		foreach ( (array) ( $listing['worktrees'] ?? array() ) as $wt ) {
+			$handle = (string) ( $wt['handle'] ?? '' );
+			if ( '' !== $handle ) {
+				$current_by_handle[ $handle ] = $wt;
+			}
+		}
+
+		$written = array();
+		$skipped = array();
+		foreach ( $planned as $row ) {
+			$handle  = (string) ( $row['handle'] ?? '' );
+			$current = $current_by_handle[ $handle ] ?? null;
+			if ( null === $current ) {
+				$skipped[] = $this->build_reconcile_apply_skip( $row, null, 'plan_not_current', 'planned worktree is no longer present in the current listing' );
+				continue;
+			}
+
+			$mismatches = array();
+			foreach ( array( 'repo', 'branch', 'path' ) as $field ) {
+				if ( (string) ( $row[ $field ] ?? '' ) !== (string) ( $current[ $field ] ?? '' ) ) {
+					$mismatches[] = sprintf( '%s planned=%s current=%s', $field, (string) ( $row[ $field ] ?? '' ), (string) ( $current[ $field ] ?? '' ) );
+				}
+			}
+			if ( array() !== $mismatches ) {
+				$skipped[] = $this->build_reconcile_apply_skip( $row, $current, 'plan_identity_mismatch', 'planned identity does not match current row: ' . implode( '; ', $mismatches ) );
+				continue;
+			}
+
+			$metadata   = (array) ( $row['proposed_metadata'] ?? array() );
+			$source_map = (array) ( $row['source_map'] ?? array() );
+			$state      = WorktreeContextInjector::normalize_state( (string) ( $metadata['lifecycle_state'] ?? '' ) );
+			if ( null === $state ) {
+				$skipped[] = $this->build_reconcile_apply_skip( $row, $current, 'invalid_lifecycle_state', 'proposed lifecycle_state is invalid' );
+				continue;
+			}
+			$metadata['lifecycle_state'] = $state;
+
+			if ( WorktreeContextInjector::STATE_CLEANUP_ELIGIBLE === $state ) {
+				$dirty    = (int) ( $current['dirty'] ?? 0 );
+				$unpushed = $this->count_unpushed_commits( (string) ( $current['path'] ?? '' ) );
+				if ( $dirty > 0 || $unpushed > 0 ) {
+					$skipped[] = $this->build_reconcile_apply_skip( $row, $current, 'unsafe_cleanup_eligible_state', 'refusing to mark dirty or unpushed worktree cleanup_eligible from a reconciliation plan' );
+					continue;
+				}
+			}
+
+			foreach ( array( 'handle', 'repo', 'branch', 'path', 'created_at', 'lifecycle_state' ) as $field ) {
+				if ( ! isset( $source_map[ $field ] ) || '' === (string) $source_map[ $field ] ) {
+					$skipped[] = $this->build_reconcile_apply_skip( $row, $current, 'missing_source_map', sprintf( 'proposed field %s is missing a source', $field ) );
+					continue 2;
+				}
+			}
+
+			$metadata['reconciled_at']      = gmdate( 'c' );
+			$metadata['reconciled_sources'] = $source_map;
+			WorktreeContextInjector::store_lifecycle_metadata( $handle, $metadata );
+
+			$written[] = array(
+				'handle'   => $handle,
+				'repo'     => (string) ( $current['repo'] ?? '' ),
+				'branch'   => (string) ( $current['branch'] ?? '' ),
+				'path'     => (string) ( $current['path'] ?? '' ),
+				'metadata' => WorktreeContextInjector::get_metadata( $handle ),
+			);
+		}
+
+		return array(
+			'success'        => true,
+			'dry_run'        => false,
+			'applied'        => true,
+			'generated_at'   => gmdate( 'c' ),
+			'workspace_path' => $this->workspace_path,
+			'proposals'      => $planned,
+			'written'        => $written,
+			'skipped'        => $skipped,
+			'summary'        => $this->build_worktree_metadata_reconciliation_summary( count( (array) ( $listing['worktrees'] ?? array() ) ), $planned, $written, $skipped ),
+		);
+	}
+
+	/**
+	 * Extract reconciliation proposals from a dry-run plan.
+	 *
+	 * @param array<string,mixed> $plan Plan file.
+	 * @return array<int,array<string,mixed>>|\WP_Error
+	 */
+	private function extract_worktree_metadata_reconciliation_plan( array $plan ): array|\WP_Error {
+		$proposals = $plan['proposals'] ?? null;
+		if ( ! is_array( $proposals ) ) {
+			return new \WP_Error( 'invalid_metadata_reconcile_plan', 'Metadata reconciliation plan must contain a proposals array.', array( 'status' => 400 ) );
+		}
+
+		foreach ( $proposals as $index => $row ) {
+			if ( ! is_array( $row ) ) {
+				return new \WP_Error( 'invalid_metadata_reconcile_plan', sprintf( 'Plan proposal #%d is not an object.', (int) $index ), array( 'status' => 400 ) );
+			}
+			foreach ( array( 'handle', 'repo', 'branch', 'path', 'proposed_metadata', 'source_map' ) as $field ) {
+				if ( ! array_key_exists( $field, $row ) || ( is_string( $row[ $field ] ) && '' === trim( $row[ $field ] ) ) ) {
+					return new \WP_Error( 'invalid_metadata_reconcile_plan', sprintf( 'Plan proposal #%d is missing %s.', (int) $index, $field ), array( 'status' => 400 ) );
+				}
+			}
+		}
+
+		return array_values( $proposals );
+	}
+
+	/**
+	 * Build an apply skip row.
+	 *
+	 * @param array<string,mixed>      $planned Planned row.
+	 * @param array<string,mixed>|null $current Current row.
+	 * @param string                   $code Reason code.
+	 * @param string                   $reason Human reason.
+	 * @return array<string,mixed>
+	 */
+	private function build_reconcile_apply_skip( array $planned, ?array $current, string $code, string $reason ): array {
+		return array(
+			'handle'      => (string) ( $planned['handle'] ?? '' ),
+			'repo'        => (string) ( $current['repo'] ?? $planned['repo'] ?? '' ),
+			'branch'      => (string) ( $current['branch'] ?? $planned['branch'] ?? '' ),
+			'path'        => (string) ( $current['path'] ?? $planned['path'] ?? '' ),
+			'reason_code' => $code,
+			'reason'      => $reason,
+			'planned'     => $planned,
+			'current'     => $current,
+		);
+	}
+
+	/**
+	 * Build stable reconciliation summary counts.
+	 *
+	 * @param int   $inspected Worktree rows inspected.
+	 * @param array $proposals Proposal rows.
+	 * @param array $written Written rows.
+	 * @param array $skipped Skipped rows.
+	 * @return array<string,mixed>
+	 */
+	private function build_worktree_metadata_reconciliation_summary( int $inspected, array $proposals, array $written, array $skipped ): array {
+		$skipped_by_reason = array();
+		foreach ( $skipped as $row ) {
+			$code                       = (string) ( $row['reason_code'] ?? 'unknown' );
+			$skipped_by_reason[ $code ] = ( $skipped_by_reason[ $code ] ?? 0 ) + 1;
+		}
+		ksort( $skipped_by_reason );
+
+		$states = array();
+		foreach ( $proposals as $row ) {
+			$state            = (string) ( $row['proposed_metadata']['lifecycle_state'] ?? 'unknown' );
+			$states[ $state ] = ( $states[ $state ] ?? 0 ) + 1;
+		}
+		ksort( $states );
+
+		return array(
+			'inspected'         => $inspected,
+			'proposed'          => count( $proposals ),
+			'written'           => count( $written ),
+			'skipped'           => count( $skipped ),
+			'skipped_by_reason' => $skipped_by_reason,
+			'proposed_by_state' => $states,
 		);
 	}
 

--- a/tests/smoke-worktree-metadata-reconcile.php
+++ b/tests/smoke-worktree-metadata-reconcile.php
@@ -1,0 +1,256 @@
+<?php
+/**
+ * Smoke test for legacy worktree metadata reconciliation.
+ *
+ * Run: php tests/smoke-worktree-metadata-reconcile.php
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Core\FilesRepository {
+	if ( ! class_exists( __NAMESPACE__ . '\FilesystemHelper' ) ) {
+		class FilesystemHelper {
+			public static function get() {
+				return null;
+			}
+		}
+	}
+}
+
+namespace DataMachineCode\Abilities {
+	if ( ! class_exists( __NAMESPACE__ . '\GitHubAbilities' ) ) {
+		class GitHubAbilities {
+			public static function getPat(): string {
+				return '';
+			}
+			public static function apiGet( string $url, array $params, string $pat ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+				return array( 'data' => array() );
+			}
+		}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			public string $code;
+			public string $message;
+			public array $data;
+			public function __construct( $code = '', $message = '', $data = array() ) {
+				$this->code    = (string) $code;
+				$this->message = (string) $message;
+				$this->data    = (array) $data;
+			}
+			public function get_error_message(): string {
+				return $this->message;
+			}
+			public function get_error_code(): string {
+				return $this->code;
+			}
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $thing ): bool {
+			return $thing instanceof \WP_Error;
+		}
+	}
+
+	if ( ! function_exists( 'wp_mkdir_p' ) ) {
+		function wp_mkdir_p( string $path ): bool {
+			return is_dir( $path ) || mkdir( $path, 0755, true );
+		}
+	}
+
+	if ( ! function_exists( 'get_option' ) ) {
+		function get_option( string $name, $default_value = false ) {
+			global $datamachine_code_test_options;
+			return $datamachine_code_test_options[ $name ] ?? $default_value;
+		}
+	}
+
+	if ( ! function_exists( 'update_option' ) ) {
+		function update_option( string $name, $value, $autoload = null ): bool { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+			global $datamachine_code_test_options;
+			$datamachine_code_test_options[ $name ] = $value;
+			return true;
+		}
+	}
+
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( string $hook_name, $value ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+			return $value;
+		}
+	}
+
+	if ( ! function_exists( 'size_format' ) ) {
+		function size_format( $bytes ): string {
+			return (string) $bytes;
+		}
+	}
+
+	require __DIR__ . '/../inc/Support/GitHubRemote.php';
+	require __DIR__ . '/../inc/Support/GitRunner.php';
+	require __DIR__ . '/../inc/Support/PathSecurity.php';
+	require __DIR__ . '/../inc/Workspace/WorkspaceMutationLock.php';
+	require __DIR__ . '/../inc/Workspace/WorktreeDiskBudget.php';
+	require __DIR__ . '/../inc/Workspace/WorktreeContextInjector.php';
+	require __DIR__ . '/../inc/Workspace/Workspace.php';
+
+	exec( 'git --version 2>&1', $_gv, $gv_exit );
+	if ( 0 !== $gv_exit ) {
+		echo "SKIP: git not available\n";
+		exit( 0 );
+	}
+
+	$tmp = sys_get_temp_dir() . '/dmc-reconcile-smoke-' . bin2hex( random_bytes( 4 ) );
+	mkdir( $tmp, 0755, true );
+	register_shutdown_function( function () use ( $tmp ) {
+		if ( is_dir( $tmp ) ) {
+			exec( 'rm -rf ' . escapeshellarg( $tmp ) );
+		}
+	} );
+
+	define( 'DATAMACHINE_WORKSPACE_PATH', realpath( $tmp ) ? realpath( $tmp ) : $tmp );
+
+	$failures = 0;
+	$total    = 0;
+	$datamachine_code_test_options = array();
+
+	$assert = function ( $expected, $actual, string $message ) use ( &$failures, &$total ): void {
+		$total++;
+		if ( $expected === $actual ) {
+			echo "  ✓ {$message}\n";
+			return;
+		}
+		$failures++;
+		echo "  ✗ {$message}\n";
+		echo '    expected: ' . var_export( $expected, true ) . "\n";
+		echo '    actual:   ' . var_export( $actual, true ) . "\n";
+	};
+
+	$run = function ( string $cmd, string $cwd = '' ): array {
+		$full = '' === $cwd ? $cmd : sprintf( 'cd %s && %s', escapeshellarg( $cwd ), $cmd );
+		exec( $full . ' 2>&1', $out, $rc );
+		return array(
+			'output' => implode( "\n", $out ),
+			'exit'   => $rc,
+		);
+	};
+
+	echo "Setting up workspace at {$tmp}\n";
+	$remote  = $tmp . '/remote.git';
+	$primary = $tmp . '/demo';
+	$run( sprintf( 'git init --bare %s', escapeshellarg( $remote ) ) );
+	$run( sprintf( 'git clone %s %s', escapeshellarg( $remote ), escapeshellarg( $primary ) ) );
+	$run( 'git config user.email test@example.com', $primary );
+	$run( 'git config user.name test', $primary );
+	file_put_contents( $primary . '/README.md', "demo\n" );
+	$run( 'git add README.md && git commit -m init', $primary );
+	$run( 'git branch -M main', $primary );
+	$run( 'git push -u origin main', $primary );
+
+	$make_branch = function ( string $branch ) use ( $primary, $run ): void {
+		$run( sprintf( 'git checkout -b %s', escapeshellarg( $branch ) ), $primary );
+		file_put_contents( $primary . '/' . str_replace( '/', '-', $branch ) . '.txt', $branch );
+		$run( sprintf( 'git add . && git commit -m %s', escapeshellarg( 'work on ' . $branch ) ), $primary );
+		$run( sprintf( 'git push -u origin %s', escapeshellarg( $branch ) ), $primary );
+		$run( 'git checkout main', $primary );
+	};
+	$make_branch( 'legacy-missing' );
+	$make_branch( 'legacy-partial' );
+	$make_branch( 'legacy-dirty' );
+	$make_branch( 'already-current' );
+
+	$run( sprintf( 'git worktree add %s legacy-missing', escapeshellarg( $tmp . '/demo@legacy-missing' ) ), $primary );
+	$run( sprintf( 'git worktree add %s legacy-partial', escapeshellarg( $tmp . '/demo@legacy-partial' ) ), $primary );
+	$run( sprintf( 'git worktree add %s legacy-dirty', escapeshellarg( $tmp . '/demo@legacy-dirty' ) ), $primary );
+	$run( sprintf( 'git worktree add %s already-current', escapeshellarg( $tmp . '/demo@already-current' ) ), $primary );
+	file_put_contents( $tmp . '/demo@legacy-dirty/scratch.txt', 'dirty' );
+
+	\DataMachineCode\Workspace\WorktreeContextInjector::store_metadata(
+		'demo@legacy-partial',
+		array(
+			'site_url'   => 'http://example.test',
+			'site_name'  => 'Example',
+			'agent_slug' => 'agent-one',
+			'abspath'    => '/example',
+			'timestamp'  => '2026-04-01T00:00:00+00:00',
+		)
+	);
+	\DataMachineCode\Workspace\WorktreeContextInjector::store_lifecycle_metadata(
+		'demo@already-current',
+		array(
+			'handle'          => 'demo@already-current',
+			'repo'            => 'demo',
+			'branch'          => 'already-current',
+			'path'            => $tmp . '/demo@already-current',
+			'created_at'      => '2026-04-01T00:00:00+00:00',
+			'lifecycle_state' => \DataMachineCode\Workspace\WorktreeContextInjector::STATE_ACTIVE,
+		)
+	);
+
+	$ws = new \DataMachineCode\Workspace\Workspace();
+
+	echo "\nDry-run reconciliation\n";
+	$plan = $ws->worktree_reconcile_metadata( array( 'dry_run' => true ) );
+	$assert( true, ! is_wp_error( $plan ) && ( $plan['success'] ?? false ), 'dry-run succeeds' );
+	$assert( true, $plan['dry_run'] ?? false, 'dry-run flag is true' );
+	$assert( 3, (int) ( $plan['summary']['proposed'] ?? 0 ), 'dry-run proposes only legacy rows' );
+	$assert( 0, (int) ( $plan['summary']['written'] ?? 0 ), 'dry-run writes nothing' );
+
+	$by_handle = array();
+	foreach ( $plan['proposals'] as $row ) {
+		$by_handle[ $row['handle'] ] = $row;
+	}
+	$assert( 'operator_plan', $by_handle['demo@legacy-missing']['source_map']['lifecycle_state'] ?? '', 'missing metadata lifecycle source is operator_plan' );
+	$assert( 'filesystem', $by_handle['demo@legacy-missing']['source_map']['created_at'] ?? '', 'missing metadata created_at source is filesystem' );
+	$assert( 'metadata', $by_handle['demo@legacy-partial']['source_map']['created_at'] ?? '', 'partial metadata preserves created_at source' );
+	$assert( 'git', $by_handle['demo@legacy-partial']['source_map']['branch'] ?? '', 'branch source is git' );
+	$assert( 1, (int) ( $by_handle['demo@legacy-dirty']['dirty'] ?? 0 ), 'dirty row is visible but not cleanup-eligible' );
+	$assert( \DataMachineCode\Workspace\WorktreeContextInjector::STATE_ACTIVE, $by_handle['demo@legacy-dirty']['proposed_metadata']['lifecycle_state'] ?? '', 'dirty row proposal stays active' );
+	$stale_plan  = $plan;
+	$unsafe_plan = $plan;
+
+	$inventory_before = $ws->worktree_cleanup_merged( array( 'dry_run' => true, 'inventory_only' => true, 'skip_github' => true ) );
+	$assert( 2, (int) ( $inventory_before['summary']['skipped_by_reason']['requires_full_scan'] ?? 0 ), 'inventory cleanup sees missing metadata before apply' );
+
+	echo "\nApply reviewed plan\n";
+	$apply = $ws->worktree_reconcile_metadata( array( 'apply_plan' => $plan ) );
+	$assert( true, ! is_wp_error( $apply ) && ( $apply['success'] ?? false ), 'apply succeeds' );
+	$assert( 3, (int) ( $apply['summary']['written'] ?? 0 ), 'apply writes exact current matches' );
+	$assert( 0, (int) ( $apply['summary']['skipped'] ?? 0 ), 'apply skips nothing for current plan' );
+	$stored = \DataMachineCode\Workspace\WorktreeContextInjector::get_metadata( 'demo@legacy-missing' );
+	$assert( 'demo@legacy-missing', $stored['handle'] ?? '', 'stored metadata includes handle' );
+	$assert( 'operator_plan', $stored['reconciled_sources']['lifecycle_state'] ?? '', 'stored metadata keeps source map' );
+
+	$inventory_after = $ws->worktree_cleanup_merged( array( 'dry_run' => true, 'inventory_only' => true, 'skip_github' => true ) );
+	$assert( 0, (int) ( $inventory_after['summary']['skipped_by_reason']['requires_full_scan'] ?? 0 ), 'inventory cleanup requires fewer full scans after apply' );
+
+	echo "\nSafety gates\n";
+	$stale_plan['proposals'][0]['branch'] = 'wrong-branch';
+	$stale_apply = $ws->worktree_reconcile_metadata( array( 'apply_plan' => $stale_plan ) );
+	$assert( 'plan_identity_mismatch', $stale_apply['skipped'][0]['reason_code'] ?? '', 'apply revalidates branch identity before writing' );
+
+	foreach ( $unsafe_plan['proposals'] as &$row ) {
+		if ( 'demo@legacy-dirty' === $row['handle'] ) {
+			$row['proposed_metadata']['lifecycle_state'] = \DataMachineCode\Workspace\WorktreeContextInjector::STATE_CLEANUP_ELIGIBLE;
+			$row['source_map']['lifecycle_state']        = 'operator_plan';
+		}
+	}
+	unset( $row );
+	$unsafe_apply = $ws->worktree_reconcile_metadata( array( 'apply_plan' => $unsafe_plan ) );
+	$unsafe_skips = array_values( array_filter( $unsafe_apply['skipped'] ?? array(), fn( $row ) => 'demo@legacy-dirty' === ( $row['handle'] ?? '' ) ) );
+	$assert( 'unsafe_cleanup_eligible_state', $unsafe_skips[0]['reason_code'] ?? '', 'dirty worktree cannot become cleanup_eligible through reconciliation plan' );
+
+	if ( $failures > 0 ) {
+		echo "\n{$failures} / {$total} assertions failed.\n";
+		exit( 1 );
+	}
+
+	echo "\nAll {$total} worktree metadata reconciliation assertions passed.\n";
+}


### PR DESCRIPTION
## Summary
- Adds a dry-run-first metadata reconciliation path for legacy DMC worktrees that predate lifecycle metadata.
- Lets reviewed plans backfill identity, timestamps, and active lifecycle state without deleting worktrees or inferring cleanup eligibility.

## Changes
- Adds `datamachine/workspace-worktree-reconcile-metadata` and `wp datamachine-code workspace worktree reconcile-metadata`.
- Dry-run emits JSON proposals with per-field source maps (`metadata`, `git`, `filesystem`, `operator_plan`).
- `--apply-plan` revalidates current handle, repo, branch, and path before writing metadata and refuses unsafe `cleanup_eligible` writes for dirty/unpushed worktrees.
- Adds a pure-PHP smoke covering dry-run proposals, exact-match apply, inventory-only cleanup improvement, stale-plan rejection, and dirty cleanup-eligible refusal.

## Tests
- `php -l inc/Workspace/Workspace.php && php -l inc/Cli/Commands/WorkspaceCommand.php && php -l inc/Abilities/WorkspaceAbilities.php && php -l tests/smoke-worktree-metadata-reconcile.php`
- `php tests/smoke-worktree-metadata-reconcile.php`
- `php tests/smoke-worktree-cleanup.php`
- `php tests/smoke-worktree-lifecycle-metadata.php`
- `php tests/smoke-worktree-finalizer-cli.php`
- `homeboy lint data-machine-code --path /Users/chubes/Developer/data-machine-code@feat-legacy-worktree-metadata-reconcile --changed-since origin/main --summary` (reported clean, but scanned 0 files)
- `homeboy audit data-machine-code --path /Users/chubes/Developer/data-machine-code@feat-legacy-worktree-metadata-reconcile --changed-since origin/main` (reported clean, but scanned 0 files)

Closes #158

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the reconciliation command/ability and smoke test; Chris to review and validate before merge.