### PR TITLE
Fix worktree finalizer CLI flag synopsis

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1108,10 +1108,12 @@ class WorkspaceCommand extends BaseCommand {
 	 * ## OPTIONS
 	 *
 	 * <operation>
-	 * : Worktree operation: add, list, remove, prune, cleanup, reconcile-metadata, refresh-context.
+	 * : Worktree operation: add, list, remove, prune, cleanup, cleanup-artifacts,
+	 *   reconcile-metadata, refresh-context, finalize, mark-cleanup-eligible.
 	 *
 	 * [<repo>]
-	 * : Primary repo name (required for add and remove). For refresh-context,
+	 * : Primary repo name (required for add and remove). For refresh-context, finalize,
+	 *   and mark-cleanup-eligible,
 	 *   pass the full worktree handle (`<repo>@<branch-slug>`) here instead.
 	 *
 	 * [<branch>]
@@ -1167,6 +1169,13 @@ class WorkspaceCommand extends BaseCommand {
 	 * : For `add`, explicitly bypass the disk-budget refusal threshold. For
 	 *   `remove`, force-remove a worktree even if it is dirty. For `cleanup`,
 	 *   force dirty-worktree removal but not the unpushed-commits safety.
+	 *
+	 * [--pr=<url-or-number>]
+	 * : Attach pull request metadata when finalizing or marking a worktree
+	 *   cleanup-eligible.
+	 *
+	 * [--state=<state>]
+	 * : Lifecycle state to record when finalizing a worktree.
 	 *
 	 * [--dry-run]
 	 * : Preview cleanup candidates without removing anything (cleanup only).

--- a/tests/smoke-worktree-finalizer-cli.php
+++ b/tests/smoke-worktree-finalizer-cli.php
@@ -118,6 +118,10 @@ namespace {
 		'datamachine/workspace-worktree-list'     => $list,
 	);
 	$command = new \DataMachineCode\Cli\Commands\WorkspaceCommand();
+	$worktree_method = new ReflectionMethod( $command, 'worktree' );
+	$worktree_docs   = (string) $worktree_method->getDocComment();
+	datamachine_code_finalizer_assert( str_contains( $worktree_docs, '[--pr=<url-or-number>]' ), 'worktree synopsis documents finalizer PR flag' );
+	datamachine_code_finalizer_assert( str_contains( $worktree_docs, '[--state=<state>]' ), 'worktree synopsis documents finalizer state flag' );
 
 	WP_CLI::$logs      = array();
 	WP_CLI::$successes = array();


### PR DESCRIPTION
## Summary
- Add the documented `workspace worktree finalize` and `mark-cleanup-eligible` finalizer options to the WP-CLI docblock synopsis.
- Extend the existing worktree finalizer smoke test so it catches missing `--pr` / `--state` synopsis coverage.

Fixes #177.

## Testing
- `php -l inc/Cli/Commands/WorkspaceCommand.php && php -l tests/smoke-worktree-finalizer-cli.php`
- `php tests/smoke-worktree-finalizer-cli.php`
- `homeboy lint` (fails on existing repo-wide phpstan/phpcs findings outside this change)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the minimal docblock/test update and ran local verification; Chris remains responsible for review and merge.