### PR TITLE
fix(environment): verify shell commands execute

### DIFF
--- a/inc/Environment.php
+++ b/inc/Environment.php
@@ -34,6 +34,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Environment {
 
 	/**
+	 * Memoized shell capability diagnostic. Null until the first probe.
+	 *
+	 * @var array{ok: bool, reason: string, output?: string, exit_code?: int|null}|null
+	 */
+	private static $shell_diagnostic_cache = null;
+
+	/**
 	 * Is the coding agent runtime bridge available on this install?
 	 *
 	 * Returns true whenever this class is loaded, which is equivalent to
@@ -50,23 +57,110 @@ class Environment {
 	}
 
 	/**
-	 * Can this install execute shell commands via `shell_exec`?
+	 * Can this install execute shell commands?
 	 *
 	 * Some hosts disable shell functions via `disable_functions` in
-	 * php.ini. Coding-agent integrations that spawn processes (e.g. MCP
-	 * bridges, git operations through proc_open) should gate on this.
+	 * php.ini. Other hosts expose the functions but cannot execute external
+	 * commands. Coding-agent integrations that spawn processes should gate on
+	 * this.
 	 *
 	 * @since 0.6.0
 	 *
-	 * @return bool True if `shell_exec` is callable.
+	 * @return bool True if command execution is usable.
 	 */
 	public static function has_shell(): bool {
-		if ( ! function_exists( 'shell_exec' ) ) {
-			return false;
+		$diagnostic = self::shell_diagnostic();
+		return true === $diagnostic['ok'];
+	}
+
+	/**
+	 * Return the shell capability diagnostic for this request.
+	 *
+	 * @since 0.24.0
+	 *
+	 * @return array{ok: bool, reason: string, output?: string, exit_code?: int|null}
+	 */
+	public static function shell_diagnostic(): array {
+		if ( null !== self::$shell_diagnostic_cache ) {
+			return self::$shell_diagnostic_cache;
 		}
 
-		$disabled = array_map( 'trim', explode( ',', (string) ini_get( 'disable_functions' ) ) );
-		return ! in_array( 'shell_exec', $disabled, true );
+		self::$shell_diagnostic_cache = self::evaluate_shell_capability(
+			static function ( string $function_name ): bool {
+				return function_exists( $function_name );
+			},
+			(string) ini_get( 'disable_functions' ),
+			static function ( string $command ): array {
+				$output    = array();
+				$exit_code = null;
+
+				// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec -- Environment capability probe.
+				exec( $command, $output, $exit_code );
+
+				return array(
+					'output'    => $output,
+					'exit_code' => $exit_code,
+				);
+			}
+		);
+
+		return self::$shell_diagnostic_cache;
+	}
+
+	/**
+	 * Evaluate shell capability with injectable probes for tests.
+	 *
+	 * @since 0.24.0
+	 *
+	 * @param callable $function_exists    Callback receiving a function name and returning availability.
+	 * @param string   $disabled_functions Raw `disable_functions` value.
+	 * @param callable $command_runner     Callback receiving command and returning output plus exit code.
+	 * @return array{ok: bool, reason: string, output?: string, exit_code?: int|null}
+	 */
+	private static function evaluate_shell_capability( callable $function_exists, string $disabled_functions, callable $command_runner ): array {
+		$required_functions = array( 'exec', 'shell_exec' );
+		$disabled           = array_filter( array_map( 'trim', explode( ',', $disabled_functions ) ) );
+
+		foreach ( $required_functions as $function_name ) {
+			if ( ! $function_exists( $function_name ) ) {
+				return array(
+					'ok'     => false,
+					'reason' => $function_name . '_missing',
+				);
+			}
+
+			if ( in_array( $function_name, $disabled, true ) ) {
+				return array(
+					'ok'     => false,
+					'reason' => $function_name . '_disabled',
+				);
+			}
+		}
+
+		$marker = '__datamachine_code_shell_ok__';
+
+		/** @var array{output: array<int, string>, exit_code: int|null} $result */
+		$result = $command_runner( 'printf ' . escapeshellarg( $marker ) . ' 2>&1' );
+
+		$output    = $result['output'];
+		$exit_code = $result['exit_code'];
+
+		$actual_output = trim( implode( "\n", array_map( 'strval', $output ) ) );
+		if ( 0 !== $exit_code || $marker !== $actual_output ) {
+			return array(
+				'ok'        => false,
+				'reason'    => 'probe_failed',
+				'output'    => $actual_output,
+				'exit_code' => $exit_code,
+			);
+		}
+
+		return array(
+			'ok'        => true,
+			'reason'    => 'ok',
+			'output'    => $actual_output,
+			'exit_code' => $exit_code,
+		);
 	}
 
 	/**

--- a/tests/smoke-environment-shell.php
+++ b/tests/smoke-environment-shell.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Pure-PHP smoke test for Environment shell capability probes.
+ *
+ * Run: php tests/smoke-environment-shell.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+declare( strict_types=1 );
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+require __DIR__ . '/../inc/Environment.php';
+
+use DataMachineCode\Environment;
+
+$failures = array();
+$assert   = function ( string $label, bool $cond ) use ( &$failures ): void {
+	if ( $cond ) {
+		echo "  [PASS] {$label}\n";
+		return;
+	}
+
+	$failures[] = $label;
+	echo "  [FAIL] {$label}\n";
+};
+
+$evaluate = new ReflectionMethod( Environment::class, 'evaluate_shell_capability' );
+
+$run_evaluation = static function ( callable $function_exists, string $disabled_functions, callable $runner ) use ( $evaluate ): array {
+	return $evaluate->invoke( null, $function_exists, $disabled_functions, $runner );
+};
+
+echo "Environment shell capability -- smoke\n";
+
+$available_function = static function ( string $function_name ): bool {
+	return in_array( $function_name, array( 'exec', 'shell_exec' ), true );
+};
+
+$success_runner = static function ( string $command ): array {
+	unset( $command );
+
+	return array(
+		'output'    => array( '__datamachine_code_shell_ok__' ),
+		'exit_code' => 0,
+	);
+};
+
+$success = $run_evaluation( $available_function, '', $success_runner );
+$assert( 'probe success reports ok', true === $success['ok'] );
+$assert( 'probe success reason is ok', 'ok' === $success['reason'] );
+$assert( 'probe success records exit code', 0 === $success['exit_code'] );
+
+$missing = $run_evaluation(
+	static function ( string $function_name ): bool {
+		return 'exec' !== $function_name;
+	},
+	'',
+	$success_runner
+);
+$assert( 'missing exec reports unavailable', false === $missing['ok'] );
+$assert( 'missing exec reason is machine-readable', 'exec_missing' === $missing['reason'] );
+
+$disabled = $run_evaluation( $available_function, 'shell_exec, passthru', $success_runner );
+$assert( 'disabled shell_exec reports unavailable', false === $disabled['ok'] );
+$assert( 'disabled shell_exec reason is machine-readable', 'shell_exec_disabled' === $disabled['reason'] );
+
+$failed = $run_evaluation(
+	$available_function,
+	'',
+	static function ( string $command ): array {
+		unset( $command );
+
+		return array(
+			'output'    => array( '' ),
+			'exit_code' => 1,
+		);
+	}
+);
+$assert( 'failed command reports unavailable', false === $failed['ok'] );
+$assert( 'failed command reason is machine-readable', 'probe_failed' === $failed['reason'] );
+$assert( 'failed command records exit code', 1 === $failed['exit_code'] );
+
+$bad_output = $run_evaluation(
+	$available_function,
+	'',
+	static function ( string $command ): array {
+		unset( $command );
+
+		return array(
+			'output'    => array( 'unexpected' ),
+			'exit_code' => 0,
+		);
+	}
+);
+$assert( 'wrong output reports unavailable', false === $bad_output['ok'] );
+$assert( 'wrong output reports probe failure', 'probe_failed' === $bad_output['reason'] );
+
+if ( Environment::has_shell() ) {
+	$live = Environment::shell_diagnostic();
+	$assert( 'live diagnostic agrees with has_shell true', true === $live['ok'] );
+} else {
+	$live = Environment::shell_diagnostic();
+	$assert( 'live diagnostic agrees with has_shell false', false === $live['ok'] );
+}
+
+if ( ! empty( $failures ) ) {
+	echo "\nFAIL: " . count( $failures ) . " assertion(s)\n";
+	foreach ( $failures as $failure ) {
+		echo "  - {$failure}\n";
+	}
+	exit( 1 );
+}
+
+echo "\nOK\n";
+exit( 0 );


### PR DESCRIPTION
## Summary
- Tightens Environment shell detection so it only reports available when command execution actually works.
- Adds machine-readable shell diagnostics for missing, disabled, and failed command probes.

## Changes
- Checks exec and shell_exec availability plus disable_functions before probing.
- Runs a tiny printf marker command and verifies both output and exit code.
- Caches the diagnostic per request and keeps Homeboy detection gated through Environment::has_shell().
- Adds a focused pure-PHP smoke for disabled-function, success, and command-failure paths.

## Tests
- php tests/smoke-environment-shell.php
- php tests/smoke-homeboy.php
- homeboy lint data-machine-code --path /Users/chubes/Developer/data-machine-code@fix-shell-capability-probe --changed-since origin/main
- homeboy audit data-machine-code --path /Users/chubes/Developer/data-machine-code@fix-shell-capability-probe --changed-since origin/main

Closes #165

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the shell capability probe fix, wrote focused smoke coverage, and ran validation. Chris remains responsible for review and merge.