### PR TITLE
Repair legacy worktree metadata reconciliation

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1909,12 +1909,15 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 
-		$summary   = (array) ( $result['summary'] ?? array() );
-		$proposals = (array) ( $result['proposals'] ?? array() );
-		$written   = (array) ( $result['written'] ?? array() );
-		$skipped   = (array) ( $result['skipped'] ?? array() );
-		$verbose   = ! empty( $assoc_args['verbose'] );
-		$limit     = $verbose ? PHP_INT_MAX : 10;
+		$summary            = (array) ( $result['summary'] ?? array() );
+		$proposals          = (array) ( $result['proposals'] ?? array() );
+		$repaired           = (array) ( $result['repaired'] ?? array() );
+		$written            = (array) ( $result['written'] ?? array() );
+		$skipped            = (array) ( $result['skipped'] ?? array() );
+		$still_unsafe      = (array) ( $result['still_unsafe'] ?? array() );
+		$external_worktrees = (array) ( $result['external_worktrees'] ?? array() );
+		$verbose            = ! empty( $assoc_args['verbose'] );
+		$limit              = $verbose ? PHP_INT_MAX : 10;
 
 		WP_CLI::log( 'Summary:' );
 		$summary_rows = array(
@@ -1929,6 +1932,10 @@ class WorkspaceCommand extends BaseCommand {
 			array(
 				'metric' => 'written',
 				'count'  => (int) ( $summary['written'] ?? count( $written ) ),
+			),
+			array(
+				'metric' => 'repaired',
+				'count'  => (int) ( $summary['repaired'] ?? count( $repaired ) ),
 			),
 			array(
 				'metric' => 'skipped',
@@ -1969,17 +1976,49 @@ class WorkspaceCommand extends BaseCommand {
 
 		if ( ! empty( $written ) ) {
 			WP_CLI::log( '' );
-			WP_CLI::log( 'Written:' );
+			WP_CLI::log( 'Repaired:' );
 			$written_rows = array_map(
 				fn( $row ) => array(
-					'handle' => $row['handle'] ?? '',
-					'branch' => $row['branch'] ?? '',
-					'state'  => $row['metadata']['lifecycle_state'] ?? '',
+					'handle'      => $row['handle'] ?? '',
+					'branch'      => $row['branch'] ?? '',
+					'state'       => $row['metadata']['lifecycle_state'] ?? '',
+					'observed_at' => $row['metadata']['observed_at'] ?? '',
 				),
 				array_slice( $written, 0, $limit )
 			);
-			$this->format_items( $written_rows, array( 'handle', 'branch', 'state' ), array( 'format' => 'table' ), 'handle' );
+			$this->format_items( $written_rows, array( 'handle', 'branch', 'state', 'observed_at' ), array( 'format' => 'table' ), 'handle' );
 			$this->render_cleanup_truncation_hint( count( $written ), $limit, 'written rows' );
+		}
+
+		if ( ! empty( $still_unsafe ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( 'Still unsafe:' );
+			$unsafe_rows = array_map(
+				fn( $row ) => array(
+					'handle'      => $row['handle'] ?? '',
+					'reason_code' => $row['reason_code'] ?? '',
+					'reason'      => $verbose ? ( $row['reason'] ?? '' ) : $this->shorten_cleanup_reason( (string) ( $row['reason'] ?? '' ) ),
+				),
+				array_slice( $still_unsafe, 0, $limit )
+			);
+			$this->format_items( $unsafe_rows, array( 'handle', 'reason_code', 'reason' ), array( 'format' => 'table' ), 'handle' );
+			$this->render_cleanup_truncation_hint( count( $still_unsafe ), $limit, 'still-unsafe rows' );
+		}
+
+		if ( ! empty( $external_worktrees ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( 'External worktrees:' );
+			$external_rows = array_map(
+				fn( $row ) => array(
+					'handle' => $row['handle'] ?? '',
+					'repo'   => $row['repo'] ?? '',
+					'branch' => $row['branch'] ?? '',
+					'path'   => $row['path'] ?? '',
+				),
+				array_slice( $external_worktrees, 0, $limit )
+			);
+			$this->format_items( $external_rows, array( 'handle', 'repo', 'branch', 'path' ), array( 'format' => 'table' ), 'handle' );
+			$this->render_cleanup_truncation_hint( count( $external_worktrees ), $limit, 'external worktree rows' );
 		}
 
 		if ( ! empty( $skipped ) ) {

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -2755,6 +2755,8 @@ class Workspace {
 			}
 		}
 
+		$classified_skips = $this->classify_worktree_metadata_reconciliation_skips( $skipped );
+
 		return array(
 			'success'        => true,
 			'dry_run'        => true,
@@ -2762,8 +2764,11 @@ class Workspace {
 			'generated_at'   => gmdate( 'c' ),
 			'workspace_path' => $this->workspace_path,
 			'proposals'      => $proposals,
+			'repaired'       => array(),
 			'written'        => array(),
 			'skipped'        => $skipped,
+			'still_unsafe'      => $classified_skips['still_unsafe'],
+			'external_worktrees' => $classified_skips['external_worktrees'],
 			'summary'        => $this->build_worktree_metadata_reconciliation_summary( count( (array) ( $listing['worktrees'] ?? array() ) ), $proposals, array(), $skipped ),
 		);
 	}
@@ -2839,6 +2844,19 @@ class Workspace {
 		$this->set_reconciled_metadata_field( $proposed, $source_map, 'repo', $repo, 'filesystem' );
 		$this->set_reconciled_metadata_field( $proposed, $source_map, 'branch', $branch, 'git' );
 		$this->set_reconciled_metadata_field( $proposed, $source_map, 'path', $path, 'git' );
+		$this->set_reconciled_metadata_field( $proposed, $source_map, 'observed_at', gmdate( 'c' ), 'reconcile_run' );
+
+		$origin_site_name = function_exists( 'get_bloginfo' ) ? (string) get_bloginfo( 'name' ) : '';
+		$origin_site_url  = function_exists( 'home_url' ) ? (string) home_url() : '';
+		if ( empty( $proposed['origin_site'] ) ) {
+			$this->set_reconciled_metadata_field( $proposed, $source_map, 'origin_site', '' !== $origin_site_name ? $origin_site_name : $origin_site_url, 'current_site' );
+		}
+		if ( empty( $proposed['origin_site_name'] ) ) {
+			$this->set_reconciled_metadata_field( $proposed, $source_map, 'origin_site_name', $origin_site_name, 'current_site' );
+		}
+		if ( empty( $proposed['origin_site_url'] ) ) {
+			$this->set_reconciled_metadata_field( $proposed, $source_map, 'origin_site_url', $origin_site_url, 'current_site' );
+		}
 
 		$created_source = '';
 		$created_at     = '';
@@ -2860,12 +2878,18 @@ class Workspace {
 			$this->set_reconciled_metadata_field( $proposed, $source_map, 'created_at', $created_at, $created_source );
 		}
 
+		$invalid_fields = array();
 		$existing_state = isset( $metadata['lifecycle_state'] ) ? WorktreeContextInjector::normalize_state( (string) $metadata['lifecycle_state'] ) : null;
+		$raw_state      = isset( $metadata['lifecycle_state'] ) ? (string) $metadata['lifecycle_state'] : '';
+		if ( '' !== $raw_state && null === $existing_state ) {
+			$invalid_fields[] = 'lifecycle_state';
+		}
 		if ( null !== $existing_state ) {
 			$this->set_reconciled_metadata_field( $proposed, $source_map, 'lifecycle_state', $existing_state, 'metadata' );
 		} else {
 			$this->set_reconciled_metadata_field( $proposed, $source_map, 'lifecycle_state', WorktreeContextInjector::STATE_ACTIVE, 'operator_plan' );
 		}
+		$proposed['metadata_repaired'] = true;
 
 		$missing_after = array_values( array_filter( array(
 			empty( $proposed['created_at'] ) ? 'created_at' : '',
@@ -2885,13 +2909,13 @@ class Workspace {
 		}
 
 		$metadata_missing = array();
-		foreach ( array( 'handle', 'repo', 'branch', 'path', 'created_at', 'lifecycle_state' ) as $field ) {
+		foreach ( array( 'handle', 'repo', 'branch', 'path', 'created_at', 'observed_at', 'lifecycle_state' ) as $field ) {
 			if ( ! array_key_exists( $field, $metadata ) || '' === (string) $metadata[ $field ] ) {
 				$metadata_missing[] = $field;
 			}
 		}
 
-		if ( array() === $metadata_missing ) {
+		if ( array() === $metadata_missing && array() === $invalid_fields ) {
 			return array();
 		}
 
@@ -2904,6 +2928,7 @@ class Workspace {
 					'dirty'             => (int) ( $wt['dirty'] ?? 0 ),
 					'unpushed'          => $this->count_unpushed_commits( $path ),
 					'missing_fields'    => $metadata_missing,
+					'invalid_fields'    => $invalid_fields,
 					'proposed_metadata' => $proposed,
 					'source_map'        => $source_map,
 				)
@@ -2992,7 +3017,7 @@ class Workspace {
 				}
 			}
 
-			foreach ( array( 'handle', 'repo', 'branch', 'path', 'created_at', 'lifecycle_state' ) as $field ) {
+			foreach ( array( 'handle', 'repo', 'branch', 'path', 'created_at', 'observed_at', 'lifecycle_state' ) as $field ) {
 				if ( ! isset( $source_map[ $field ] ) || '' === (string) $source_map[ $field ] ) {
 					$skipped[] = $this->build_reconcile_apply_skip( $row, $current, 'missing_source_map', sprintf( 'proposed field %s is missing a source', $field ) );
 					continue 2;
@@ -3012,6 +3037,8 @@ class Workspace {
 			);
 		}
 
+		$classified_skips = $this->classify_worktree_metadata_reconciliation_skips( $skipped );
+
 		return array(
 			'success'        => true,
 			'dry_run'        => false,
@@ -3019,9 +3046,38 @@ class Workspace {
 			'generated_at'   => gmdate( 'c' ),
 			'workspace_path' => $this->workspace_path,
 			'proposals'      => $planned,
+			'repaired'       => $written,
 			'written'        => $written,
 			'skipped'        => $skipped,
+			'still_unsafe'      => $classified_skips['still_unsafe'],
+			'external_worktrees' => $classified_skips['external_worktrees'],
 			'summary'        => $this->build_worktree_metadata_reconciliation_summary( count( (array) ( $listing['worktrees'] ?? array() ) ), $planned, $written, $skipped ),
+		);
+	}
+
+	/**
+	 * Split reconciliation skips into stable operator-facing buckets.
+	 *
+	 * @param array<int,array<string,mixed>> $skipped Skipped rows.
+	 * @return array{still_unsafe:array<int,array<string,mixed>>,external_worktrees:array<int,array<string,mixed>>}
+	 */
+	private function classify_worktree_metadata_reconciliation_skips( array $skipped ): array {
+		$still_unsafe       = array();
+		$external_worktrees = array();
+
+		foreach ( $skipped as $row ) {
+			$reason_code = (string) ( $row['reason_code'] ?? '' );
+			if ( 'external_worktree' === $reason_code ) {
+				$external_worktrees[] = $row;
+			}
+			if ( in_array( $reason_code, array( 'unsafe_cleanup_eligible_state', 'plan_identity_mismatch', 'plan_not_current' ), true ) ) {
+				$still_unsafe[] = $row;
+			}
+		}
+
+		return array(
+			'still_unsafe'      => $still_unsafe,
+			'external_worktrees' => $external_worktrees,
 		);
 	}
 
@@ -3097,10 +3153,18 @@ class Workspace {
 		}
 		ksort( $states );
 
+		$repaired_metadata = 0;
+		foreach ( $written as $row ) {
+			if ( ! empty( $row['metadata']['metadata_repaired'] ) ) {
+				++$repaired_metadata;
+			}
+		}
+
 		return array(
 			'inspected'         => $inspected,
 			'proposed'          => count( $proposals ),
 			'written'           => count( $written ),
+			'repaired'          => $repaired_metadata,
 			'skipped'           => count( $skipped ),
 			'skipped_by_reason' => $skipped_by_reason,
 			'proposed_by_state' => $states,
@@ -3269,10 +3333,12 @@ class Workspace {
 			}
 
 			if ( WorktreeContextInjector::STATE_CLEANUP_ELIGIBLE !== ( $metadata['lifecycle_state'] ?? null ) ) {
+				$repaired = ! empty( $metadata['metadata_repaired'] );
 				$skipped[] = array_merge( $base_row, array(
-					'reason_code' => 'no_inventory_cleanup_signal',
-					'reason'      => 'no explicit inventory cleanup signal — leaving in place',
-					'hint'        => 'Mark the worktree cleanup-eligible after review, or run full cleanup to detect merge signals.',
+					'reason_code'   => $repaired ? 'missing_metadata_repaired' : 'no_inventory_cleanup_signal',
+					'reason'        => $repaired ? 'legacy metadata was repaired conservatively; no cleanup signal yet' : 'no explicit inventory cleanup signal — leaving in place',
+					'repair_status' => $repaired ? 'missing_metadata_repaired' : null,
+					'hint'          => 'Mark the worktree cleanup-eligible after review, or run full cleanup to detect merge signals.',
 				) );
 				continue;
 			}
@@ -3721,6 +3787,7 @@ class Workspace {
 	private function build_worktree_cleanup_summary( array $candidates, array $removed, array $skipped, ?array $age_filter = null ): array {
 		$skipped_by_reason    = array();
 		$candidates_by_signal = array();
+		$repair_status_counts = array();
 		$size_by_repo         = array();
 		$artifact_by_repo     = array();
 		$total_size_bytes     = 0;
@@ -3741,6 +3808,11 @@ class Workspace {
 			$repo           = (string) ( $row['repo'] ?? 'unknown' );
 			$size_bytes     = isset( $row['size_bytes'] ) ? (int) $row['size_bytes'] : 0;
 			$artifact_bytes = isset( $row['artifact_size_bytes'] ) ? (int) $row['artifact_size_bytes'] : 0;
+			$repair_status  = (string) ( $row['repair_status'] ?? '' );
+
+			if ( '' !== $repair_status ) {
+				$repair_status_counts[ $repair_status ] = ( $repair_status_counts[ $repair_status ] ?? 0 ) + 1;
+			}
 
 			if ( $size_bytes > 0 ) {
 				$size_by_repo[ $repo ] = ( $size_by_repo[ $repo ] ?? 0 ) + $size_bytes;
@@ -3754,6 +3826,7 @@ class Workspace {
 
 		ksort( $skipped_by_reason );
 		ksort( $candidates_by_signal );
+		ksort( $repair_status_counts );
 		arsort( $size_by_repo );
 		arsort( $artifact_by_repo );
 
@@ -3763,6 +3836,7 @@ class Workspace {
 			'skipped'               => count( $skipped ),
 			'skipped_by_reason'     => $skipped_by_reason,
 			'candidates_by_signal'  => $candidates_by_signal,
+			'repair_status'         => $repair_status_counts,
 			'total_size_bytes'      => $total_size_bytes,
 			'artifact_size_bytes'   => $total_artifact_bytes,
 			'size_by_repo'          => $size_by_repo,

--- a/inc/Workspace/WorktreeContextInjector.php
+++ b/inc/Workspace/WorktreeContextInjector.php
@@ -94,8 +94,11 @@ class WorktreeContextInjector {
 		$agent     = self::resolve_origin_agent();
 		$session   = self::resolve_origin_session();
 
+		$created_at = gmdate( 'c' );
+
 		$metadata = array(
-			'created_at'       => gmdate( 'c' ),
+			'created_at'       => $created_at,
+			'observed_at'      => $created_at,
 			'lifecycle_state'  => self::STATE_ACTIVE,
 			'handle'           => isset( $args['handle'] ) && '' !== (string) $args['handle'] ? (string) $args['handle'] : null,
 			'path'             => isset( $args['path'] ) && '' !== (string) $args['path'] ? (string) $args['path'] : null,

--- a/tests/smoke-worktree-metadata-reconcile.php
+++ b/tests/smoke-worktree-metadata-reconcile.php
@@ -87,6 +87,18 @@ namespace {
 		}
 	}
 
+	if ( ! function_exists( 'home_url' ) ) {
+		function home_url(): string {
+			return 'http://origin.test';
+		}
+	}
+
+	if ( ! function_exists( 'get_bloginfo' ) ) {
+		function get_bloginfo( string $show = '' ): string { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+			return 'Origin Test';
+		}
+	}
+
 	if ( ! function_exists( 'size_format' ) ) {
 		function size_format( $bytes ): string {
 			return (string) $bytes;
@@ -112,6 +124,9 @@ namespace {
 	register_shutdown_function( function () use ( $tmp ) {
 		if ( is_dir( $tmp ) ) {
 			exec( 'rm -rf ' . escapeshellarg( $tmp ) );
+		}
+		if ( is_dir( $tmp . '-external' ) ) {
+			exec( 'rm -rf ' . escapeshellarg( $tmp . '-external' ) );
 		}
 	} );
 
@@ -164,12 +179,17 @@ namespace {
 	$make_branch( 'legacy-missing' );
 	$make_branch( 'legacy-partial' );
 	$make_branch( 'legacy-dirty' );
+	$make_branch( 'legacy-invalid' );
 	$make_branch( 'already-current' );
+	$make_branch( 'external-branch' );
 
 	$run( sprintf( 'git worktree add %s legacy-missing', escapeshellarg( $tmp . '/demo@legacy-missing' ) ), $primary );
 	$run( sprintf( 'git worktree add %s legacy-partial', escapeshellarg( $tmp . '/demo@legacy-partial' ) ), $primary );
 	$run( sprintf( 'git worktree add %s legacy-dirty', escapeshellarg( $tmp . '/demo@legacy-dirty' ) ), $primary );
+	$run( sprintf( 'git worktree add %s legacy-invalid', escapeshellarg( $tmp . '/demo@legacy-invalid' ) ), $primary );
 	$run( sprintf( 'git worktree add %s already-current', escapeshellarg( $tmp . '/demo@already-current' ) ), $primary );
+	mkdir( $tmp . '-external', 0755, true );
+	$run( sprintf( 'git worktree add %s external-branch', escapeshellarg( $tmp . '-external/demo-external' ) ), $primary );
 	file_put_contents( $tmp . '/demo@legacy-dirty/scratch.txt', 'dirty' );
 
 	\DataMachineCode\Workspace\WorktreeContextInjector::store_metadata(
@@ -183,6 +203,17 @@ namespace {
 		)
 	);
 	\DataMachineCode\Workspace\WorktreeContextInjector::store_lifecycle_metadata(
+		'demo@legacy-invalid',
+		array(
+			'handle'          => 'demo@legacy-invalid',
+			'repo'            => 'demo',
+			'branch'          => 'legacy-invalid',
+			'path'            => $tmp . '/demo@legacy-invalid',
+			'created_at'      => '2026-04-02T00:00:00+00:00',
+			'lifecycle_state' => 'donezo',
+		)
+	);
+	\DataMachineCode\Workspace\WorktreeContextInjector::store_lifecycle_metadata(
 		'demo@already-current',
 		array(
 			'handle'          => 'demo@already-current',
@@ -190,6 +221,7 @@ namespace {
 			'branch'          => 'already-current',
 			'path'            => $tmp . '/demo@already-current',
 			'created_at'      => '2026-04-01T00:00:00+00:00',
+			'observed_at'     => '2026-04-01T00:00:00+00:00',
 			'lifecycle_state' => \DataMachineCode\Workspace\WorktreeContextInjector::STATE_ACTIVE,
 		)
 	);
@@ -200,8 +232,10 @@ namespace {
 	$plan = $ws->worktree_reconcile_metadata( array( 'dry_run' => true ) );
 	$assert( true, ! is_wp_error( $plan ) && ( $plan['success'] ?? false ), 'dry-run succeeds' );
 	$assert( true, $plan['dry_run'] ?? false, 'dry-run flag is true' );
-	$assert( 3, (int) ( $plan['summary']['proposed'] ?? 0 ), 'dry-run proposes only legacy rows' );
+	$assert( 4, (int) ( $plan['summary']['proposed'] ?? 0 ), 'dry-run proposes only legacy rows' );
 	$assert( 0, (int) ( $plan['summary']['written'] ?? 0 ), 'dry-run writes nothing' );
+	$assert( 1, (int) ( $plan['summary']['skipped_by_reason']['external_worktree'] ?? 0 ), 'dry-run distinguishes external worktrees' );
+	$assert( 1, count( $plan['external_worktrees'] ?? array() ), 'dry-run exposes external worktree bucket' );
 
 	$by_handle = array();
 	foreach ( $plan['proposals'] as $row ) {
@@ -209,8 +243,12 @@ namespace {
 	}
 	$assert( 'operator_plan', $by_handle['demo@legacy-missing']['source_map']['lifecycle_state'] ?? '', 'missing metadata lifecycle source is operator_plan' );
 	$assert( 'filesystem', $by_handle['demo@legacy-missing']['source_map']['created_at'] ?? '', 'missing metadata created_at source is filesystem' );
+	$assert( 'reconcile_run', $by_handle['demo@legacy-missing']['source_map']['observed_at'] ?? '', 'missing metadata observed_at source is reconcile run' );
+	$assert( 'current_site', $by_handle['demo@legacy-missing']['source_map']['origin_site'] ?? '', 'missing metadata origin site is inferred from current site' );
 	$assert( 'metadata', $by_handle['demo@legacy-partial']['source_map']['created_at'] ?? '', 'partial metadata preserves created_at source' );
 	$assert( 'git', $by_handle['demo@legacy-partial']['source_map']['branch'] ?? '', 'branch source is git' );
+	$assert( array( 'lifecycle_state' ), $by_handle['demo@legacy-invalid']['invalid_fields'] ?? array(), 'invalid lifecycle state is planned for repair' );
+	$assert( \DataMachineCode\Workspace\WorktreeContextInjector::STATE_ACTIVE, $by_handle['demo@legacy-invalid']['proposed_metadata']['lifecycle_state'] ?? '', 'invalid lifecycle state becomes conservative active proposal' );
 	$assert( 1, (int) ( $by_handle['demo@legacy-dirty']['dirty'] ?? 0 ), 'dirty row is visible but not cleanup-eligible' );
 	$assert( \DataMachineCode\Workspace\WorktreeContextInjector::STATE_ACTIVE, $by_handle['demo@legacy-dirty']['proposed_metadata']['lifecycle_state'] ?? '', 'dirty row proposal stays active' );
 	$stale_plan  = $plan;
@@ -222,14 +260,20 @@ namespace {
 	echo "\nApply reviewed plan\n";
 	$apply = $ws->worktree_reconcile_metadata( array( 'apply_plan' => $plan ) );
 	$assert( true, ! is_wp_error( $apply ) && ( $apply['success'] ?? false ), 'apply succeeds' );
-	$assert( 3, (int) ( $apply['summary']['written'] ?? 0 ), 'apply writes exact current matches' );
+	$assert( 4, (int) ( $apply['summary']['written'] ?? 0 ), 'apply writes exact current matches' );
+	$assert( 4, (int) ( $apply['summary']['repaired'] ?? 0 ), 'apply reports repaired metadata rows' );
 	$assert( 0, (int) ( $apply['summary']['skipped'] ?? 0 ), 'apply skips nothing for current plan' );
+	$assert( 4, count( $apply['repaired'] ?? array() ), 'apply exposes repaired rows distinctly' );
 	$stored = \DataMachineCode\Workspace\WorktreeContextInjector::get_metadata( 'demo@legacy-missing' );
 	$assert( 'demo@legacy-missing', $stored['handle'] ?? '', 'stored metadata includes handle' );
+	$assert( true, ! empty( $stored['observed_at'] ), 'stored metadata includes observed_at' );
+	$assert( 'Origin Test', $stored['origin_site'] ?? '', 'stored metadata includes origin site when available' );
 	$assert( 'operator_plan', $stored['reconciled_sources']['lifecycle_state'] ?? '', 'stored metadata keeps source map' );
 
 	$inventory_after = $ws->worktree_cleanup_merged( array( 'dry_run' => true, 'inventory_only' => true, 'skip_github' => true ) );
 	$assert( 0, (int) ( $inventory_after['summary']['skipped_by_reason']['requires_full_scan'] ?? 0 ), 'inventory cleanup requires fewer full scans after apply' );
+	$assert( 4, (int) ( $inventory_after['summary']['skipped_by_reason']['missing_metadata_repaired'] ?? 0 ), 'inventory cleanup distinguishes repaired legacy metadata' );
+	$assert( 4, (int) ( $inventory_after['summary']['repair_status']['missing_metadata_repaired'] ?? 0 ), 'inventory cleanup summarizes repaired legacy metadata' );
 
 	echo "\nSafety gates\n";
 	$stale_plan['proposals'][0]['branch'] = 'wrong-branch';
@@ -246,6 +290,7 @@ namespace {
 	$unsafe_apply = $ws->worktree_reconcile_metadata( array( 'apply_plan' => $unsafe_plan ) );
 	$unsafe_skips = array_values( array_filter( $unsafe_apply['skipped'] ?? array(), fn( $row ) => 'demo@legacy-dirty' === ( $row['handle'] ?? '' ) ) );
 	$assert( 'unsafe_cleanup_eligible_state', $unsafe_skips[0]['reason_code'] ?? '', 'dirty worktree cannot become cleanup_eligible through reconciliation plan' );
+	$assert( 1, count( $unsafe_apply['still_unsafe'] ?? array() ), 'apply exposes still-unsafe rows distinctly' );
 
 	if ( $failures > 0 ) {
 		echo "\n{$failures} / {$total} assertions failed.\n";


### PR DESCRIPTION
## Summary
- Backfill legacy worktree lifecycle metadata with handle, repo, branch, path, created_at, observed_at, conservative active state, and origin-site fields when available.
- Preserve dry-run/apply-plan review while reporting repaired, still-unsafe, and external worktree rows distinctly.
- Teach inventory cleanup to distinguish repaired legacy metadata from opaque missing metadata.

Fixes #183.

## Testing
- `php -l inc/Workspace/Workspace.php`
- `php -l inc/Workspace/WorktreeContextInjector.php`
- `php -l inc/Cli/Commands/WorkspaceCommand.php`
- `php -l tests/smoke-worktree-metadata-reconcile.php`
- `php tests/smoke-worktree-metadata-reconcile.php`
- `php tests/smoke-worktree-lifecycle-metadata.php`
- `php tests/smoke-worktree-cleanup.php`
- `php tests/smoke-worktree-cleanup-cli.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafting and testing this focused worktree metadata reconciliation fix; Chris remains responsible for review and merge.