### PR TITLE
feat(code-task): scaffold tasks from evidence packets

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -48,6 +48,7 @@ function datamachine_code_bootstrap() {
 	new \DataMachineCode\Abilities\GitHubAbilities();
 	new \DataMachineCode\Abilities\WorkspaceAbilities();
 	new \DataMachineCode\Abilities\GitSyncAbilities();
+	new \DataMachineCode\Abilities\CodeTaskAbilities();
 
 	// Load Handlers (they self-register).
 	new \DataMachineCode\Handlers\GitHub\GitHub();
@@ -98,6 +99,14 @@ function datamachine_code_register_ability_categories() {
 		array(
 			'label'       => __( 'GitSync', 'data-machine-code' ),
 			'description' => __( 'Bind site-owned directories to remote git repositories with pull/status/list semantics.', 'data-machine-code' ),
+		)
+	);
+
+	wp_register_ability_category(
+		'datamachine-code-code-task',
+		array(
+			'label'       => __( 'Code Tasks', 'data-machine-code' ),
+			'description' => __( 'Create isolated coding tasks from structured source evidence packets.', 'data-machine-code' ),
 		)
 	);
 }
@@ -183,6 +192,7 @@ function datamachine_code_register_cli_commands() {
 	\WP_CLI::add_command( 'datamachine-code github', \DataMachineCode\Cli\Commands\GitHubCommand::class );
 	\WP_CLI::add_command( 'datamachine-code workspace', \DataMachineCode\Cli\Commands\WorkspaceCommand::class );
 	\WP_CLI::add_command( 'datamachine-code gitsync', \DataMachineCode\Cli\Commands\GitSyncCommand::class );
+	\WP_CLI::add_command( 'datamachine-code code-task', \DataMachineCode\Cli\Commands\CodeTaskCommand::class );
 }
 add_action( 'plugins_loaded', 'datamachine_code_register_cli_commands', 21 );
 

