### PR TITLE
Add emergency worktree cleanup mode

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -1296,6 +1296,49 @@ class WorkspaceAbilities {
 					'meta'                => array( 'show_in_rest' => false ),
 				)
 			);
+
+			wp_register_ability(
+				'datamachine/workspace-worktree-emergency-cleanup',
+				array(
+					'label'               => 'Emergency Cleanup Worktrees',
+					'description'         => 'Build or apply a disk-pressure emergency cleanup plan using cheap workspace inventory first. The plan prioritizes artifact/cache deletion and oldest finalized or cleanup-eligible worktrees without running full git status or GitHub checks before initial output.',
+					'category'            => 'datamachine-code-workspace',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'dry_run'    => array(
+								'type'        => 'boolean',
+								'description' => 'If true, return the emergency plan without deleting anything. Emergency cleanup defaults to dry-run unless apply_plan is provided.',
+							),
+							'force'      => array(
+								'type'        => 'boolean',
+								'description' => 'If true during apply-plan, allow dirty or unpushed worktree deletion after human review. Primary checkouts remain protected.',
+							),
+							'apply_plan' => array(
+								'type'        => 'object',
+								'description' => 'Decoded emergency cleanup dry-run report to apply after current-state revalidation.',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'             => array( 'type' => 'boolean' ),
+							'mode'                => array( 'type' => 'string' ),
+							'dry_run'             => array( 'type' => 'boolean' ),
+							'artifact_candidates' => array( 'type' => 'array' ),
+							'worktree_candidates' => array( 'type' => 'array' ),
+							'removed_artifacts'   => array( 'type' => 'array' ),
+							'removed_worktrees'   => array( 'type' => 'array' ),
+							'skipped'             => array( 'type' => 'array' ),
+							'summary'             => array( 'type' => 'object' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'worktreeEmergencyCleanup' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
 		};
 
 		if ( doing_action( 'wp_abilities_api_init' ) ) {
@@ -1744,6 +1787,25 @@ class WorkspaceAbilities {
 		}
 
 		return $workspace->worktree_cleanup_artifacts( $opts );
+	}
+
+	/**
+	 * Build or apply a disk-pressure emergency cleanup plan.
+	 *
+	 * @param array $input Input parameters (dry_run, force, apply_plan).
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public static function worktreeEmergencyCleanup( array $input ): array|\WP_Error {
+		$workspace = new Workspace();
+		$opts      = array(
+			'dry_run' => ! empty( $input['dry_run'] ),
+			'force'   => ! empty( $input['force'] ),
+		);
+		if ( isset( $input['apply_plan'] ) && is_array( $input['apply_plan'] ) ) {
+			$opts['apply_plan'] = $input['apply_plan'];
+		}
+
+		return $workspace->worktree_emergency_cleanup( $opts );
 	}
 
 	/**

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1251,6 +1251,10 @@ class WorkspaceCommand extends BaseCommand {
 	 *     wp datamachine-code workspace worktree cleanup-artifacts --dry-run --format=json > artifact-plan.json
 	 *     wp datamachine-code workspace worktree cleanup-artifacts --apply-plan=artifact-plan.json
 	 *
+	 *     # Emergency disk-pressure plan: cheap inventory first, artifacts before worktrees
+	 *     wp datamachine-code workspace worktree emergency-cleanup --format=json > emergency-plan.json
+	 *     wp datamachine-code workspace worktree emergency-cleanup --apply-plan=emergency-plan.json
+	 *
 	 *     # Local-only detection (no GitHub API call)
 	 *     wp datamachine-code workspace worktree cleanup --skip-github
 	 *
@@ -1287,7 +1291,7 @@ class WorkspaceCommand extends BaseCommand {
 		$operation = $args[0] ?? '';
 
 		if ( '' === $operation ) {
-			WP_CLI::error( 'Usage: wp datamachine-code workspace worktree <add|list|remove|prune|cleanup|cleanup-artifacts|reconcile-metadata|refresh-context|finalize|mark-cleanup-eligible> [<repo>] [<branch>] [--flags]' );
+			WP_CLI::error( 'Usage: wp datamachine-code workspace worktree <add|list|remove|prune|cleanup|cleanup-artifacts|emergency-cleanup|reconcile-metadata|refresh-context|finalize|mark-cleanup-eligible> [<repo>] [<branch>] [--flags]' );
 			return;
 		}
 
@@ -1298,6 +1302,7 @@ class WorkspaceCommand extends BaseCommand {
 			'prune'                 => 'datamachine/workspace-worktree-prune',
 			'cleanup'               => 'datamachine/workspace-worktree-cleanup',
 			'cleanup-artifacts'     => 'datamachine/workspace-worktree-cleanup-artifacts',
+			'emergency-cleanup'     => 'datamachine/workspace-worktree-emergency-cleanup',
 			'reconcile-metadata'    => 'datamachine/workspace-worktree-reconcile-metadata',
 			'refresh-context'       => 'datamachine/workspace-worktree-refresh-context',
 			'finalize'              => 'datamachine/workspace-worktree-finalize',
@@ -1431,6 +1436,15 @@ class WorkspaceCommand extends BaseCommand {
 					$input['apply_plan'] = $this->read_worktree_cleanup_plan( (string) $assoc_args['apply-plan'] );
 				}
 				break;
+
+			case 'emergency-cleanup':
+				$input['dry_run'] = true;
+				$input['force']   = ! empty( $assoc_args['force'] );
+				if ( ! empty( $assoc_args['apply-plan'] ) ) {
+					$input['dry_run']    = false;
+					$input['apply_plan'] = $this->read_worktree_json_plan( (string) $assoc_args['apply-plan'], 'emergency cleanup' );
+				}
+				break;
 		}
 
 		$result = $ability->execute( $input );
@@ -1515,6 +1529,10 @@ class WorkspaceCommand extends BaseCommand {
 
 			case 'cleanup-artifacts':
 				$this->render_worktree_artifact_cleanup_result( $result, $assoc_args );
+				return;
+
+			case 'emergency-cleanup':
+				$this->render_worktree_emergency_cleanup_result( $result, $assoc_args );
 				return;
 
 			case 'add':
@@ -2118,6 +2136,119 @@ class WorkspaceCommand extends BaseCommand {
 		}
 
 		return $flat;
+	}
+
+	/**
+	 * Render emergency cleanup output.
+	 *
+	 * @param array $result     Emergency cleanup result.
+	 * @param array $assoc_args CLI args.
+	 * @return void
+	 */
+	private function render_worktree_emergency_cleanup_result( array $result, array $assoc_args ): void {
+		$format = isset( $assoc_args['format'] ) ? (string) $assoc_args['format'] : 'table';
+		if ( 'json' === $format ) {
+			$json = wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+			WP_CLI::log( false === $json ? '{}' : $json );
+			return;
+		}
+
+		$summary             = (array) ( $result['summary'] ?? array() );
+		$artifact_candidates = (array) ( $result['artifact_candidates'] ?? array() );
+		$worktree_candidates = (array) ( $result['worktree_candidates'] ?? array() );
+		$removed_artifacts   = (array) ( $result['removed_artifacts'] ?? array() );
+		$removed_worktrees   = (array) ( $result['removed_worktrees'] ?? array() );
+		$skipped             = (array) ( $result['skipped'] ?? array() );
+		$dry_run             = ! empty( $result['dry_run'] );
+
+		WP_CLI::log( 'Emergency cleanup summary:' );
+		$summary_rows = array(
+			array(
+				'metric' => 'would_remove_artifacts',
+				'count'  => (int) ( $summary['would_remove_artifacts'] ?? 0 ),
+			),
+			array(
+				'metric' => 'would_remove_worktrees',
+				'count'  => (int) ( $summary['would_remove_worktrees'] ?? 0 ),
+			),
+			array(
+				'metric' => 'removed_artifacts',
+				'count'  => (int) ( $summary['removed_artifacts'] ?? 0 ),
+			),
+			array(
+				'metric' => 'removed_worktrees',
+				'count'  => (int) ( $summary['removed_worktrees'] ?? 0 ),
+			),
+			array(
+				'metric' => 'artifact_size',
+				'count'  => $this->format_bytes( $summary['artifact_size_bytes'] ?? null ),
+			),
+			array(
+				'metric' => 'worktree_size',
+				'count'  => $this->format_bytes( $summary['worktree_size_bytes'] ?? null ),
+			),
+			array(
+				'metric' => 'skipped',
+				'count'  => (int) ( $summary['skipped'] ?? 0 ),
+			),
+		);
+		$this->format_items( $summary_rows, array( 'metric', 'count' ), array( 'format' => 'table' ), 'metric' );
+
+		if ( ! empty( $artifact_candidates ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( 'Priority 1 - artifact/cache deletion:' );
+			$this->format_items( $this->flatten_artifact_cleanup_rows( $artifact_candidates ), array( 'handle', 'repo', 'branch', 'artifact', 'size', 'path' ), array( 'format' => 'table' ), 'handle' );
+		}
+
+		if ( ! empty( $worktree_candidates ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( 'Priority 2 - oldest finalized/eligible worktrees:' );
+			$rows = array_map(
+				fn( $row ) => array(
+					'handle'      => $row['handle'] ?? '',
+					'branch'      => $row['branch'] ?? '',
+					'age_days'    => $row['age_days'] ?? '',
+					'size'        => $this->format_bytes( $row['size_bytes'] ?? null ),
+					'signal'      => $row['signal'] ?? '',
+					'reason_code' => $row['reason_code'] ?? '',
+				),
+				$worktree_candidates
+			);
+			$this->format_items( $rows, array( 'handle', 'branch', 'age_days', 'size', 'signal', 'reason_code' ), array( 'format' => 'table' ), 'handle' );
+		}
+
+		if ( ! empty( $removed_artifacts ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( 'Removed artifacts:' );
+			$this->format_items( $this->flatten_artifact_cleanup_rows( $removed_artifacts ), array( 'handle', 'repo', 'branch', 'artifact', 'size', 'path' ), array( 'format' => 'table' ), 'handle' );
+		}
+
+		if ( ! empty( $removed_worktrees ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( 'Removed worktrees:' );
+			$this->format_items( $removed_worktrees, array( 'handle', 'repo', 'branch', 'path' ), array( 'format' => 'table' ), 'handle' );
+		}
+
+		if ( ! empty( $skipped ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( 'Skipped:' );
+			$rows = array_map(
+				fn( $row ) => array(
+					'handle'      => $row['handle'] ?? '',
+					'reason_code' => $row['reason_code'] ?? '',
+					'reason'      => $this->shorten_cleanup_reason( (string) ( $row['reason'] ?? '' ) ),
+				),
+				$skipped
+			);
+			$this->format_items( $rows, array( 'handle', 'reason_code', 'reason' ), array( 'format' => 'table' ), 'handle' );
+		}
+
+		WP_CLI::log( '' );
+		if ( $dry_run ) {
+			WP_CLI::success( 'Emergency plan generated. Review JSON, then apply with --apply-plan=<file>.' );
+			return;
+		}
+		WP_CLI::success( sprintf( 'Emergency cleanup removed %d artifact group(s) and %d worktree(s); %d skipped.', count( $removed_artifacts ), count( $removed_worktrees ), count( $skipped ) ) );
 	}
 
 	/**

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -3205,6 +3205,399 @@ class Workspace {
 	}
 
 	/**
+	 * Build or apply a disk-pressure emergency cleanup plan.
+	 *
+	 * The dry-run path intentionally uses only top-level workspace inventory,
+	 * lifecycle metadata, directory size estimates, and artifact profiles. It does
+	 * not run per-worktree git status, fetch, or GitHub checks before returning a
+	 * reviewable plan. Applying a reviewed plan revalidates the current worktree
+	 * list and keeps dirty/unpushed worktree deletion behind explicit force.
+	 *
+	 * @param array $opts Emergency cleanup options (dry_run, force, apply_plan).
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function worktree_emergency_cleanup( array $opts = array() ): array|\WP_Error {
+		$force      = ! empty( $opts['force'] );
+		$apply_plan = isset( $opts['apply_plan'] ) && is_array( $opts['apply_plan'] ) ? $opts['apply_plan'] : null;
+		$dry_run    = null === $apply_plan;
+
+		if ( null !== $apply_plan ) {
+			return $this->apply_worktree_emergency_cleanup_plan( $apply_plan, $force );
+		}
+
+		$plan = $this->build_worktree_emergency_cleanup_plan();
+		if ( $plan instanceof \WP_Error ) {
+			return $plan;
+		}
+
+		$plan['dry_run'] = $dry_run;
+		return $plan;
+	}
+
+	/**
+	 * Build a fast emergency cleanup plan from workspace inventory only.
+	 *
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private function build_worktree_emergency_cleanup_plan(): array|\WP_Error {
+		$artifact_candidates = array();
+		$worktree_candidates = array();
+		$skipped             = array();
+
+		foreach ( $this->build_workspace_inventory_rows() as $wt ) {
+			if ( ! empty( $wt['is_primary'] ) ) {
+				continue;
+			}
+
+			$handle     = (string) ( $wt['handle'] ?? '' );
+			$repo       = (string) ( $wt['repo'] ?? '' );
+			$branch     = $this->emergency_inventory_branch( $wt );
+			$path       = (string) ( $wt['path'] ?? '' );
+			$metadata   = is_array( $wt['metadata'] ?? null ) ? (array) $wt['metadata'] : null;
+			$created_at = is_string( $wt['created_at'] ?? null ) ? (string) $wt['created_at'] : null;
+			$disk       = $this->build_worktree_disk_report( $repo, $path, true, $created_at, $metadata );
+			$base_row   = array_merge(
+				array(
+					'handle'     => $handle,
+					'repo'       => $repo,
+					'branch'     => $branch,
+					'path'       => $path,
+					'created_at' => $created_at,
+					'metadata'   => $metadata,
+				),
+				$disk
+			);
+
+			if ( '' === $handle || '' === $repo || '' === $branch || '' === $path ) {
+				$skipped[] = array_merge( $base_row, array(
+					'reason_code' => 'missing_inventory_identity',
+					'reason'      => 'inventory row is missing handle, repo, branch, or path',
+				) );
+				continue;
+			}
+
+			if ( $this->is_active_studio_symlink_target( $path ) ) {
+				$skipped[] = array_merge( $base_row, array(
+					'reason_code' => 'active_symlink_target',
+					'reason'      => 'worktree is an active plugin/theme symlink target',
+				) );
+				continue;
+			}
+
+			if ( ! empty( $disk['artifacts'] ) ) {
+				$artifact_candidates[] = array_merge( $base_row, array(
+					'artifacts'           => $disk['artifacts'],
+					'artifact_count'      => count( (array) $disk['artifacts'] ),
+					'artifact_size_bytes' => (int) ( $disk['artifact_size_bytes'] ?? 0 ),
+					'reason_code'         => 'profile_artifacts',
+					'reason'              => 'profile-derived reconstructable artifacts can be removed first under disk pressure',
+				) );
+			}
+
+			$lifecycle_state = is_array( $metadata ) ? (string) ( $metadata['lifecycle_state'] ?? '' ) : '';
+			if ( in_array( $lifecycle_state, $this->emergency_cleanup_lifecycle_states(), true ) ) {
+				$worktree_candidates[] = array_merge( $base_row, array(
+					'dirty'       => 0,
+					'signal'      => $lifecycle_state,
+					'reason_code' => $lifecycle_state,
+					'reason'      => sprintf( 'worktree lifecycle state is %s; deletion requires reviewed apply-plan revalidation', $lifecycle_state ),
+					'pr_url'      => $metadata['pr_url'] ?? null,
+				) );
+			} else {
+				$skipped[] = array_merge( $base_row, array(
+					'reason_code' => is_array( $metadata ) ? 'no_emergency_worktree_signal' : 'requires_metadata_or_full_scan',
+					'reason'      => is_array( $metadata ) ? 'no finalized or cleanup-eligible lifecycle signal for worktree deletion' : 'missing lifecycle metadata; emergency mode will only consider artifacts from this row',
+				) );
+			}
+		}
+
+		usort( $artifact_candidates, fn( $a, $b ) => (int) ( $b['artifact_size_bytes'] ?? 0 ) <=> (int) ( $a['artifact_size_bytes'] ?? 0 ) );
+		usort( $worktree_candidates, fn( $a, $b ) => (int) ( $b['age_days'] ?? -1 ) <=> (int) ( $a['age_days'] ?? -1 ) );
+
+		return array(
+			'success'             => true,
+			'mode'                => 'emergency',
+			'dry_run'             => true,
+			'generated_at'        => gmdate( 'c' ),
+			'workspace_path'      => $this->workspace_path,
+			'artifact_candidates' => $artifact_candidates,
+			'worktree_candidates' => $worktree_candidates,
+			'removed_artifacts'   => array(),
+			'removed_worktrees'   => array(),
+			'skipped'             => $skipped,
+			'summary'             => $this->build_worktree_emergency_cleanup_summary( $artifact_candidates, $worktree_candidates, array(), array(), $skipped ),
+		);
+	}
+
+	/**
+	 * Apply a reviewed emergency cleanup plan.
+	 *
+	 * @param array<string,mixed> $plan  Reviewed emergency cleanup plan.
+	 * @param bool                $force Whether to allow dirty/unpushed worktree deletion.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private function apply_worktree_emergency_cleanup_plan( array $plan, bool $force ): array|\WP_Error {
+		$planned_artifacts = $this->extract_emergency_plan_rows( $plan, 'artifact_candidates' );
+		if ( $planned_artifacts instanceof \WP_Error ) {
+			return $planned_artifacts;
+		}
+		$planned_worktrees = $this->extract_emergency_plan_rows( $plan, 'worktree_candidates' );
+		if ( $planned_worktrees instanceof \WP_Error ) {
+			return $planned_worktrees;
+		}
+
+		$listing = $this->worktree_list();
+		if ( $listing instanceof \WP_Error ) {
+			return $listing;
+		}
+
+		$current_by_handle = array();
+		foreach ( (array) ( $listing['worktrees'] ?? array() ) as $wt ) {
+			if ( ! empty( $wt['is_primary'] ) ) {
+				continue;
+			}
+			$handle = (string) ( $wt['handle'] ?? '' );
+			if ( '' !== $handle ) {
+				$current_by_handle[ $handle ] = $wt;
+			}
+		}
+
+		$removed_artifacts = array();
+		$removed_worktrees = array();
+		$skipped           = array();
+
+		foreach ( $planned_artifacts as $row ) {
+			$current = $current_by_handle[ (string) ( $row['handle'] ?? '' ) ] ?? null;
+			if ( null === $current || ! $this->emergency_row_identity_matches_current( $row, $current, false ) ) {
+				$skipped[] = $this->build_emergency_apply_skip( $row, $current, 'emergency_artifact_plan_not_current', 'planned artifact row no longer matches the current worktree' );
+				continue;
+			}
+
+			$removed_for_row = array();
+			foreach ( (array) ( $row['artifacts'] ?? array() ) as $artifact ) {
+				$relative = is_array( $artifact ) ? (string) ( $artifact['path'] ?? '' ) : '';
+				$remove   = $this->remove_worktree_artifact_path( (string) ( $current['path'] ?? '' ), $relative );
+				if ( $remove instanceof \WP_Error ) {
+					$skipped[] = $this->build_emergency_apply_skip( $row, $current, 'emergency_artifact_remove_failed', sprintf( 'artifact %s removal failed: %s', $relative, $remove->get_error_message() ) );
+					continue 2;
+				}
+				$removed_for_row[] = $artifact;
+			}
+
+			$removed_artifacts[] = array_merge( $row, array( 'artifacts' => $removed_for_row ) );
+		}
+
+		foreach ( $planned_worktrees as $row ) {
+			$current = $current_by_handle[ (string) ( $row['handle'] ?? '' ) ] ?? null;
+			if ( null === $current || ! $this->emergency_row_identity_matches_current( $row, $current, true ) ) {
+				$skipped[] = $this->build_emergency_apply_skip( $row, $current, 'emergency_worktree_plan_not_current', 'planned worktree row no longer matches the current worktree' );
+				continue;
+			}
+
+			$metadata = is_array( $current['metadata'] ?? null ) ? (array) $current['metadata'] : array();
+			$state    = (string) ( $metadata['lifecycle_state'] ?? '' );
+			if ( ! in_array( $state, $this->emergency_cleanup_lifecycle_states(), true ) ) {
+				$skipped[] = $this->build_emergency_apply_skip( $row, $current, 'emergency_lifecycle_not_current', 'current lifecycle state is no longer finalized or cleanup-eligible' );
+				continue;
+			}
+
+			$dirty = (int) ( $current['dirty'] ?? 0 );
+			if ( $dirty > 0 && ! $force ) {
+				$skipped[] = $this->build_emergency_apply_skip( $row, $current, 'dirty_worktree', sprintf( 'working tree dirty (%d files) - pass --force only after human review', $dirty ) );
+				continue;
+			}
+
+			$unpushed = $this->count_unpushed_commits( (string) ( $current['path'] ?? '' ) );
+			if ( $unpushed > 0 && ! $force ) {
+				$skipped[] = $this->build_emergency_apply_skip( $row, $current, 'unpushed_commits', sprintf( '%d unpushed commit(s) - pass --force only after human review', $unpushed ) );
+				continue;
+			}
+
+			$remove = WorkspaceMutationLock::with_repo(
+				$this->workspace_path,
+				(string) ( $current['repo'] ?? '' ),
+				fn() => $this->remove_worktree_by_path( (string) ( $current['repo'] ?? '' ), (string) ( $current['branch'] ?? '' ), (string) ( $current['path'] ?? '' ), $force )
+			);
+			if ( $remove instanceof \WP_Error ) {
+				$skipped[] = $this->build_emergency_apply_skip( $row, $current, 'emergency_worktree_remove_failed', 'worktree removal failed: ' . $remove->get_error_message() );
+				continue;
+			}
+
+			$removed_worktrees[] = array_merge( $row, array( 'current' => $current ) );
+		}
+
+		$this->worktree_prune();
+
+		return array(
+			'success'             => true,
+			'mode'                => 'emergency',
+			'dry_run'             => false,
+			'generated_at'        => gmdate( 'c' ),
+			'workspace_path'      => $this->workspace_path,
+			'artifact_candidates' => $planned_artifacts,
+			'worktree_candidates' => $planned_worktrees,
+			'removed_artifacts'   => $removed_artifacts,
+			'removed_worktrees'   => $removed_worktrees,
+			'skipped'             => $skipped,
+			'summary'             => $this->build_worktree_emergency_cleanup_summary( $planned_artifacts, $planned_worktrees, $removed_artifacts, $removed_worktrees, $skipped ),
+		);
+	}
+
+	/**
+	 * Lifecycle states that are eligible for emergency worktree deletion review.
+	 *
+	 * @return array<int,string>
+	 */
+	private function emergency_cleanup_lifecycle_states(): array {
+		return array(
+			WorktreeContextInjector::STATE_CLEANUP_ELIGIBLE,
+			WorktreeContextInjector::STATE_MERGED,
+			WorktreeContextInjector::STATE_CLOSED,
+			WorktreeContextInjector::STATE_ABANDONED,
+		);
+	}
+
+	/**
+	 * Resolve the best branch value available from cheap inventory metadata.
+	 *
+	 * @param array<string,mixed> $wt Inventory row.
+	 * @return string
+	 */
+	private function emergency_inventory_branch( array $wt ): string {
+		$metadata = is_array( $wt['metadata'] ?? null ) ? (array) $wt['metadata'] : array();
+		foreach ( array( $metadata['branch'] ?? '', $metadata['branch_name'] ?? '', $wt['branch_slug'] ?? '' ) as $candidate ) {
+			$candidate = trim( (string) $candidate );
+			if ( '' !== $candidate ) {
+				return $candidate;
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Extract emergency cleanup rows from a reviewed plan.
+	 *
+	 * @param array<string,mixed> $plan Plan object.
+	 * @param string              $key  Plan row key.
+	 * @return array<int,array<string,mixed>>|\WP_Error
+	 */
+	private function extract_emergency_plan_rows( array $plan, string $key ): array|\WP_Error {
+		$rows = $plan[ $key ] ?? null;
+		if ( ! is_array( $rows ) ) {
+			return new \WP_Error( 'invalid_emergency_cleanup_plan', sprintf( 'Emergency cleanup plan must contain a %s array.', $key ), array( 'status' => 400 ) );
+		}
+
+		foreach ( $rows as $index => $row ) {
+			if ( ! is_array( $row ) ) {
+				return new \WP_Error( 'invalid_emergency_cleanup_plan', sprintf( 'Emergency cleanup %s row #%d is not an object.', $key, (int) $index ), array( 'status' => 400 ) );
+			}
+			foreach ( array( 'handle', 'repo', 'branch', 'path' ) as $field ) {
+				if ( '' === trim( (string) ( $row[ $field ] ?? '' ) ) ) {
+					return new \WP_Error( 'invalid_emergency_cleanup_plan', sprintf( 'Emergency cleanup %s row #%d is missing %s.', $key, (int) $index, $field ), array( 'status' => 400 ) );
+				}
+			}
+			if ( 'artifact_candidates' === $key && ( ! isset( $row['artifacts'] ) || ! is_array( $row['artifacts'] ) || array() === $row['artifacts'] ) ) {
+				return new \WP_Error( 'invalid_emergency_cleanup_plan', sprintf( 'Emergency cleanup artifact row #%d is missing artifacts.', (int) $index ), array( 'status' => 400 ) );
+			}
+		}
+
+		return array_values( $rows );
+	}
+
+	/**
+	 * Compare a reviewed emergency row to current worktree state.
+	 *
+	 * @param array<string,mixed> $planned          Reviewed row.
+	 * @param array<string,mixed> $current          Current worktree row.
+	 * @param bool                $require_branch   Whether branch identity must match exactly.
+	 * @return bool
+	 */
+	private function emergency_row_identity_matches_current( array $planned, array $current, bool $require_branch ): bool {
+		foreach ( array( 'handle', 'repo', 'path' ) as $field ) {
+			if ( (string) ( $planned[ $field ] ?? '' ) !== (string) ( $current[ $field ] ?? '' ) ) {
+				return false;
+			}
+		}
+
+		return ! $require_branch || (string) ( $planned['branch'] ?? '' ) === (string) ( $current['branch'] ?? '' );
+	}
+
+	/**
+	 * Build an emergency apply skip row.
+	 *
+	 * @param array<string,mixed>      $planned Planned row.
+	 * @param array<string,mixed>|null $current Current row.
+	 * @param string                   $code    Stable reason code.
+	 * @param string                   $reason  Human-readable reason.
+	 * @return array<string,mixed>
+	 */
+	private function build_emergency_apply_skip( array $planned, ?array $current, string $code, string $reason ): array {
+		return array(
+			'handle'      => (string) ( $planned['handle'] ?? '' ),
+			'repo'        => (string) ( $current['repo'] ?? $planned['repo'] ?? '' ),
+			'branch'      => (string) ( $current['branch'] ?? $planned['branch'] ?? '' ),
+			'path'        => (string) ( $current['path'] ?? $planned['path'] ?? '' ),
+			'reason_code' => $code,
+			'reason'      => $reason,
+			'planned'     => $planned,
+			'current'     => $current,
+		);
+	}
+
+	/**
+	 * Build summary counts for emergency cleanup plans.
+	 *
+	 * @param array<int,array> $artifact_candidates Artifact rows planned.
+	 * @param array<int,array> $worktree_candidates Worktree rows planned.
+	 * @param array<int,array> $removed_artifacts   Artifact rows removed.
+	 * @param array<int,array> $removed_worktrees   Worktree rows removed.
+	 * @param array<int,array> $skipped             Skip rows.
+	 * @return array<string,mixed>
+	 */
+	private function build_worktree_emergency_cleanup_summary( array $artifact_candidates, array $worktree_candidates, array $removed_artifacts, array $removed_worktrees, array $skipped ): array {
+		$artifact_bytes    = 0;
+		$removed_bytes     = 0;
+		$artifact_count    = 0;
+		$removed_count     = 0;
+		$skipped_by_reason = array();
+
+		foreach ( $artifact_candidates as $row ) {
+			foreach ( (array) ( $row['artifacts'] ?? array() ) as $artifact ) {
+				$artifact_bytes += max( 0, (int) ( is_array( $artifact ) ? ( $artifact['size_bytes'] ?? 0 ) : 0 ) );
+				++$artifact_count;
+			}
+		}
+
+		foreach ( $removed_artifacts as $row ) {
+			foreach ( (array) ( $row['artifacts'] ?? array() ) as $artifact ) {
+				$removed_bytes += max( 0, (int) ( is_array( $artifact ) ? ( $artifact['size_bytes'] ?? 0 ) : 0 ) );
+				++$removed_count;
+			}
+		}
+
+		foreach ( $skipped as $row ) {
+			$code                       = (string) ( $row['reason_code'] ?? 'unknown' );
+			$skipped_by_reason[ $code ] = ( $skipped_by_reason[ $code ] ?? 0 ) + 1;
+		}
+		ksort( $skipped_by_reason );
+
+		return array(
+			'would_remove_artifacts'  => $artifact_count,
+			'would_remove_worktrees'  => count( $worktree_candidates ),
+			'removed_artifacts'       => $removed_count,
+			'removed_worktrees'       => count( $removed_worktrees ),
+			'skipped'                 => count( $skipped ),
+			'skipped_by_reason'       => $skipped_by_reason,
+			'artifact_size_bytes'     => 0 === $removed_count ? $artifact_bytes : $removed_bytes,
+			'removed_artifact_bytes'  => $removed_bytes,
+			'worktree_size_bytes'     => array_sum( array_map( fn( $row ) => max( 0, (int) ( $row['size_bytes'] ?? 0 ) ), $worktree_candidates ) ),
+			'top_artifacts_by_size'   => $this->summarize_top_worktree_rows( $artifact_candidates, 'artifact_size_bytes' ),
+			'top_worktrees_by_age'    => $this->summarize_top_worktree_rows( $worktree_candidates, 'age_days' ),
+		);
+	}
+
+	/**
 	 * Build a bounded cleanup review from top-level inventory only.
 	 *
 	 * This mode is deliberately dry-run-only. It avoids git worktree discovery,

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -194,6 +194,52 @@ namespace {
 		}
 	}
 
+	class FakeEmergencyCleanupAbility {
+		public array $last_input = array();
+
+		public function execute( array $input ): array {
+			$this->last_input = $input;
+			return array(
+				'success'             => true,
+				'mode'                => 'emergency',
+				'dry_run'             => empty( $input['apply_plan'] ),
+				'artifact_candidates' => array(
+					array(
+						'handle'    => 'repo@old',
+						'repo'      => 'repo',
+						'branch'    => 'old',
+						'path'      => '/workspace/repo@old',
+						'artifacts' => array( array( 'path' => 'target', 'size_bytes' => 1024 ) ),
+					),
+				),
+				'worktree_candidates' => array(
+					array(
+						'handle'      => 'repo@eligible',
+						'repo'        => 'repo',
+						'branch'      => 'eligible',
+						'path'        => '/workspace/repo@eligible',
+						'age_days'    => 90,
+						'size_bytes'  => 4096,
+						'signal'      => 'cleanup_eligible',
+						'reason_code' => 'cleanup_eligible',
+					),
+				),
+				'removed_artifacts'   => empty( $input['apply_plan'] ) ? array() : array( array( 'handle' => 'repo@old', 'repo' => 'repo', 'branch' => 'old', 'path' => '/workspace/repo@old', 'artifacts' => array( array( 'path' => 'target', 'size_bytes' => 1024 ) ) ) ),
+				'removed_worktrees'   => array(),
+				'skipped'             => array(),
+				'summary'             => array(
+					'would_remove_artifacts' => 1,
+					'would_remove_worktrees' => 1,
+					'removed_artifacts'      => empty( $input['apply_plan'] ) ? 0 : 1,
+					'removed_worktrees'      => 0,
+					'skipped'                => 0,
+					'artifact_size_bytes'    => 1024,
+					'worktree_size_bytes'    => 4096,
+				),
+			);
+		}
+	}
+
 	class FakeListAbility {
 		public function execute( array $input ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 			return array(
@@ -246,10 +292,12 @@ namespace {
 
 	$ability = new FakeCleanupAbility();
 	$artifact_ability = new FakeArtifactCleanupAbility();
+	$emergency_ability = new FakeEmergencyCleanupAbility();
 	$list_ability = new FakeListAbility();
 	$GLOBALS['__abilities'] = array(
 		'datamachine/workspace-worktree-cleanup'           => $ability,
 		'datamachine/workspace-worktree-cleanup-artifacts' => $artifact_ability,
+		'datamachine/workspace-worktree-emergency-cleanup' => $emergency_ability,
 		'datamachine/workspace-worktree-list'              => $list_ability,
 	);
 	$command = new \DataMachineCode\Cli\Commands\WorkspaceCommand();
@@ -361,6 +409,26 @@ namespace {
 	WP_CLI::$successes = array();
 	$command->worktree( array( 'cleanup' ), array( 'dry-run' => true, 'inventory-only' => true, 'skip-github' => true, 'format' => 'json' ) );
 	datamachine_code_cleanup_assert( true === ( $ability->last_input['inventory_only'] ?? null ), '--inventory-only forwards to cleanup ability' );
+
+	echo "\n[8b] emergency-cleanup emits fast plan and apply-plan path\n";
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->worktree( array( 'emergency-cleanup' ), array( 'format' => 'json' ) );
+	datamachine_code_cleanup_assert( array( 'dry_run' => true, 'force' => false ) === $emergency_ability->last_input, 'emergency-cleanup defaults to dry-run and no force' );
+	$emergency_json = json_decode( WP_CLI::$logs[0] ?? '', true );
+	datamachine_code_cleanup_assert( 'emergency' === ( $emergency_json['mode'] ?? '' ), 'emergency-cleanup JSON includes mode' );
+	datamachine_code_cleanup_assert( 'target' === ( $emergency_json['artifact_candidates'][0]['artifacts'][0]['path'] ?? '' ), 'emergency-cleanup JSON includes artifact candidates first' );
+
+	$emergency_plan_file = sys_get_temp_dir() . '/dmc-emergency-cleanup-plan-' . bin2hex( random_bytes( 3 ) ) . '.json';
+	file_put_contents( $emergency_plan_file, wp_json_encode( $emergency_json ) );
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->worktree( array( 'emergency-cleanup' ), array( 'apply-plan' => $emergency_plan_file, 'force' => true ) );
+	datamachine_code_cleanup_assert( false === ( $emergency_ability->last_input['dry_run'] ?? null ), 'emergency-cleanup apply-plan enters apply mode' );
+	datamachine_code_cleanup_assert( true === ( $emergency_ability->last_input['force'] ?? null ), 'emergency-cleanup forwards explicit force for human-reviewed apply' );
+	datamachine_code_cleanup_assert( 'repo@old' === ( $emergency_ability->last_input['apply_plan']['artifact_candidates'][0]['handle'] ?? '' ), 'emergency-cleanup forwards decoded apply plan' );
+	datamachine_code_cleanup_assert( 'Emergency cleanup summary:' === ( WP_CLI::$logs[0] ?? '' ), 'emergency-cleanup human output uses emergency summary' );
+	unlink( $emergency_plan_file );
 
 	echo "\n[9] cleanup-artifacts forwards plan-first flags and renders separately\n";
 	WP_CLI::$logs      = array();

--- a/tests/smoke-worktree-cleanup.php
+++ b/tests/smoke-worktree-cleanup.php
@@ -385,6 +385,25 @@ namespace {
 	$inventory_apply = $inventory_ws->worktree_cleanup_merged( array( 'inventory_only' => true ) );
 	$assert( true, is_wp_error( $inventory_apply ), 'inventory-only cleanup refuses non-dry-run apply path' );
 
+	echo "\nEmergency cleanup dry-run scenario\n";
+	$emergency_ws   = new Cleanup_Inventory_Workspace();
+	$emergency_plan = $emergency_ws->worktree_emergency_cleanup();
+	$assert( true, ! is_wp_error( $emergency_plan ) && ( $emergency_plan['success'] ?? false ), 'emergency cleanup dry-run returns success' );
+	$assert( 'emergency', $emergency_plan['mode'] ?? '', 'emergency cleanup exposes mode' );
+	$assert( true, $emergency_plan['dry_run'] ?? false, 'emergency cleanup defaults to dry-run' );
+	$assert( 0, $emergency_ws->full_listing_calls, 'emergency cleanup initial plan does not call full worktree_list' );
+	$assert_contains( $emergency_plan['artifact_candidates'] ?? array(), 'demo@merged-autodelete', 'emergency cleanup prioritizes reconstructable artifacts' );
+	$assert_contains( $emergency_plan['worktree_candidates'] ?? array(), 'demo@inventory-cleanup-eligible', 'emergency cleanup includes explicit cleanup-eligible worktrees' );
+	$assert( 1, (int) ( $emergency_plan['summary']['would_remove_worktrees'] ?? 0 ), 'emergency cleanup counts worktree candidates separately' );
+	$assert( true, (int) ( $emergency_plan['summary']['would_remove_artifacts'] ?? 0 ) > 0, 'emergency cleanup counts artifact candidates separately' );
+	foreach ( array_merge( $emergency_plan['artifact_candidates'] ?? array(), $emergency_plan['worktree_candidates'] ?? array() ) as $candidate ) {
+		if ( ! empty( $candidate['is_primary'] ) || 'demo' === ( $candidate['handle'] ?? '' ) ) {
+			$failures++;
+			$total++;
+			echo "  ✗ emergency cleanup listed primary as a candidate\n";
+		}
+	}
+
 	$size_plan = $ws->worktree_cleanup_merged(
 		array(
 			'dry_run'     => true,


### PR DESCRIPTION
## Summary
- Adds `workspace worktree emergency-cleanup` for disk-pressure incidents, producing a fast reviewable plan from cheap workspace inventory before any full git/GitHub checks.
- Prioritizes artifact/cache deletion first, then oldest finalized or cleanup-eligible worktrees, while never planning primary checkout deletion.
- Supports reviewed `--apply-plan` execution with current-state revalidation; dirty/unpushed worktree deletion requires explicit `--force`.

Fixes #184.

## Testing
- `php -l inc/Workspace/Workspace.php`
- `php -l inc/Abilities/WorkspaceAbilities.php`
- `php -l inc/Cli/Commands/WorkspaceCommand.php`
- `php -l tests/smoke-worktree-cleanup.php && php -l tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-worktree-cleanup.php`
- `php tests/smoke-worktree-cleanup-cli.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafting and testing this focused emergency cleanup mode fix; Chris remains responsible for review and merge.