### PR TITLE
Register workspace maintenance pipeline templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Sibling extensions like `data-machine-socials` and `data-machine-business` are *
 - Clone and manage git repositories in a secure workspace directory
 - Read, write, and edit files within workspace repos
 - List directory contents with file metadata
+- Bundled Data Machine pipeline templates for workspace inventory, metadata repair, artifact cleanup, retention cleanup, and emergency cleanup
 
 ### Git Operations
 - Status, log, diff (read-only)
@@ -151,6 +152,30 @@ array(
 ```
 
 Workspace git policies are configured via the `datamachine_workspace_git_policies` option for per-repo write/push controls.
+
+### Workspace maintenance pipelines
+
+DMC registers bundled, agent-generic Data Machine pipeline templates for recurring workspace maintenance. They are discoverable through the normal pipeline surface:
+
+```bash
+wp datamachine pipeline list --search="DMC Workspace"
+```
+
+Terminology:
+
+- **Pipeline**: reusable recipe/template, owned by DMC and safe to inspect without running anything.
+- **Flow**: agent/site-specific instance of a pipeline with scheduling and config such as workspace root, thresholds, retention windows, artifact profile, and dry-run/apply mode.
+- **Job**: one execution created when a flow runs.
+
+Bundled templates:
+
+- **DMC Workspace Inventory**: cheap disk/worktree inventory and top cleanup offenders.
+- **DMC Workspace Metadata Repair**: review-first lifecycle metadata reconciliation plan.
+- **DMC Workspace Artifact Cleanup**: artifact-first cleanup for reconstructable generated files.
+- **DMC Workspace Retention Cleanup**: age-gated cleanup for finalized, merged, or stale worktrees.
+- **DMC Workspace Emergency Cleanup**: disk-pressure recovery template that starts with inventory and escalates only after review.
+
+The bundled records do not provision flows or schedules. Create flows from these pipelines when an agent/site has explicit maintenance policy, thresholds, and dry-run/apply settings.
 
 ## Architecture
 

--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -59,6 +59,9 @@ function datamachine_code_bootstrap() {
 
 	// Register GitHub issue creation ability via SystemAbilities hook.
 	add_action( 'wp_abilities_api_init', 'datamachine_code_register_system_abilities' );
+
+	// Register bundled Data Machine pipeline templates owned by DMC.
+	\DataMachineCode\Pipelines\WorkspaceMaintenancePipelineTemplates::register();
 }
 add_action( 'plugins_loaded', 'datamachine_code_bootstrap', 20 );
 

--- a/inc/Pipelines/WorkspaceMaintenancePipelineTemplates.php
+++ b/inc/Pipelines/WorkspaceMaintenancePipelineTemplates.php
@@ -1,0 +1,233 @@
+<?php
+/**
+ * Bundled workspace maintenance pipeline templates.
+ *
+ * @package DataMachineCode\Pipelines
+ */
+
+namespace DataMachineCode\Pipelines;
+
+use DataMachine\Core\Database\Pipelines\Pipelines;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Installs DMC-owned, agent-generic workspace maintenance pipeline templates.
+ */
+class WorkspaceMaintenancePipelineTemplates {
+
+	public const VERSION = '2026-05-03';
+	public const OPTION_NAME = 'datamachine_code_workspace_maintenance_pipeline_templates_version';
+
+	/**
+	 * Register the installer hook.
+	 */
+	public static function register(): void {
+		add_action( 'init', array( self::class, 'install' ), 30 );
+	}
+
+	/**
+	 * Install or refresh bundled template pipelines.
+	 */
+	public static function install(): void {
+		if ( get_option( self::OPTION_NAME ) === self::VERSION ) {
+			return;
+		}
+
+		if ( ! class_exists( Pipelines::class ) ) {
+			return;
+		}
+
+		$repo = new Pipelines();
+		foreach ( self::templates() as $template ) {
+			$pipeline_data = array(
+				'user_id'         => 0,
+				'pipeline_name'   => $template['name'],
+				'pipeline_config' => self::pipeline_config( $template ),
+				'portable_slug'   => $template['slug'],
+			);
+
+			$existing = self::find_existing_pipeline( $template['slug'] );
+			if ( $existing > 0 ) {
+				$repo->update_pipeline( $existing, $pipeline_data );
+				continue;
+			}
+
+			$repo->create_pipeline( $pipeline_data );
+		}
+
+		update_option( self::OPTION_NAME, self::VERSION, true );
+	}
+
+	/**
+	 * Return bundled template definitions.
+	 *
+	 * @return array<string,array<string,mixed>>
+	 */
+	public static function templates(): array {
+		return array(
+			'workspace-inventory' => array(
+				'slug'        => 'dmc-workspace-inventory',
+				'name'        => 'DMC Workspace Inventory',
+				'description' => 'Cheap disk/worktree inventory, disk budget state, and top cleanup offenders.',
+				'inputs'      => array( 'workspace_root', 'size_limit', 'include_cleanup', 'include_sizes', 'include_worktree_status' ),
+				'steps'       => array(
+					array(
+						'id'             => 'workspace_hygiene_report',
+						'type'           => 'system_task',
+						'label'          => 'Inventory workspace disk and worktrees',
+						'handler_config' => array(
+							'task'   => 'workspace_hygiene_report',
+							'params' => array(
+								'include_cleanup'         => true,
+								'include_sizes'           => true,
+								'include_worktree_status' => false,
+								'size_limit'              => 200,
+							),
+						),
+					),
+				),
+			),
+			'workspace-metadata-repair' => array(
+				'slug'        => 'dmc-workspace-metadata-repair',
+				'name'        => 'DMC Workspace Metadata Repair',
+				'description' => 'Review-first lifecycle metadata backfill for legacy worktrees.',
+				'inputs'      => array( 'workspace_root', 'dry_run', 'apply_plan' ),
+				'steps'       => array(
+					array(
+						'id'             => 'reconcile_metadata_plan',
+						'type'           => 'ai',
+						'label'          => 'Plan metadata reconciliation',
+						'enabled_tools'  => array( 'workspace_path', 'workspace_list' ),
+						'user_message'   => 'Inspect DMC workspace inventory and prepare a review-first metadata reconciliation plan. Apply nothing automatically; use `studio wp datamachine-code workspace worktree reconcile-metadata --dry-run` for the canonical plan and only apply a reviewed plan later.',
+					),
+				),
+			),
+			'workspace-artifact-cleanup' => array(
+				'slug'        => 'dmc-workspace-artifact-cleanup',
+				'name'        => 'DMC Workspace Artifact Cleanup',
+				'description' => 'Remove safe generated artifacts before touching worktrees.',
+				'inputs'      => array( 'workspace_root', 'artifact_profiles', 'dry_run', 'apply_plan', 'force' ),
+				'steps'       => array(
+					array(
+						'id'             => 'artifact_cleanup_plan',
+						'type'           => 'system_task',
+						'label'          => 'Plan artifact-only cleanup',
+						'handler_config' => array(
+							'task'   => 'workspace_retention_cleanup',
+							'params' => array(
+								'dry_run'          => true,
+								'artifact_cleanup' => true,
+								'worktree_cleanup' => false,
+								'skip_github'      => true,
+							),
+						),
+					),
+				),
+			),
+			'workspace-retention-cleanup' => array(
+				'slug'        => 'dmc-workspace-retention-cleanup',
+				'name'        => 'DMC Workspace Retention Cleanup',
+				'description' => 'Age-gated cleanup for finalized, merged, or stale worktrees after retention windows.',
+				'inputs'      => array( 'workspace_root', 'retention_windows', 'dry_run', 'apply_plan', 'force', 'skip_github' ),
+				'steps'       => array(
+					array(
+						'id'             => 'retention_cleanup',
+						'type'           => 'system_task',
+						'label'          => 'Run retention cleanup',
+						'handler_config' => array(
+							'task'   => 'workspace_retention_cleanup',
+							'params' => array(
+								'dry_run'              => true,
+								'worktree_older_than'  => '14d',
+								'artifact_cleanup'     => true,
+								'worktree_cleanup'     => true,
+								'skip_github'          => true,
+							),
+						),
+					),
+				),
+			),
+			'workspace-emergency-cleanup' => array(
+				'slug'        => 'dmc-workspace-emergency-cleanup',
+				'name'        => 'DMC Workspace Emergency Cleanup',
+				'description' => 'Disk-pressure recovery template: artifact-first, reviewable, escalating only after a plan is inspected.',
+				'inputs'      => array( 'workspace_root', 'disk_thresholds', 'dry_run', 'apply_plan', 'force' ),
+				'steps'       => array(
+					array(
+						'id'             => 'emergency_inventory',
+						'type'           => 'system_task',
+						'label'          => 'Build emergency inventory',
+						'handler_config' => array(
+							'task'   => 'workspace_hygiene_report',
+							'params' => array(
+								'include_cleanup'         => true,
+								'include_sizes'           => true,
+								'include_worktree_status' => false,
+								'size_limit'              => 500,
+							),
+						),
+					),
+					array(
+						'id'             => 'emergency_review',
+						'type'           => 'ai',
+						'label'          => 'Review emergency cleanup plan',
+						'enabled_tools'  => array( 'workspace_path', 'workspace_list' ),
+						'user_message'   => 'Prioritize artifact/cache cleanup before worktree deletion. Escalate if disk pressure remains after safe artifact removal. Never apply destructive cleanup without a reviewed plan.',
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Build Data Machine pipeline_config from a template definition.
+	 *
+	 * @param array<string,mixed> $template Template definition.
+	 * @return array<string,array<string,mixed>>
+	 */
+	private static function pipeline_config( array $template ): array {
+		$config = array();
+		foreach ( array_values( $template['steps'] ?? array() ) as $index => $step ) {
+			$step_id = sanitize_key( $template['slug'] . '-' . ( $step['id'] ?? 'step-' . $index ) );
+			$config[ $step_id ] = array_filter(
+				array(
+					'pipeline_step_id' => $step_id,
+					'step_type'        => $step['type'] ?? '',
+					'execution_order'  => $index,
+					'label'            => $step['label'] ?? ucfirst( str_replace( '_', ' ', (string) ( $step['type'] ?? '' ) ) ),
+					'system_prompt'    => $step['user_message'] ?? null,
+					'enabled_tools'    => $step['enabled_tools'] ?? null,
+					'handler_config'   => $step['handler_config'] ?? null,
+					'template_meta'    => array(
+						'slug'        => $template['slug'],
+						'description' => $template['description'],
+						'inputs'      => $template['inputs'],
+					),
+				),
+				fn( $value ) => null !== $value
+			);
+		}
+
+		return $config;
+	}
+
+	/**
+	 * Find an existing shared DMC template pipeline by portable slug.
+	 */
+	private static function find_existing_pipeline( string $slug ): int {
+		global $wpdb;
+
+		$table = $wpdb->prefix . 'datamachine_pipelines';
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$pipeline_id = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT pipeline_id FROM {$table} WHERE portable_slug = %s AND user_id = 0 AND (agent_id IS NULL OR agent_id = 0) LIMIT 1",
+				$slug
+			)
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		return $pipeline_id ? (int) $pipeline_id : 0;
+	}
+}

--- a/tests/smoke-workspace-maintenance-pipeline-templates.php
+++ b/tests/smoke-workspace-maintenance-pipeline-templates.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Smoke test for bundled workspace maintenance pipeline templates.
+ *
+ *   php tests/smoke-workspace-maintenance-pipeline-templates.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ );
+	}
+
+	function sanitize_key( string $key ): string {
+		$key = strtolower( $key );
+		return preg_replace( '/[^a-z0-9_\-]/', '', $key ) ?? '';
+	}
+
+	require_once dirname( __DIR__ ) . '/inc/Pipelines/WorkspaceMaintenancePipelineTemplates.php';
+
+	function datamachine_code_pipeline_templates_assert( bool $condition, string $message ): void {
+		if ( $condition ) {
+			echo "  [PASS] {$message}\n";
+			return;
+		}
+		echo "  [FAIL] {$message}\n";
+		exit( 1 );
+	}
+
+	echo "=== smoke-workspace-maintenance-pipeline-templates ===\n";
+
+	$templates = \DataMachineCode\Pipelines\WorkspaceMaintenancePipelineTemplates::templates();
+
+	echo "\n[1] Bundled template set\n";
+	datamachine_code_pipeline_templates_assert( 5 === count( $templates ), 'five workspace maintenance templates are bundled' );
+	foreach ( array( 'workspace-inventory', 'workspace-metadata-repair', 'workspace-artifact-cleanup', 'workspace-retention-cleanup', 'workspace-emergency-cleanup' ) as $key ) {
+		datamachine_code_pipeline_templates_assert( isset( $templates[ $key ] ), "template {$key} exists" );
+		datamachine_code_pipeline_templates_assert( str_starts_with( (string) $templates[ $key ]['slug'], 'dmc-' ), "template {$key} has DMC portable slug" );
+		datamachine_code_pipeline_templates_assert( ! empty( $templates[ $key ]['inputs'] ), "template {$key} exposes configurable inputs" );
+	}
+
+	echo "\n[2] Persisted pipeline_config shape\n";
+	$reflection = new \ReflectionClass( \DataMachineCode\Pipelines\WorkspaceMaintenancePipelineTemplates::class );
+	$method     = $reflection->getMethod( 'pipeline_config' );
+	foreach ( $templates as $key => $template ) {
+		$config = $method->invoke( null, $template );
+		datamachine_code_pipeline_templates_assert( ! empty( $config ), "template {$key} builds pipeline steps" );
+		foreach ( $config as $step_id => $step ) {
+			datamachine_code_pipeline_templates_assert( $step_id === ( $step['pipeline_step_id'] ?? '' ), "template {$key} uses stable step IDs" );
+			datamachine_code_pipeline_templates_assert( ! empty( $step['step_type'] ), "template {$key} step has step_type" );
+			datamachine_code_pipeline_templates_assert( isset( $step['execution_order'] ), "template {$key} step has execution order" );
+			datamachine_code_pipeline_templates_assert( ( $step['template_meta']['slug'] ?? '' ) === $template['slug'], "template {$key} keeps template metadata inspectable" );
+		}
+	}
+
+	echo "\nAll workspace maintenance pipeline template smoke tests passed.\n";
+}


### PR DESCRIPTION
## Summary
- Registers five DMC-owned workspace maintenance pipeline templates as shared, agent-generic Data Machine pipelines.
- Adds stable portable slugs and inspectable template metadata for inventory, metadata repair, artifact cleanup, retention cleanup, and emergency cleanup.
- Documents pipeline vs flow vs job terminology and adds a focused smoke test for the bundled template definitions.

Fixes #199.

## Testing
- `php -l data-machine-code.php && php -l inc/Pipelines/WorkspaceMaintenancePipelineTemplates.php && php -l tests/smoke-workspace-maintenance-pipeline-templates.php`
- `php tests/smoke-workspace-maintenance-pipeline-templates.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafting and testing this focused fix; Chris remains responsible for review and merge.