### PR TITLE
Refuse unsafe worktree disk budgets

### DIFF
--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -1280,9 +1280,13 @@ class Workspace {
 			return new \WP_Error(
 				'worktree_disk_budget_exceeded',
 				sprintf(
-					"Refusing to create worktree: %s\nRun %s to review cleanup candidates, or retry with --force to override the disk-budget refusal threshold.",
-					implode( ' ', (array) ( $disk_budget['warnings'] ?? array() ) ),
-					$disk_budget['cleanup_dry_run_command']
+					"Refusing to create worktree before bootstrap/install because the workspace disk budget is unsafe.\n%s\nThreshold: keep at least %.1f GiB free and %.1f%% free; effective floor on this filesystem is %.1f GiB.\nRun %s to review cleanup candidates, run %s to review artifact cleanup, or retry with --force only when a human explicitly accepts the disk-pressure risk.",
+					WorktreeDiskBudget::format_summary( $disk_budget ),
+					(float) ( $disk_budget['refuse_free_gib'] ?? 0 ),
+					(float) ( $disk_budget['refuse_free_percent'] ?? 0 ),
+					(float) ( $disk_budget['effective_refuse_gib'] ?? 0 ),
+					$disk_budget['cleanup_dry_run_command'],
+					$disk_budget['artifact_cleanup_command']
 				),
 				array(
 					'status'      => 507,

--- a/inc/Workspace/WorktreeDiskBudget.php
+++ b/inc/Workspace/WorktreeDiskBudget.php
@@ -21,9 +21,19 @@ final class WorktreeDiskBudget {
 	private const DEFAULT_WARN_FREE_GIB = 20;
 
 	/**
-	 * Default refusal threshold: 5 GiB free.
+	 * Default refusal threshold: 10 GiB free.
 	 */
-	private const DEFAULT_REFUSE_FREE_GIB = 5;
+	private const DEFAULT_REFUSE_FREE_GIB = 10;
+
+	/**
+	 * Default warning threshold: 15% free.
+	 */
+	private const DEFAULT_WARN_FREE_PERCENT = 15.0;
+
+	/**
+	 * Default refusal threshold: 10% free.
+	 */
+	private const DEFAULT_REFUSE_FREE_PERCENT = 10.0;
 
 	/**
 	 * Default worktree-count warning threshold.
@@ -41,13 +51,16 @@ final class WorktreeDiskBudget {
 	public static function inspect( string $workspace_path, array $thresholds = array(), bool $forced = false ): array {
 		$thresholds = self::normalize_thresholds( $thresholds );
 		$free_bytes = is_dir( $workspace_path ) ? disk_free_space( $workspace_path ) : false; // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_disk_free_space
+		$total_bytes = is_dir( $workspace_path ) ? disk_total_space( $workspace_path ) : false; // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_disk_total_space
 		$free_bytes = is_float( $free_bytes ) ? (int) $free_bytes : null;
+		$total_bytes = is_float( $total_bytes ) ? (int) $total_bytes : null;
 		$worktrees  = self::count_worktree_like_dirs( $workspace_path );
 
 		return self::evaluate(
 			array(
 				'workspace_path' => $workspace_path,
 				'free_bytes'     => $free_bytes,
+				'total_bytes'    => $total_bytes,
 				'worktree_count' => $worktrees,
 			),
 			$thresholds,
@@ -66,23 +79,39 @@ final class WorktreeDiskBudget {
 	public static function evaluate( array $metrics, array $thresholds = array(), bool $forced = false ): array {
 		$thresholds = self::normalize_thresholds( $thresholds );
 		$free_bytes = isset( $metrics['free_bytes'] ) && is_numeric( $metrics['free_bytes'] ) ? (int) $metrics['free_bytes'] : null;
+		$total_bytes = isset( $metrics['total_bytes'] ) && is_numeric( $metrics['total_bytes'] ) ? (int) $metrics['total_bytes'] : null;
+		$free_percent = null;
+		if ( null !== $free_bytes && null !== $total_bytes && $total_bytes > 0 ) {
+			$free_percent = ( $free_bytes / $total_bytes ) * 100;
+		}
 		$count      = isset( $metrics['worktree_count'] ) && is_numeric( $metrics['worktree_count'] ) ? (int) $metrics['worktree_count'] : 0;
 		$warnings   = array();
 		$refused    = false;
 
+		$effective_refuse_bytes = $thresholds['refuse_free_bytes'];
+		$effective_warn_bytes   = $thresholds['warn_free_bytes'];
+		if ( null !== $total_bytes && $total_bytes > 0 ) {
+			$effective_refuse_bytes = max( $effective_refuse_bytes, (int) ceil( $total_bytes * ( $thresholds['refuse_free_percent'] / 100 ) ) );
+			$effective_warn_bytes   = max( $effective_warn_bytes, (int) ceil( $total_bytes * ( $thresholds['warn_free_percent'] / 100 ) ) );
+		}
+
 		if ( null !== $free_bytes ) {
-			if ( $free_bytes < $thresholds['refuse_free_bytes'] ) {
+			if ( $free_bytes < $effective_refuse_bytes ) {
 				$refused    = ! $forced;
 				$warnings[] = sprintf(
-					'Free disk space is %.1f GiB, below the %.1f GiB refusal threshold.',
+					'Free disk space is %.1f GiB%s, below the refusal threshold of %.1f GiB or %.1f%% free, whichever is stricter.',
 					self::bytes_to_gib( $free_bytes ),
-					self::bytes_to_gib( $thresholds['refuse_free_bytes'] )
+					null === $free_percent ? '' : sprintf( ' (%.1f%%)', $free_percent ),
+					self::bytes_to_gib( $thresholds['refuse_free_bytes'] ),
+					$thresholds['refuse_free_percent']
 				);
-			} elseif ( $free_bytes < $thresholds['warn_free_bytes'] ) {
+			} elseif ( $free_bytes < $effective_warn_bytes ) {
 				$warnings[] = sprintf(
-					'Free disk space is %.1f GiB, below the %.1f GiB warning threshold.',
+					'Free disk space is %.1f GiB%s, below the warning threshold of %.1f GiB or %.1f%% free, whichever is stricter.',
 					self::bytes_to_gib( $free_bytes ),
-					self::bytes_to_gib( $thresholds['warn_free_bytes'] )
+					null === $free_percent ? '' : sprintf( ' (%.1f%%)', $free_percent ),
+					self::bytes_to_gib( $thresholds['warn_free_bytes'] ),
+					$thresholds['warn_free_percent']
 				);
 			}
 		} else {
@@ -103,18 +132,26 @@ final class WorktreeDiskBudget {
 			'workspace_path'          => (string) ( $metrics['workspace_path'] ?? '' ),
 			'free_bytes'              => $free_bytes,
 			'free_gib'                => null === $free_bytes ? null : round( self::bytes_to_gib( $free_bytes ), 2 ),
+			'total_bytes'             => $total_bytes,
+			'total_gib'               => null === $total_bytes ? null : round( self::bytes_to_gib( $total_bytes ), 2 ),
+			'free_percent'            => null === $free_percent ? null : round( $free_percent, 2 ),
 			'workspace_size_bytes'    => null,
 			'workspace_size_exact'    => false,
 			'worktree_count'          => $count,
 			'warn_free_bytes'         => $thresholds['warn_free_bytes'],
 			'warn_free_gib'           => round( self::bytes_to_gib( $thresholds['warn_free_bytes'] ), 2 ),
+			'warn_free_percent'       => $thresholds['warn_free_percent'],
 			'refuse_free_bytes'       => $thresholds['refuse_free_bytes'],
 			'refuse_free_gib'         => round( self::bytes_to_gib( $thresholds['refuse_free_bytes'] ), 2 ),
+			'refuse_free_percent'     => $thresholds['refuse_free_percent'],
+			'effective_refuse_bytes'  => $effective_refuse_bytes,
+			'effective_refuse_gib'    => round( self::bytes_to_gib( $effective_refuse_bytes ), 2 ),
 			'warn_worktree_count'     => $thresholds['warn_worktree_count'],
 			'forced'                  => $forced,
 			'status'                  => $status,
 			'warnings'                => $warnings,
-			'cleanup_dry_run_command' => 'studio wp datamachine-code workspace worktree cleanup --dry-run',
+			'cleanup_dry_run_command'  => 'studio wp datamachine-code workspace worktree cleanup --dry-run',
+			'artifact_cleanup_command' => 'studio wp datamachine-code workspace worktree cleanup-artifacts --dry-run',
 			'force_override_required' => $refused,
 			'force_override_applied'  => $forced && ! empty( $warnings ),
 		);
@@ -125,12 +162,14 @@ final class WorktreeDiskBudget {
 	 *
 	 * @param string $repo   Repository name.
 	 * @param string $branch Branch name.
-	 * @return array<string,int>
+	 * @return array<string,int|float>
 	 */
 	public static function thresholds( string $repo, string $branch ): array {
 		$thresholds = array(
 			'warn_free_bytes'     => self::DEFAULT_WARN_FREE_GIB * self::BYTES_PER_GIB,
 			'refuse_free_bytes'   => self::DEFAULT_REFUSE_FREE_GIB * self::BYTES_PER_GIB,
+			'warn_free_percent'   => self::DEFAULT_WARN_FREE_PERCENT,
+			'refuse_free_percent' => self::DEFAULT_REFUSE_FREE_PERCENT,
 			'warn_worktree_count' => self::DEFAULT_WARN_WORKTREE_COUNT,
 		);
 
@@ -157,9 +196,15 @@ final class WorktreeDiskBudget {
 	 */
 	public static function format_summary( array $budget ): string {
 		$free = null === ( $budget['free_gib'] ?? null ) ? 'unknown' : sprintf( '%.1f GiB', (float) $budget['free_gib'] );
+		if ( null !== ( $budget['free_percent'] ?? null ) ) {
+			$free .= sprintf( ' (%.1f%%)', (float) $budget['free_percent'] );
+		}
+		$total = null === ( $budget['total_gib'] ?? null ) ? 'unknown total' : sprintf( '%.1f GiB total', (float) $budget['total_gib'] );
 		return sprintf(
-			'Disk budget: %s free, %d worktree-like dirs, status=%s.',
+			'Disk budget: workspace=%s, %s free of %s, %d worktree-like dirs, status=%s.',
+			(string) ( $budget['workspace_path'] ?? '' ),
 			$free,
+			$total,
 			(int) ( $budget['worktree_count'] ?? 0 ),
 			(string) ( $budget['status'] ?? 'unknown' )
 		);
@@ -169,26 +214,37 @@ final class WorktreeDiskBudget {
 	 * Normalize threshold inputs.
 	 *
 	 * @param array $thresholds Raw thresholds.
-	 * @return array<string,int>
+	 * @return array<string,int|float>
 	 */
 	private static function normalize_thresholds( array $thresholds ): array {
-		$warn_free   = isset( $thresholds['warn_free_bytes'] ) && is_numeric( $thresholds['warn_free_bytes'] )
+		$warn_free      = isset( $thresholds['warn_free_bytes'] ) && is_numeric( $thresholds['warn_free_bytes'] )
 			? max( 0, (int) $thresholds['warn_free_bytes'] )
 			: self::DEFAULT_WARN_FREE_GIB * self::BYTES_PER_GIB;
-		$refuse_free = isset( $thresholds['refuse_free_bytes'] ) && is_numeric( $thresholds['refuse_free_bytes'] )
+		$refuse_free    = isset( $thresholds['refuse_free_bytes'] ) && is_numeric( $thresholds['refuse_free_bytes'] )
 			? max( 0, (int) $thresholds['refuse_free_bytes'] )
 			: self::DEFAULT_REFUSE_FREE_GIB * self::BYTES_PER_GIB;
-		$count       = isset( $thresholds['warn_worktree_count'] ) && is_numeric( $thresholds['warn_worktree_count'] )
+		$warn_percent   = isset( $thresholds['warn_free_percent'] ) && is_numeric( $thresholds['warn_free_percent'] )
+			? max( 0.0, min( 100.0, (float) $thresholds['warn_free_percent'] ) )
+			: self::DEFAULT_WARN_FREE_PERCENT;
+		$refuse_percent = isset( $thresholds['refuse_free_percent'] ) && is_numeric( $thresholds['refuse_free_percent'] )
+			? max( 0.0, min( 100.0, (float) $thresholds['refuse_free_percent'] ) )
+			: self::DEFAULT_REFUSE_FREE_PERCENT;
+		$count          = isset( $thresholds['warn_worktree_count'] ) && is_numeric( $thresholds['warn_worktree_count'] )
 			? max( 0, (int) $thresholds['warn_worktree_count'] )
 			: self::DEFAULT_WARN_WORKTREE_COUNT;
 
 		if ( $refuse_free > $warn_free ) {
 			$warn_free = $refuse_free;
 		}
+		if ( $refuse_percent > $warn_percent ) {
+			$warn_percent = $refuse_percent;
+		}
 
 		return array(
 			'warn_free_bytes'     => $warn_free,
 			'refuse_free_bytes'   => $refuse_free,
+			'warn_free_percent'   => $warn_percent,
+			'refuse_free_percent' => $refuse_percent,
 			'warn_worktree_count' => $count,
 		);
 	}

--- a/tests/smoke-worktree-disk-budget.php
+++ b/tests/smoke-worktree-disk-budget.php
@@ -30,7 +30,9 @@ echo "=== smoke-worktree-disk-budget ===\n";
 $gib        = 1073741824;
 $thresholds = array(
 	'warn_free_bytes'     => 20 * $gib,
-	'refuse_free_bytes'   => 5 * $gib,
+	'refuse_free_bytes'   => 10 * $gib,
+	'warn_free_percent'   => 15,
+	'refuse_free_percent' => 10,
 	'warn_worktree_count' => 100,
 );
 
@@ -39,6 +41,7 @@ $budget = WorktreeDiskBudget::evaluate(
 	array(
 		'workspace_path' => '/tmp/workspace',
 		'free_bytes'     => 25 * $gib,
+		'total_bytes'    => 100 * $gib,
 		'worktree_count' => 10,
 	),
 	$thresholds
@@ -52,7 +55,8 @@ echo "\n[2] low free space warns above refusal threshold\n";
 $budget = WorktreeDiskBudget::evaluate(
 	array(
 		'workspace_path' => '/tmp/workspace',
-		'free_bytes'     => 10 * $gib,
+		'free_bytes'     => 15 * $gib,
+		'total_bytes'    => 100 * $gib,
 		'worktree_count' => 10,
 	),
 	$thresholds
@@ -65,20 +69,23 @@ echo "\n[3] critically low free space refuses without force\n";
 $budget = WorktreeDiskBudget::evaluate(
 	array(
 		'workspace_path' => '/tmp/workspace',
-		'free_bytes'     => 1 * $gib,
+		'free_bytes'     => 5 * $gib,
+		'total_bytes'    => 100 * $gib,
 		'worktree_count' => 10,
 	),
 	$thresholds
 );
-datamachine_code_budget_assert( 'refused' === $budget['status'], 'refused status below 5 GiB' );
+datamachine_code_budget_assert( 'refused' === $budget['status'], 'refused status below 10 GiB' );
 datamachine_code_budget_assert( true === $budget['force_override_required'], 'force required below refusal threshold' );
 datamachine_code_budget_assert( str_contains( $budget['cleanup_dry_run_command'], 'workspace worktree cleanup --dry-run' ), 'cleanup dry-run command is present' );
+datamachine_code_budget_assert( str_contains( $budget['artifact_cleanup_command'], 'workspace worktree cleanup-artifacts --dry-run' ), 'artifact cleanup dry-run command is present' );
 
 echo "\n[4] force makes low-space override explicit\n";
 $budget = WorktreeDiskBudget::evaluate(
 	array(
 		'workspace_path' => '/tmp/workspace',
-		'free_bytes'     => 1 * $gib,
+		'free_bytes'     => 5 * $gib,
+		'total_bytes'    => 100 * $gib,
 		'worktree_count' => 10,
 	),
 	$thresholds,
@@ -88,11 +95,26 @@ datamachine_code_budget_assert( 'warning' === $budget['status'], 'forced low-spa
 datamachine_code_budget_assert( true === $budget['forced'], 'forced flag is recorded' );
 datamachine_code_budget_assert( true === $budget['force_override_applied'], 'force override is visible in output data' );
 
-echo "\n[5] high worktree count warns independently\n";
+echo "\n[5] percent floor refuses even when absolute free space is above 10 GiB\n";
+$budget = WorktreeDiskBudget::evaluate(
+	array(
+		'workspace_path' => '/tmp/workspace',
+		'free_bytes'     => 15 * $gib,
+		'total_bytes'    => 200 * $gib,
+		'worktree_count' => 10,
+	),
+	$thresholds
+);
+datamachine_code_budget_assert( 'refused' === $budget['status'], 'refused status below 10 percent free' );
+datamachine_code_budget_assert( 20.0 === $budget['effective_refuse_gib'], 'effective refusal floor uses stricter percentage threshold' );
+datamachine_code_budget_assert( 7.5 === $budget['free_percent'], 'free percentage is reported' );
+
+echo "\n[6] high worktree count warns independently\n";
 $budget = WorktreeDiskBudget::evaluate(
 	array(
 		'workspace_path' => '/tmp/workspace',
 		'free_bytes'     => 25 * $gib,
+		'total_bytes'    => 100 * $gib,
 		'worktree_count' => 101,
 	),
 	$thresholds
@@ -100,7 +122,7 @@ $budget = WorktreeDiskBudget::evaluate(
 datamachine_code_budget_assert( 'warning' === $budget['status'], 'high worktree count warns' );
 datamachine_code_budget_assert( str_contains( $budget['warnings'][0], '101 worktree-like directories' ), 'worktree-count warning is descriptive' );
 
-echo "\n[6] inspect counts only worktree-like directories\n";
+echo "\n[7] inspect counts only worktree-like directories\n";
 $tmp = sys_get_temp_dir() . '/dmc-budget-' . uniqid( '', true );
 mkdir( $tmp );
 mkdir( $tmp . '/repo' );
@@ -110,7 +132,9 @@ file_put_contents( $tmp . '/repo@not-a-dir', 'file' );
 $budget = WorktreeDiskBudget::inspect( $tmp, $thresholds );
 datamachine_code_budget_assert( 2 === $budget['worktree_count'], 'inspect counts @ directories only' );
 datamachine_code_budget_assert( null !== $budget['free_bytes'], 'inspect reports free bytes' );
+datamachine_code_budget_assert( null !== $budget['total_bytes'], 'inspect reports total bytes' );
 datamachine_code_budget_assert( str_contains( WorktreeDiskBudget::format_summary( $budget ), 'worktree-like dirs' ), 'summary includes worktree count' );
+datamachine_code_budget_assert( str_contains( WorktreeDiskBudget::format_summary( $budget ), $tmp ), 'summary includes workspace root' );
 unlink( $tmp . '/repo@not-a-dir' );
 rmdir( $tmp . '/repo@feature-two' );
 rmdir( $tmp . '/repo@feature-one' );

--- a/tests/smoke-worktree-lifecycle-metadata.php
+++ b/tests/smoke-worktree-lifecycle-metadata.php
@@ -100,7 +100,11 @@ namespace {
 	}
 
 	if ( ! function_exists( 'apply_filters' ) ) {
-		function apply_filters( string $hook_name, $value ) {
+		function apply_filters( string $hook_name, $value, ...$args ) {
+			global $datamachine_code_test_filters;
+			if ( isset( $datamachine_code_test_filters[ $hook_name ] ) && is_callable( $datamachine_code_test_filters[ $hook_name ] ) ) {
+				return $datamachine_code_test_filters[ $hook_name ]( $value, ...$args );
+			}
 			return $value;
 		}
 	}
@@ -195,7 +199,20 @@ namespace {
 	putenv( 'OPENCODE_RUN_ID=smoke-run-123' );
 	putenv( 'OPENCODE_PID=12345' );
 
-	$ws     = new \DataMachineCode\Workspace\Workspace();
+	$ws = new \DataMachineCode\Workspace\Workspace();
+
+	$GLOBALS['datamachine_code_test_filters']['datamachine_worktree_disk_budget_thresholds'] = function ( array $thresholds ): array {
+		$thresholds['refuse_free_bytes'] = PHP_INT_MAX;
+		$thresholds['warn_free_bytes']   = PHP_INT_MAX;
+		return $thresholds;
+	};
+	$refused = $ws->worktree_add( 'demo', 'feature/disk-budget-refusal', 'HEAD', true, true, true, false, false );
+	unset( $GLOBALS['datamachine_code_test_filters']['datamachine_worktree_disk_budget_thresholds'] );
+	$assert( true, is_wp_error( $refused ), 'worktree_add refuses before creation when disk budget is unsafe' );
+	$assert( false, is_dir( DATAMACHINE_WORKSPACE_PATH . '/demo@feature-disk-budget-refusal' ), 'refused disk budget does not leave a worktree directory' );
+	$assert( true, str_contains( $refused->get_error_message(), DATAMACHINE_WORKSPACE_PATH ), 'disk budget refusal names workspace root' );
+	$assert( true, str_contains( $refused->get_error_message(), 'cleanup-artifacts --dry-run' ), 'disk budget refusal suggests artifact cleanup' );
+
 	$result = $ws->worktree_add( 'demo', 'feature/metadata', 'HEAD', false, false, true, false );
 	$assert( true, ! is_wp_error( $result ) && ( $result['success'] ?? false ), 'worktree_add succeeds without context injection' );
 


### PR DESCRIPTION
## Summary
- Refuse `workspace worktree add` before bootstrap/install when workspace free space is below the stricter of 10 GiB or 10% free.
- Include workspace root, current free/total space, effective threshold, cleanup command, and artifact cleanup command in the refusal guidance.
- Keep `--force` as the explicit override and surface the override in the disk budget report.

## Tests
- `php -l inc/Workspace/WorktreeDiskBudget.php`
- `php -l inc/Workspace/Workspace.php`
- `php -l tests/smoke-worktree-disk-budget.php`
- `php -l tests/smoke-worktree-lifecycle-metadata.php`
- `php tests/smoke-worktree-disk-budget.php`
- `php tests/smoke-worktree-lifecycle-metadata.php`
- `git diff --check`

Fixes #182.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafting and testing this focused disk-budget refusal fix; Chris remains responsible for review and merge.