### PR TITLE
Fix release-blocking workspace lint

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -1067,7 +1067,7 @@ class WorkspaceAbilities {
 								'type'  => 'array',
 								'items' => array(
 									'type'       => 'object',
-										'properties' => array(
+									'properties' => array(
 										'handle'          => array( 'type' => 'string' ),
 										'repo'            => array( 'type' => 'string' ),
 										'is_worktree'     => array( 'type' => 'boolean' ),

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1998,7 +1998,7 @@ class WorkspaceCommand extends BaseCommand {
 			sprintf(
 				'Cleanup progress: %s%s checked=%d/%d candidates=%d skipped=%d removed=%d elapsed=%.1fs',
 				$label,
-				'' !== (string) ( $event['handle'] ?? '' ) ? ' handle=' . (string) $event['handle'] : '',
+				(string) ( $event['handle'] ?? '' ) !== '' ? ' handle=' . (string) $event['handle'] : '',
 				(int) ( $event['checked'] ?? 0 ),
 				(int) ( $event['total'] ?? 0 ),
 				(int) ( $event['candidates'] ?? 0 ),


### PR DESCRIPTION
## Summary
- Fixes the remaining PHPCS/Yoda findings blocking `homeboy release data-machine-code` after the workspace lifecycle cleanup PRs landed.

## Tests
- `homeboy lint --summary --errors-only`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Identifying the release-blocking lint findings and applying the minimal formatting/Yoda fixes; Chris remains responsible for review and merge.