### PR TITLE
Expose cheap workspace disk inventory offenders

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -1012,7 +1012,7 @@ class WorkspaceAbilities {
 							),
 							'size_limit'      => array(
 								'type'        => 'integer',
-								'description' => 'Maximum top-level workspace entries to size. Default 200.',
+								'description' => 'Maximum top-level workspace entries to size. Default 1000.',
 							),
 						),
 					),

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -316,7 +316,7 @@ class WorkspaceCommand extends BaseCommand {
 	 * [--size-limit=<count>]
 	 * : Maximum top-level workspace entries to size.
 	 * ---
-	 * default: 200
+	 * default: 1000
 	 * ---
 	 *
 	 * ## EXAMPLES
@@ -1648,6 +1648,10 @@ class WorkspaceCommand extends BaseCommand {
 					'value'  => (string) ( $worktrees['worktrees'] ?? 0 ),
 				),
 				array(
+					'metric' => 'artifact_dirs',
+					'value'  => (string) ( $worktrees['artifacts'] ?? 0 ),
+				),
+				array(
 					'metric' => 'dirty_protected',
 					'value'  => (string) ( $worktrees['protected_dirty'] ?? 0 ),
 				),
@@ -1674,6 +1678,47 @@ class WorkspaceCommand extends BaseCommand {
 		);
 
 		$top_size = array_slice( (array) ( $report['top_repos_by_size'] ?? array() ), 0, 10 );
+		$by_kind  = array_slice( (array) ( $size['by_kind'] ?? array() ), 0, 10 );
+		$entries  = array_slice( (array) ( $size['top_entries'] ?? array() ), 0, 10 );
+
+		if ( array() !== $by_kind ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( 'Workspace size by kind:' );
+			$this->format_items(
+				array_map(
+					fn( $row ) => array(
+						'kind'  => $row['kind'] ?? '',
+						'size'  => $row['human'] ?? '',
+						'bytes' => $row['bytes'] ?? 0,
+					),
+					$by_kind
+				),
+				array( 'kind', 'size', 'bytes' ),
+				array( 'format' => 'table' ),
+				'bytes'
+			);
+		}
+
+		if ( array() !== $entries ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( 'Top workspace entries by size:' );
+			$this->format_items(
+				array_map(
+					fn( $row ) => array(
+						'handle' => $row['handle'] ?? '',
+						'kind'   => $row['kind'] ?? '',
+						'repo'   => $row['repo'] ?? '',
+						'size'   => $row['human'] ?? '',
+						'bytes'  => $row['bytes'] ?? 0,
+					),
+					$entries
+				),
+				array( 'handle', 'kind', 'repo', 'size', 'bytes' ),
+				array( 'format' => 'table' ),
+				'bytes'
+			);
+		}
+
 		if ( array() !== $top_size ) {
 			WP_CLI::log( '' );
 			WP_CLI::log( 'Top repos by size:' );

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -44,7 +44,7 @@ class Workspace {
 	/**
 	 * Default number of workspace entries to size in hygiene reports.
 	 */
-	private const HYGIENE_DEFAULT_SIZE_LIMIT = 200;
+	private const HYGIENE_DEFAULT_SIZE_LIMIT = 1000;
 
 	/**
 	 * @var string Resolved workspace path.
@@ -1768,7 +1768,7 @@ class Workspace {
 	 *     @type bool $include_cleanup         Whether to include a cleanup dry-run. Default true.
 	 *     @type bool $include_sizes           Whether to include best-effort `du` sizes. Default true.
 	 *     @type bool $include_worktree_status Whether to include full git worktree status. Default false.
-	 *     @type int  $size_limit              Maximum top-level workspace entries to size. Default 200.
+	 *     @type int  $size_limit              Maximum top-level workspace entries to size. Default 1000.
 	 * }
 	 * @return array<string,mixed>|\WP_Error
 	 */
@@ -1863,14 +1863,16 @@ class Workspace {
 			}
 
 			$parsed      = $this->parse_handle( $entry );
-			$is_worktree = ! empty( $parsed['is_worktree'] );
+			$kind        = $this->classify_workspace_entry_kind( $entry, $parsed, $path );
+			$is_worktree = 'worktree' === $kind;
 			$metadata    = $is_worktree ? WorktreeContextInjector::get_metadata( $parsed['dir_name'] ) : null;
 
 			$rows[] = array(
 				'handle'           => $parsed['dir_name'],
 				'repo'             => $parsed['repo'],
+				'kind'             => $kind,
 				'is_worktree'      => $is_worktree,
-				'is_primary'       => ! $is_worktree,
+				'is_primary'       => 'primary' === $kind,
 				'external'         => false,
 				'branch_slug'      => $parsed['branch_slug'],
 				'path'             => $path,
@@ -1927,6 +1929,7 @@ class Workspace {
 				'handle'      => $entry,
 				'repo'        => $parsed['repo'],
 				'is_worktree' => ! empty( $parsed['is_worktree'] ),
+				'kind'        => $this->classify_workspace_entry_kind( $entry, $parsed, $path ),
 				'path'        => $path,
 				'bytes'       => $size,
 				'human'       => $this->format_bytes( $size ),
@@ -1945,6 +1948,7 @@ class Workspace {
 			'scan_complete'   => $scanned_count >= $total_dirs,
 			'total_bytes'     => $total,
 			'total_human'     => $this->format_bytes( $total ),
+			'by_kind'         => $this->workspace_size_by_kind( $rows ),
 			'entries'         => $rows,
 			'top_entries'     => array_slice( $rows, 0, 10 ),
 		);
@@ -1967,6 +1971,7 @@ class Workspace {
 			'scan_complete'   => true,
 			'total_bytes'     => 0,
 			'total_human'     => $this->format_bytes( 0 ),
+			'by_kind'         => array(),
 			'entries'         => array(),
 			'top_entries'     => array(),
 		);
@@ -2030,6 +2035,7 @@ class Workspace {
 			'total'              => count( $worktrees ),
 			'primaries'          => 0,
 			'worktrees'          => 0,
+			'artifacts'          => 0,
 			'external'           => 0,
 			'dirty'              => 0,
 			'protected_dirty'    => 0,
@@ -2040,8 +2046,10 @@ class Workspace {
 		foreach ( $worktrees as $row ) {
 			if ( ! empty( $row['is_primary'] ) ) {
 				++$summary['primaries'];
-			} else {
+			} elseif ( ! empty( $row['is_worktree'] ) ) {
 				++$summary['worktrees'];
+			} elseif ( 'artifact' === (string) ( $row['kind'] ?? '' ) ) {
+				++$summary['artifacts'];
 			}
 
 			if ( ! empty( $row['external'] ) ) {
@@ -2125,7 +2133,7 @@ class Workspace {
 	private function top_repos_by_worktree_count( array $worktrees, int $limit ): array {
 		$counts = array();
 		foreach ( $worktrees as $row ) {
-			if ( ! empty( $row['is_primary'] ) ) {
+			if ( empty( $row['is_worktree'] ) ) {
 				continue;
 			}
 			$repo = (string) ( $row['repo'] ?? '' );
@@ -2173,6 +2181,66 @@ class Workspace {
 			);
 		}
 		return $rows;
+	}
+
+	/**
+	 * Sum best-effort size rows by top-level workspace entry kind.
+	 *
+	 * @param array<int,array> $entries Size rows.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function workspace_size_by_kind( array $entries ): array {
+		$sizes = array(
+			'primary'  => 0,
+			'worktree' => 0,
+			'artifact' => 0,
+			'other'    => 0,
+		);
+
+		foreach ( $entries as $entry ) {
+			$kind = (string) ( $entry['kind'] ?? 'other' );
+			if ( ! array_key_exists( $kind, $sizes ) ) {
+				$kind = 'other';
+			}
+			$sizes[ $kind ] += (int) ( $entry['bytes'] ?? 0 );
+		}
+
+		$rows = array();
+		foreach ( $sizes as $kind => $bytes ) {
+			$rows[] = array(
+				'kind'  => $kind,
+				'bytes' => (int) $bytes,
+				'human' => $this->format_bytes( (int) $bytes ),
+			);
+		}
+
+		usort( $rows, fn( $a, $b ) => (int) $b['bytes'] <=> (int) $a['bytes'] );
+		return $rows;
+	}
+
+	/**
+	 * Classify a top-level workspace directory without probing git state.
+	 *
+	 * @param string $entry  Directory basename.
+	 * @param array  $parsed Parsed workspace handle.
+	 * @param string $path   Top-level directory path.
+	 * @return string
+	 */
+	private function classify_workspace_entry_kind( string $entry, array $parsed, string $path ): string {
+		if ( ! empty( $parsed['is_worktree'] ) ) {
+			return 'worktree';
+		}
+
+		if ( is_dir( rtrim( $path, '/' ) . '/.git' ) ) {
+			return 'primary';
+		}
+
+		$artifact_names = array( '.cache', '.composer', '.npm', '.pnpm-store', '.tmp', 'artifacts', 'cache', 'tmp' );
+		if ( in_array( strtolower( $entry ), $artifact_names, true ) ) {
+			return 'artifact';
+		}
+
+		return '' !== (string) ( $parsed['repo'] ?? '' ) ? 'primary' : 'other';
 	}
 
 	/**
@@ -3240,7 +3308,7 @@ class Workspace {
 		$skipped    = array();
 
 		foreach ( $this->build_workspace_inventory_rows() as $wt ) {
-			if ( ! empty( $wt['is_primary'] ) ) {
+			if ( empty( $wt['is_worktree'] ) ) {
 				continue;
 			}
 

--- a/tests/smoke-workspace-hygiene-cli.php
+++ b/tests/smoke-workspace-hygiene-cli.php
@@ -74,13 +74,19 @@ namespace {
 				'mode_note'       => 'Workspace size is best-effort.',
 				'total_human'     => '712.6 GiB',
 				'scan_complete'   => true,
-				'top_entries'     => array(),
+				'by_kind'         => array(
+					array( 'kind' => 'worktree', 'bytes' => 4096, 'human' => '4.0 KiB' ),
+				),
+				'top_entries'     => array(
+					array( 'handle' => 'data-machine@big', 'kind' => 'worktree', 'repo' => 'data-machine', 'bytes' => 4096, 'human' => '4.0 KiB' ),
+				),
 			),
 			'disk'                      => array(
 				'free_human' => '1.1 GiB',
 			),
 			'worktrees'                 => array(
 				'worktrees'          => 42,
+				'artifacts'          => 1,
 				'protected_dirty'    => 3,
 				'protected_unpushed' => 2,
 				'missing_metadata'   => 4,
@@ -145,7 +151,9 @@ namespace {
 	$GLOBALS['__cli_logs'] = array();
 	$command->hygiene( array(), array() );
 	datamachine_code_hygiene_assert( 'Workspace hygiene:' === ( $GLOBALS['__cli_logs'][0] ?? '' ), 'human output starts with report heading' );
-	datamachine_code_hygiene_assert( in_array( 'table:12:metric,value', $GLOBALS['__cli_logs'], true ), 'human output renders summary table' );
+	datamachine_code_hygiene_assert( in_array( 'table:13:metric,value', $GLOBALS['__cli_logs'], true ), 'human output renders summary table' );
+	datamachine_code_hygiene_assert( in_array( 'Workspace size by kind:', $GLOBALS['__cli_logs'], true ), 'human output renders size kind grouping' );
+	datamachine_code_hygiene_assert( in_array( 'Top workspace entries by size:', $GLOBALS['__cli_logs'], true ), 'human output renders top offenders' );
 	datamachine_code_hygiene_assert( in_array( 'Top repos by size:', $GLOBALS['__cli_logs'], true ), 'human output renders size leaders' );
 	datamachine_code_hygiene_assert( in_array( 'Top repos by worktree count:', $GLOBALS['__cli_logs'], true ), 'human output renders worktree-count leaders' );
 	datamachine_code_hygiene_assert( in_array( 'Cleanup candidates:', $GLOBALS['__cli_logs'], true ), 'human output renders cleanup candidates' );

--- a/tests/smoke-workspace-hygiene-report.php
+++ b/tests/smoke-workspace-hygiene-report.php
@@ -26,6 +26,10 @@ namespace {
 	mkdir( $workspace_root . '/alpha@feat-one', 0755, true );
 	mkdir( $workspace_root . '/beta@missing-metadata', 0755, true );
 	mkdir( $workspace_root . '/gamma@eligible', 0755, true );
+	mkdir( $workspace_root . '/cache', 0755, true );
+	file_put_contents( $workspace_root . '/alpha/payload.bin', str_repeat( 'a', 1024 ) );
+	file_put_contents( $workspace_root . '/alpha@feat-one/payload.bin', str_repeat( 'b', 2048 ) );
+	file_put_contents( $workspace_root . '/cache/payload.bin', str_repeat( 'c', 3072 ) );
 	file_put_contents( $workspace_root . '/not-a-dir.txt', 'ignored' );
 
 	define( 'ABSPATH', __DIR__ . '/' );
@@ -140,6 +144,21 @@ namespace {
 		datamachine_code_hygiene_report_assert( 1 === (int) ( $minimal['worktrees']['missing_metadata'] ?? 0 ), 'inventory counts missing metadata from registry only' );
 		datamachine_code_hygiene_report_assert( 'alpha' === ( $minimal['top_repos_by_worktrees'][0]['repo'] ?? '' ), 'inventory builds repo count leaders' );
 		datamachine_code_hygiene_report_assert( 1 === (int) ( $minimal['top_repos_by_worktrees'][0]['worktree_count'] ?? 0 ), 'repo count leaders ignore primaries and missing-metadata repo still sorts after alpha' );
+
+		echo "\n[1a] Size report exposes top offenders and kind grouping\n";
+		$with_sizes = $workspace->workspace_hygiene_report(
+			array(
+				'include_cleanup' => false,
+				'size_limit'      => 10,
+			)
+		);
+		datamachine_code_hygiene_report_assert( ! is_wp_error( $with_sizes ), 'size report succeeds' );
+		datamachine_code_hygiene_report_assert( true === ( $with_sizes['size']['scan_complete'] ?? false ), 'bounded size scan completes under limit' );
+		datamachine_code_hygiene_report_assert( ! empty( $with_sizes['size']['top_entries'][0]['kind'] ), 'top entries include kind classification' );
+		$kind_rows = array_column( $with_sizes['size']['by_kind'] ?? array(), 'bytes', 'kind' );
+		datamachine_code_hygiene_report_assert( array_key_exists( 'primary', $kind_rows ), 'size grouping includes primary bucket' );
+		datamachine_code_hygiene_report_assert( array_key_exists( 'worktree', $kind_rows ), 'size grouping includes worktree bucket' );
+		datamachine_code_hygiene_report_assert( array_key_exists( 'artifact', $kind_rows ), 'size grouping includes artifact bucket' );
 
 		echo "\n[1b] Default cleanup summary uses inventory-only review\n";
 		$with_cleanup = $workspace->workspace_hygiene_report(


### PR DESCRIPTION
## Summary
- Extends `workspace hygiene` with top workspace entries by size and size totals grouped by `primary`, `worktree`, `artifact`, and `other`.
- Keeps the default report cheap for large workspaces by avoiding git status/GitHub probes unless explicitly requested, while raising the bounded size inventory limit to cover hundreds of worktrees.
- Updates focused hygiene smoke coverage for JSON/human output and inventory classification.

Fixes #181.

## Testing
- `php -l inc/Workspace/Workspace.php`
- `php -l inc/Cli/Commands/WorkspaceCommand.php`
- `php -l inc/Abilities/WorkspaceAbilities.php`
- `php -l tests/smoke-workspace-hygiene-report.php`
- `php -l tests/smoke-workspace-hygiene-cli.php`
- `php tests/smoke-workspace-hygiene-report.php`
- `php tests/smoke-workspace-hygiene-cli.php`
- `php tests/smoke-worktree-disk-budget.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafting and testing this focused workspace hygiene/disk inventory fix; Chris remains responsible for review and merge.