--- a/inc/Abilities/CodeTaskAbilities.php
+++ b/inc/Abilities/CodeTaskAbilities.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Code-task abilities.
+ *
+ * @package DataMachineCode\Abilities
+ */
+
+namespace DataMachineCode\Abilities;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachineCode\CodeTask\CodeTaskCreator;
+use DataMachineCode\CodeTask\EvidencePacket;
+
+defined( 'ABSPATH' ) || exit;
+
+class CodeTaskAbilities {
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) || self::$registered ) {
+			return;
+		}
+
+		add_action( 'wp_abilities_api_init', array( $this, 'register' ) );
+		self::$registered = true;
+	}
+
+	public function register(): void {
+		wp_register_ability(
+			'datamachine/create-code-task',
+			array(
+				'label'               => 'Create Code Task',
+				'description'         => 'Create an isolated workspace worktree from a structured evidence packet.',
+				'category'            => 'datamachine-code-code-task',
+				'input_schema'        => self::input_schema(),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success'     => array( 'type' => 'boolean' ),
+						'repo'        => array( 'type' => 'string' ),
+						'branch'      => array( 'type' => 'string' ),
+						'handle'      => array( 'type' => 'string' ),
+						'path'        => array( 'type' => 'string' ),
+						'prompt_path' => array( 'type' => 'string' ),
+						'packet_path' => array( 'type' => 'string' ),
+						'source_url'  => array( 'type' => 'string' ),
+					),
+				),
+				'execute_callback'    => array( self::class, 'create' ),
+				'permission_callback' => fn() => PermissionHelper::can_manage(),
+				'meta'                => array( 'show_in_rest' => false ),
+			)
+		);
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	public static function input_schema(): array {
+		return array(
+			'type'       => 'object',
+			'required'   => array( 'packet' ),
+			'properties' => array(
+				'packet'      => array(
+					'type'        => 'object',
+					'description' => 'Structured evidence packet describing the source evidence and target repository.',
+				),
+				'branch'      => array(
+					'type'        => 'string',
+					'description' => 'Optional explicit branch name. Defaults to deterministic code-task/<source>-<title>-<hash>.',
+				),
+				'base_ref'    => array(
+					'type'        => 'string',
+					'description' => 'Optional base ref for the worktree. Defaults to origin/main.',
+				),
+				'allow_stale' => array( 'type' => 'boolean' ),
+				'force'       => array( 'type' => 'boolean' ),
+			),
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $input Ability input.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public static function create( array $input ): array|\WP_Error {
+		$packet = EvidencePacket::from_array( $input['packet'] ?? null );
+		if ( $packet instanceof \WP_Error ) {
+			return $packet;
+		}
+
+		$creator = new CodeTaskCreator();
+		return $creator->create( $packet, $input );
+	}
+}

--- a/inc/Cli/Commands/CodeTaskCommand.php
+++ b/inc/Cli/Commands/CodeTaskCommand.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * WP-CLI code-task command.
+ *
+ * @package DataMachineCode\Cli\Commands
+ */
+
+namespace DataMachineCode\Cli\Commands;
+
+use DataMachine\Cli\BaseCommand;
+use WP_CLI;
+
+defined( 'ABSPATH' ) || exit;
+
+class CodeTaskCommand extends BaseCommand {
+
+	/**
+	 * Create a workspace coding task from an evidence packet.
+	 *
+	 * ## OPTIONS
+	 *
+	 * --packet=<path>
+	 * : Path to a JSON evidence packet file.
+	 *
+	 * [--branch=<branch>]
+	 * : Optional explicit branch name.
+	 *
+	 * [--base-ref=<ref>]
+	 * : Optional base ref for the worktree. Defaults to origin/main.
+	 *
+	 * [--allow-stale]
+	 * : Allow creating a worktree from a stale base.
+	 *
+	 * [--force]
+	 * : Override workspace disk-budget refusal threshold.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-code code-task create --packet=packet.json --format=json
+	 *
+	 * @subcommand create
+	 */
+	public function create( array $args, array $assoc_args ): void {
+		if ( empty( $assoc_args['packet'] ) ) {
+			WP_CLI::error( 'Usage: wp datamachine-code code-task create --packet=<packet.json> [--format=json]' );
+			return;
+		}
+
+		$packet = $this->read_packet_file( (string) $assoc_args['packet'] );
+		$input  = array( 'packet' => $packet );
+		foreach ( array( 'branch', 'base-ref' ) as $key ) {
+			if ( isset( $assoc_args[ $key ] ) && '' !== trim( (string) $assoc_args[ $key ] ) ) {
+				$input[ str_replace( '-', '_', $key ) ] = (string) $assoc_args[ $key ];
+			}
+		}
+
+		$input['allow_stale'] = ! empty( $assoc_args['allow-stale'] );
+		$input['force']       = ! empty( $assoc_args['force'] );
+
+		$ability = wp_get_ability( 'datamachine/create-code-task' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'Code-task ability not available.' );
+			return;
+		}
+
+		$result = $ability->execute( $input );
+		if ( $result instanceof \WP_Error ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
+
+		if ( 'json' === ( $assoc_args['format'] ?? 'table' ) ) {
+			WP_CLI::log( wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		$this->format_items(
+			array(
+				array(
+					'repo'        => $result['repo'] ?? '',
+					'branch'      => $result['branch'] ?? '',
+					'handle'      => $result['handle'] ?? '',
+					'prompt_path' => $result['prompt_path'] ?? '',
+					'source_url'  => $result['source_url'] ?? '',
+				),
+			),
+			array( 'repo', 'branch', 'handle', 'prompt_path', 'source_url' ),
+			$assoc_args,
+			'repo'
+		);
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	private function read_packet_file( string $path ): array {
+		if ( ! is_file( $path ) || ! is_readable( $path ) ) {
+			WP_CLI::error( sprintf( 'Packet file not readable: %s', $path ) );
+			return array();
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$json = file_get_contents( $path );
+		if ( false === $json ) {
+			WP_CLI::error( sprintf( 'Failed to read packet file: %s', $path ) );
+			return array();
+		}
+
+		$decoded = json_decode( $json, true );
+		if ( JSON_ERROR_NONE !== json_last_error() || ! is_array( $decoded ) ) {
+			WP_CLI::error( sprintf( 'Packet file is not valid JSON object: %s', $path ) );
+			return array();
+		}
+
+		return $decoded;
+	}
+}

--- a/inc/CodeTask/CodeTaskCreator.php
+++ b/inc/CodeTask/CodeTaskCreator.php
@@ -1,0 +1,250 @@
+<?php
+/**
+ * Create isolated code-task worktrees from evidence packets.
+ *
+ * @package DataMachineCode\CodeTask
+ */
+
+namespace DataMachineCode\CodeTask;
+
+use DataMachineCode\Workspace\Workspace;
+use DataMachineCode\Workspace\WorkspaceWriter;
+
+defined( 'ABSPATH' ) || exit;
+
+class CodeTaskCreator {
+
+	private CodeTaskWorkspaceInterface $workspace;
+	private CodeTaskEvidenceWriterInterface $writer;
+
+	public function __construct( ?CodeTaskWorkspaceInterface $workspace = null, ?CodeTaskEvidenceWriterInterface $writer = null ) {
+		$workspace       = $workspace ?? new WorkspaceCodeTaskWorkspace( new Workspace() );
+		$this->workspace = $workspace;
+		$this->writer    = $writer ?? new WorkspaceCodeTaskEvidenceWriter( new WorkspaceWriter( $workspace->workspace() ) );
+	}
+
+	/**
+	 * Create a code-task worktree and write deterministic evidence files.
+	 *
+	 * @param EvidencePacket      $packet Packet to scaffold.
+	 * @param array<string,mixed> $args Optional creation args.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function create( EvidencePacket $packet, array $args = array() ): array|\WP_Error {
+		$repo = self::resolve_repo( $packet->repo() );
+		if ( $repo instanceof \WP_Error ) {
+			return $repo;
+		}
+
+		$branch = isset( $args['branch'] ) && '' !== trim( (string) $args['branch'] )
+			? self::sanitize_branch( (string) $args['branch'] )
+			: self::build_branch_name( $packet );
+
+		if ( '' === $branch ) {
+			return new \WP_Error( 'invalid_branch', 'Could not derive a safe branch name for the code task.', array( 'status' => 400 ) );
+		}
+
+		$primary_path = $this->workspace->get_primary_path( $repo['name'] );
+		$cloned       = false;
+		if ( ! is_dir( $primary_path ) ) {
+			$clone = $this->workspace->clone_repo( $repo['url'], $repo['name'] );
+			if ( $clone instanceof \WP_Error ) {
+				return $clone;
+			}
+
+			$cloned = true;
+		}
+
+		$base_ref = isset( $args['base_ref'] ) && '' !== trim( (string) $args['base_ref'] )
+			? (string) $args['base_ref']
+			: 'origin/main';
+
+		$worktree = $this->workspace->worktree_add(
+			$repo['name'],
+			$branch,
+			$base_ref,
+			true,
+			true,
+			! empty( $args['allow_stale'] ),
+			false,
+			! empty( $args['force'] )
+		);
+
+		if ( $worktree instanceof \WP_Error ) {
+			return $worktree;
+		}
+
+		$handle       = (string) ( $worktree['handle'] ?? $repo['name'] . '@' . str_replace( '/', '-', $branch ) );
+		$prompt_path  = '.datamachine-code/code-task.md';
+		$packet_path  = '.datamachine-code/evidence-packet.json';
+		$packet_json  = wp_json_encode( $packet->to_array(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+		$packet_json  = false === $packet_json ? '{}' : $packet_json;
+		$prompt_write = $this->writer->write_file( $handle, $prompt_path, self::render_prompt( $packet, $repo, $branch ) );
+		if ( $prompt_write instanceof \WP_Error ) {
+			return $prompt_write;
+		}
+
+		$packet_write = $this->writer->write_file(
+			$handle,
+			$packet_path,
+			$packet_json . "\n"
+		);
+		if ( $packet_write instanceof \WP_Error ) {
+			return $packet_write;
+		}
+
+		return array(
+			'success'      => true,
+			'repo'         => $repo['slug'],
+			'repo_name'    => $repo['name'],
+			'repo_url'     => $repo['url'],
+			'cloned'       => $cloned,
+			'branch'       => $branch,
+			'handle'       => $handle,
+			'path'         => $worktree['path'] ?? $this->workspace->get_repo_path( $handle ),
+			'prompt_path'  => $prompt_path,
+			'packet_path'  => $packet_path,
+			'source'       => $packet->source(),
+			'source_url'   => $packet->source_url(),
+			'pr_title'     => $packet->title(),
+			'pr_body_seed' => self::render_pr_body_seed( $packet ),
+			'worktree'     => $worktree,
+		);
+	}
+
+	/**
+	 * Resolve a packet repo value into a safe GitHub clone URL.
+	 *
+	 * @param string $repo Repo slug or GitHub URL.
+	 * @return array{slug:string,name:string,url:string}|\WP_Error
+	 */
+	public static function resolve_repo( string $repo ): array|\WP_Error {
+		$repo = trim( $repo );
+		if ( preg_match( '#^([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)$#', $repo, $matches ) ) {
+			$slug = $matches[1] . '/' . $matches[2];
+			return array(
+				'slug' => $slug,
+				'name' => self::repo_name_from_slug( $slug ),
+				'url'  => 'https://github.com/' . $slug . '.git',
+			);
+		}
+
+		if ( preg_match( '#^https://github\.com/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+?)(?:\.git)?/?$#', $repo, $matches ) ) {
+			$slug = $matches[1] . '/' . $matches[2];
+			return array(
+				'slug' => $slug,
+				'name' => self::repo_name_from_slug( $slug ),
+				'url'  => 'https://github.com/' . $slug . '.git',
+			);
+		}
+
+		return new \WP_Error( 'invalid_repo', 'Repository must be a GitHub owner/repo slug or https://github.com/owner/repo URL.', array( 'status' => 400 ) );
+	}
+
+	public static function build_branch_name( EvidencePacket $packet ): string {
+		$source = self::slugify( $packet->source() );
+		$title  = self::slugify( $packet->title() );
+		$hash   = substr( hash( 'sha256', $packet->source_url() . "\n" . $packet->title() ), 0, 8 );
+
+		$title = '' === $title ? 'evidence-task' : substr( $title, 0, 48 );
+		return self::sanitize_branch( sprintf( 'code-task/%s-%s-%s', $source, $title, $hash ) );
+	}
+
+	/**
+	 * Render the deterministic agent prompt/evidence file.
+	 *
+	 * @param array{slug:string,name:string,url:string} $repo Resolved repo.
+	 */
+	public static function render_prompt( EvidencePacket $packet, array $repo, string $branch ): string {
+		$lines = array(
+			'# Code Task Evidence',
+			'',
+			'## Task',
+			$packet->title(),
+			'',
+			'## Source',
+			'- Source: ' . $packet->source(),
+			'- URL: ' . $packet->source_url(),
+			'',
+			'## Target',
+			'- Repo: ' . $repo['slug'],
+			'- Branch: ' . $branch,
+			'',
+			'## Summary',
+			$packet->summary(),
+			'',
+			'## Classification',
+		);
+
+		foreach ( $packet->classification() as $classification ) {
+			$lines[] = '- ' . $classification;
+		}
+
+		$lines[]         = '';
+		$lines[]         = '## Suggested Tests';
+		$suggested_tests = $packet->suggested_tests();
+		if ( array() === $suggested_tests ) {
+			$suggested_tests = array( 'Add or update the smallest regression coverage that proves the fix.' );
+		}
+		foreach ( $suggested_tests as $test ) {
+			$lines[] = '- ' . $test;
+		}
+
+		$lines[]     = '';
+		$lines[]     = '## Constraints';
+		$constraints = $packet->constraints();
+		if ( array() === $constraints ) {
+			$constraints = array( 'Keep the change narrowly scoped to the evidence above.' );
+		}
+		foreach ( $constraints as $constraint ) {
+			$lines[] = '- ' . $constraint;
+		}
+
+		$lines[] = '';
+		$lines[] = '## Instructions';
+		$lines[] = '- Inspect the referenced source evidence before editing code.';
+		$lines[] = '- Make the smallest correct change in the target repo.';
+		$lines[] = '- Run focused tests and record the commands/results in the PR body.';
+		$lines[] = '- Preserve a link back to the source URL in the PR description.';
+		$lines[] = '';
+
+		return implode( "\n", $lines );
+	}
+
+	public static function render_pr_body_seed( EvidencePacket $packet ): string {
+		return implode(
+			"\n",
+			array(
+				'## Source evidence',
+				'- Source: ' . $packet->source(),
+				'- URL: ' . $packet->source_url(),
+				'',
+				'## Summary',
+				$packet->summary(),
+			)
+		);
+	}
+
+	private static function repo_name_from_slug( string $slug ): string {
+		$parts = explode( '/', $slug );
+		$name  = end( $parts );
+		return sanitize_key( $name );
+	}
+
+	private static function slugify( string $value ): string {
+		$value = strtolower( $value );
+		$value = preg_replace( '/[^a-z0-9]+/', '-', $value );
+		$value = trim( (string) $value, '-' );
+		return '' === $value ? 'unknown' : $value;
+	}
+
+	private static function sanitize_branch( string $branch ): string {
+		$branch = trim( $branch );
+		$branch = preg_replace( '#[^A-Za-z0-9._/-]+#', '-', $branch );
+		$branch = preg_replace( '#/{2,}#', '/', (string) $branch );
+		$branch = preg_replace( '/-{2,}/', '-', (string) $branch );
+		$branch = trim( (string) $branch, '/.-' );
+
+		return substr( $branch, 0, 96 );
+	}
+}

--- a/inc/CodeTask/CodeTaskEvidenceWriterInterface.php
+++ b/inc/CodeTask/CodeTaskEvidenceWriterInterface.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Evidence writer facade for code-task scaffolding.
+ *
+ * @package DataMachineCode\CodeTask
+ */
+
+namespace DataMachineCode\CodeTask;
+
+defined( 'ABSPATH' ) || exit;
+
+interface CodeTaskEvidenceWriterInterface {
+	/**
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function write_file( string $handle, string $path, string $content ): array|\WP_Error;
+}

--- a/inc/CodeTask/CodeTaskWorkspaceInterface.php
+++ b/inc/CodeTask/CodeTaskWorkspaceInterface.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Workspace facade for code-task scaffolding.
+ *
+ * @package DataMachineCode\CodeTask
+ */
+
+namespace DataMachineCode\CodeTask;
+
+use DataMachineCode\Workspace\Workspace;
+
+defined( 'ABSPATH' ) || exit;
+
+interface CodeTaskWorkspaceInterface {
+	public function workspace(): Workspace;
+
+	public function get_primary_path( string $repo ): string;
+
+	/**
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function clone_repo( string $url, string $name ): array|\WP_Error;
+
+	/**
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function worktree_add( string $repo, string $branch, ?string $from, bool $inject_context, bool $bootstrap, bool $allow_stale, bool $rebase_base, bool $force ): array|\WP_Error;
+
+	public function get_repo_path( string $handle ): string;
+}

--- a/inc/CodeTask/EvidencePacket.php
+++ b/inc/CodeTask/EvidencePacket.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Structured evidence packet for code-task scaffolding.
+ *
+ * @package DataMachineCode\CodeTask
+ */
+
+namespace DataMachineCode\CodeTask;
+
+defined( 'ABSPATH' ) || exit;
+
+class EvidencePacket {
+
+	/**
+	 * Raw normalized packet data.
+	 *
+	 * @var array<string,mixed>
+	 */
+	private array $data;
+
+	/**
+	 * @param array<string,mixed> $data Normalized packet data.
+	 */
+	private function __construct( array $data ) {
+		$this->data = $data;
+	}
+
+	/**
+	 * Build and validate a packet from decoded JSON input.
+	 *
+	 * @param mixed $packet Decoded packet.
+	 * @return self|\WP_Error
+	 */
+	public static function from_array( mixed $packet ): self|\WP_Error {
+		if ( ! is_array( $packet ) ) {
+			return new \WP_Error( 'invalid_packet', 'Evidence packet must be a JSON object.', array( 'status' => 400 ) );
+		}
+
+		$required = array( 'source', 'source_url', 'title', 'summary', 'classification', 'repo' );
+		foreach ( $required as $field ) {
+			if ( ! array_key_exists( $field, $packet ) || self::is_empty_value( $packet[ $field ] ) ) {
+				return new \WP_Error( 'missing_packet_field', sprintf( 'Evidence packet is missing required field: %s', $field ), array( 'status' => 400 ) );
+			}
+		}
+
+		if ( ! is_string( $packet['source_url'] ) || ! wp_http_validate_url( $packet['source_url'] ) ) {
+			return new \WP_Error( 'invalid_source_url', 'Evidence packet source_url must be a valid http(s) URL.', array( 'status' => 400 ) );
+		}
+
+		$classification = self::normalize_string_list( $packet['classification'], 'classification' );
+		if ( $classification instanceof \WP_Error ) {
+			return $classification;
+		}
+
+		$suggested_tests = self::normalize_string_list( $packet['suggested_tests'] ?? array(), 'suggested_tests', false );
+		if ( $suggested_tests instanceof \WP_Error ) {
+			return $suggested_tests;
+		}
+
+		$constraints = self::normalize_string_list( $packet['constraints'] ?? array(), 'constraints', false );
+		if ( $constraints instanceof \WP_Error ) {
+			return $constraints;
+		}
+
+		$data = array(
+			'source'          => sanitize_text_field( (string) $packet['source'] ),
+			'source_url'      => esc_url_raw( (string) $packet['source_url'] ),
+			'title'           => sanitize_text_field( (string) $packet['title'] ),
+			'summary'         => sanitize_textarea_field( (string) $packet['summary'] ),
+			'classification'  => $classification,
+			'repo'            => trim( (string) $packet['repo'] ),
+			'suggested_tests' => $suggested_tests,
+			'constraints'     => $constraints,
+		);
+
+		return new self( $data );
+	}
+
+	/**
+	 * Return the normalized packet as an array.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public function to_array(): array {
+		return $this->data;
+	}
+
+	public function source(): string {
+		return (string) $this->data['source'];
+	}
+
+	public function source_url(): string {
+		return (string) $this->data['source_url'];
+	}
+
+	public function title(): string {
+		return (string) $this->data['title'];
+	}
+
+	public function summary(): string {
+		return (string) $this->data['summary'];
+	}
+
+	public function repo(): string {
+		return (string) $this->data['repo'];
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function classification(): array {
+		return $this->data['classification'];
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function suggested_tests(): array {
+		return $this->data['suggested_tests'];
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function constraints(): array {
+		return $this->data['constraints'];
+	}
+
+	/**
+	 * @param mixed $value Value to inspect.
+	 */
+	private static function is_empty_value( mixed $value ): bool {
+		if ( is_array( $value ) ) {
+			return array() === $value;
+		}
+
+		return '' === trim( (string) $value );
+	}
+
+	/**
+	 * Normalize a list of strings.
+	 *
+	 * @param mixed  $value List value.
+	 * @param string $field Field label.
+	 * @param bool   $require_non_empty Whether at least one item is required.
+	 * @return string[]|\WP_Error
+	 */
+	private static function normalize_string_list( mixed $value, string $field, bool $require_non_empty = true ): array|\WP_Error {
+		if ( ! is_array( $value ) ) {
+			return new \WP_Error( 'invalid_packet_field', sprintf( 'Evidence packet field %s must be an array of strings.', $field ), array( 'status' => 400 ) );
+		}
+
+		$items = array();
+		foreach ( $value as $item ) {
+			if ( ! is_scalar( $item ) ) {
+				return new \WP_Error( 'invalid_packet_field', sprintf( 'Evidence packet field %s must contain only strings.', $field ), array( 'status' => 400 ) );
+			}
+
+			$item = trim( (string) $item );
+			if ( '' !== $item ) {
+				$items[] = sanitize_text_field( $item );
+			}
+		}
+
+		if ( $require_non_empty && array() === $items ) {
+			return new \WP_Error( 'invalid_packet_field', sprintf( 'Evidence packet field %s must contain at least one string.', $field ), array( 'status' => 400 ) );
+		}
+
+		return $items;
+	}
+}

--- a/inc/CodeTask/WorkspaceCodeTaskEvidenceWriter.php
+++ b/inc/CodeTask/WorkspaceCodeTaskEvidenceWriter.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * WorkspaceWriter-backed code-task evidence writer.
+ *
+ * @package DataMachineCode\CodeTask
+ */
+
+namespace DataMachineCode\CodeTask;
+
+use DataMachineCode\Workspace\WorkspaceWriter;
+
+defined( 'ABSPATH' ) || exit;
+
+class WorkspaceCodeTaskEvidenceWriter implements CodeTaskEvidenceWriterInterface {
+	public function __construct( private WorkspaceWriter $writer ) {}
+
+	public function write_file( string $handle, string $path, string $content ): array|\WP_Error {
+		return $this->writer->write_file( $handle, $path, $content );
+	}
+}

--- a/inc/CodeTask/WorkspaceCodeTaskWorkspace.php
+++ b/inc/CodeTask/WorkspaceCodeTaskWorkspace.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Workspace-backed code-task workspace facade.
+ *
+ * @package DataMachineCode\CodeTask
+ */
+
+namespace DataMachineCode\CodeTask;
+
+use DataMachineCode\Workspace\Workspace;
+
+defined( 'ABSPATH' ) || exit;
+
+class WorkspaceCodeTaskWorkspace implements CodeTaskWorkspaceInterface {
+	public function __construct( private Workspace $workspace ) {}
+
+	public function workspace(): Workspace {
+		return $this->workspace;
+	}
+
+	public function get_primary_path( string $repo ): string {
+		return $this->workspace->get_primary_path( $repo );
+	}
+
+	public function clone_repo( string $url, string $name ): array|\WP_Error {
+		return $this->workspace->clone_repo( $url, $name );
+	}
+
+	public function worktree_add( string $repo, string $branch, ?string $from, bool $inject_context, bool $bootstrap, bool $allow_stale, bool $rebase_base, bool $force ): array|\WP_Error {
+		return $this->workspace->worktree_add( $repo, $branch, $from, $inject_context, $bootstrap, $allow_stale, $rebase_base, $force );
+	}
+
+	public function get_repo_path( string $handle ): string {
+		return $this->workspace->get_repo_path( $handle );
+	}
+}

--- a/tests/smoke-code-task-evidence-packet.php
+++ b/tests/smoke-code-task-evidence-packet.php
@@ -1,0 +1,214 @@
+<?php
+/**
+ * Smoke test for evidence-packet code-task scaffolding.
+ *
+ *   php tests/smoke-code-task-evidence-packet.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ );
+	}
+
+	class WP_Error {
+		private string $code;
+		private string $message;
+		private array $data;
+
+		public function __construct( string $code, string $message, array $data = array() ) {
+			$this->code    = $code;
+			$this->message = $message;
+			$this->data    = $data;
+		}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+
+		public function get_error_data(): array {
+			return $this->data;
+		}
+	}
+
+	function is_wp_error( $value ): bool {
+		return $value instanceof WP_Error;
+	}
+
+	function sanitize_text_field( $value ): string {
+		return trim( preg_replace( '/[\r\n\t]+/', ' ', wp_strip_all_tags( (string) $value ) ) );
+	}
+
+	function sanitize_textarea_field( $value ): string {
+		return trim( wp_strip_all_tags( (string) $value ) );
+	}
+
+	function sanitize_key( $value ): string {
+		$value = strtolower( (string) $value );
+		return preg_replace( '/[^a-z0-9_-]/', '', $value );
+	}
+
+	function esc_url_raw( $value ): string {
+		return (string) $value;
+	}
+
+	function wp_http_validate_url( $url ): string|false {
+		$parts = parse_url( (string) $url );
+		if ( ! is_array( $parts ) || empty( $parts['scheme'] ) || empty( $parts['host'] ) ) {
+			return false;
+		}
+
+		return in_array( $parts['scheme'], array( 'http', 'https' ), true ) ? (string) $url : false;
+	}
+
+	function wp_strip_all_tags( $value ): string {
+		return strip_tags( (string) $value );
+	}
+
+	function wp_json_encode( $data, int $flags = 0 ): string|false {
+		return json_encode( $data, $flags );
+	}
+}
+
+namespace DataMachineCode\Workspace {
+	class Workspace {}
+	class WorkspaceWriter {}
+}
+
+namespace {
+	require_once dirname( __DIR__ ) . '/inc/CodeTask/EvidencePacket.php';
+	require_once dirname( __DIR__ ) . '/inc/CodeTask/CodeTaskWorkspaceInterface.php';
+	require_once dirname( __DIR__ ) . '/inc/CodeTask/CodeTaskEvidenceWriterInterface.php';
+	require_once dirname( __DIR__ ) . '/inc/CodeTask/CodeTaskCreator.php';
+
+	function datamachine_code_assert( bool $condition, string $message ): void {
+		if ( $condition ) {
+			echo "  [PASS] {$message}\n";
+			return;
+		}
+
+		echo "  [FAIL] {$message}\n";
+		exit( 1 );
+	}
+
+	function datamachine_code_packet(): array {
+		return array(
+			'source'          => 'wporg/trac',
+			'source_url'      => 'https://core.trac.wordpress.org/ticket/50781',
+			'title'           => '500 error caused by customize_changeset_uuid for non-authenticated users',
+			'summary'         => 'Unauthenticated requests with customize_changeset_uuid can trigger a 500.',
+			'classification'  => array( 'high_confidence_bug', 'has_repro', 'code_cookable' ),
+			'repo'            => 'WordPress/wordpress-develop',
+			'suggested_tests' => array( 'request/query-param regression test' ),
+			'constraints'     => array( 'do not change public behavior beyond invalid unauthenticated changeset handling' ),
+		);
+	}
+
+	class FakeCodeTaskWorkspace implements \DataMachineCode\CodeTask\CodeTaskWorkspaceInterface {
+		public string $primary_path;
+		public array $clones = array();
+		public array $worktrees = array();
+
+		public function __construct( string $primary_path ) {
+			$this->primary_path = $primary_path;
+		}
+
+		public function workspace(): \DataMachineCode\Workspace\Workspace {
+			return new \DataMachineCode\Workspace\Workspace();
+		}
+
+		public function get_primary_path( string $repo ): string {
+			return $this->primary_path;
+		}
+
+		public function clone_repo( string $url, string $name ): array {
+			$this->clones[] = compact( 'url', 'name' );
+			mkdir( $this->primary_path, 0755, true );
+			return array( 'success' => true, 'name' => $name, 'path' => $this->primary_path );
+		}
+
+		public function worktree_add( string $repo, string $branch, ?string $from, bool $inject_context, bool $bootstrap, bool $allow_stale, bool $rebase_base, bool $force ): array {
+			$this->worktrees[] = compact( 'repo', 'branch', 'from', 'inject_context', 'bootstrap', 'allow_stale', 'rebase_base', 'force' );
+			return array(
+				'success' => true,
+				'handle'  => $repo . '@' . str_replace( '/', '-', $branch ),
+				'path'    => dirname( $this->primary_path ) . '/' . $repo . '@' . str_replace( '/', '-', $branch ),
+				'branch'  => $branch,
+			);
+		}
+
+		public function get_repo_path( string $handle ): string {
+			return dirname( $this->primary_path ) . '/' . $handle;
+		}
+	}
+
+	class FakeCodeTaskWriter implements \DataMachineCode\CodeTask\CodeTaskEvidenceWriterInterface {
+		public array $writes = array();
+
+		public function write_file( string $handle, string $path, string $content ): array {
+			$this->writes[] = compact( 'handle', 'path', 'content' );
+			return array( 'success' => true, 'path' => $path, 'size' => strlen( $content ), 'created' => true );
+		}
+	}
+
+	echo "=== smoke-code-task-evidence-packet ===\n";
+
+	echo "\n[1] packet parsing normalizes required fields\n";
+	$packet = \DataMachineCode\CodeTask\EvidencePacket::from_array( datamachine_code_packet() );
+	datamachine_code_assert( ! is_wp_error( $packet ), 'valid packet parses' );
+	datamachine_code_assert( 'WordPress/wordpress-develop' === $packet->repo(), 'repo field preserved' );
+	datamachine_code_assert( array( 'high_confidence_bug', 'has_repro', 'code_cookable' ) === $packet->classification(), 'classification list preserved' );
+
+	echo "\n[2] invalid packets fail safely\n";
+	$missing = datamachine_code_packet();
+	unset( $missing['repo'] );
+	$error = \DataMachineCode\CodeTask\EvidencePacket::from_array( $missing );
+	datamachine_code_assert( is_wp_error( $error ), 'missing repo returns WP_Error' );
+	datamachine_code_assert( 'missing_packet_field' === $error->get_error_code(), 'missing field error code is stable' );
+	$bad_repo = \DataMachineCode\CodeTask\CodeTaskCreator::resolve_repo( 'ssh://github.com/WordPress/wordpress-develop' );
+	datamachine_code_assert( is_wp_error( $bad_repo ), 'arbitrary protocols are rejected' );
+	datamachine_code_assert( 'invalid_repo' === $bad_repo->get_error_code(), 'invalid repo error code is stable' );
+
+	echo "\n[3] repo and branch output are deterministic\n";
+	$repo = \DataMachineCode\CodeTask\CodeTaskCreator::resolve_repo( 'https://github.com/WordPress/wordpress-develop.git' );
+	datamachine_code_assert( ! is_wp_error( $repo ), 'GitHub https repo resolves' );
+	datamachine_code_assert( 'WordPress/wordpress-develop' === $repo['slug'], 'resolved slug strips .git' );
+	datamachine_code_assert( 'wordpress-develop' === $repo['name'], 'workspace repo name uses basename' );
+	datamachine_code_assert( 'https://github.com/WordPress/wordpress-develop.git' === $repo['url'], 'clone URL is normalized' );
+	$branch = \DataMachineCode\CodeTask\CodeTaskCreator::build_branch_name( $packet );
+	datamachine_code_assert( str_starts_with( $branch, 'code-task/wporg-trac-500-error-caused-by-customize-changeset-uuid' ), 'branch includes source and title slug' );
+	datamachine_code_assert( $branch === \DataMachineCode\CodeTask\CodeTaskCreator::build_branch_name( $packet ), 'branch is deterministic' );
+	datamachine_code_assert( ! str_contains( $branch, ' ' ), 'branch contains no spaces' );
+
+	echo "\n[4] prompt is deterministic and source-linked\n";
+	$prompt = \DataMachineCode\CodeTask\CodeTaskCreator::render_prompt( $packet, $repo, $branch );
+	datamachine_code_assert( str_contains( $prompt, '# Code Task Evidence' ), 'prompt has fixed title' );
+	datamachine_code_assert( str_contains( $prompt, 'https://core.trac.wordpress.org/ticket/50781' ), 'prompt preserves source URL' );
+	datamachine_code_assert( str_contains( $prompt, '- request/query-param regression test' ), 'prompt includes suggested tests' );
+	datamachine_code_assert( $prompt === \DataMachineCode\CodeTask\CodeTaskCreator::render_prompt( $packet, $repo, $branch ), 'prompt rendering is deterministic' );
+
+	echo "\n[5] creator clones missing repos, creates worktree, writes evidence files\n";
+	$root      = sys_get_temp_dir() . '/dmc-code-task-' . uniqid( '', true );
+	$workspace = new FakeCodeTaskWorkspace( $root . '/wordpress-develop' );
+	$writer    = new FakeCodeTaskWriter();
+	$creator   = new \DataMachineCode\CodeTask\CodeTaskCreator( $workspace, $writer );
+	$result    = $creator->create( $packet, array( 'base_ref' => 'origin/trunk', 'allow_stale' => true, 'force' => true ) );
+	datamachine_code_assert( ! is_wp_error( $result ), 'creator succeeds with fake workspace' );
+	datamachine_code_assert( true === $result['cloned'], 'missing primary repo is cloned' );
+	datamachine_code_assert( 'https://github.com/WordPress/wordpress-develop.git' === $workspace->clones[0]['url'], 'clone uses validated GitHub URL' );
+	datamachine_code_assert( 'origin/trunk' === $workspace->worktrees[0]['from'], 'base ref forwarded to worktree add' );
+	datamachine_code_assert( true === $workspace->worktrees[0]['allow_stale'], 'allow_stale forwarded' );
+	datamachine_code_assert( true === $workspace->worktrees[0]['force'], 'force forwarded' );
+	datamachine_code_assert( 2 === count( $writer->writes ), 'prompt and packet files are written' );
+	datamachine_code_assert( '.datamachine-code/code-task.md' === $writer->writes[0]['path'], 'prompt path is deterministic' );
+	datamachine_code_assert( '.datamachine-code/evidence-packet.json' === $writer->writes[1]['path'], 'packet path is deterministic' );
+	datamachine_code_assert( str_contains( $writer->writes[1]['content'], '"source_url": "https://core.trac.wordpress.org/ticket/50781"' ), 'packet JSON preserves source URL' );
+	datamachine_code_assert( str_contains( $result['pr_body_seed'], '## Source evidence' ), 'result includes PR body seed' );
+
+	echo "\nAll code-task evidence packet smoke tests passed.\n";
+}


### PR DESCRIPTION
## Summary
- Adds a generic code-task evidence packet primitive that validates structured source evidence and scaffolds an isolated workspace worktree.
- Registers wp datamachine-code code-task create and datamachine/create-code-task so domain brains can hand off code-cookable packets without hardcoding Trac.

## Changes
- Defines evidence packet validation for source, source_url, title, summary, classification, repo, suggested_tests, and constraints.
- Resolves safe GitHub owner/repo slugs or https GitHub URLs into workspace clone targets and deterministic code-task branches.
- Creates the target worktree through existing workspace primitives and writes .datamachine-code/code-task.md plus .datamachine-code/evidence-packet.json.
- Returns PR seed metadata with source linkback while intentionally avoiding push, commit, PR creation, or automatic agent execution.

## Tests
- php tests/smoke-code-task-evidence-packet.php
- php -l inc/CodeTask/EvidencePacket.php
- php -l inc/CodeTask/CodeTaskCreator.php
- php -l inc/Abilities/CodeTaskAbilities.php
- php -l inc/Cli/Commands/CodeTaskCommand.php
- Targeted Homeboy lint passed for all new runtime files and the smoke file.
- Full homeboy test data-machine-code currently fails before DMC tests run in the existing Playground bootstrap path: Data Machine activation calls get_user_by() while the test install has not loaded the user API.

Closes #152

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the evidence packet parser, task scaffolding primitive, CLI/ability entry points, and focused smoke coverage; Chris remains responsible for review and merge.