### PR TITLE
Bound worktree cleanup probes

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -1705,6 +1705,9 @@ class WorkspaceAbilities {
 		if ( isset( $input['sort'] ) && '' !== trim( (string) $input['sort'] ) ) {
 			$opts['sort'] = trim( (string) $input['sort'] );
 		}
+		if ( isset( $input['progress_callback'] ) && is_callable( $input['progress_callback'] ) ) {
+			$opts['progress_callback'] = $input['progress_callback'];
+		}
 
 		return $workspace->worktree_cleanup_merged( $opts );
 	}

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1403,6 +1403,11 @@ class WorkspaceCommand extends BaseCommand {
 				$input['force']          = ! empty( $assoc_args['force'] );
 				$input['skip_github']    = ! empty( $assoc_args['skip-github'] );
 				$input['inventory_only'] = ! empty( $assoc_args['inventory-only'] );
+				if ( ! in_array( (string) ( $assoc_args['format'] ?? '' ), array( 'json', 'yaml' ), true ) ) {
+					$input['progress_callback'] = function ( array $event ): void {
+						$this->render_worktree_cleanup_progress( $event );
+					};
+				}
 				if ( ! empty( $assoc_args['apply-plan'] ) ) {
 					if ( ! empty( $assoc_args['force'] ) ) {
 						WP_CLI::error( 'Do not combine --apply-plan with --force. Plan application always revalidates and refuses dirty worktrees.' );
@@ -1892,6 +1897,34 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 		WP_CLI::success( sprintf( 'Removed %d worktree(s); %d skipped.', count( $result['removed'] ?? array() ), count( $result['skipped'] ?? array() ) ) );
+	}
+
+	/**
+	 * Render one human cleanup progress line.
+	 *
+	 * @param array $event Progress event.
+	 * @return void
+	 */
+	private function render_worktree_cleanup_progress( array $event ): void {
+		$label = (string) ( $event['event'] ?? 'progress' );
+		if ( 'start' === $label ) {
+			WP_CLI::log( sprintf( 'Cleanup progress: starting scan of %d worktree(s).', (int) ( $event['total'] ?? 0 ) ) );
+			return;
+		}
+
+		WP_CLI::log(
+			sprintf(
+				'Cleanup progress: %s%s checked=%d/%d candidates=%d skipped=%d removed=%d elapsed=%.1fs',
+				$label,
+				'' !== (string) ( $event['handle'] ?? '' ) ? ' handle=' . (string) $event['handle'] : '',
+				(int) ( $event['checked'] ?? 0 ),
+				(int) ( $event['total'] ?? 0 ),
+				(int) ( $event['candidates'] ?? 0 ),
+				(int) ( $event['skipped'] ?? 0 ),
+				(int) ( $event['removed'] ?? 0 ),
+				(float) ( $event['elapsed'] ?? 0 )
+			)
+		);
 	}
 
 	/**

--- a/inc/Support/GitRunner.php
+++ b/inc/Support/GitRunner.php
@@ -27,13 +27,18 @@ final class GitRunner {
 	 * caller — this class does not re-check. It only shell-escapes and routes
 	 * stderr into the output stream for a single source of truth on errors.
 	 *
-	 * @param string $path Absolute working-tree path (passed to `git -C`).
-	 * @param string $args Git arguments (without leading `git`).
+	 * @param string $path            Absolute working-tree path (passed to `git -C`).
+	 * @param string $args            Git arguments (without leading `git`).
+	 * @param int    $timeout_seconds Optional timeout in seconds. Zero disables timeout.
 	 * @return array{success: true, output: string}|\WP_Error
 	 */
-	public static function run( string $path, string $args ): array|\WP_Error {
+	public static function run( string $path, string $args, int $timeout_seconds = 0 ): array|\WP_Error {
 		$escaped = escapeshellarg( $path );
 		$command = sprintf( 'git -C %s %s 2>&1', $escaped, $args );
+
+		if ( $timeout_seconds > 0 ) {
+			return self::run_with_timeout( $command, $timeout_seconds );
+		}
 
 		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
 		exec( $command, $output, $exit_code );
@@ -52,6 +57,96 @@ final class GitRunner {
 		return array(
 			'success' => true,
 			'output'  => implode( "\n", $output ),
+		);
+	}
+
+	/**
+	 * Run a command with a wall-clock timeout.
+	 *
+	 * @param string $command         Shell command.
+	 * @param int    $timeout_seconds Timeout in seconds.
+	 * @return array{success: true, output: string}|\WP_Error
+	 */
+	private static function run_with_timeout( string $command, int $timeout_seconds ): array|\WP_Error {
+		$descriptor_spec = array(
+			1 => array( 'pipe', 'w' ),
+			2 => array( 'pipe', 'w' ),
+		);
+
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_proc_open
+		$process = proc_open( $command, $descriptor_spec, $pipes );
+		if ( ! is_resource( $process ) ) {
+			return new \WP_Error( 'git_command_failed', 'Git command failed to start.', array( 'status' => 500 ) );
+		}
+
+		stream_set_blocking( $pipes[1], false );
+		stream_set_blocking( $pipes[2], false );
+		$output    = '';
+		$deadline  = microtime( true ) + $timeout_seconds;
+		$exit_code = null;
+
+		while ( true ) {
+			$output .= (string) stream_get_contents( $pipes[1] );
+			$output .= (string) stream_get_contents( $pipes[2] );
+
+			$status = proc_get_status( $process );
+			if ( empty( $status['running'] ) ) {
+				$exit_code = isset( $status['exitcode'] ) ? (int) $status['exitcode'] : null;
+				break;
+			}
+
+			if ( microtime( true ) >= $deadline ) {
+				proc_terminate( $process );
+				usleep( 100000 );
+				$status = proc_get_status( $process );
+				if ( ! empty( $status['running'] ) ) {
+					proc_terminate( $process, 9 );
+				}
+
+				foreach ( $pipes as $pipe ) {
+					fclose( $pipe );
+				}
+				proc_close( $process );
+
+				return new \WP_Error(
+					'git_command_timeout',
+					sprintf( 'Git command timed out after %d second(s).', $timeout_seconds ),
+					array(
+						'status'  => 500,
+						'timeout' => $timeout_seconds,
+						'output'  => trim( $output ),
+					)
+				);
+			}
+
+			usleep( 50000 );
+		}
+
+		$output .= (string) stream_get_contents( $pipes[1] );
+		$output .= (string) stream_get_contents( $pipes[2] );
+		foreach ( $pipes as $pipe ) {
+			fclose( $pipe );
+		}
+
+		$close_code = proc_close( $process );
+		if ( null === $exit_code ) {
+			$exit_code = $close_code;
+		}
+		$output    = trim( $output );
+		if ( 0 !== $exit_code ) {
+			return new \WP_Error(
+				'git_command_failed',
+				sprintf( 'Git command failed (exit %d): %s', $exit_code, $output ),
+				array(
+					'status' => 500,
+					'output' => $output,
+				)
+			);
+		}
+
+		return array(
+			'success' => true,
+			'output'  => $output,
 		);
 	}
 }

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -32,6 +32,11 @@ class Workspace {
 	private const CLEANUP_GITHUB_TIMEOUT = 5;
 
 	/**
+	 * Bound per-worktree git cleanup probes so one wedged checkout cannot stall cleanup.
+	 */
+	private const CLEANUP_GIT_PROBE_TIMEOUT = 5;
+
+	/**
 	 * Closed PR pages to inspect per repo during cleanup.
 	 */
 	private const CLEANUP_GITHUB_MAX_PAGES = 3;
@@ -2340,6 +2345,8 @@ class Workspace {
 		$apply_plan     = isset( $opts['apply_plan'] ) && is_array( $opts['apply_plan'] ) ? $opts['apply_plan'] : null;
 		$older_than     = isset( $opts['older_than'] ) ? trim( (string) $opts['older_than'] ) : '';
 		$sort           = isset( $opts['sort'] ) ? trim( (string) $opts['sort'] ) : '';
+		$progress       = isset( $opts['progress_callback'] ) && is_callable( $opts['progress_callback'] ) ? $opts['progress_callback'] : null;
+		$started_at     = microtime( true );
 
 		if ( '' !== $sort && ! in_array( $sort, array( 'size', 'age' ), true ) ) {
 			return new \WP_Error( 'invalid_cleanup_sort', 'Invalid cleanup sort. Use size or age.', array( 'status' => 400 ) );
@@ -2396,15 +2403,17 @@ class Workspace {
 		$candidates         = array();
 		$skipped            = array();
 		$github_cache       = array();
+		$worktrees          = array_values( array_filter( (array) $listing['worktrees'], fn( $wt ) => empty( $wt['is_primary'] ) ) );
+		$checked            = 0;
+		$removed_count      = 0;
+
+		$this->emit_worktree_cleanup_progress( $progress, 'start', '', $checked, count( $worktrees ), $candidates, $skipped, $removed_count, $started_at );
 
 		// Fetch + prune each primary once up-front so upstream-gone signals are fresh.
 		$fetched = array();
+		$fetch_timeouts = array();
 
-		foreach ( $listing['worktrees'] as $wt ) {
-			if ( ! empty( $wt['is_primary'] ) ) {
-				continue;
-			}
-
+		foreach ( $worktrees as $wt ) {
 			$handle       = $wt['handle'] ?? '?';
 			$repo         = $wt['repo'] ?? '';
 			$branch       = $wt['branch'] ?? '';
@@ -2432,6 +2441,9 @@ class Workspace {
 			}
 
 			$dirty_count = (int) ( $wt['dirty'] ?? 0 );
+
+			++$checked;
+			$this->emit_worktree_cleanup_progress( $progress, 'checking', (string) $handle, $checked, count( $worktrees ), $candidates, $skipped, $removed_count, $started_at );
 
 			if ( '' === $repo || '' === $branch || '' === $wt_path ) {
 				$missing_fields = array();
@@ -2495,7 +2507,11 @@ class Workspace {
 			// remote branch without merging — nuking the worktree would lose
 			// those commits. `force` does NOT override this: data loss is a
 			// harder problem than dirty-file loss, and this guard is cheap.
-			$unpushed = $this->count_unpushed_commits( $wt_path );
+			$unpushed = $this->count_unpushed_commits( $wt_path, self::CLEANUP_GIT_PROBE_TIMEOUT );
+			if ( is_wp_error( $unpushed ) ) {
+				$skipped[] = $this->build_worktree_probe_timeout_skip( $handle, $repo, $branch, $wt_path, $created_at, $metadata, $disk_fields, $unpushed );
+				continue;
+			}
 			if ( $unpushed > 0 ) {
 				$skipped[] = array_merge( array(
 					'handle'      => $handle,
@@ -2527,8 +2543,18 @@ class Workspace {
 				continue;
 			}
 
+			if ( isset( $fetch_timeouts[ $repo ] ) ) {
+				$skipped[] = $this->build_worktree_probe_timeout_skip( $handle, $repo, $branch, $wt_path, $created_at, $metadata, $disk_fields, $fetch_timeouts[ $repo ] );
+				continue;
+			}
+
 			if ( empty( $fetched[ $repo ] ) ) {
-				$this->run_git( $primary_path, 'fetch --prune --quiet origin' );
+				$fetch = $this->run_git( $primary_path, 'fetch --prune --quiet origin', self::CLEANUP_GIT_PROBE_TIMEOUT );
+				if ( $this->is_git_timeout_error( $fetch ) ) {
+					$fetch_timeouts[ $repo ] = $fetch;
+					$skipped[]              = $this->build_worktree_probe_timeout_skip( $handle, $repo, $branch, $wt_path, $created_at, $metadata, $disk_fields, $fetch );
+					continue;
+				}
 				$fetched[ $repo ] = true;
 			}
 
@@ -2552,6 +2578,20 @@ class Workspace {
 					'path'        => $wt_path,
 					'reason_code' => 'no_merge_signal',
 					'reason'      => 'no merge signal — leaving in place',
+					'created_at'  => $created_at,
+					'metadata'    => $metadata,
+				), $disk_fields );
+				continue;
+			}
+
+			if ( 'probe-timeout' === ( $signal['signal'] ?? '' ) ) {
+				$skipped[] = array_merge( array(
+					'handle'      => $handle,
+					'repo'        => $repo,
+					'branch'      => $branch,
+					'path'        => $wt_path,
+					'reason_code' => 'probe_timeout',
+					'reason'      => $signal['reason'],
 					'created_at'  => $created_at,
 					'metadata'    => $metadata,
 				), $disk_fields );
@@ -2654,6 +2694,8 @@ class Workspace {
 		$summary = $this->build_worktree_cleanup_summary( $candidates, array(), $skipped, $age_filter );
 
 		if ( $dry_run ) {
+			$this->emit_worktree_cleanup_progress( $progress, 'done', '', $checked, count( $worktrees ), $candidates, $skipped, $removed_count, $started_at );
+
 			return array(
 				'success'    => true,
 				'dry_run'    => true,
@@ -2667,6 +2709,7 @@ class Workspace {
 		$removed = array();
 
 		foreach ( $candidates as $cand ) {
+			$this->emit_worktree_cleanup_progress( $progress, 'removing', (string) ( $cand['handle'] ?? '' ), $checked, count( $worktrees ), $candidates, $skipped, $removed_count, $started_at );
 			$remove = WorkspaceMutationLock::with_repo(
 				$this->workspace_path,
 				$cand['repo'],
@@ -2698,10 +2741,13 @@ class Workspace {
 				continue;
 			}
 			$removed[] = $cand;
+			++$removed_count;
 		}
 
 		// Final sweep to drop any remaining registry entries.
 		$this->worktree_prune();
+
+		$this->emit_worktree_cleanup_progress( $progress, 'done', '', $checked, count( $worktrees ), $candidates, $skipped, $removed_count, $started_at );
 
 		return array(
 			'success'    => true,
@@ -2710,6 +2756,68 @@ class Workspace {
 			'removed'    => $removed,
 			'skipped'    => $skipped,
 			'summary'    => $this->build_worktree_cleanup_summary( $candidates, $removed, $skipped, $age_filter ),
+		);
+	}
+
+	/**
+	 * Emit a bounded cleanup progress event for human CLI callers.
+	 *
+	 * @param callable|null $callback      Progress callback.
+	 * @param string        $event         Event name.
+	 * @param string        $handle        Current worktree handle.
+	 * @param int           $checked       Checked worktree count.
+	 * @param int           $total         Total worktree count.
+	 * @param array         $candidates    Candidate rows.
+	 * @param array         $skipped       Skipped rows.
+	 * @param int           $removed_count Removed count.
+	 * @param float         $started_at    Start timestamp from microtime(true).
+	 * @return void
+	 */
+	private function emit_worktree_cleanup_progress( ?callable $callback, string $event, string $handle, int $checked, int $total, array $candidates, array $skipped, int $removed_count, float $started_at ): void {
+		if ( null === $callback ) {
+			return;
+		}
+
+		$callback(
+			array(
+				'event'      => $event,
+				'handle'     => $handle,
+				'checked'    => $checked,
+				'total'      => $total,
+				'candidates' => count( $candidates ),
+				'skipped'    => count( $skipped ),
+				'removed'    => $removed_count,
+				'elapsed'    => round( max( 0, microtime( true ) - $started_at ), 1 ),
+			)
+		);
+	}
+
+	/**
+	 * Build a standard cleanup skip row for timed-out safety probes.
+	 *
+	 * @param string    $handle     Worktree handle.
+	 * @param string    $repo       Repo name.
+	 * @param string    $branch     Branch name.
+	 * @param string    $path       Worktree path.
+	 * @param mixed     $created_at Created timestamp.
+	 * @param mixed     $metadata   Worktree metadata.
+	 * @param array     $disk_fields Disk summary fields.
+	 * @param \WP_Error $error      Probe error.
+	 * @return array<string,mixed>
+	 */
+	private function build_worktree_probe_timeout_skip( string $handle, string $repo, string $branch, string $path, mixed $created_at, mixed $metadata, array $disk_fields, \WP_Error $error ): array {
+		return array_merge(
+			array(
+				'handle'      => $handle,
+				'repo'        => $repo,
+				'branch'      => $branch,
+				'path'        => $path,
+				'reason_code' => 'probe_timeout',
+				'reason'      => 'cleanup safety probe timed out - leaving in place: ' . $error->get_error_message(),
+				'created_at'  => $created_at,
+				'metadata'    => $metadata,
+			),
+			$disk_fields
 		);
 	}
 
@@ -3420,7 +3528,15 @@ class Workspace {
 				continue;
 			}
 
-			$unpushed = $this->count_unpushed_commits( $wt_path );
+			$unpushed = $this->count_unpushed_commits( $wt_path, self::CLEANUP_GIT_PROBE_TIMEOUT );
+			if ( is_wp_error( $unpushed ) ) {
+				$skipped[] = array_merge( $base_row, array(
+					'reason_code' => 'probe_timeout',
+					'reason'      => 'artifact cleanup safety probe timed out - leaving artifacts in place: ' . $unpushed->get_error_message(),
+					'artifacts'   => $artifacts,
+				) );
+				continue;
+			}
 			if ( $unpushed > 0 && ! $force ) {
 				$skipped[] = array_merge( $base_row, array(
 					'reason_code' => 'unpushed_commits',
@@ -4287,7 +4403,14 @@ class Workspace {
 	private function detect_merge_signal( string $primary_path, string $repo, string $branch, bool $skip_github, array &$github_cache = array() ): ?array {
 		$ref    = 'refs/heads/' . $branch;
 		$format = '%(upstream:track)';
-		$result = $this->run_git( $primary_path, sprintf( 'for-each-ref --format=%s %s', escapeshellarg( $format ), escapeshellarg( $ref ) ) );
+		$result = $this->run_git( $primary_path, sprintf( 'for-each-ref --format=%s %s', escapeshellarg( $format ), escapeshellarg( $ref ) ), self::CLEANUP_GIT_PROBE_TIMEOUT );
+
+		if ( $this->is_git_timeout_error( $result ) ) {
+			return array(
+				'signal' => 'probe-timeout',
+				'reason' => $result->get_error_message(),
+			);
+		}
 
 		if ( ! is_wp_error( $result ) ) {
 			$track = trim( (string) ( $result['output'] ?? '' ) );
@@ -4351,7 +4474,13 @@ class Workspace {
 	 * @return array{signal: string, reason: string}|null
 	 */
 	private function detect_local_merged_signal( string $primary_path, string $branch ): ?array {
-		$default_ref = $this->resolve_remote_default_ref( $primary_path );
+		$default_ref = $this->resolve_remote_default_ref( $primary_path, self::CLEANUP_GIT_PROBE_TIMEOUT );
+		if ( $default_ref instanceof \WP_Error ) {
+			return array(
+				'signal' => 'probe-timeout',
+				'reason' => $default_ref->get_error_message(),
+			);
+		}
 		if ( null === $default_ref ) {
 			return null;
 		}
@@ -4359,8 +4488,15 @@ class Workspace {
 		$branch_ref = 'refs/heads/' . $branch;
 		$result     = $this->run_git(
 			$primary_path,
-			sprintf( 'rev-list --count %s..%s', escapeshellarg( $default_ref ), escapeshellarg( $branch_ref ) )
+			sprintf( 'rev-list --count %s..%s', escapeshellarg( $default_ref ), escapeshellarg( $branch_ref ) ),
+			self::CLEANUP_GIT_PROBE_TIMEOUT
 		);
+		if ( $this->is_git_timeout_error( $result ) ) {
+			return array(
+				'signal' => 'probe-timeout',
+				'reason' => $result->get_error_message(),
+			);
+		}
 		if ( is_wp_error( $result ) ) {
 			return null;
 		}
@@ -4380,10 +4516,13 @@ class Workspace {
 	 * Resolve the remote default branch ref for local cleanup checks.
 	 *
 	 * @param string $primary_path Path to the primary git checkout.
-	 * @return string|null Fully-qualified remote default ref, or null when unavailable.
+	 * @return string|\WP_Error|null Fully-qualified remote default ref, timeout error, or null when unavailable.
 	 */
-	private function resolve_remote_default_ref( string $primary_path ): ?string {
-		$result = $this->run_git( $primary_path, 'symbolic-ref --quiet refs/remotes/origin/HEAD' );
+	private function resolve_remote_default_ref( string $primary_path, int $timeout_seconds = 0 ): string|\WP_Error|null {
+		$result = $this->run_git( $primary_path, 'symbolic-ref --quiet refs/remotes/origin/HEAD', $timeout_seconds );
+		if ( $this->is_git_timeout_error( $result ) ) {
+			return $result;
+		}
 		if ( is_wp_error( $result ) ) {
 			return null;
 		}
@@ -4761,11 +4900,30 @@ class Workspace {
 	 * Run a git command in a repository.
 	 *
 	 * @param string $repo_path Resolved repository path.
-	 * @param string $git_args  Git arguments (without leading "git").
+	 * @param string $git_args        Git arguments (without leading "git").
+	 * @param int    $timeout_seconds Optional timeout in seconds.
 	 * @return array
 	 */
-	private function run_git( string $repo_path, string $git_args ): array|\WP_Error {
-		return GitRunner::run( $repo_path, $git_args );
+	private function run_git( string $repo_path, string $git_args, int $timeout_seconds = 0 ): array|\WP_Error {
+		return GitRunner::run( $repo_path, $git_args, $timeout_seconds );
+	}
+
+	/**
+	 * Determine whether a git result is a timeout error.
+	 *
+	 * @param mixed $result Git result.
+	 * @return bool
+	 */
+	private function is_git_timeout_error( mixed $result ): bool {
+		if ( ! is_wp_error( $result ) ) {
+			return false;
+		}
+
+		if ( method_exists( $result, 'get_error_code' ) ) {
+			return 'git_command_timeout' === $result->get_error_code();
+		}
+
+		return isset( $result->code ) && 'git_command_timeout' === $result->code;
 	}
 
 	/**
@@ -5035,15 +5193,14 @@ class Workspace {
 	 *
 	 * Returns >0 when the worktree has unambiguously unpushed commits.
 	 *
-	 * @param string $wt_path Worktree path.
-	 * @return int Number of unpushed commits (0 when safe or indeterminate).
+	 * @param string $wt_path         Worktree path.
+	 * @param int    $timeout_seconds Optional git probe timeout in seconds.
+	 * @return int|\WP_Error Number of unpushed commits (0 when safe or indeterminate), or timeout error.
 	 */
-	private function count_unpushed_commits( string $wt_path ): int {
+	private function count_unpushed_commits( string $wt_path, int $timeout_seconds = 0 ): int|\WP_Error {
 		if ( '' === $wt_path || ! is_dir( $wt_path ) ) {
 			return 0;
 		}
-
-		$escaped = escapeshellarg( $wt_path );
 
 		// Prefer `@{push}` (respects push.default / push.remote mapping); fall
 		// back to `@{upstream}` for the common case where they're the same.
@@ -5051,15 +5208,20 @@ class Workspace {
 		// returns non-zero exit and we can't compute unpushed — treat as 0
 		// and let dirty / merge-signal checks handle it.
 		$commands = array(
-			'git -C %s rev-list --count @{push}..HEAD 2>/dev/null',
-			'git -C %s rev-list --count @{upstream}..HEAD 2>/dev/null',
+			'rev-list --count @{push}..HEAD',
+			'rev-list --count @{upstream}..HEAD',
 		);
 
-		foreach ( $commands as $template ) {
-			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
-			$output = exec( sprintf( $template, $escaped ), $_, $exit_code );
-			if ( 0 === $exit_code && '' !== $output && ctype_digit( (string) $output ) ) {
-				return (int) $output;
+		foreach ( $commands as $command ) {
+			$result = $this->run_git( $wt_path, $command, $timeout_seconds );
+			if ( $this->is_git_timeout_error( $result ) ) {
+				return $result;
+			}
+			if ( ! is_wp_error( $result ) ) {
+				$output = trim( (string) ( $result['output'] ?? '' ) );
+				if ( '' !== $output && ctype_digit( $output ) ) {
+					return (int) $output;
+				}
 			}
 		}
 

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -141,6 +141,20 @@ namespace {
 
 		public function execute( array $input ): array {
 			$this->last_input = $input;
+			if ( isset( $input['progress_callback'] ) && is_callable( $input['progress_callback'] ) ) {
+				$input['progress_callback'](
+					array(
+						'event'      => 'checking',
+						'handle'     => 'repo@merged',
+						'checked'    => 1,
+						'total'      => 13,
+						'candidates' => 1,
+						'skipped'    => 0,
+						'removed'    => 0,
+						'elapsed'    => 1.2,
+					)
+				);
+			}
 			$report = datamachine_code_cleanup_report();
 			if ( isset( $input['older_than'] ) ) {
 				$report['summary']['age_filter'] = array(
@@ -300,7 +314,8 @@ namespace {
 	WP_CLI::$logs      = array();
 	WP_CLI::$successes = array();
 	$command->worktree( array( 'cleanup' ), array( 'dry-run' => true, 'skip-github' => true ) );
-	datamachine_code_cleanup_assert( 'Summary:' === ( WP_CLI::$logs[0] ?? '' ), 'human output starts with summary' );
+	datamachine_code_cleanup_assert( str_starts_with( WP_CLI::$logs[0] ?? '', 'Cleanup progress:' ), 'human output streams cleanup progress before summary' );
+	datamachine_code_cleanup_assert( in_array( 'Summary:', WP_CLI::$logs, true ), 'human output includes summary after progress' );
 	datamachine_code_cleanup_assert( in_array( 'table:1:handle,branch,age_days,size,artifacts,signal,reason_code', WP_CLI::$logs, true ), 'default candidate table uses compact disk fields' );
 	datamachine_code_cleanup_assert( in_array( 'table:10:handle,reason_code,age_days,size,artifacts,reason', WP_CLI::$logs, true ), 'default skipped table omits path and hint fields but keeps disk fields' );
 	datamachine_code_cleanup_assert( in_array( 'Top repos by worktree size:', WP_CLI::$logs, true ), 'human output includes top repo size summary' );
@@ -340,7 +355,8 @@ namespace {
 	WP_CLI::$logs      = array();
 	WP_CLI::$successes = array();
 	$command->worktree( array( 'cleanup' ), array( 'dry-run' => true, 'skip-github' => true, 'older-than' => '7d' ) );
-	datamachine_code_cleanup_assert( array( 'dry_run' => true, 'force' => false, 'skip_github' => true, 'inventory_only' => false, 'older_than' => '7d' ) === $ability->last_input, 'older-than forwards to cleanup ability as older_than' );
+	datamachine_code_cleanup_assert( '7d' === ( $ability->last_input['older_than'] ?? null ), 'older-than forwards to cleanup ability as older_than' );
+	datamachine_code_cleanup_assert( is_callable( $ability->last_input['progress_callback'] ?? null ), 'human cleanup passes progress callback to ability' );
 	datamachine_code_cleanup_assert( in_array( 'table:10:metric,count', WP_CLI::$logs, true ), 'age filter and disk summary rows are rendered' );
 
 	WP_CLI::$logs      = array();


### PR DESCRIPTION
## Summary
- Stream human cleanup progress with current handle, checked/candidate/skipped/removed counts, and elapsed time while keeping JSON output quiet.
- Bound cleanup git probes with timeouts and skip timed-out rows instead of stalling the run.
- Preserve existing GitHub lookup skip/cache behavior and add CLI smoke coverage for progress output.

Fixes #185.
Fixes #186.

## Testing
- `php -l inc/Support/GitRunner.php && php -l inc/Workspace/Workspace.php && php -l inc/Abilities/WorkspaceAbilities.php && php -l inc/Cli/Commands/WorkspaceCommand.php && php -l tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-worktree-cleanup.php`
- `php tests/smoke-worktree-cleanup-artifacts.php`
- `php tests/smoke-worktree-cleanup-github-cache.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafting and testing this focused cleanup progress and timeout fix; Chris remains responsible for review and validation.