### PR TITLE
Fix finalized worktree cleanup eligibility

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1219,6 +1219,16 @@ class WorkspaceCommand extends BaseCommand {
 	 *   candidates, would-remove, would_remove, removed, no_merge_signal, dirty_worktree,
 	 *   unpushed_commits, missing_metadata, external_worktree, age_filter, unknown_age.
 	 *
+	 * [--pr=<url-or-number>]
+	 * : Pull request URL or number for `finalize` or `mark-cleanup-eligible`
+	 *   metadata. Supplying `--pr` to `finalize` defaults the requested finalizer
+	 *   state to `pr_opened` and records the worktree as cleanup-eligible.
+	 *
+	 * [--state=<state>]
+	 * : Requested lifecycle state for `finalize`. Defaults to `pr_opened` when
+	 *   `--pr` is supplied, otherwise `active`. PR/completed states are safely
+	 *   transitioned to cleanup eligibility metadata.
+	 *
 	 * [--format=<format>]
 	 * : Output format for list and cleanup (table, json, csv, yaml).
 	 *

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -2790,10 +2790,10 @@ class Workspace {
 			}
 
 			$signal = null;
-			if ( is_array( $metadata ) && WorktreeContextInjector::STATE_CLEANUP_ELIGIBLE === ( $metadata['lifecycle_state'] ?? null ) ) {
+			if ( is_array( $metadata ) && WorktreeContextInjector::has_cleanup_signal( $metadata ) ) {
 				$signal = array(
 					'signal' => 'cleanup_eligible',
-					'reason' => 'worktree explicitly marked cleanup_eligible',
+					'reason' => 'worktree finalized or explicitly marked cleanup_eligible',
 				);
 				if ( ! empty( $metadata['pr_url'] ) ) {
 					$signal['pr_url'] = (string) $metadata['pr_url'];
@@ -4064,7 +4064,7 @@ class Workspace {
 				continue;
 			}
 
-			if ( WorktreeContextInjector::STATE_CLEANUP_ELIGIBLE !== ( $metadata['lifecycle_state'] ?? null ) ) {
+			if ( ! WorktreeContextInjector::has_cleanup_signal( $metadata ) ) {
 				$repaired = ! empty( $metadata['metadata_repaired'] );
 				$skipped[] = array_merge( $base_row, array(
 					'reason_code'   => $repaired ? 'missing_metadata_repaired' : 'no_inventory_cleanup_signal',
@@ -4114,7 +4114,7 @@ class Workspace {
 				'dirty'       => 0,
 				'signal'      => 'cleanup_eligible',
 				'reason_code' => 'cleanup_eligible',
-				'reason'      => 'worktree explicitly marked cleanup_eligible',
+				'reason'      => 'worktree finalized or explicitly marked cleanup_eligible',
 				'pr_url'      => $metadata['pr_url'] ?? null,
 			) );
 			if ( null !== $age_filter && is_string( $created_at ) && '' !== $created_at ) {

--- a/inc/Workspace/WorktreeContextInjector.php
+++ b/inc/Workspace/WorktreeContextInjector.php
@@ -156,7 +156,70 @@ class WorktreeContextInjector {
 			$metadata = array_merge( $metadata, $pr_metadata );
 		}
 
+		if ( self::should_mark_cleanup_eligible( $normalized, $pr_metadata ) ) {
+			$metadata['finalized_state']     = $normalized;
+			$metadata['lifecycle_state']     = self::STATE_CLEANUP_ELIGIBLE;
+			$metadata['cleanup_eligible_at'] = $metadata['finalized_at'];
+		}
+
 		return $metadata;
+	}
+
+	/**
+	 * Determine whether a finalizer transition is safe to expose as a cleanup signal.
+	 *
+	 * @param string              $state       Normalized requested lifecycle state.
+	 * @param array<string,mixed> $pr_metadata Parsed PR metadata.
+	 * @return bool
+	 */
+	private static function should_mark_cleanup_eligible( string $state, array $pr_metadata ): bool {
+		if ( self::STATE_CLEANUP_ELIGIBLE === $state ) {
+			return true;
+		}
+
+		if ( in_array( $state, array( self::STATE_MERGED, self::STATE_CLOSED, self::STATE_ABANDONED ), true ) ) {
+			return true;
+		}
+
+		return self::STATE_PR_OPENED === $state && ! empty( $pr_metadata );
+	}
+
+	/**
+	 * Determine whether persisted lifecycle metadata exposes a cleanup signal.
+	 *
+	 * This accepts both current records (`lifecycle_state=cleanup_eligible`) and
+	 * older PR-finalized records that were stored before the cleanup transition
+	 * was automatic.
+	 *
+	 * @param array<string,mixed> $metadata Worktree lifecycle metadata.
+	 * @return bool
+	 */
+	public static function has_cleanup_signal( array $metadata ): bool {
+		$state = isset( $metadata['lifecycle_state'] ) ? self::normalize_state( (string) $metadata['lifecycle_state'] ) : null;
+		if ( null !== $state && self::should_mark_cleanup_eligible( $state, self::extract_pr_metadata( $metadata ) ) ) {
+			return true;
+		}
+
+		$finalized_state = isset( $metadata['finalized_state'] ) ? self::normalize_state( (string) $metadata['finalized_state'] ) : null;
+		return null !== $finalized_state && self::should_mark_cleanup_eligible( $finalized_state, self::extract_pr_metadata( $metadata ) );
+	}
+
+	/**
+	 * Extract PR-like fields from a persisted metadata record.
+	 *
+	 * @param array<string,mixed> $metadata Worktree lifecycle metadata.
+	 * @return array<string,mixed>
+	 */
+	private static function extract_pr_metadata( array $metadata ): array {
+		return array_filter(
+			array(
+				'pr_ref'    => $metadata['pr_ref'] ?? null,
+				'pr_url'    => $metadata['pr_url'] ?? null,
+				'pr_number' => $metadata['pr_number'] ?? null,
+				'pr_repo'   => $metadata['pr_repo'] ?? null,
+			),
+			fn( $value ) => null !== $value && '' !== $value
+		);
 	}
 
 	/**

--- a/tests/smoke-worktree-cleanup.php
+++ b/tests/smoke-worktree-cleanup.php
@@ -274,6 +274,7 @@ namespace {
 		)
 	);
 	mkdir( $tmp . '/demo@inventory-cleanup-eligible', 0755, true );
+	mkdir( $tmp . '/demo@inventory-finalized-pr', 0755, true );
 	mkdir( $tmp . '/demo@inventory-active', 0755, true );
 	mkdir( $tmp . '/demo@inventory-missing-metadata', 0755, true );
 	\DataMachineCode\Workspace\WorktreeContextInjector::store_lifecycle_metadata(
@@ -283,6 +284,16 @@ namespace {
 			'lifecycle_state' => \DataMachineCode\Workspace\WorktreeContextInjector::STATE_CLEANUP_ELIGIBLE,
 			'pr_url'          => 'https://github.com/acme/demo/pull/42',
 			'pr_number'       => 42,
+		)
+	);
+	\DataMachineCode\Workspace\WorktreeContextInjector::store_lifecycle_metadata(
+		'demo@inventory-finalized-pr',
+		array(
+			'created_at'      => '2026-04-01T00:00:00+00:00',
+			'lifecycle_state' => \DataMachineCode\Workspace\WorktreeContextInjector::STATE_PR_OPENED,
+			'finalized_at'    => '2026-04-02T00:00:00+00:00',
+			'pr_url'          => 'https://github.com/acme/demo/pull/43',
+			'pr_number'       => 43,
 		)
 	);
 	\DataMachineCode\Workspace\WorktreeContextInjector::store_lifecycle_metadata(
@@ -377,7 +388,8 @@ namespace {
 	$assert( true, $inventory_plan['inventory_only'] ?? false, 'inventory-only flag echoes back true' );
 	$assert( 0, $inventory_ws->full_listing_calls, 'inventory-only cleanup does not call full worktree_list' );
 	$assert_contains( $inventory_plan['candidates'] ?? array(), 'demo@inventory-cleanup-eligible', 'inventory-only flags explicit cleanup_eligible worktree' );
-	$assert( 1, count( $inventory_plan['candidates'] ?? array() ), 'inventory-only only returns explicit cheap cleanup signals as candidates' );
+	$assert_contains( $inventory_plan['candidates'] ?? array(), 'demo@inventory-finalized-pr', 'inventory-only flags persisted PR-finalized worktree' );
+	$assert( 2, count( $inventory_plan['candidates'] ?? array() ), 'inventory-only only returns cheap cleanup signals as candidates' );
 	$inventory_active = array_values( array_filter( $inventory_plan['skipped'] ?? array(), fn( $s ) => ( $s['handle'] ?? '' ) === 'demo@inventory-active' ) )[0] ?? array();
 	$assert( 'no_inventory_cleanup_signal', $inventory_active['reason_code'] ?? '', 'inventory-only active metadata uses stable ambiguous reason' );
 	$inventory_missing = array_values( array_filter( $inventory_plan['skipped'] ?? array(), fn( $s ) => ( $s['handle'] ?? '' ) === 'demo@inventory-missing-metadata' ) )[0] ?? array();

--- a/tests/smoke-worktree-lifecycle-metadata.php
+++ b/tests/smoke-worktree-lifecycle-metadata.php
@@ -237,11 +237,13 @@ namespace {
 
 	$finalized = $ws->worktree_finalize( 'demo@feature-metadata', 'pr_opened', 'https://github.com/acme/demo/pull/123' );
 	$assert( true, ! is_wp_error( $finalized ) && ( $finalized['success'] ?? false ), 'worktree_finalize succeeds with PR URL' );
-	$assert( 'pr_opened', $finalized['lifecycle_state'] ?? null, 'finalizer stores pr_opened state' );
+	$assert( 'cleanup_eligible', $finalized['lifecycle_state'] ?? null, 'PR finalizer safely transitions lifecycle state to cleanup_eligible' );
+	$assert( 'pr_opened', $finalized['metadata']['finalized_state'] ?? null, 'PR finalizer preserves requested finalizer state' );
+	$assert( true, isset( $finalized['metadata']['cleanup_eligible_at'] ), 'PR finalizer records cleanup eligibility timestamp' );
 	$assert( 123, $finalized['metadata']['pr_number'] ?? null, 'finalizer extracts PR number' );
 	$assert( 'https://github.com/acme/demo/pull/123', $finalized['metadata']['pr_url'] ?? null, 'finalizer stores normalized PR URL' );
 
-	$filtered = $ws->worktree_list( 'demo', 'pr_opened' );
+	$filtered = $ws->worktree_list( 'demo', 'cleanup_eligible' );
 	$filtered_items = array_values( array_filter( $filtered['worktrees'] ?? array(), fn( $wt ) => ( $wt['handle'] ?? '' ) === 'demo@feature-metadata' ) );
 	$assert( 1, count( $filtered_items ), 'worktree_list can filter by lifecycle state' );
 
@@ -250,6 +252,11 @@ namespace {
 
 	$eligible = $ws->worktree_finalize( 'demo@feature-metadata', 'cleanup_eligible' );
 	$assert( true, ! is_wp_error( $eligible ) && ( $eligible['success'] ?? false ), 'worktree can be marked cleanup_eligible' );
+
+	$merged = $ws->worktree_finalize( 'demo@feature-metadata', 'merged' );
+	$assert( true, ! is_wp_error( $merged ) && ( $merged['success'] ?? false ), 'merged finalizer succeeds' );
+	$assert( 'cleanup_eligible', $merged['lifecycle_state'] ?? null, 'merged finalizer safely transitions lifecycle state to cleanup_eligible' );
+	$assert( 'merged', $merged['metadata']['finalized_state'] ?? null, 'merged finalizer preserves requested finalizer state' );
 
 	$result_old = $ws->worktree_add( 'demo', 'feature/old-record', 'HEAD', false, false, true, false );
 	$assert( true, ! is_wp_error( $result_old ) && ( $result_old['success'] ?? false ), 'second worktree_add succeeds' );


### PR DESCRIPTION
## Summary
- Mark PR/completed worktree finalization as cleanup-eligible while preserving the requested finalizer state in metadata.
- Let cleanup detect both new cleanup eligibility metadata and older persisted PR-finalized metadata in inventory-only mode.
- Declare `--pr` and `--state` in the worktree CLI synopsis so documented `finalize --pr` commands pass WP-CLI validation.

Fixes #179.
Fixes #177.

## Testing
- `php -l inc/Cli/Commands/WorkspaceCommand.php inc/Workspace/WorktreeContextInjector.php inc/Workspace/Workspace.php tests/smoke-worktree-cleanup.php tests/smoke-worktree-finalizer-cli.php tests/smoke-worktree-lifecycle-metadata.php`
- `php tests/smoke-worktree-finalizer-cli.php`
- `php tests/smoke-worktree-lifecycle-metadata.php`
- `php tests/smoke-worktree-cleanup.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafting and testing this focused finalizer cleanup eligibility fix; Chris remains responsible for review and merge.