### PR TITLE
docs(workspace): clarify checkout discovery wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ The workspace is **worktree-native**. Each branch lives in its own directory at
 agent sessions can edit different branches of the same repo simultaneously without
 stepping on each other.
 
+DMC discovers primary checkouts and worktrees by scanning the configured workspace
+root. Worktree lifecycle metadata supports cleanup and reconciliation; if that
+workspace path is not visible to PHP, DMC cannot see the checkouts.
+
 The primary checkout (bare `<repo>`) is **read-only by default** for mutating
 operations — pass `--allow-primary-mutation` to override. The default-deny is
 intentional: the primary tracks the deployed branch, and silent branch-switches

--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -402,7 +402,8 @@ Discover the full command surface: `{$wp} datamachine --help`. The groups below 
 
 **Code (data-machine-code):** All code changes happen in worktrees under `{$workspace_path}`. DMC owns workspace lifecycle, evidence capture, GitHub workflow glue, and GitSync; file CRUD inside a worktree uses whatever tool is fastest.
 - Workspace root: `{$workspace_path}`
-- **Workspace lifecycle:** `{$wp} datamachine-code workspace clone|worktree add|worktree list|worktree cleanup|worktree remove` — keeps the on-disk registry consistent and enforces the `<repo>@<slug>` handle convention.
+- **Workspace lifecycle:** `{$wp} datamachine-code workspace clone|worktree add|worktree list|worktree cleanup|worktree remove` — scans the workspace root for primary checkouts and `<repo>@<slug>` worktrees; owns worktree lifecycle metadata, cleanup, and handle conventions.
+- **Path visibility:** If the configured workspace path is not visible to PHP, DMC cannot see the checkouts.
 - **Workspace hygiene:** `worktree cleanup|cleanup-artifacts|reconcile-metadata|refresh-context` plus `workspace hygiene` for disk/metadata maintenance and evidence that worktrees are still safe to keep.
 - **Code tasks:** `{$wp} datamachine-code code-task create` — turn evidence packets into reviewable workspace tasks with prompts and branches.
 - **GitHub:** `{$wp} datamachine-code github issues|pulls|repos|status|view|close|review-flow|comment` — create PRs, manage issues, inspect state, install review flows, comment on reviews.

--- a/tests/smoke-agents-md-marker.php
+++ b/tests/smoke-agents-md-marker.php
@@ -38,6 +38,7 @@ $stale_marker               = 'datamachine agent compose AGENTS.md';
 $expected_agent_cli         = 'datamachine agent list|create|access|token|installed|install|diff';
 $stale_agent_cli            = 'datamachine agents list|create|access|tokens';
 $expected_worktree_cli      = 'datamachine-code workspace clone|worktree add|worktree list|worktree cleanup|worktree remove';
+$expected_workspace_scan    = 'scans the workspace root for primary checkouts and `<repo>@<slug>` worktrees';
 $expected_workspace_hygiene = 'worktree cleanup|cleanup-artifacts|reconcile-metadata|refresh-context';
 $expected_code_task_cli     = 'datamachine-code code-task create';
 $expected_gitsync_cli       = 'gitsync bind|status|pull|submit|push|policy';
@@ -46,6 +47,7 @@ $expected_homeboy_path      = '--path <checkout>';
 $expected_homeboy_trace     = 'homeboy trace';
 $expected_homeboy_review    = 'homeboy review --changed-since --report=pr-comment';
 $stale_homeboy_git          = 'homeboy git changes';
+$stale_workspace_registry   = 'keeps the on-disk registry consistent';
 
 $assert(
 	'auto-generated marker uses memory compose command',
@@ -70,6 +72,14 @@ $assert(
 $assert(
 	'workspace lifecycle guidance includes cleanup command',
 	str_contains( $source, $expected_worktree_cli )
+);
+$assert(
+	'workspace guidance describes scanned checkouts instead of a primary registry',
+	str_contains( $source, $expected_workspace_scan )
+);
+$assert(
+	'stale workspace registry wording is absent',
+	! str_contains( $source, $stale_workspace_registry )
 );
 $assert(
 	'workspace hygiene guidance includes modern maintenance surfaces',


### PR DESCRIPTION
## Summary

- Clarifies DMC workspace docs so primary checkouts are described as discovered by scanning the configured workspace root, not as entries in a DB-like registry.
- Documents that DMC owns worktree lifecycle metadata/cleanup and that PHP path visibility controls what checkouts DMC can see.

## Changes

- Updates the generated AGENTS section wording in `data-machine-code.php`.
- Adds matching README language in the worktree-native workspace section.
- Extends the AGENTS smoke to assert the scanned-checkout wording and reject the stale “on-disk registry” phrase.

## Tests

- `php tests/smoke-agents-md-marker.php`
- `homeboy audit data-machine-code --path /Users/chubes/Developer/data-machine-code@docs-workspace-registry-wording --changed-since origin/main`
- `homeboy lint data-machine-code --path /Users/chubes/Developer/data-machine-code@docs-workspace-registry-wording --changed-since origin/main` *(reports 4 pre-existing PHPStan `add_action(..., ..., priority)` findings in `data-machine-code.php` once that file is in the changed-since set; no docs-change lint findings)*

Closes #167

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the wording update, added the focused smoke assertion, ran validation, and prepared this PR for Chris to review.
