### PR TITLE
feat(workspace): adopt existing primary checkouts

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -288,6 +288,42 @@ class WorkspaceAbilities {
 			);
 
 			wp_register_ability(
+				'datamachine/workspace-adopt',
+				array(
+					'label'               => 'Adopt Workspace Repo',
+					'description'         => 'Validate an existing git primary checkout already located under the workspace root so it can be managed by workspace commands.',
+					'category'            => 'datamachine-code-workspace',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'path' => array(
+								'type'        => 'string',
+								'description' => 'Existing git primary checkout path under DATAMACHINE_WORKSPACE_PATH.',
+							),
+							'name' => array(
+								'type'        => 'string',
+								'description' => 'Workspace name override (derived from path basename if omitted).',
+							),
+						),
+						'required'   => array( 'path' ),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'         => array( 'type' => 'boolean' ),
+							'name'            => array( 'type' => 'string' ),
+							'path'            => array( 'type' => 'string' ),
+							'already_adopted' => array( 'type' => 'boolean' ),
+							'message'         => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'adoptRepo' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
 				'datamachine/workspace-remove',
 				array(
 					'label'               => 'Remove Workspace Repo',
@@ -1367,6 +1403,20 @@ class WorkspaceAbilities {
 		$workspace = new Workspace();
 		return $workspace->clone_repo(
 			$input['url'] ?? '',
+			$input['name'] ?? null
+		);
+	}
+
+	/**
+	 * Adopt an existing primary checkout already under the workspace root.
+	 *
+	 * @param array $input Input parameters with 'path', optional 'name'.
+	 * @return array Result.
+	 */
+	public static function adoptRepo( array $input ): array|\WP_Error {
+		$workspace = new Workspace();
+		return $workspace->adopt_repo(
+			$input['path'] ?? '',
 			$input['name'] ?? null
 		);
 	}

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -193,6 +193,52 @@ class WorkspaceCommand extends BaseCommand {
 	}
 
 	/**
+	 * Adopt an existing primary checkout already under the workspace root.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <path>
+	 * : Existing git primary checkout path to adopt.
+	 *
+	 * [--name=<name>]
+	 * : Workspace name (derived from path basename if omitted).
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine workspace adopt /Users/chubes/Developer/homeboy --name=homeboy
+	 *
+	 * @subcommand adopt
+	 */
+	public function adopt_repo( array $args, array $assoc_args ): void {
+		if ( empty( $args[0] ) ) {
+			WP_CLI::error( 'Checkout path is required.' );
+			return;
+		}
+
+		$ability = wp_get_ability( 'datamachine/workspace-adopt' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'Workspace adopt ability not available.' );
+			return;
+		}
+
+		$input = array( 'path' => $args[0] );
+		if ( ! empty( $assoc_args['name'] ) ) {
+			$input['name'] = $assoc_args['name'];
+		}
+
+		$result = $ability->execute( $input );
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
+
+		WP_CLI::success( $result['message'] );
+		WP_CLI::log( sprintf( 'Name: %s', $result['name'] ) );
+		WP_CLI::log( sprintf( 'Path: %s', $result['path'] ) );
+	}
+
+	/**
 	 * Remove a repository from the workspace.
 	 *
 	 * ## OPTIONS

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -383,6 +383,83 @@ class Workspace {
 	}
 
 	/**
+	 * Adopt an existing primary checkout already located in the workspace.
+	 *
+	 * There is no persistent primary registry today; primary checkouts are
+	 * discovered by their on-disk directory names. Adoption is therefore a
+	 * non-destructive validation step that makes that convention explicit.
+	 *
+	 * @param string      $path Existing checkout path.
+	 * @param string|null $name Workspace name override (derived from basename if null).
+	 * @return array{success: bool, name?: string, path?: string, already_adopted?: bool, message?: string}|\WP_Error
+	 */
+	public function adopt_repo( string $path, ?string $name = null ): array|\WP_Error {
+		$path = rtrim( trim( $path ), '/' );
+		if ( '' === $path ) {
+			return new \WP_Error( 'missing_path', 'Checkout path is required.', array( 'status' => 400 ) );
+		}
+
+		if ( ! is_dir( $path ) || ! is_readable( $path ) ) {
+			return new \WP_Error( 'adopt_path_unreadable', sprintf( 'Checkout path does not exist or is not readable: %s', $path ), array( 'status' => 400 ) );
+		}
+
+		$ensure = $this->ensure_exists();
+		if ( is_wp_error( $ensure ) ) {
+			return $ensure;
+		}
+
+		$validation = $this->validate_containment( $path, $this->workspace_path );
+		if ( ! $validation['valid'] ) {
+			return new \WP_Error( 'adopt_outside_workspace', 'Only checkouts already under DATAMACHINE_WORKSPACE_PATH can be adopted.', array( 'status' => 400 ) );
+		}
+
+		$real_path = $validation['real_path'] ?? '';
+		if ( '' === $real_path ) {
+			return new \WP_Error( 'adopt_path_unresolved', sprintf( 'Could not resolve checkout path: %s', $path ), array( 'status' => 400 ) );
+		}
+
+		$git_path  = $real_path . '/.git';
+		if ( is_file( $git_path ) ) {
+			return new \WP_Error( 'adopt_linked_worktree', 'Cannot adopt a linked worktree as a primary checkout. Pass the primary checkout path instead.', array( 'status' => 400 ) );
+		}
+
+		if ( ! is_dir( $git_path ) ) {
+			return new \WP_Error( 'adopt_not_git_primary', sprintf( 'Path is not a git primary checkout: %s', $real_path ), array( 'status' => 400 ) );
+		}
+
+		if ( null === $name || '' === trim( $name ) ) {
+			$name = basename( $real_path );
+		}
+
+		if ( str_contains( $name, '@' ) ) {
+			return new \WP_Error( 'invalid_adopt_name', 'Repository names cannot contain "@". The "@<branch-slug>" suffix is reserved for worktrees.', array( 'status' => 400 ) );
+		}
+
+		$name = $this->sanitize_name( $name );
+		if ( '' === $name ) {
+			return new \WP_Error( 'invalid_adopt_name', 'Adopted repository name is empty after sanitization.', array( 'status' => 400 ) );
+		}
+
+		$expected_path = $this->workspace_path . '/' . $name;
+		if ( is_dir( $expected_path ) ) {
+			$expected_real = realpath( $expected_path );
+			if ( false !== $expected_real && $expected_real !== $real_path ) {
+				return new \WP_Error( 'adopt_name_collision', sprintf( 'Workspace name "%s" already points at a different directory: %s', $name, $expected_real ), array( 'status' => 400 ) );
+			}
+		} else {
+			return new \WP_Error( 'adopt_requires_workspace_path', sprintf( 'Adoption is non-destructive: %s must already be located at %s. Move or symlink operations are intentionally not performed by v1.', $real_path, $expected_path ), array( 'status' => 400 ) );
+		}
+
+		return array(
+			'success'         => true,
+			'name'            => $name,
+			'path'            => $real_path,
+			'already_adopted' => true,
+			'message'         => sprintf( 'Workspace checkout "%s" is already adopted at %s. No filesystem changes were made.', $name, $real_path ),
+		);
+	}
+
+	/**
 	 * Remove a repository from the workspace.
 	 *
 	 * @param string $handle Workspace handle.

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -418,7 +418,7 @@ class Workspace {
 			return new \WP_Error( 'adopt_path_unresolved', sprintf( 'Could not resolve checkout path: %s', $path ), array( 'status' => 400 ) );
 		}
 
-		$git_path  = $real_path . '/.git';
+		$git_path = $real_path . '/.git';
 		if ( is_file( $git_path ) ) {
 			return new \WP_Error( 'adopt_linked_worktree', 'Cannot adopt a linked worktree as a primary checkout. Pass the primary checkout path instead.', array( 'status' => 400 ) );
 		}

--- a/tests/smoke-workspace-adopt.php
+++ b/tests/smoke-workspace-adopt.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * Pure-PHP smoke test for workspace primary checkout adoption.
+ *
+ * Run: php tests/smoke-workspace-adopt.php
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Core\FilesRepository {
+	if ( ! class_exists( __NAMESPACE__ . '\\FilesystemHelper' ) ) {
+		class FilesystemHelper {
+			public static function get() {
+				return null;
+			}
+		}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			public string $code;
+			public string $message;
+			public array $data;
+
+			public function __construct( $code = '', $message = '', $data = array() ) {
+				$this->code    = (string) $code;
+				$this->message = (string) $message;
+				$this->data    = (array) $data;
+			}
+
+			public function get_error_code(): string {
+				return $this->code;
+			}
+
+			public function get_error_message(): string {
+				return $this->message;
+			}
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $thing ): bool {
+			return $thing instanceof \WP_Error;
+		}
+	}
+
+	if ( ! function_exists( 'wp_mkdir_p' ) ) {
+		function wp_mkdir_p( string $path ): bool {
+			return is_dir( $path ) || mkdir( $path, 0755, true );
+		}
+	}
+
+	if ( ! function_exists( 'get_option' ) ) {
+		function get_option( string $name, $default = false ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+			return $default;
+		}
+	}
+
+	if ( ! function_exists( 'size_format' ) ) {
+		function size_format( $bytes ): string {
+			return (string) $bytes;
+		}
+	}
+
+	require __DIR__ . '/../inc/Support/GitHubRemote.php';
+	require __DIR__ . '/../inc/Support/GitRunner.php';
+	require __DIR__ . '/../inc/Support/PathSecurity.php';
+	require __DIR__ . '/../inc/Workspace/WorkspaceMutationLock.php';
+	require __DIR__ . '/../inc/Workspace/WorktreeDiskBudget.php';
+	require __DIR__ . '/../inc/Workspace/WorktreeContextInjector.php';
+	require __DIR__ . '/../inc/Workspace/Workspace.php';
+
+	exec( 'git --version 2>&1', $_git_version, $git_version_exit );
+	if ( 0 !== $git_version_exit ) {
+		echo "SKIP: git not available\n";
+		exit( 0 );
+	}
+
+	$tmp = sys_get_temp_dir() . '/dmc-adopt-smoke-' . bin2hex( random_bytes( 4 ) );
+	mkdir( $tmp, 0755, true );
+	register_shutdown_function( function () use ( $tmp ) {
+		if ( is_dir( $tmp ) ) {
+			exec( 'rm -rf ' . escapeshellarg( $tmp ) );
+		}
+	} );
+
+	define( 'DATAMACHINE_WORKSPACE_PATH', realpath( $tmp ) ? realpath( $tmp ) : $tmp );
+
+	$failures = 0;
+	$total    = 0;
+
+	$assert = function ( $expected, $actual, string $message ) use ( &$failures, &$total ): void {
+		$total++;
+		if ( $expected === $actual ) {
+			echo "  ✓ {$message}\n";
+			return;
+		}
+		$failures++;
+		echo "  ✗ {$message}\n";
+		echo '    expected: ' . var_export( $expected, true ) . "\n";
+		echo '    actual:   ' . var_export( $actual, true ) . "\n";
+	};
+
+	$run = function ( string $cmd, string $cwd = '' ): array {
+		$full = '' === $cwd ? $cmd : sprintf( 'cd %s && %s', escapeshellarg( $cwd ), $cmd );
+		exec( $full . ' 2>&1', $out, $rc );
+		return array(
+			'output' => implode( "\n", $out ),
+			'exit'   => $rc,
+		);
+	};
+
+	$make_repo = function ( string $name ) use ( $tmp, $run ): string {
+		$path = $tmp . '/' . $name;
+		mkdir( $path, 0755, true );
+		$run( 'git init', $path );
+		$run( 'git config user.email test@example.com', $path );
+		$run( 'git config user.name test', $path );
+		file_put_contents( $path . '/README.md', $name . "\n" );
+		$run( 'git add README.md && git commit -m init', $path );
+		return $path;
+	};
+
+	echo "Setting up workspace at {$tmp}\n";
+	$primary        = $make_repo( 'homeboy' );
+	$explicit       = $make_repo( 'explicit-name' );
+	$collision      = $make_repo( 'collision' );
+	$collision_path = $make_repo( 'collision-path' );
+	$non_git        = $tmp . '/not-git';
+	mkdir( $non_git, 0755, true );
+
+	$run( 'git branch linked', $primary );
+	$linked = $tmp . '/homeboy@linked';
+	$run( sprintf( 'git worktree add %s linked', escapeshellarg( $linked ) ), $primary );
+	$outside = sys_get_temp_dir() . '/dmc-adopt-outside-' . bin2hex( random_bytes( 4 ) );
+	mkdir( $outside, 0755, true );
+	$run( 'git init', $outside );
+	register_shutdown_function( function () use ( $outside ) {
+		if ( is_dir( $outside ) ) {
+			exec( 'rm -rf ' . escapeshellarg( $outside ) );
+		}
+	} );
+
+	$ws = new \DataMachineCode\Workspace\Workspace();
+	$adopt = function ( string $path, ?string $name = null ) use ( $ws ): array|\WP_Error {
+		// @phpstan-ignore-next-line Pure-PHP smoke requires the production class at runtime.
+		return $ws->adopt_repo( $path, $name );
+	};
+
+	echo "\nAdopt existing primary\n";
+	$result = $adopt( $primary );
+	$assert( true, ! is_wp_error( $result ) && ( $result['success'] ?? false ), 'existing primary under workspace adopts' );
+	$assert( 'homeboy', is_wp_error( $result ) ? '' : $result['name'], 'omitted name derives path basename' );
+	$assert( realpath( $primary ), is_wp_error( $result ) ? '' : $result['path'], 'adopted path is real primary path' );
+	$assert( true, is_wp_error( $result ) ? false : $result['already_adopted'], 'adoption reports already_adopted' );
+
+	$result = $adopt( $explicit, 'explicit-name' );
+	$assert( true, ! is_wp_error( $result ) && ( $result['success'] ?? false ), 'explicit matching name adopts' );
+	$assert( 'explicit-name', is_wp_error( $result ) ? '' : $result['name'], 'explicit name is used' );
+
+	echo "\nReject invalid adoption targets\n";
+	$result = $adopt( $linked );
+	$assert( true, is_wp_error( $result ), 'linked worktree is rejected' );
+	$assert( 'adopt_linked_worktree', is_wp_error( $result ) ? $result->get_error_code() : '', 'linked worktree error code' );
+
+	$result = $adopt( $non_git );
+	$assert( true, is_wp_error( $result ), 'non-git path is rejected' );
+	$assert( 'adopt_not_git_primary', is_wp_error( $result ) ? $result->get_error_code() : '', 'non-git error code' );
+
+	$result = $adopt( $outside );
+	$assert( true, is_wp_error( $result ), 'outside workspace path is rejected' );
+	$assert( 'adopt_outside_workspace', is_wp_error( $result ) ? $result->get_error_code() : '', 'outside workspace error code' );
+
+	$result = $adopt( $collision_path, 'collision' );
+	$assert( true, is_wp_error( $result ), 'name collision is rejected' );
+	$assert( 'adopt_name_collision', is_wp_error( $result ) ? $result->get_error_code() : '', 'collision error code' );
+
+	$result = $adopt( $collision_path, 'future-name' );
+	$assert( true, is_wp_error( $result ), 'adoption refuses moves or symlinks' );
+	$assert( 'adopt_requires_workspace_path', is_wp_error( $result ) ? $result->get_error_code() : '', 'move/symlink refusal error code' );
+
+	echo "\nResult: " . ( $total - $failures ) . "/{$total} passed\n";
+	exit( $failures > 0 ? 1 : 0 );
+}


### PR DESCRIPTION
## Summary
- Adds a first-class `workspace adopt` flow for existing primary checkouts that already live under the workspace root.
- Keeps v1 non-destructive: adoption validates the checkout and reports that it is already managed by workspace naming conventions instead of moving or symlinking directories.

## Changes
- Adds `Workspace::adopt_repo()` with validation for readable paths, workspace containment, git primary checkouts, linked-worktree rejection, sanitized names, and name/path collisions.
- Registers `datamachine/workspace-adopt` as a CLI-only ability and wires `wp datamachine-code workspace adopt <path> [--name=...]` through the existing workspace command layer.
- Adds `tests/smoke-workspace-adopt.php` covering successful primary adoption, basename-derived names, explicit names, linked worktree rejection, non-git rejection, outside-workspace rejection, name collisions, and move/symlink refusal.

## Tests
- `php tests/smoke-workspace-adopt.php` — 16/16 passed
- `php -l inc/Workspace/Workspace.php && php -l inc/Cli/Commands/WorkspaceCommand.php && php -l inc/Abilities/WorkspaceAbilities.php && php -l tests/smoke-workspace-adopt.php`
- `git diff --check`
- `homeboy audit data-machine-code --path /Users/chubes/Developer/data-machine-code@feat-workspace-adopt-existing --changed-since origin/main` — passed; reported contextual non-blocking audit findings because no changed-since baseline exists
- `homeboy lint data-machine-code --path /Users/chubes/Developer/data-machine-code@feat-workspace-adopt-existing --changed-since origin/main` — failed on existing touched-file PHPCS/PHPStan debt in `Workspace.php`, `WorkspaceAbilities.php`, and `WorkspaceCommand.php`; focused smoke/syntax checks for this PR pass

Closes #168

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the adopt flow, wrote the focused smoke coverage, ran validation, and drafted this PR body. Chris remains responsible for review and merge.