### PR TITLE
fix(workspace): diagnose invisible workspace roots

### DIFF
--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -120,6 +120,95 @@ class Workspace {
 	}
 
 	/**
+	 * Inspect whether the configured workspace root is visible to PHP.
+	 *
+	 * @return array{path: string, configured: bool, is_dir: bool, is_readable: bool, scandir: string, readable: bool}
+	 */
+	public function inspect_workspace_path(): array {
+		$path        = $this->workspace_path;
+		$is_dir      = '' !== $path && is_dir( $path );
+		$is_readable = '' !== $path && is_readable( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_readable
+		$entries     = ( $is_dir && $is_readable ) ? scandir( $path ) : false;
+
+		return array(
+			'path'        => $path,
+			'configured'  => defined( 'DATAMACHINE_WORKSPACE_PATH' ),
+			'is_dir'      => $is_dir,
+			'is_readable' => $is_readable,
+			'scandir'     => false === $entries ? 'failed' : 'ok',
+			'readable'    => $is_dir && false !== $entries,
+		);
+	}
+
+	/**
+	 * Require the configured workspace root to be visible before substrate checks.
+	 *
+	 * @return \WP_Error|null
+	 */
+	private function require_workspace_visible(): ?\WP_Error {
+		$diagnostic = $this->inspect_workspace_path();
+
+		if ( '' === $diagnostic['path'] ) {
+			return new \WP_Error(
+				'workspace_unavailable',
+				'Workspace unavailable: no writable path outside the web root. Define DATAMACHINE_WORKSPACE_PATH in wp-config.php, ensure /var/lib/datamachine/ is writable, or ensure $HOME is set.',
+				$this->workspace_visibility_error_data( $diagnostic )
+			);
+		}
+
+		if ( ! $diagnostic['is_dir'] ) {
+			if ( empty( $diagnostic['configured'] ) ) {
+				return null;
+			}
+
+			return new \WP_Error(
+				'workspace_path_invisible',
+				$this->format_workspace_visibility_message( $diagnostic ),
+				$this->workspace_visibility_error_data( $diagnostic )
+			);
+		}
+
+		if ( ! $diagnostic['readable'] ) {
+			return new \WP_Error(
+				'workspace_path_unreadable',
+				$this->format_workspace_visibility_message( $diagnostic ),
+				$this->workspace_visibility_error_data( $diagnostic )
+			);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Build error data for workspace visibility failures.
+	 *
+	 * @param array<string,mixed> $diagnostic Path visibility details.
+	 * @return array{status: int, workspace: array<string,mixed>}
+	 */
+	private function workspace_visibility_error_data( array $diagnostic ): array {
+		return array(
+			'status'    => 500,
+			'workspace' => $diagnostic,
+		);
+	}
+
+	/**
+	 * Format a workspace visibility diagnostic for CLI/API callers.
+	 *
+	 * @param array<string,mixed> $diagnostic Path visibility details.
+	 * @return string
+	 */
+	private function format_workspace_visibility_message( array $diagnostic ): string {
+		return sprintf(
+			'Workspace path is not accessible from PHP: %s (is_dir=%s, is_readable=%s, scandir=%s). If this is a Studio/local host path, ensure the path is mounted into the PHP runtime or update DATAMACHINE_WORKSPACE_PATH to a PHP-visible workspace.',
+			(string) ( $diagnostic['path'] ?? '' ),
+			! empty( $diagnostic['is_dir'] ) ? 'true' : 'false',
+			! empty( $diagnostic['is_readable'] ) ? 'true' : 'false',
+			(string) ( $diagnostic['scandir'] ?? 'failed' )
+		);
+	}
+
+	/**
 	 * Get the full path to a workspace handle.
 	 *
 	 * Handles can be either a primary checkout (`<repo>`) or a worktree
@@ -222,10 +311,16 @@ class Workspace {
 		$path = $this->workspace_path;
 
 		if ( '' === $path ) {
-			return new \WP_Error( 'workspace_unavailable', 'Workspace unavailable: no writable path outside the web root. Define DATAMACHINE_WORKSPACE_PATH in wp-config.php, ensure /var/lib/datamachine/ is writable, or ensure $HOME is set.', array( 'status' => 500 ) );
+			$visible = $this->require_workspace_visible();
+			return null !== $visible ? $visible : new \WP_Error( 'workspace_unavailable', 'Workspace unavailable: no writable path outside the web root.', array( 'status' => 500 ) );
 		}
 
 		if ( is_dir( $path ) ) {
+			$visible = $this->require_workspace_visible();
+			if ( null !== $visible ) {
+				return $visible;
+			}
+
 			return array(
 				'success' => true,
 				'path'    => $path,
@@ -256,10 +351,14 @@ class Workspace {
 	/**
 	 * List repositories in the workspace.
 	 *
-	 * @return array{success: bool, repos: array, path: string}
+	 * @return array{success: bool, repos: array, path: string}|\WP_Error
 	 */
-	public function list_repos(): array {
-		$path = $this->workspace_path;
+	public function list_repos(): array|\WP_Error {
+		$path    = $this->workspace_path;
+		$visible = $this->require_workspace_visible();
+		if ( null !== $visible ) {
+			return $visible;
+		}
 
 		if ( ! is_dir( $path ) ) {
 			return array(
@@ -330,6 +429,11 @@ class Workspace {
 	 * @return array{success: bool, name?: string, path?: string, message?: string}|\WP_Error
 	 */
 	public function clone_repo( string $url, ?string $name = null ): array|\WP_Error {
+		$visible = $this->require_workspace_visible();
+		if ( null !== $visible ) {
+			return $visible;
+		}
+
 		// Validate URL.
 		if ( empty( $url ) ) {
 			return new \WP_Error( 'missing_url', 'Repository URL is required.', array( 'status' => 400 ) );
@@ -1061,6 +1165,11 @@ class Workspace {
 	 * @return array{success: bool, handle: string, path: string, branch: string, slug: string, created_branch: bool, message: string, disk_budget?: array, context_injected?: bool, context_files?: string[], context_skip_reason?: string, bootstrap?: array, fetch_failed?: bool, fetch_error?: string, stale_commits_behind?: int, upstream?: string, base_stale_commits_behind?: int, base_upstream?: string, gate_threshold?: int, rebase_attempted?: bool, rebase_succeeded?: bool, rebase_error?: string, rebase_target?: string}|\WP_Error
 	 */
 	public function worktree_add( string $repo, string $branch, ?string $from = null, bool $inject_context = true, bool $bootstrap = true, bool $allow_stale = false, bool $rebase_base = false, bool $force = false ): array|\WP_Error {
+		$visible = $this->require_workspace_visible();
+		if ( null !== $visible ) {
+			return $visible;
+		}
+
 		$repo   = $this->sanitize_name( $repo );
 		$branch = trim( $branch );
 

--- a/tests/smoke-workspace-path-diagnostics.php
+++ b/tests/smoke-workspace-path-diagnostics.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Pure-PHP smoke test for workspace root visibility diagnostics.
+ *
+ * Run: php tests/smoke-workspace-path-diagnostics.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	if ( ! defined( 'DATAMACHINE_WORKSPACE_PATH' ) ) {
+		define( 'DATAMACHINE_WORKSPACE_PATH', __DIR__ . '/fixtures/nonexistent-host-workspace' );
+	}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			private string $code;
+			private string $message;
+			private $data;
+
+			public function __construct( string $code = '', string $message = '', $data = array() ) {
+				$this->code    = $code;
+				$this->message = $message;
+				$this->data    = $data;
+			}
+
+			public function get_error_code(): string {
+				return $this->code;
+			}
+
+			public function get_error_message(): string {
+				return $this->message;
+			}
+
+			public function get_error_data() {
+				return $this->data;
+			}
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $thing ): bool {
+			return $thing instanceof \WP_Error;
+		}
+	}
+
+	if ( ! function_exists( 'wp_mkdir_p' ) ) {
+		function wp_mkdir_p( string $path ): bool {
+			return is_dir( $path ) || mkdir( $path, 0755, true );
+		}
+	}
+
+	if ( ! function_exists( 'get_option' ) ) {
+		function get_option( string $_name, $default = false ) {
+			return $default;
+		}
+	}
+
+	if ( ! function_exists( 'size_format' ) ) {
+		function size_format( $bytes ): string {
+			return (string) $bytes;
+		}
+	}
+
+	require __DIR__ . '/../inc/Workspace/Workspace.php';
+
+	$failures = 0;
+	$total    = 0;
+
+	$assert = function ( bool $condition, string $message ) use ( &$failures, &$total ): void {
+		$total++;
+		if ( $condition ) {
+			echo "  [PASS] {$message}\n";
+			return;
+		}
+
+		$failures++;
+		echo "  [FAIL] {$message}\n";
+	};
+
+	$assert_same = function ( $expected, $actual, string $message ) use ( &$failures, &$total ): void {
+		$total++;
+		if ( $expected === $actual ) {
+			echo "  [PASS] {$message}\n";
+			return;
+		}
+
+		$failures++;
+		echo "  [FAIL] {$message}\n";
+		echo '    expected: ' . var_export( $expected, true ) . "\n";
+		echo '    actual:   ' . var_export( $actual, true ) . "\n";
+	};
+
+	echo "=== smoke-workspace-path-diagnostics ===\n";
+
+	$workspace  = new \DataMachineCode\Workspace\Workspace();
+	$diagnostic = $workspace->inspect_workspace_path();
+
+	echo "\n[1] Inspect configured invisible path\n";
+	$assert_same( DATAMACHINE_WORKSPACE_PATH, $diagnostic['path'], 'diagnostic includes configured path' );
+	$assert_same( true, $diagnostic['configured'], 'diagnostic marks path as explicitly configured' );
+	$assert_same( false, $diagnostic['is_dir'], 'diagnostic includes is_dir=false' );
+	$assert_same( false, $diagnostic['is_readable'], 'diagnostic includes is_readable=false' );
+	$assert_same( 'failed', $diagnostic['scandir'], 'diagnostic includes scandir outcome' );
+
+	echo "\n[2] List fails with workspace visibility error instead of empty success\n";
+	$list = $workspace->list_repos();
+	$assert( is_wp_error( $list ), 'list_repos returns WP_Error' );
+	$assert_same( 'workspace_path_invisible', $list->get_error_code(), 'list_repos uses workspace_path_invisible code' );
+	$assert( str_contains( $list->get_error_message(), 'is_dir=false' ), 'list_repos error includes is_dir diagnostic' );
+	$assert( str_contains( $list->get_error_message(), 'scandir=failed' ), 'list_repos error includes scandir diagnostic' );
+	$assert( str_contains( $list->get_error_message(), 'Studio/local host path' ), 'list_repos error includes Studio/PHP mount hint' );
+
+	echo "\n[3] Clone preflights workspace before git clone\n";
+	$clone = $workspace->clone_repo( 'https://github.com/Extra-Chill/homeboy.git' );
+	$assert( is_wp_error( $clone ), 'clone_repo returns WP_Error' );
+	$assert_same( 'workspace_path_invisible', $clone->get_error_code(), 'clone_repo surfaces workspace visibility error' );
+	$clone_data = $clone->get_error_data();
+	$assert_same( DATAMACHINE_WORKSPACE_PATH, $clone_data['workspace']['path'] ?? null, 'clone_repo error data includes configured path' );
+
+	echo "\n[4] Worktree add preflights workspace before primary checkout check\n";
+	$worktree = $workspace->worktree_add( 'homeboy', 'fix/example', null, false, false );
+	$assert( is_wp_error( $worktree ), 'worktree_add returns WP_Error' );
+	$assert_same( 'workspace_path_invisible', $worktree->get_error_code(), 'worktree_add surfaces workspace visibility error' );
+	$assert( ! str_contains( $worktree->get_error_message(), 'Primary checkout' ), 'worktree_add does not claim primary checkout is missing' );
+
+	echo "\nResult: " . ( $total - $failures ) . "/{$total} passed\n";
+	exit( $failures > 0 ? 1 : 0 );
+}


### PR DESCRIPTION
## Summary
- Add a shared workspace root visibility diagnostic so DMC can distinguish an empty workspace from a PHP-invisible configured host path.
- Preflight list, clone, and worktree creation before repo-specific substrate checks.

## Changes
- Added `Workspace::inspect_workspace_path()` with configured path, is_dir, is_readable, and scandir diagnostics.
- Return `workspace_path_invisible` or `workspace_path_unreadable` before listing, cloning, or checking primary worktree paths.
- Added a pure-PHP smoke covering the misleading empty-list/git-clone/primary-missing cases.

## Tests
- `php tests/smoke-workspace-path-diagnostics.php`
- `php -l inc/Workspace/Workspace.php && php -l tests/smoke-workspace-path-diagnostics.php`
- `homeboy audit data-machine-code --path /Users/chubes/Developer/data-machine-code@fix-workspace-substrate-diagnostics --changed-since origin/main` passed with contextual non-blocking findings.
- `homeboy lint data-machine-code --path /Users/chubes/Developer/data-machine-code@fix-workspace-substrate-diagnostics --changed-since origin/main` fails on existing full-file `inc/Workspace/Workspace.php` PHPStan/format findings when the file is touched; no focused smoke or syntax failures were found.

Closes #164
Closes #166

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the workspace diagnostics, smoke test, and validation; Chris remains responsible for review and merge.