### PR TITLE
Add workspace retention cleanup task

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -217,9 +217,10 @@ add_action( 'plugins_loaded', 'datamachine_code_load_chat_tools', 25 );
  * Register system tasks.
  */
 add_filter( 'datamachine_tasks', function ( array $tasks ): array {
-	$tasks['github_create_issue']      = \DataMachineCode\Tasks\GitHubIssueTask::class;
-	$tasks['worktree_cleanup']         = \DataMachineCode\Tasks\WorktreeCleanupTask::class;
-	$tasks['workspace_hygiene_report'] = \DataMachineCode\Tasks\WorkspaceHygieneReportTask::class;
+	$tasks['github_create_issue']         = \DataMachineCode\Tasks\GitHubIssueTask::class;
+	$tasks['worktree_cleanup']            = \DataMachineCode\Tasks\WorktreeCleanupTask::class;
+	$tasks['workspace_retention_cleanup'] = \DataMachineCode\Tasks\WorkspaceRetentionCleanupTask::class;
+	$tasks['workspace_hygiene_report']    = \DataMachineCode\Tasks\WorkspaceHygieneReportTask::class;
 	return $tasks;
 } );
 
@@ -243,6 +244,19 @@ add_filter( 'datamachine_recurring_schedules', function ( array $schedules ): ar
 		'default_enabled' => false,
 		'label'           => 'Daily — cleans up merged worktrees',
 		'task_params'     => array( 'source' => 'recurring_schedule' ),
+	);
+	$schedules['workspace_retention_cleanup'] = array(
+		'task_type'       => 'workspace_retention_cleanup',
+		'interval'        => 'daily',
+		'enabled_setting' => \DataMachineCode\Tasks\WorkspaceRetentionCleanupTask::SETTING_KEY,
+		'default_enabled' => false,
+		'label'           => 'Daily — applies workspace retention cleanup',
+		'task_params'     => array(
+			'source'              => 'recurring_schedule',
+			'worktree_older_than' => '14d',
+			'skip_github'         => true,
+			'artifact_cleanup'    => true,
+		),
 	);
 	$schedules['workspace_hygiene_report'] = array(
 		'task_type'       => 'workspace_hygiene_report',

--- a/inc/Tasks/WorkspaceRetentionCleanupTask.php
+++ b/inc/Tasks/WorkspaceRetentionCleanupTask.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Workspace Retention Cleanup System Task.
+ *
+ * @package DataMachineCode\Tasks
+ */
+
+namespace DataMachineCode\Tasks;
+
+use DataMachine\Core\PluginSettings;
+use DataMachine\Engine\AI\System\Tasks\SystemTask;
+use DataMachineCode\Workspace\Workspace;
+
+defined( 'ABSPATH' ) || exit;
+
+class WorkspaceRetentionCleanupTask extends SystemTask {
+
+	/**
+	 * PluginSettings key that gates recurring/manual task execution.
+	 */
+	public const SETTING_KEY = 'workspace_retention_cleanup_enabled';
+
+	/**
+	 * Task type identifier.
+	 *
+	 * @return string
+	 */
+	public function getTaskType(): string {
+		return 'workspace_retention_cleanup';
+	}
+
+	/**
+	 * Task metadata for Data Machine system-task surfaces.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public static function getTaskMeta(): array {
+		return array(
+			'label'           => 'Workspace Retention Cleanup',
+			'description'     => 'Age-gated cleanup for stale DMC worktrees plus aggressive cleanup of reconstructable artifacts. Runs daily when enabled.',
+			'setting_key'     => self::SETTING_KEY,
+			'default_enabled' => false,
+			'supports_run'    => true,
+		);
+	}
+
+	/**
+	 * Execute retention cleanup.
+	 *
+	 * @param int   $jobId  Job ID.
+	 * @param array $params Task params.
+	 * @return void
+	 */
+	public function executeTask( int $jobId, array $params ): void {
+		$enabled = (bool) PluginSettings::get( self::SETTING_KEY, false );
+		if ( ! $enabled ) {
+			$this->completeJob(
+				$jobId,
+				array(
+					'skipped' => true,
+					'reason'  => sprintf( 'Workspace retention cleanup disabled (PluginSettings: %s=false).', self::SETTING_KEY ),
+				)
+			);
+			return;
+		}
+
+		$opts = array(
+			'dry_run'          => ! empty( $params['dry_run'] ),
+			'force'            => ! empty( $params['force'] ),
+			'skip_github'      => array_key_exists( 'skip_github', $params ) ? (bool) $params['skip_github'] : true,
+			'worktree_cleanup' => array_key_exists( 'worktree_cleanup', $params ) ? (bool) $params['worktree_cleanup'] : true,
+			'artifact_cleanup' => array_key_exists( 'artifact_cleanup', $params ) ? (bool) $params['artifact_cleanup'] : true,
+		);
+		if ( isset( $params['worktree_older_than'] ) && '' !== trim( (string) $params['worktree_older_than'] ) ) {
+			$opts['worktree_older_than'] = trim( (string) $params['worktree_older_than'] );
+		}
+
+		$workspace = new Workspace();
+		$result    = $workspace->workspace_retention_cleanup( $opts );
+
+		if ( $result instanceof \WP_Error ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'Workspace retention cleanup failed',
+				array(
+					'task'  => $this->getTaskType(),
+					'jobId' => $jobId,
+					'error' => $result->get_error_message(),
+					'code'  => $result->get_error_code(),
+				)
+			);
+			$this->failJob( $jobId, $result->get_error_message() );
+			return;
+		}
+
+		$report = (array) ( $result['report'] ?? array() );
+		do_action(
+			'datamachine_log',
+			'info',
+			sprintf(
+				'Workspace retention cleanup %s: removed %d item(s), freed %s, skipped %d dirty/unpushed, %s remaining.',
+				! empty( $result['dry_run'] ) ? 'dry-run' : 'executed',
+				(int) ( $report['removed_count'] ?? 0 ),
+				(string) ( $report['freed_human'] ?? '0 B' ),
+				(int) ( $report['skipped_dirty_unpushed_count'] ?? 0 ),
+				(string) ( $report['remaining_disk_budget_human'] ?? 'unknown disk' )
+			),
+			array(
+				'task'   => $this->getTaskType(),
+				'jobId'  => $jobId,
+				'report' => $result,
+			)
+		);
+
+		$this->completeJob( $jobId, $result );
+	}
+}

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -1833,6 +1833,90 @@ class Workspace {
 	}
 
 	/**
+	 * Run age-gated workspace retention cleanup and return a compact report.
+	 *
+	 * This is the scheduled/manual orchestration layer over the lower-level
+	 * cleanup primitives: whole worktrees require a merge/finalization signal,
+	 * while reconstructable artifacts are removed from any currently safe
+	 * non-active worktree.
+	 *
+	 * @param array $opts Retention options.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function workspace_retention_cleanup( array $opts = array() ): array|\WP_Error {
+		$dry_run             = ! empty( $opts['dry_run'] );
+		$force               = ! empty( $opts['force'] );
+		$skip_github         = array_key_exists( 'skip_github', $opts ) ? (bool) $opts['skip_github'] : true;
+		$worktree_cleanup    = array_key_exists( 'worktree_cleanup', $opts ) ? (bool) $opts['worktree_cleanup'] : true;
+		$artifact_cleanup    = array_key_exists( 'artifact_cleanup', $opts ) ? (bool) $opts['artifact_cleanup'] : true;
+		$worktree_older_than = isset( $opts['worktree_older_than'] ) && '' !== trim( (string) $opts['worktree_older_than'] ) ? trim( (string) $opts['worktree_older_than'] ) : '14d';
+
+		$worktree_result = null;
+		$artifact_result = null;
+
+		if ( $worktree_cleanup ) {
+			$worktree_result = $this->worktree_cleanup_merged(
+				array(
+					'dry_run'     => $dry_run,
+					'force'       => $force,
+					'skip_github' => $skip_github,
+					'older_than'  => $worktree_older_than,
+					'sort'        => 'age',
+				)
+			);
+			if ( $worktree_result instanceof \WP_Error ) {
+				return $worktree_result;
+			}
+		}
+
+		if ( $artifact_cleanup ) {
+			$artifact_plan = $this->worktree_cleanup_artifacts(
+				array(
+					'dry_run' => true,
+					'force'   => $force,
+				)
+			);
+			if ( $artifact_plan instanceof \WP_Error ) {
+				return $artifact_plan;
+			}
+
+			$artifact_result = $artifact_plan;
+			if ( ! $dry_run && ! empty( $artifact_plan['candidates'] ) ) {
+				$artifact_result = $this->worktree_cleanup_artifacts(
+					array(
+						'apply_plan' => $artifact_plan,
+						'force'      => $force,
+					)
+				);
+				if ( $artifact_result instanceof \WP_Error ) {
+					return $artifact_result;
+				}
+			}
+		}
+
+		$report = $this->build_workspace_retention_report( $worktree_result, $artifact_result, $dry_run );
+
+		return array(
+			'success'        => true,
+			'dry_run'        => $dry_run,
+			'destructive'    => ! $dry_run,
+			'generated_at'   => gmdate( 'c' ),
+			'workspace_path' => $this->workspace_path,
+			'policy'         => array(
+				'worktree_cleanup'    => $worktree_cleanup,
+				'artifact_cleanup'    => $artifact_cleanup,
+				'worktree_older_than' => $worktree_older_than,
+				'skip_github'         => $skip_github,
+				'force'               => $force,
+			),
+			'report'         => $report,
+			'worktrees'      => $worktree_result,
+			'artifacts'      => $artifact_result,
+			'disk'           => $this->build_workspace_disk_report(),
+		);
+	}
+
+	/**
 	 * Build cheap workspace inventory rows from top-level directory names.
 	 *
 	 * This intentionally avoids `git worktree list` and per-worktree `git status`.
@@ -2113,6 +2197,81 @@ class Workspace {
 			'skipped_by_reason'    => $cleanup['summary']['skipped_by_reason'] ?? array(),
 			'candidates_by_signal' => $cleanup['summary']['candidates_by_signal'] ?? array(),
 		);
+	}
+
+	/**
+	 * Build the compact retention cleanup report used by automation surfaces.
+	 *
+	 * @param array|null $worktree_result Whole-worktree cleanup result.
+	 * @param array|null $artifact_result Artifact cleanup result.
+	 * @param bool       $dry_run         Whether the retention run was non-destructive.
+	 * @return array<string,mixed>
+	 */
+	private function build_workspace_retention_report( ?array $worktree_result, ?array $artifact_result, bool $dry_run ): array {
+		$worktree_summary = (array) ( $worktree_result['summary'] ?? array() );
+		$artifact_summary = (array) ( $artifact_result['summary'] ?? array() );
+		$disk             = $this->build_workspace_disk_report();
+
+		$removed_worktree_bytes = $this->sum_cleanup_rows_bytes( (array) ( $worktree_result['removed'] ?? array() ), 'size_bytes' );
+		$removed_artifact_bytes = (int) ( $artifact_summary['removed_size_bytes'] ?? 0 );
+		$would_free_bytes       = (int) ( $worktree_summary['total_size_bytes'] ?? 0 ) + (int) ( $artifact_summary['artifact_size_bytes'] ?? 0 );
+		$freed_bytes            = $dry_run ? 0 : $removed_worktree_bytes + $removed_artifact_bytes;
+		$skip_reasons           = array_merge_recursive(
+			(array) ( $worktree_summary['skipped_by_reason'] ?? array() ),
+			(array) ( $artifact_summary['skipped_by_reason'] ?? array() )
+		);
+		$dirty_skipped          = $this->sum_reason_count( $skip_reasons, 'dirty_worktree' );
+		$unpushed_skipped       = $this->sum_reason_count( $skip_reasons, 'unpushed_commits' );
+
+		return array(
+			'removed_count'                 => (int) ( $worktree_summary['removed'] ?? 0 ) + (int) ( $artifact_summary['removed_artifacts'] ?? 0 ),
+			'removed_worktrees'             => (int) ( $worktree_summary['removed'] ?? 0 ),
+			'removed_artifacts'             => (int) ( $artifact_summary['removed_artifacts'] ?? 0 ),
+			'would_remove_worktrees'        => (int) ( $worktree_summary['would_remove'] ?? 0 ),
+			'would_remove_artifacts'        => (int) ( $artifact_summary['would_remove_artifacts'] ?? 0 ),
+			'freed_bytes'                   => $freed_bytes,
+			'freed_human'                   => $this->format_bytes( $freed_bytes ),
+			'would_free_bytes'              => $would_free_bytes,
+			'would_free_human'              => $this->format_bytes( $would_free_bytes ),
+			'skipped_dirty_unpushed_count'  => $dirty_skipped + $unpushed_skipped,
+			'skipped_dirty_count'           => $dirty_skipped,
+			'skipped_unpushed_count'        => $unpushed_skipped,
+			'remaining_disk_budget_bytes'   => $disk['free_bytes'] ?? null,
+			'remaining_disk_budget_human'   => $disk['free_human'] ?? null,
+			'remaining_disk_budget_summary' => sprintf( '%s free', (string) ( $disk['free_human'] ?? 'unknown' ) ),
+			'worktree_skipped_by_reason'    => (array) ( $worktree_summary['skipped_by_reason'] ?? array() ),
+			'artifact_skipped_by_reason'    => (array) ( $artifact_summary['skipped_by_reason'] ?? array() ),
+		);
+	}
+
+	/**
+	 * Sum an integer field across cleanup rows.
+	 *
+	 * @param array<int,array> $rows  Cleanup rows.
+	 * @param string           $field Field to sum.
+	 * @return int
+	 */
+	private function sum_cleanup_rows_bytes( array $rows, string $field ): int {
+		$total = 0;
+		foreach ( $rows as $row ) {
+			$total += max( 0, (int) ( is_array( $row ) ? ( $row[ $field ] ?? 0 ) : 0 ) );
+		}
+		return $total;
+	}
+
+	/**
+	 * Read a reason count from a possibly merge_recursive-shaped map.
+	 *
+	 * @param array  $reasons Reason count map.
+	 * @param string $key     Reason key.
+	 * @return int
+	 */
+	private function sum_reason_count( array $reasons, string $key ): int {
+		$value = $reasons[ $key ] ?? 0;
+		if ( is_array( $value ) ) {
+			return array_sum( array_map( 'intval', $value ) );
+		}
+		return (int) $value;
 	}
 
 	/**

--- a/tests/smoke-workspace-retention-cleanup.php
+++ b/tests/smoke-workspace-retention-cleanup.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Smoke test for workspace retention cleanup orchestration.
+ *
+ *   php tests/smoke-workspace-retention-cleanup.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Core\FilesRepository {
+	if ( ! class_exists( __NAMESPACE__ . '\FilesystemHelper' ) ) {
+		class FilesystemHelper {
+			public static function get() {
+				return null;
+			}
+		}
+	}
+}
+
+namespace {
+	$workspace_root = sys_get_temp_dir() . '/dmc-retention-cleanup-' . getmypid() . '-' . bin2hex( random_bytes( 4 ) );
+	mkdir( $workspace_root, 0755, true );
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+	if ( ! defined( 'DATAMACHINE_WORKSPACE_PATH' ) ) {
+		define( 'DATAMACHINE_WORKSPACE_PATH', $workspace_root );
+	}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			public function __construct( $code = '', $message = '', $data = array() ) {}
+		}
+	}
+
+	function is_wp_error( $value ): bool {
+		return $value instanceof \WP_Error;
+	}
+
+	require __DIR__ . '/../inc/Workspace/Workspace.php';
+
+	function datamachine_code_retention_assert( bool $condition, string $message ): void {
+		if ( $condition ) {
+			echo "  [PASS] {$message}\n";
+			return;
+		}
+		echo "  [FAIL] {$message}\n";
+		exit( 1 );
+	}
+
+	class Retention_Cleanup_Workspace extends \DataMachineCode\Workspace\Workspace {
+		public array $worktree_opts = array();
+		public array $artifact_opts = array();
+
+		public function worktree_cleanup_merged( array $opts = array() ): array|\WP_Error {
+			$this->worktree_opts = $opts;
+			return array(
+				'success'    => true,
+				'dry_run'    => ! empty( $opts['dry_run'] ),
+				'candidates' => array(),
+				'removed'    => empty( $opts['dry_run'] ) ? array( array( 'handle' => 'repo@old', 'size_bytes' => 2048 ) ) : array(),
+				'skipped'    => array(),
+				'summary'    => array(
+					'would_remove'      => 1,
+					'removed'           => empty( $opts['dry_run'] ) ? 1 : 0,
+					'total_size_bytes'  => 2048,
+					'skipped_by_reason' => array( 'dirty_worktree' => 1 ),
+				),
+			);
+		}
+
+		public function worktree_cleanup_artifacts( array $opts = array() ): array|\WP_Error {
+			$this->artifact_opts[] = $opts;
+			$is_apply = isset( $opts['apply_plan'] );
+			return array(
+				'success'    => true,
+				'dry_run'    => ! $is_apply,
+				'candidates' => array( array( 'handle' => 'repo@active' ) ),
+				'removed'    => $is_apply ? array( array( 'handle' => 'repo@active', 'artifacts' => array( array( 'path' => 'vendor', 'size_bytes' => 512 ) ) ) ) : array(),
+				'skipped'    => array(),
+				'summary'    => array(
+					'would_remove_artifacts' => 1,
+					'removed_artifacts'      => $is_apply ? 1 : 0,
+					'artifact_size_bytes'    => 512,
+					'removed_size_bytes'     => $is_apply ? 512 : 0,
+					'skipped_by_reason'      => array( 'unpushed_commits' => 2 ),
+				),
+			);
+		}
+	}
+
+	echo "=== smoke-workspace-retention-cleanup ===\n";
+
+	try {
+		$workspace = new Retention_Cleanup_Workspace();
+		$result    = $workspace->workspace_retention_cleanup( array( 'worktree_older_than' => '30d' ) );
+
+		datamachine_code_retention_assert( ! is_wp_error( $result ), 'retention cleanup succeeds' );
+		datamachine_code_retention_assert( false === (bool) ( $result['dry_run'] ?? true ), 'retention cleanup defaults to destructive apply mode' );
+		datamachine_code_retention_assert( '30d' === ( $workspace->worktree_opts['older_than'] ?? '' ), 'worktree age policy is forwarded' );
+		datamachine_code_retention_assert( true === ( $workspace->worktree_opts['skip_github'] ?? false ), 'scheduled-safe cleanup skips GitHub by default' );
+		datamachine_code_retention_assert( 2 === count( $workspace->artifact_opts ), 'artifact cleanup dry-runs then applies reviewed plan' );
+		datamachine_code_retention_assert( 2 === (int) ( $result['report']['removed_count'] ?? 0 ), 'report includes removed worktree plus artifact counts' );
+		datamachine_code_retention_assert( 2560 === (int) ( $result['report']['freed_bytes'] ?? 0 ), 'report sums freed worktree and artifact bytes' );
+		datamachine_code_retention_assert( 3 === (int) ( $result['report']['skipped_dirty_unpushed_count'] ?? 0 ), 'report sums dirty and unpushed safety skips' );
+		datamachine_code_retention_assert( isset( $result['report']['remaining_disk_budget_human'] ), 'report exposes remaining disk budget' );
+	} finally {
+		rmdir( $workspace_root );
+	}
+
+	echo "\nAll workspace retention cleanup smoke tests passed.\n";
+}

--- a/tests/smoke-workspace-retention-task.php
+++ b/tests/smoke-workspace-retention-task.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Smoke test for workspace retention cleanup system task.
+ *
+ *   php tests/smoke-workspace-retention-task.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ );
+	}
+
+	$GLOBALS['__retention_task_logs'] = array();
+
+	function is_wp_error( $value ): bool {
+		return false;
+	}
+
+	function do_action( string $hook, ...$args ): void {
+		$GLOBALS['__retention_task_logs'][] = array( $hook, $args );
+	}
+}
+
+namespace DataMachine\Core {
+	class PluginSettings {
+		public static bool $enabled = false;
+
+		public static function get( string $key, $default = null ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+			return self::$enabled;
+		}
+	}
+}
+
+namespace DataMachine\Engine\AI\System\Tasks {
+	abstract class SystemTask {
+		public array $completed = array();
+		public array $failed = array();
+
+		abstract public function getTaskType(): string;
+
+		protected function completeJob( int $jobId, array $data ): void {
+			$this->completed[] = array( $jobId, $data );
+		}
+
+		protected function failJob( int $jobId, string $message ): void {
+			$this->failed[] = array( $jobId, $message );
+		}
+	}
+}
+
+namespace DataMachineCode\Workspace {
+	class Workspace {
+		public function workspace_retention_cleanup( array $opts = array() ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+			return array(
+				'success' => true,
+				'dry_run' => ! empty( $opts['dry_run'] ),
+				'report'  => array(
+					'removed_count'                => 2,
+					'freed_human'                  => '16.0 MiB',
+					'skipped_dirty_unpushed_count' => 3,
+					'remaining_disk_budget_human'  => '400.0 GiB',
+				),
+			);
+		}
+	}
+}
+
+namespace {
+	require_once dirname( __DIR__ ) . '/inc/Tasks/WorkspaceRetentionCleanupTask.php';
+
+	function datamachine_code_retention_task_assert( bool $condition, string $message ): void {
+		if ( $condition ) {
+			echo "  [PASS] {$message}\n";
+			return;
+		}
+		echo "  [FAIL] {$message}\n";
+		exit( 1 );
+	}
+
+	echo "=== smoke-workspace-retention-task ===\n";
+
+	echo "\n[1] Disabled task completes as skipped\n";
+	$settings_class = '\\DataMachine\\Core\\PluginSettings';
+	$enabled_prop   = 'enabled';
+	$settings_class::$$enabled_prop = false;
+	$task = new \DataMachineCode\Tasks\WorkspaceRetentionCleanupTask();
+	$task->executeTask( 201, array() );
+	$completed_prop = 'completed';
+	$failed_prop    = 'failed';
+	$completed      = $task->{$completed_prop};
+	$failed         = $task->{$failed_prop};
+	datamachine_code_retention_task_assert( 'workspace_retention_cleanup' === $task->getTaskType(), 'task type is stable' );
+	datamachine_code_retention_task_assert( true === ( $completed[0][1]['skipped'] ?? false ), 'disabled task reports skipped completion' );
+	datamachine_code_retention_task_assert( array() === $failed, 'disabled task does not fail the job' );
+
+	echo "\n[2] Enabled task stores report and logs concise summary\n";
+	$GLOBALS['__retention_task_logs'] = array();
+	$settings_class::$$enabled_prop = true;
+	$task = new \DataMachineCode\Tasks\WorkspaceRetentionCleanupTask();
+	$task->executeTask( 202, array( 'dry_run' => true ) );
+	$completed = $task->{$completed_prop};
+	datamachine_code_retention_task_assert( true === (bool) ( $completed[0][1]['dry_run'] ?? false ), 'enabled task forwards dry-run flag' );
+	datamachine_code_retention_task_assert( 2 === (int) ( $completed[0][1]['report']['removed_count'] ?? 0 ), 'enabled task stores compact report' );
+	datamachine_code_retention_task_assert( 1 === count( $GLOBALS['__retention_task_logs'] ), 'enabled task emits one datamachine_log event' );
+	$first_log = $GLOBALS['__retention_task_logs'][0] ?? array();
+	datamachine_code_retention_task_assert( str_contains( (string) ( $first_log[1][1] ?? '' ), 'removed 2 item(s)' ), 'log summary includes removed count' );
+
+	echo "\nAll workspace retention task smoke tests passed.\n";
+}


### PR DESCRIPTION
## Summary
- Add `workspace_retention_cleanup`, a scheduled/manual system task that age-gates stale worktree removal and applies artifact cleanup from an internally revalidated plan.
- Register a daily opt-in recurring schedule with configurable `worktree_older_than`, local-only default detection, and compact cleanup reporting.
- Add smoke coverage for retention orchestration and task logging.

## Testing
- `php -l inc/Workspace/Workspace.php && php -l inc/Tasks/WorkspaceRetentionCleanupTask.php && php -l data-machine-code.php && php -l tests/smoke-workspace-retention-cleanup.php && php -l tests/smoke-workspace-retention-task.php`
- `php tests/smoke-workspace-retention-cleanup.php`
- `php tests/smoke-workspace-retention-task.php`
- `php tests/smoke-worktree-cleanup-artifacts.php`
- `php tests/smoke-workspace-hygiene-report.php`

Fixes #180.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafting and testing this focused workspace retention cleanup fix; Chris remains responsible for review and merge.