### PR TITLE
Add flow-backed cleanup CLI controls

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -23,6 +23,54 @@ defined( 'ABSPATH' ) || exit;
 
 class WorkspaceCommand extends BaseCommand {
 
+	private const CLEANUP_FLOW_SOURCE = 'workspace_cleanup_cli';
+
+	private const CLEANUP_MODES = array(
+		'inventory' => array(
+			'task_type' => 'worktree_cleanup',
+			'params'    => array(
+				'dry_run'        => true,
+				'inventory_only' => true,
+				'skip_github'    => true,
+			),
+		),
+		'metadata'  => array(
+			'task_type' => 'worktree_cleanup',
+			'params'    => array(
+				'dry_run'        => true,
+				'inventory_only' => true,
+				'skip_github'    => true,
+			),
+		),
+		'artifacts' => array(
+			'task_type' => 'workspace_retention_cleanup',
+			'params'    => array(
+				'dry_run'          => false,
+				'artifact_cleanup' => true,
+				'worktree_cleanup' => false,
+				'skip_github'      => true,
+			),
+		),
+		'retention' => array(
+			'task_type' => 'workspace_retention_cleanup',
+			'params'    => array(
+				'dry_run'          => false,
+				'artifact_cleanup' => true,
+				'worktree_cleanup' => true,
+				'skip_github'      => true,
+			),
+		),
+		'emergency' => array(
+			'task_type' => 'workspace_retention_cleanup',
+			'params'    => array(
+				'dry_run'          => false,
+				'artifact_cleanup' => true,
+				'worktree_cleanup' => true,
+				'skip_github'      => true,
+			),
+		),
+	);
+
 	/**
 	 * Show the workspace directory path.
 	 *
@@ -236,6 +284,358 @@ class WorkspaceCommand extends BaseCommand {
 		WP_CLI::success( $result['message'] );
 		WP_CLI::log( sprintf( 'Name: %s', $result['name'] ) );
 		WP_CLI::log( sprintf( 'Path: %s', $result['path'] ) );
+	}
+
+	/**
+	 * Control flow-backed workspace cleanup runs.
+	 *
+	 * This is the high-level operator surface for cleanup. It starts a Data
+	 * Machine flow and returns immediately with run/flow/job identifiers; heavy
+	 * cleanup work runs from the queued flow job. The lower-level
+	 * `workspace worktree cleanup*` commands remain available for targeted
+	 * debugging and plan rendering.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <operation>
+	 * : Cleanup operation. One of: <run|status|resume|cancel|evidence>.
+	 *
+	 * [<run-id>]
+	 * : Run identifier returned by `run` (currently the Data Machine job ID, or
+	 *   cleanup-run-<job_id>).
+	 *
+	 * [--mode=<mode>]
+	 * : Cleanup mode for `run`.
+	 * ---
+	 * default: retention
+	 * options:
+	 *   - inventory
+	 *   - metadata
+	 *   - artifacts
+	 *   - retention
+	 *   - emergency
+	 * ---
+	 *
+	 * [--flow=<flow_id>]
+	 * : Run an existing cleanup flow instead of creating a fresh one.
+	 *
+	 * [--dry-run]
+	 * : Request dry-run task params where the selected mode supports it.
+	 *
+	 * [--force]
+	 * : Pass force=true into the cleanup task params for modes that support it.
+	 *
+	 * [--older-than=<duration>]
+	 * : Pass an age gate such as 7d or 24h into cleanup task params.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Start flow-backed retention cleanup and return immediately
+	 *     wp datamachine-code workspace cleanup run --mode=retention
+	 *
+	 *     # Inspect progress for a returned run
+	 *     wp datamachine-code workspace cleanup status cleanup-run-123
+	 *
+	 *     # Retry a failed/incomplete run through Data Machine jobs
+	 *     wp datamachine-code workspace cleanup resume cleanup-run-123
+	 *
+	 *     # Cancel a processing run safely by failing the parent job
+	 *     wp datamachine-code workspace cleanup cancel cleanup-run-123
+	 *
+	 *     # Print recorded evidence / engine data
+	 *     wp datamachine-code workspace cleanup evidence cleanup-run-123 --format=json
+	 *
+	 * @subcommand cleanup
+	 */
+	public function cleanup( array $args, array $assoc_args ): void {
+		$operation = (string) ( $args[0] ?? '' );
+		if ( '' === $operation ) {
+			WP_CLI::error( 'Usage: wp datamachine-code workspace cleanup <run|status|resume|cancel|evidence> [<run-id>] [--mode=<mode>]' );
+			return;
+		}
+
+		switch ( $operation ) {
+			case 'run':
+				$this->run_cleanup_flow( $assoc_args );
+				return;
+
+			case 'status':
+			case 'evidence':
+				$job_id = $this->cleanup_run_job_id( (string) ( $args[1] ?? '' ) );
+				if ( $job_id <= 0 ) {
+					WP_CLI::error( 'Usage: wp datamachine-code workspace cleanup ' . $operation . ' <run-id>' );
+					return;
+				}
+				$this->render_cleanup_run_status( $job_id, $assoc_args, 'evidence' === $operation );
+				return;
+
+			case 'resume':
+			case 'cancel':
+				$job_id = $this->cleanup_run_job_id( (string) ( $args[1] ?? '' ) );
+				if ( $job_id <= 0 ) {
+					WP_CLI::error( 'Usage: wp datamachine-code workspace cleanup ' . $operation . ' <run-id>' );
+					return;
+				}
+				$this->control_cleanup_run_job( $operation, $job_id, $assoc_args );
+				return;
+
+			default:
+				WP_CLI::error( sprintf( 'Unknown cleanup operation: %s', $operation ) );
+				return;
+		}
+	}
+
+	private function run_cleanup_flow( array $assoc_args ): void {
+		$mode = strtolower( preg_replace( '/[^a-z0-9_\-]/', '', (string) ( $assoc_args['mode'] ?? 'retention' ) ) );
+		if ( ! isset( self::CLEANUP_MODES[ $mode ] ) ) {
+			WP_CLI::error( sprintf( 'Unknown cleanup mode: %s. Expected one of: %s.', $mode, implode( ', ', array_keys( self::CLEANUP_MODES ) ) ) );
+			return;
+		}
+
+		$flow_created = false;
+		$flow_id      = isset( $assoc_args['flow'] ) ? (int) $assoc_args['flow'] : 0;
+		if ( $flow_id <= 0 ) {
+			$created = $this->create_cleanup_flow( $mode, $assoc_args );
+			if ( ! ( $created['success'] ?? false ) ) {
+				WP_CLI::error( (string) ( $created['error'] ?? 'Failed to create cleanup flow.' ) );
+				return;
+			}
+			$flow_id      = (int) ( $created['flow_id'] ?? 0 );
+			$flow_created = true;
+		}
+
+		$ability = wp_get_ability( 'datamachine/run-flow' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'Run flow ability not registered.' );
+			return;
+		}
+
+		$result = $ability->execute(
+			array(
+				'flow_id'      => $flow_id,
+				'initial_data' => array(
+					'cleanup_run' => array(
+						'mode'       => $mode,
+						'source'     => self::CLEANUP_FLOW_SOURCE,
+						'created_at' => gmdate( 'c' ),
+					),
+				),
+			)
+		);
+
+		if ( ! ( $result['success'] ?? false ) ) {
+			WP_CLI::error( (string) ( $result['error'] ?? 'Failed to run cleanup flow.' ) );
+			return;
+		}
+
+		$job_id = (int) ( $result['job_id'] ?? 0 );
+		$output = array(
+			'success'      => true,
+			'state'        => $flow_created ? 'flow_created' : 'jobs_queued',
+			'run_id'       => $this->cleanup_run_id( $job_id ),
+			'flow_id'      => $flow_id,
+			'job_id'       => $job_id,
+			'first_step'   => $result['first_step'] ?? '',
+			'mode'         => $mode,
+			'flow_created' => $flow_created,
+		);
+
+		$this->render_cleanup_control_result( $output, $assoc_args );
+	}
+
+	private function create_cleanup_flow( string $mode, array $assoc_args ): array {
+		$ability = wp_get_ability( 'datamachine/create-pipeline' );
+		if ( ! $ability ) {
+			return array(
+				'success' => false,
+				'error'   => 'Create pipeline ability not registered. Pass --flow=<flow_id> for an existing cleanup flow.',
+			);
+		}
+
+		$mode_config = self::CLEANUP_MODES[ $mode ];
+		$params      = $this->cleanup_mode_params( $mode, $assoc_args );
+
+		return $ability->execute(
+			array(
+				'pipeline_name' => sprintf( 'DMC Cleanup: %s', $mode ),
+				'workflow'      => array(
+					'steps' => array(
+						array(
+							'type'           => 'system_task',
+							'label'          => sprintf( 'Run %s cleanup', $mode ),
+							'handler_config' => array(
+								'task'   => $mode_config['task_type'],
+								'params' => $params,
+							),
+						),
+					),
+				),
+				'flow_config'   => array(
+					'flow_name'         => sprintf( 'DMC Cleanup: %s', $mode ),
+					'scheduling_config' => array( 'interval' => 'manual' ),
+				),
+			)
+		);
+	}
+
+	private function cleanup_mode_params( string $mode, array $assoc_args ): array {
+		$params           = self::CLEANUP_MODES[ $mode ]['params'];
+		$params['source'] = self::CLEANUP_FLOW_SOURCE;
+
+		if ( isset( $assoc_args['dry-run'] ) ) {
+			$params['dry_run'] = (bool) $assoc_args['dry-run'];
+		}
+		if ( isset( $assoc_args['force'] ) ) {
+			$params['force'] = (bool) $assoc_args['force'];
+		}
+		if ( isset( $assoc_args['older-than'] ) && '' !== trim( (string) $assoc_args['older-than'] ) ) {
+			if ( 'workspace_retention_cleanup' === self::CLEANUP_MODES[ $mode ]['task_type'] ) {
+				$params['worktree_older_than'] = trim( (string) $assoc_args['older-than'] );
+			} else {
+				$params['older_than'] = trim( (string) $assoc_args['older-than'] );
+			}
+		}
+
+		return $params;
+	}
+
+	private function render_cleanup_run_status( int $job_id, array $assoc_args, bool $evidence ): void {
+		$job = $this->get_cleanup_run_job( $job_id );
+		if ( empty( $job ) ) {
+			WP_CLI::error( sprintf( 'Cleanup run not found: %s', $this->cleanup_run_id( $job_id ) ) );
+			return;
+		}
+
+		$engine_data = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		$output      = array(
+			'success'     => true,
+			'state'       => $this->cleanup_job_state( (string) ( $job['status'] ?? '' ) ),
+			'run_id'      => $this->cleanup_run_id( $job_id ),
+			'job_id'      => $job_id,
+			'flow_id'     => $job['flow_id'] ?? null,
+			'pipeline_id' => $job['pipeline_id'] ?? null,
+			'status'      => $job['status'] ?? '',
+			'created_at'  => $job['created_at'] ?? '',
+			'completed_at' => $job['completed_at'] ?? '',
+		);
+
+		if ( $evidence ) {
+			$output['evidence'] = array(
+				'engine_data' => $engine_data,
+				'job'         => $job,
+			);
+		} else {
+			$output['mode'] = $engine_data['cleanup_run']['mode'] ?? '';
+			if ( isset( $engine_data['system_task_result'] ) ) {
+				$output['system_task_result'] = $engine_data['system_task_result'];
+			}
+		}
+
+		$this->render_cleanup_control_result( $output, $assoc_args );
+	}
+
+	private function control_cleanup_run_job( string $operation, int $job_id, array $assoc_args ): void {
+		$ability_name = 'resume' === $operation ? 'datamachine/retry-job' : 'datamachine/fail-job';
+		$ability      = wp_get_ability( $ability_name );
+		if ( ! $ability ) {
+			WP_CLI::error( sprintf( 'Job control ability not registered: %s', $ability_name ) );
+			return;
+		}
+
+		$input = array( 'job_id' => $job_id );
+		if ( 'resume' === $operation ) {
+			$input['force'] = ! empty( $assoc_args['force'] );
+		} else {
+			$input['reason'] = 'cleanup_cancelled';
+		}
+
+		$result = $ability->execute( $input );
+		if ( ! ( $result['success'] ?? false ) ) {
+			WP_CLI::error( (string) ( $result['error'] ?? 'Cleanup run control failed.' ) );
+			return;
+		}
+
+		$result['run_id'] = $this->cleanup_run_id( $job_id );
+		$result['state']  = 'resume' === $operation ? 'running' : 'cancelled';
+		$this->render_cleanup_control_result( $result, $assoc_args );
+	}
+
+	private function get_cleanup_run_job( int $job_id ): array {
+		$ability = wp_get_ability( 'datamachine/get-jobs' );
+		if ( ! $ability ) {
+			return array();
+		}
+
+		$result = $ability->execute( array( 'job_id' => $job_id ) );
+		if ( ! ( $result['success'] ?? false ) ) {
+			return array();
+		}
+
+		$jobs = $result['jobs'] ?? array();
+		return is_array( $jobs ) && ! empty( $jobs[0] ) && is_array( $jobs[0] ) ? $jobs[0] : array();
+	}
+
+	private function render_cleanup_control_result( array $result, array $assoc_args ): void {
+		$format = (string) ( $assoc_args['format'] ?? 'table' );
+		if ( 'json' === $format ) {
+			WP_CLI::log( (string) wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+		if ( 'yaml' === $format && class_exists( 'Spyc' ) ) {
+			WP_CLI::log( (string) call_user_func( array( 'Spyc', 'YAMLDump' ), $result, false, false, true ) );
+			return;
+		}
+
+		WP_CLI::log( sprintf( 'State: %s', $result['state'] ?? 'unknown' ) );
+		foreach ( array( 'run_id', 'flow_id', 'job_id', 'pipeline_id', 'mode', 'status', 'first_step' ) as $key ) {
+			if ( isset( $result[ $key ] ) && '' !== (string) $result[ $key ] ) {
+				WP_CLI::log( sprintf( '%s: %s', ucfirst( str_replace( '_', ' ', $key ) ), (string) $result[ $key ] ) );
+			}
+		}
+		if ( ! empty( $result['evidence'] ) ) {
+			WP_CLI::log( (string) wp_json_encode( $result['evidence'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+		}
+	}
+
+	private function cleanup_run_id( int $job_id ): string {
+		return 'cleanup-run-' . $job_id;
+	}
+
+	private function cleanup_run_job_id( string $run_id ): int {
+		$run_id = trim( $run_id );
+		if ( is_numeric( $run_id ) ) {
+			return (int) $run_id;
+		}
+		if ( preg_match( '/cleanup-run-(\d+)/', $run_id, $matches ) ) {
+			return (int) $matches[1];
+		}
+		return 0;
+	}
+
+	private function cleanup_job_state( string $status ): string {
+		if ( in_array( $status, array( 'pending', 'processing' ), true ) ) {
+			return 'running';
+		}
+		if ( str_starts_with( $status, 'failed - cleanup_cancelled' ) ) {
+			return 'cancelled';
+		}
+		if ( str_starts_with( $status, 'failed' ) ) {
+			return 'partial_failure';
+		}
+		if ( str_starts_with( $status, 'completed' ) ) {
+			return 'complete';
+		}
+		return 'unknown';
 	}
 
 	/**

--- a/inc/Tasks/WorkspaceRetentionCleanupTask.php
+++ b/inc/Tasks/WorkspaceRetentionCleanupTask.php
@@ -52,7 +52,8 @@ class WorkspaceRetentionCleanupTask extends SystemTask {
 	 * @return void
 	 */
 	public function executeTask( int $jobId, array $params ): void {
-		$enabled = (bool) PluginSettings::get( self::SETTING_KEY, false );
+		$enabled = (bool) PluginSettings::get( self::SETTING_KEY, false )
+			|| 'workspace_cleanup_cli' === (string) ( $params['source'] ?? '' );
 		if ( ! $enabled ) {
 			$this->completeJob(
 				$jobId,

--- a/inc/Tasks/WorktreeCleanupTask.php
+++ b/inc/Tasks/WorktreeCleanupTask.php
@@ -125,7 +125,8 @@ class WorktreeCleanupTask extends SystemTask {
 		// wouldn't fire when the setting is off, but manual runs via
 		// `wp datamachine system run worktree_cleanup` bypass the
 		// schedule layer, so the task itself has to self-police too.
-		$enabled = (bool) PluginSettings::get( self::SETTING_KEY, false );
+		$enabled = (bool) PluginSettings::get( self::SETTING_KEY, false )
+			|| 'workspace_cleanup_cli' === (string) ( $params['source'] ?? '' );
 		if ( ! $enabled ) {
 			$this->completeJob(
 				$jobId,

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -302,24 +302,160 @@ namespace {
 		}
 	}
 
+	class FakeCreatePipelineAbility {
+		public array $last_input = array();
+
+		public function execute( array $input ): array {
+			$this->last_input = $input;
+			return array(
+				'success'     => true,
+				'pipeline_id' => 77,
+				'flow_id'     => 88,
+				'flow_name'   => $input['flow_config']['flow_name'] ?? 'DMC Cleanup',
+			);
+		}
+	}
+
+	class FakeRunFlowAbility {
+		public array $last_input = array();
+
+		public function execute( array $input ): array {
+			$this->last_input = $input;
+			return array(
+				'success'    => true,
+				'flow_id'    => (int) $input['flow_id'],
+				'job_id'     => 123,
+				'first_step' => 'step_1',
+			);
+		}
+	}
+
+	class FakeGetJobsAbility {
+		public function execute( array $input ): array {
+			return array(
+				'success' => true,
+				'jobs'    => array(
+					array(
+						'job_id'       => (int) $input['job_id'],
+						'flow_id'      => 88,
+						'pipeline_id'  => 77,
+						'source'       => 'pipeline',
+						'status'       => 'processing',
+						'created_at'   => '2026-05-03 00:00:00',
+						'completed_at' => null,
+						'engine_data'  => array(
+							'cleanup_run' => array(
+								'mode'   => 'retention',
+								'source' => 'workspace_cleanup_cli',
+							),
+						),
+					),
+				),
+			);
+		}
+	}
+
+	class FakeRetryJobAbility {
+		public array $last_input = array();
+
+		public function execute( array $input ): array {
+			$this->last_input = $input;
+			return array(
+				'success'         => true,
+				'job_id'          => (int) $input['job_id'],
+				'previous_status' => 'failed - test',
+				'message'         => 'retried',
+			);
+		}
+	}
+
+	class FakeFailJobAbility {
+		public array $last_input = array();
+
+		public function execute( array $input ): array {
+			$this->last_input = $input;
+			return array(
+				'success'         => true,
+				'job_id'          => (int) $input['job_id'],
+				'previous_status' => 'processing',
+				'new_status'      => 'failed - cleanup_cancelled',
+			);
+		}
+	}
+
 	echo "=== smoke-worktree-cleanup-cli ===\n";
 
 	$ability = new FakeCleanupAbility();
 	$artifact_ability = new FakeArtifactCleanupAbility();
 	$emergency_ability = new FakeEmergencyCleanupAbility();
 	$list_ability = new FakeListAbility();
+	$create_pipeline_ability = new FakeCreatePipelineAbility();
+	$run_flow_ability = new FakeRunFlowAbility();
+	$get_jobs_ability = new FakeGetJobsAbility();
+	$retry_job_ability = new FakeRetryJobAbility();
+	$fail_job_ability = new FakeFailJobAbility();
 	$GLOBALS['__abilities'] = array(
 		'datamachine/workspace-worktree-cleanup'           => $ability,
 		'datamachine/workspace-worktree-cleanup-artifacts' => $artifact_ability,
 		'datamachine/workspace-worktree-emergency-cleanup' => $emergency_ability,
 		'datamachine/workspace-worktree-list'              => $list_ability,
+		'datamachine/create-pipeline'                      => $create_pipeline_ability,
+		'datamachine/run-flow'                             => $run_flow_ability,
+		'datamachine/get-jobs'                             => $get_jobs_ability,
+		'datamachine/retry-job'                            => $retry_job_ability,
+		'datamachine/fail-job'                             => $fail_job_ability,
 	);
 	$command = new \DataMachineCode\Cli\Commands\WorkspaceCommand();
 	$doc_comment = ( new ReflectionMethod( $command, 'worktree' ) )->getDocComment() ?: '';
+	$cleanup_doc_comment = ( new ReflectionMethod( $command, 'cleanup' ) )->getDocComment() ?: '';
 
 	echo "\n[0a] WP-CLI synopsis exposes cleanup flags\n";
 	datamachine_code_cleanup_assert( str_contains( $doc_comment, "\n\t * [--inventory-only]" ), 'worktree synopsis declares --inventory-only at top level' );
 	datamachine_code_cleanup_assert( ! str_contains( $doc_comment, "\n\t\t * [--apply-plan=<file>]" ), 'cleanup flags are not hidden behind nested docblock indentation' );
+	datamachine_code_cleanup_assert( str_contains( $cleanup_doc_comment, 'Control flow-backed workspace cleanup runs.' ), 'workspace cleanup command documents flow-backed controller surface' );
+	datamachine_code_cleanup_assert( str_contains( $cleanup_doc_comment, '<run|status|resume|cancel|evidence>' ), 'workspace cleanup synopsis exposes run/status/resume/cancel/evidence' );
+
+	echo "\n[0b] flow-backed workspace cleanup run/status/control output\n";
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->cleanup( array( 'run' ), array( 'mode' => 'retention', 'format' => 'json' ) );
+	$run_json = json_decode( WP_CLI::$logs[0] ?? '', true );
+	datamachine_code_cleanup_assert( 'flow_created' === ( $run_json['state'] ?? '' ), 'cleanup run distinguishes newly-created flow state' );
+	datamachine_code_cleanup_assert( 'cleanup-run-123' === ( $run_json['run_id'] ?? '' ), 'cleanup run returns stable run id' );
+	datamachine_code_cleanup_assert( 88 === (int) ( $run_json['flow_id'] ?? 0 ), 'cleanup run returns flow id' );
+	datamachine_code_cleanup_assert( 'workspace_retention_cleanup' === ( $create_pipeline_ability->last_input['workflow']['steps'][0]['handler_config']['task'] ?? '' ), 'retention mode creates a system-task cleanup flow' );
+	datamachine_code_cleanup_assert( 'workspace_cleanup_cli' === ( $create_pipeline_ability->last_input['workflow']['steps'][0]['handler_config']['params']['source'] ?? '' ), 'cleanup flow params identify explicit CLI source' );
+	datamachine_code_cleanup_assert( 'retention' === ( $run_flow_ability->last_input['initial_data']['cleanup_run']['mode'] ?? '' ), 'run-flow receives cleanup run metadata' );
+
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->cleanup( array( 'run' ), array( 'flow' => 55, 'mode' => 'inventory', 'format' => 'json' ) );
+	$existing_flow_json = json_decode( WP_CLI::$logs[0] ?? '', true );
+	datamachine_code_cleanup_assert( 'jobs_queued' === ( $existing_flow_json['state'] ?? '' ), 'cleanup run distinguishes existing flow queued state' );
+	datamachine_code_cleanup_assert( 55 === (int) ( $run_flow_ability->last_input['flow_id'] ?? 0 ), 'cleanup run can target an existing flow id' );
+
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->cleanup( array( 'status', 'cleanup-run-123' ), array( 'format' => 'json' ) );
+	$status_json = json_decode( WP_CLI::$logs[0] ?? '', true );
+	datamachine_code_cleanup_assert( 'running' === ( $status_json['state'] ?? '' ), 'cleanup status maps processing job to running state' );
+	datamachine_code_cleanup_assert( 88 === (int) ( $status_json['flow_id'] ?? 0 ), 'cleanup status links underlying flow id' );
+
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->cleanup( array( 'evidence', '123' ), array( 'format' => 'json' ) );
+	$evidence_json = json_decode( WP_CLI::$logs[0] ?? '', true );
+	datamachine_code_cleanup_assert( isset( $evidence_json['evidence']['engine_data'] ), 'cleanup evidence emits engine data' );
+
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->cleanup( array( 'resume', 'cleanup-run-123' ), array( 'force' => true, 'format' => 'json' ) );
+	datamachine_code_cleanup_assert( true === ( $retry_job_ability->last_input['force'] ?? null ), 'cleanup resume forwards force retry flag' );
+
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->cleanup( array( 'cancel', 'cleanup-run-123' ), array( 'format' => 'json' ) );
+	datamachine_code_cleanup_assert( 'cleanup_cancelled' === ( $fail_job_ability->last_input['reason'] ?? '' ), 'cleanup cancel fails job with cleanup cancellation reason' );
 
 	echo "\n[0] list stale output exposes disk fields\n";
 	WP_CLI::$logs      = array();


### PR DESCRIPTION
## Summary
- Add `workspace cleanup run/status/resume/cancel/evidence` as a fast flow-backed cleanup control surface.
- Create one-step Data Machine cleanup flows for operator-triggered modes, or run an existing flow via `--flow=<id>`.
- Keep low-level worktree cleanup commands available while routing docs/smokes toward the flow controller.

## Testing
- `php tests/smoke-worktree-cleanup-cli.php`
- `php -l inc/Cli/Commands/WorkspaceCommand.php && php -l inc/Tasks/WorktreeCleanupTask.php && php -l inc/Tasks/WorkspaceRetentionCleanupTask.php && php -l tests/smoke-worktree-cleanup-cli.php`
- `homeboy test --path /Users/chubes/Developer/data-machine-code@feat-cleanup-flow-cli` failed before running tests in Playground bootstrap: Data Machine activation hit missing `wptests_options`/`wptests_users` tables and undefined `get_user_by()`.
- `homeboy lint --path /Users/chubes/Developer/data-machine-code@feat-cleanup-flow-cli` reported existing repository-wide PHPCS alignment findings outside this change.

Fixes #203.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the CLI control implementation, smoke coverage, and verification commands; Chris remains responsible for review and merge.