### PR TITLE
Run cleanup chunks as Data Machine jobs

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -218,6 +218,7 @@ add_action( 'plugins_loaded', 'datamachine_code_load_chat_tools', 25 );
  */
 add_filter( 'datamachine_tasks', function ( array $tasks ): array {
 	$tasks['github_create_issue']         = \DataMachineCode\Tasks\GitHubIssueTask::class;
+	$tasks['worktree_cleanup_chunk']      = \DataMachineCode\Tasks\WorktreeCleanupChunkTask::class;
 	$tasks['worktree_cleanup']            = \DataMachineCode\Tasks\WorktreeCleanupTask::class;
 	$tasks['workspace_retention_cleanup'] = \DataMachineCode\Tasks\WorkspaceRetentionCleanupTask::class;
 	$tasks['workspace_hygiene_report']    = \DataMachineCode\Tasks\WorkspaceHygieneReportTask::class;

--- a/inc/Tasks/WorkspaceRetentionCleanupTask.php
+++ b/inc/Tasks/WorkspaceRetentionCleanupTask.php
@@ -9,6 +9,7 @@ namespace DataMachineCode\Tasks;
 
 use DataMachine\Core\PluginSettings;
 use DataMachine\Engine\AI\System\Tasks\SystemTask;
+use DataMachine\Engine\Tasks\TaskScheduler;
 use DataMachineCode\Workspace\Workspace;
 
 defined( 'ABSPATH' ) || exit;
@@ -70,13 +71,16 @@ class WorkspaceRetentionCleanupTask extends SystemTask {
 			'skip_github'      => array_key_exists( 'skip_github', $params ) ? (bool) $params['skip_github'] : true,
 			'worktree_cleanup' => array_key_exists( 'worktree_cleanup', $params ) ? (bool) $params['worktree_cleanup'] : true,
 			'artifact_cleanup' => array_key_exists( 'artifact_cleanup', $params ) ? (bool) $params['artifact_cleanup'] : true,
+			'metadata_repair'  => array_key_exists( 'metadata_repair', $params ) ? (bool) $params['metadata_repair'] : true,
 		);
 		if ( isset( $params['worktree_older_than'] ) && '' !== trim( (string) $params['worktree_older_than'] ) ) {
 			$opts['worktree_older_than'] = trim( (string) $params['worktree_older_than'] );
 		}
 
 		$workspace = new Workspace();
-		$result    = $workspace->workspace_retention_cleanup( $opts );
+		$result    = ! empty( $opts['dry_run'] )
+			? $workspace->workspace_retention_cleanup( $opts )
+			: $this->schedule_job_backed_cleanup( $jobId, $workspace, $opts, $params );
 
 		if ( $result instanceof \WP_Error ) {
 			do_action(
@@ -114,5 +118,207 @@ class WorkspaceRetentionCleanupTask extends SystemTask {
 		);
 
 		$this->completeJob( $jobId, $result );
+	}
+
+	/**
+	 * Build reviewed plans and schedule cleanup chunks as child Data Machine jobs.
+	 *
+	 * @param int       $jobId     Parent job ID.
+	 * @param Workspace $workspace Workspace service.
+	 * @param array     $opts      Normalized options.
+	 * @param array     $params    Raw task params.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private function schedule_job_backed_cleanup( int $jobId, Workspace $workspace, array $opts, array $params ): array|\WP_Error {
+		$started_at       = microtime( true );
+		$chunk_rows       = $this->build_cleanup_chunk_rows( $workspace, $opts );
+		if ( $chunk_rows instanceof \WP_Error ) {
+			return $chunk_rows;
+		}
+
+		$chunk_row_counts = array(
+			'artifacts' => count( $chunk_rows['artifacts'] ),
+			'metadata'  => count( $chunk_rows['metadata'] ),
+			'worktrees' => count( $chunk_rows['worktrees'] ),
+		);
+		$item_params      = $this->build_cleanup_chunk_params( $chunk_rows, $opts, $params );
+
+		if ( array() === $item_params ) {
+			return array(
+				'success'           => true,
+				'dry_run'           => false,
+				'destructive'       => false,
+				'job_backed'        => true,
+				'generated_at'      => gmdate( 'c' ),
+				'workspace_path'    => $workspace->get_path(),
+				'chunk_row_counts'  => $chunk_row_counts,
+				'chunks'            => array(),
+				'report'            => array(
+					'removed_count'                   => 0,
+					'bytes_reclaimed'                 => 0,
+					'freed_human'                     => '0 B',
+					'skipped_dirty_unpushed_count'    => 0,
+					'remaining_disk_budget_human'     => 'unknown disk',
+				),
+				'evidence'          => array(
+					'elapsed_ms' => (int) round( ( microtime( true ) - $started_at ) * 1000 ),
+					'note'       => 'No cleanup chunks were eligible after plan generation.',
+				),
+			);
+		}
+
+		if ( ! class_exists( TaskScheduler::class ) ) {
+			return new \WP_Error( 'task_scheduler_unavailable', 'Data Machine TaskScheduler is unavailable; cannot schedule cleanup chunks.', array( 'status' => 500 ) );
+		}
+
+		$batch = TaskScheduler::scheduleBatch(
+			'worktree_cleanup_chunk',
+			$item_params,
+			array(
+				'parent_job_id' => $jobId,
+				'source'        => 'workspace_retention_cleanup',
+				'user_id'       => (int) ( $params['user_id'] ?? 0 ),
+				'agent_id'      => (int) ( $params['agent_id'] ?? 0 ),
+			)
+		);
+
+		if ( false === $batch ) {
+			return new \WP_Error( 'cleanup_chunk_schedule_failed', 'Failed to schedule cleanup chunk jobs.', array( 'status' => 500 ) );
+		}
+
+		return array(
+			'success'           => true,
+			'dry_run'           => false,
+			'destructive'       => true,
+			'job_backed'        => true,
+			'generated_at'      => gmdate( 'c' ),
+			'workspace_path'    => $workspace->get_path(),
+			'policy'            => array(
+				'worktree_cleanup'    => (bool) $opts['worktree_cleanup'],
+				'artifact_cleanup'    => (bool) $opts['artifact_cleanup'],
+				'metadata_repair'     => (bool) $opts['metadata_repair'],
+				'worktree_older_than' => (string) ( $opts['worktree_older_than'] ?? '14d' ),
+				'skip_github'         => (bool) $opts['skip_github'],
+				'force'               => (bool) $opts['force'],
+			),
+			'chunk_row_counts'  => $chunk_row_counts,
+			'chunks'            => $batch,
+			'report'            => array(
+				'removed_count'                => 0,
+				'bytes_reclaimed'              => 0,
+				'freed_human'                  => 'pending child jobs',
+				'skipped_dirty_unpushed_count' => 0,
+				'remaining_disk_budget_human'  => 'pending child jobs',
+			),
+			'evidence'          => array(
+				'elapsed_ms'       => (int) round( ( microtime( true ) - $started_at ) * 1000 ),
+				'planned_chunks'   => count( $item_params ),
+				'planned_handles'  => $this->cleanup_chunk_handles( $chunk_rows ),
+				'batch_job_id'     => (int) ( $batch['batch_job_id'] ?? 0 ),
+				'direct_job_ids'   => $batch['job_ids'] ?? array(),
+			),
+		);
+	}
+
+	/**
+	 * Build cleanup rows from reviewed dry-run plans.
+	 *
+	 * @param Workspace $workspace Workspace service.
+	 * @param array     $opts Normalized options.
+	 * @return array{artifacts:array<int,array>,metadata:array<int,array>,worktrees:array<int,array>}|\WP_Error
+	 */
+	private function build_cleanup_chunk_rows( Workspace $workspace, array $opts ): array|\WP_Error {
+		$rows = array(
+			'artifacts' => array(),
+			'metadata'  => array(),
+			'worktrees' => array(),
+		);
+
+		if ( ! empty( $opts['artifact_cleanup'] ) ) {
+			$artifact_plan = $workspace->worktree_cleanup_artifacts(
+				array(
+					'dry_run' => true,
+					'force'   => ! empty( $opts['force'] ),
+				)
+			);
+			if ( $artifact_plan instanceof \WP_Error ) {
+				return $artifact_plan;
+			}
+			$rows['artifacts'] = array_values( (array) ( $artifact_plan['candidates'] ?? array() ) );
+		}
+
+		if ( ! empty( $opts['metadata_repair'] ) ) {
+			$metadata_plan = $workspace->worktree_reconcile_metadata( array( 'dry_run' => true ) );
+			if ( $metadata_plan instanceof \WP_Error ) {
+				return $metadata_plan;
+			}
+			$rows['metadata'] = array_values( (array) ( $metadata_plan['proposals'] ?? array() ) );
+		}
+
+		if ( ! empty( $opts['worktree_cleanup'] ) ) {
+			$worktree_plan = $workspace->worktree_cleanup_merged(
+				array(
+					'dry_run'     => true,
+					'force'       => ! empty( $opts['force'] ),
+					'skip_github' => ! empty( $opts['skip_github'] ),
+					'older_than'  => (string) ( $opts['worktree_older_than'] ?? '14d' ),
+					'sort'        => 'age',
+				)
+			);
+			if ( $worktree_plan instanceof \WP_Error ) {
+				return $worktree_plan;
+			}
+			$rows['worktrees'] = array_values( (array) ( $worktree_plan['candidates'] ?? array() ) );
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * Convert planned rows into child task params.
+	 *
+	 * @param array $chunk_rows Chunk rows by type.
+	 * @param array $opts Normalized options.
+	 * @param array $params Raw task params.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function build_cleanup_chunk_params( array $chunk_rows, array $opts, array $params ): array {
+		$item_params = array();
+		$sizes       = array(
+			'artifacts' => max( 1, (int) ( $params['artifact_chunk_size'] ?? 10 ) ),
+			'metadata'  => max( 1, (int) ( $params['metadata_chunk_size'] ?? 10 ) ),
+			// Whole-worktree removal intentionally stays single-row per child job to
+			// keep git worktree metadata mutations conservative and lock-friendly.
+			'worktrees' => 1,
+		);
+
+		foreach ( array( 'artifacts', 'metadata', 'worktrees' ) as $type ) {
+			foreach ( array_chunk( (array) ( $chunk_rows[ $type ] ?? array() ), $sizes[ $type ] ) as $index => $rows ) {
+				$item_params[] = array(
+					'chunk_type'  => $type,
+					'chunk_index' => $index,
+					'rows'        => $rows,
+					'force'       => ! empty( $opts['force'] ),
+					'skip_github' => ! empty( $opts['skip_github'] ),
+				);
+			}
+		}
+
+		return $item_params;
+	}
+
+	/**
+	 * Summarize planned handles by chunk type.
+	 *
+	 * @param array $chunk_rows Chunk rows by type.
+	 * @return array<string,array<int,string>>
+	 */
+	private function cleanup_chunk_handles( array $chunk_rows ): array {
+		$handles = array();
+		foreach ( $chunk_rows as $type => $rows ) {
+			$handles[ $type ] = array_values( array_unique( array_filter( array_map( fn( $row ) => is_array( $row ) ? (string) ( $row['handle'] ?? '' ) : '', (array) $rows ) ) ) );
+		}
+
+		return $handles;
 	}
 }

--- a/inc/Tasks/WorktreeCleanupChunkTask.php
+++ b/inc/Tasks/WorktreeCleanupChunkTask.php
@@ -1,0 +1,267 @@
+<?php
+/**
+ * Worktree cleanup chunk system task.
+ *
+ * @package DataMachineCode\Tasks
+ */
+
+namespace DataMachineCode\Tasks;
+
+use DataMachine\Engine\AI\System\Tasks\SystemTask;
+use DataMachineCode\Workspace\Workspace;
+
+defined( 'ABSPATH' ) || exit;
+
+class WorktreeCleanupChunkTask extends SystemTask {
+
+	/**
+	 * Task type identifier.
+	 *
+	 * @return string
+	 */
+	public function getTaskType(): string {
+		return 'worktree_cleanup_chunk';
+	}
+
+	/**
+	 * Task metadata for Data Machine job surfaces.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public static function getTaskMeta(): array {
+		return array(
+			'label'           => 'Worktree Cleanup Chunk',
+			'description'     => 'Applies one reviewed cleanup chunk for artifacts, metadata repair, or worktree removal.',
+			'setting_key'     => null,
+			'default_enabled' => true,
+			'supports_run'    => false,
+		);
+	}
+
+	/**
+	 * Execute one cleanup chunk.
+	 *
+	 * @param int   $jobId  Job ID.
+	 * @param array $params Task params.
+	 * @return void
+	 */
+	public function executeTask( int $jobId, array $params ): void {
+		$started_at = microtime( true );
+		$chunk_type = (string) ( $params['chunk_type'] ?? '' );
+		$rows       = is_array( $params['rows'] ?? null ) ? array_values( (array) $params['rows'] ) : array();
+
+		if ( '' === $chunk_type || array() === $rows ) {
+			$this->completeJob(
+				$jobId,
+				$this->build_chunk_result(
+					$chunk_type,
+					$rows,
+					array(),
+					array(),
+					$this->rows_to_failed( $rows, 'invalid_chunk', 'chunk_type and rows are required' ),
+					0,
+					$started_at,
+					array( 'error' => 'chunk_type and rows are required' )
+				)
+			);
+			return;
+		}
+
+		$workspace = new Workspace();
+		$result    = match ( $chunk_type ) {
+			'artifacts' => $workspace->worktree_cleanup_artifacts(
+				array(
+					'apply_plan' => array( 'candidates' => $rows ),
+					'force'      => ! empty( $params['force'] ),
+				)
+			),
+			'metadata'  => $workspace->worktree_reconcile_metadata(
+				array(
+					'apply_plan' => array( 'proposals' => $rows ),
+				)
+			),
+			'worktrees' => $workspace->worktree_cleanup_merged(
+				array(
+					'apply_plan'  => array( 'candidates' => $rows ),
+					'skip_github' => array_key_exists( 'skip_github', $params ) ? (bool) $params['skip_github'] : true,
+				)
+			),
+			default     => new \WP_Error( 'invalid_cleanup_chunk_type', sprintf( 'Unknown cleanup chunk type: %s', $chunk_type ), array( 'status' => 400 ) ),
+		};
+
+		if ( $result instanceof \WP_Error ) {
+			$failed = $this->rows_to_failed( $rows, $result->get_error_code(), $result->get_error_message() );
+			$this->completeJob(
+				$jobId,
+				$this->build_chunk_result(
+					$chunk_type,
+					$rows,
+					array(),
+					array(),
+					$failed,
+					0,
+					$started_at,
+					array(
+						'error_code' => $result->get_error_code(),
+						'error'      => $result->get_error_message(),
+					)
+				)
+			);
+			return;
+		}
+
+		$applied         = $this->extract_applied_rows( $chunk_type, $result );
+		$skipped         = array_values( (array) ( $result['skipped'] ?? array() ) );
+		$bytes_reclaimed = $this->bytes_reclaimed( $chunk_type, $applied, $result );
+
+		$this->completeJob(
+			$jobId,
+			$this->build_chunk_result(
+				$chunk_type,
+				$rows,
+				$applied,
+				$skipped,
+				array(),
+				$bytes_reclaimed,
+				$started_at,
+				array(
+					'summary' => $result['summary'] ?? array(),
+					'result'  => $this->compact_evidence_result( $result ),
+				)
+			)
+		);
+	}
+
+	/**
+	 * Build the persisted chunk result.
+	 *
+	 * @param string $chunk_type Cleanup chunk type.
+	 * @param array  $planned Planned rows.
+	 * @param array  $applied Applied rows.
+	 * @param array  $skipped Skipped rows.
+	 * @param array  $failed Failed rows.
+	 * @param int    $bytes_reclaimed Bytes reclaimed.
+	 * @param float  $started_at Start timestamp.
+	 * @param array  $evidence Evidence payload.
+	 * @return array<string,mixed>
+	 */
+	private function build_chunk_result( string $chunk_type, array $planned, array $applied, array $skipped, array $failed, int $bytes_reclaimed, float $started_at, array $evidence ): array {
+		$elapsed_ms = (int) round( ( microtime( true ) - $started_at ) * 1000 );
+
+		return array(
+			'success'         => array() === $failed,
+			'chunk_type'      => $chunk_type,
+			'planned_count'   => count( $planned ),
+			'applied_count'   => count( $applied ),
+			'skipped_count'   => count( $skipped ),
+			'failed_count'    => count( $failed ),
+			'bytes_reclaimed' => $bytes_reclaimed,
+			'elapsed_ms'      => $elapsed_ms,
+			'applied'         => $applied,
+			'skipped'         => $skipped,
+			'failed'          => $failed,
+			'evidence'        => array_merge(
+				array(
+					'planned_handles' => $this->row_handles( $planned ),
+					'applied_handles' => $this->row_handles( $applied ),
+					'skipped_handles' => $this->row_handles( $skipped ),
+					'failed_handles'  => $this->row_handles( $failed ),
+				),
+				$evidence
+			),
+		);
+	}
+
+	/**
+	 * Extract applied rows from a workspace result.
+	 *
+	 * @param string $chunk_type Cleanup chunk type.
+	 * @param array  $result Workspace result.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function extract_applied_rows( string $chunk_type, array $result ): array {
+		return match ( $chunk_type ) {
+			'metadata'  => array_values( (array) ( $result['written'] ?? $result['repaired'] ?? array() ) ),
+			'worktrees' => array_values( (array) ( $result['removed'] ?? array() ) ),
+			default     => array_values( (array) ( $result['removed'] ?? array() ) ),
+		};
+	}
+
+	/**
+	 * Calculate reclaimed bytes for applied rows.
+	 *
+	 * @param string $chunk_type Cleanup chunk type.
+	 * @param array  $applied Applied rows.
+	 * @param array  $result Workspace result.
+	 * @return int
+	 */
+	private function bytes_reclaimed( string $chunk_type, array $applied, array $result ): int {
+		if ( 'artifacts' === $chunk_type ) {
+			return max( 0, (int) ( $result['summary']['removed_size_bytes'] ?? 0 ) );
+		}
+
+		if ( 'worktrees' !== $chunk_type ) {
+			return 0;
+		}
+
+		$total = 0;
+		foreach ( $applied as $row ) {
+			$total += max( 0, (int) ( is_array( $row ) ? ( $row['size_bytes'] ?? 0 ) : 0 ) );
+		}
+
+		return $total;
+	}
+
+	/**
+	 * Convert rows to failed row payloads.
+	 *
+	 * @param array  $rows Rows.
+	 * @param string $code Error code.
+	 * @param string $reason Error reason.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function rows_to_failed( array $rows, string $code, string $reason ): array {
+		$failed = array();
+		foreach ( $rows as $row ) {
+			$failed[] = array(
+				'handle'      => is_array( $row ) ? (string) ( $row['handle'] ?? '' ) : '',
+				'reason_code' => $code,
+				'reason'      => $reason,
+				'row'         => $row,
+			);
+		}
+
+		return $failed;
+	}
+
+	/**
+	 * Return stable row handles for summaries.
+	 *
+	 * @param array $rows Rows.
+	 * @return array<int,string>
+	 */
+	private function row_handles( array $rows ): array {
+		$handles = array();
+		foreach ( $rows as $row ) {
+			if ( is_array( $row ) && '' !== (string) ( $row['handle'] ?? '' ) ) {
+				$handles[] = (string) $row['handle'];
+			}
+		}
+
+		return array_values( array_unique( $handles ) );
+	}
+
+	/**
+	 * Keep evidence bounded while retaining operator-relevant summaries.
+	 *
+	 * @param array $result Workspace result.
+	 * @return array<string,mixed>
+	 */
+	private function compact_evidence_result( array $result ): array {
+		return array(
+			'success'      => (bool) ( $result['success'] ?? true ),
+			'dry_run'      => (bool) ( $result['dry_run'] ?? false ),
+			'generated_at' => $result['generated_at'] ?? null,
+		);
+	}
+}

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -4370,14 +4370,32 @@ class Workspace {
 			$handle  = (string) ( $plan_row['handle'] ?? '' );
 			$current = $current_by_handle[ $handle ] ?? null;
 			if ( null === $current ) {
-				$skip                   = $skipped_by_handle[ $handle ] ?? array(
+				$path      = (string) ( $plan_row['path'] ?? '' );
+				$artifacts = (array) ( $plan_row['artifacts'] ?? array() );
+				$complete  = '' !== $path;
+				foreach ( $artifacts as $artifact ) {
+					$relative = is_array( $artifact ) ? trim( (string) ( $artifact['path'] ?? '' ), '/' ) : '';
+					if ( '' !== $relative && is_dir( rtrim( $path, '/' ) . '/' . $relative ) ) {
+						$complete = false;
+						break;
+					}
+				}
+
+				$skip                   = $complete ? array(
 					'handle'      => $handle,
 					'repo'        => (string) ( $plan_row['repo'] ?? '' ),
 					'branch'      => (string) ( $plan_row['branch'] ?? '' ),
-					'path'        => (string) ( $plan_row['path'] ?? '' ),
+					'path'        => $path,
+					'reason_code' => 'artifact_already_removed',
+					'reason'      => 'planned artifact path is already absent; treating retry as complete',
+				) : ( $skipped_by_handle[ $handle ] ?? array(
+					'handle'      => $handle,
+					'repo'        => (string) ( $plan_row['repo'] ?? '' ),
+					'branch'      => (string) ( $plan_row['branch'] ?? '' ),
+					'path'        => $path,
 					'reason_code' => 'artifact_plan_not_current',
 					'reason'      => 'planned artifact cleanup row is no longer a current safe candidate',
-				);
+				) );
 				$skip['planned_artifacts'] = $plan_row['artifacts'] ?? array();
 				$scoped_skipped[]          = $skip;
 				continue;

--- a/tests/smoke-worktree-cleanup-chunks.php
+++ b/tests/smoke-worktree-cleanup-chunks.php
@@ -1,0 +1,223 @@
+<?php
+/**
+ * Smoke test for job-backed cleanup chunks.
+ *
+ *   php tests/smoke-worktree-cleanup-chunks.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Core\FilesRepository {
+	if ( ! class_exists( __NAMESPACE__ . '\\FilesystemHelper' ) ) {
+		class FilesystemHelper {
+			public static function get() {
+				return null;
+			}
+		}
+	}
+}
+
+namespace DataMachine\Engine\AI\System\Tasks {
+	if ( ! class_exists( __NAMESPACE__ . '\\SystemTask' ) ) {
+		abstract class SystemTask {
+			abstract public function executeTask( int $jobId, array $params ): void;
+			abstract public function getTaskType(): string;
+			protected function completeJob( int $jobId, array $data ): void {
+				$GLOBALS['datamachine_code_chunk_jobs'][ $jobId ] = $data;
+			}
+			protected function failJob( int $jobId, string $message ): void {
+				$GLOBALS['datamachine_code_chunk_jobs'][ $jobId ] = array( 'error' => $message );
+			}
+		}
+	}
+}
+
+namespace DataMachineCode\Abilities {
+	if ( ! class_exists( __NAMESPACE__ . '\\GitHubAbilities' ) ) {
+		class GitHubAbilities {
+			public static function getPat(): string {
+				return '';
+			}
+			public static function apiGet( string $url, array $params, string $pat ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+				return array( 'data' => array() );
+			}
+		}
+	}
+}
+
+namespace {
+	$tmp      = sys_get_temp_dir() . '/dmc-cleanup-chunk-smoke-' . bin2hex( random_bytes( 4 ) );
+	$site_tmp = $tmp . '-site';
+	mkdir( $tmp, 0755, true );
+	mkdir( $site_tmp . '/wp-content/plugins', 0755, true );
+	mkdir( $site_tmp . '/wp-content/themes', 0755, true );
+
+	register_shutdown_function( function () use ( $tmp, $site_tmp ): void {
+		foreach ( array( $tmp, $site_tmp ) as $path ) {
+			if ( is_dir( $path ) ) {
+				// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
+				exec( 'rm -rf ' . escapeshellarg( $path ) );
+			}
+		}
+	} );
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', $site_tmp . '/' );
+	}
+	if ( ! defined( 'DATAMACHINE_WORKSPACE_PATH' ) ) {
+		define( 'DATAMACHINE_WORKSPACE_PATH', realpath( $tmp ) ?: $tmp );
+	}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			public string $code;
+			public string $message;
+			public array $data;
+			public function __construct( $code = '', $message = '', $data = array() ) {
+				$this->code    = (string) $code;
+				$this->message = (string) $message;
+				$this->data    = (array) $data;
+			}
+			public function get_error_code(): string {
+				return $this->code;
+			}
+			public function get_error_message(): string {
+				return $this->message;
+			}
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $thing ): bool {
+			return $thing instanceof \WP_Error;
+		}
+	}
+
+	if ( ! function_exists( 'wp_mkdir_p' ) ) {
+		function wp_mkdir_p( string $path ): bool {
+			return is_dir( $path ) || mkdir( $path, 0755, true );
+		}
+	}
+
+	if ( ! function_exists( 'get_option' ) ) {
+		function get_option( string $name, $default_value = false ) {
+			global $datamachine_code_test_options;
+			return $datamachine_code_test_options[ $name ] ?? $default_value;
+		}
+	}
+
+	if ( ! function_exists( 'update_option' ) ) {
+		function update_option( string $name, $value, $autoload = null ): bool { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+			global $datamachine_code_test_options;
+			$datamachine_code_test_options[ $name ] = $value;
+			return true;
+		}
+	}
+
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( string $hook_name, $value ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+			return $value;
+		}
+	}
+
+	require __DIR__ . '/../inc/Support/GitHubRemote.php';
+	require __DIR__ . '/../inc/Support/GitRunner.php';
+	require __DIR__ . '/../inc/Support/PathSecurity.php';
+	require __DIR__ . '/../inc/Workspace/WorkspaceMutationLock.php';
+	require __DIR__ . '/../inc/Workspace/WorktreeDiskBudget.php';
+	require __DIR__ . '/../inc/Workspace/WorktreeContextInjector.php';
+	require __DIR__ . '/../inc/Workspace/Workspace.php';
+	require __DIR__ . '/../inc/Tasks/WorktreeCleanupChunkTask.php';
+
+	// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
+	exec( 'git --version 2>&1', $_gv, $gv_exit );
+	if ( 0 !== $gv_exit ) {
+		echo "SKIP: git not available\n";
+		exit( 0 );
+	}
+
+	$failures = 0;
+	$total    = 0;
+	$datamachine_code_test_options = array();
+	$GLOBALS['datamachine_code_chunk_jobs'] = array();
+
+	$assert = function ( $expected, $actual, string $message ) use ( &$failures, &$total ): void {
+		++$total;
+		if ( $expected === $actual ) {
+			echo "  [PASS] {$message}\n";
+			return;
+		}
+		++$failures;
+		echo "  [FAIL] {$message}\n";
+		echo '    expected: ' . var_export( $expected, true ) . "\n";
+		echo '    actual:   ' . var_export( $actual, true ) . "\n";
+	};
+
+	$run = function ( string $cmd, string $cwd = '' ): void {
+		$full = '' === $cwd ? $cmd : sprintf( 'cd %s && %s', escapeshellarg( $cwd ), $cmd );
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
+		exec( $full . ' 2>&1', $out, $rc );
+		if ( 0 !== $rc ) {
+			throw new RuntimeException( "Command failed: {$full}\n" . implode( "\n", $out ) );
+		}
+	};
+
+	$remote = $tmp . '/remote.git';
+	$run( sprintf( 'git init --bare %s', escapeshellarg( $remote ) ) );
+
+	$primary = $tmp . '/demo';
+	$run( sprintf( 'git clone %s %s', escapeshellarg( $remote ), escapeshellarg( $primary ) ) );
+	$run( 'git config user.email test@example.com', $primary );
+	$run( 'git config user.name test', $primary );
+	file_put_contents( $primary . '/README.md', "demo\n" );
+	file_put_contents( $primary . '/Cargo.toml', "[package]\nname = \"demo\"\nversion = \"0.1.0\"\n" );
+	file_put_contents( $primary . '/.gitignore', "target/\n" );
+	$run( 'git add README.md Cargo.toml .gitignore && git commit -m init', $primary );
+	$run( 'git branch -M main', $primary );
+	$run( 'git push -u origin main', $primary );
+	$run( 'git checkout -b clean', $primary );
+	file_put_contents( $primary . '/clean.txt', 'clean' );
+	$run( 'git add clean.txt && git commit -m clean', $primary );
+	$run( 'git push -u origin clean', $primary );
+	$run( 'git checkout main', $primary );
+	$run( sprintf( 'git worktree add %s clean', escapeshellarg( $tmp . '/demo@clean' ) ), $primary );
+	mkdir( $tmp . '/demo@clean/target', 0755, true );
+	file_put_contents( $tmp . '/demo@clean/target/artifact.bin', str_repeat( 'x', 2048 ) );
+
+	$workspace = new \DataMachineCode\Workspace\Workspace();
+	$plan      = $workspace->worktree_cleanup_artifacts( array( 'dry_run' => true ) );
+	$task      = new \DataMachineCode\Tasks\WorktreeCleanupChunkTask();
+
+	echo "=== smoke-worktree-cleanup-chunks ===\n";
+
+	$assert( false, is_wp_error( $plan ), 'artifact dry-run plan succeeds' );
+	$rows = array_values( (array) ( $plan['candidates'] ?? array() ) );
+	$assert( 1, count( $rows ), 'plan contains one artifact row' );
+
+	$task->executeTask( 101, array( 'chunk_type' => 'artifacts', 'rows' => $rows ) );
+	$first = $GLOBALS['datamachine_code_chunk_jobs'][101] ?? array();
+	$assert( true, (bool) ( $first['success'] ?? false ), 'first chunk succeeds' );
+	$assert( 1, (int) ( $first['applied_count'] ?? 0 ), 'first chunk records applied row' );
+	$assert( 0, (int) ( $first['failed_count'] ?? -1 ), 'first chunk records zero failed rows' );
+	$assert( true, (int) ( $first['bytes_reclaimed'] ?? 0 ) > 0, 'first chunk records reclaimed bytes' );
+	$assert( true, (int) ( $first['elapsed_ms'] ?? -1 ) >= 0, 'first chunk records elapsed time' );
+	$assert( array( 'demo@clean' ), $first['evidence']['planned_handles'] ?? array(), 'first chunk evidence includes planned handle' );
+	$assert( false, is_dir( $tmp . '/demo@clean/target' ), 'artifact directory removed' );
+
+	$task->executeTask( 102, array( 'chunk_type' => 'artifacts', 'rows' => $rows ) );
+	$retry = $GLOBALS['datamachine_code_chunk_jobs'][102] ?? array();
+	$assert( true, (bool) ( $retry['success'] ?? false ), 'retry chunk succeeds' );
+	$assert( 0, (int) ( $retry['applied_count'] ?? -1 ), 'retry does not reapply missing artifact' );
+	$assert( 1, (int) ( $retry['skipped_count'] ?? 0 ), 'retry records skipped row' );
+	$assert( 'artifact_already_removed', $retry['skipped'][0]['reason_code'] ?? '', 'missing artifact is treated as already complete' );
+	$assert( array( 'demo@clean' ), $retry['evidence']['skipped_handles'] ?? array(), 'retry evidence includes skipped handle' );
+
+	if ( $failures > 0 ) {
+		echo "\nFAILURES: {$failures}/{$total}\n";
+		exit( 1 );
+	}
+
+	echo "\nAll {$total} cleanup chunk smoke assertions passed.\n";
+}


### PR DESCRIPTION
## Summary
- Adds a `worktree_cleanup_chunk` system task that applies reviewed artifact, metadata, and worktree cleanup rows through Data Machine child jobs.
- Updates retention cleanup to fan out job-backed chunks with conservative one-row worktree removal jobs and evidence/elapsed/reclaimed-byte summaries.
- Treats missing artifact paths as idempotent skipped/completed retry rows and adds a smoke for retry/evidence behavior.

## Testing
- `php tests/smoke-worktree-cleanup-chunks.php`
- `php tests/smoke-worktree-cleanup-artifacts.php`
- `php tests/smoke-worktree-cleanup.php`
- `php tests/smoke-worktree-metadata-reconcile.php`
- `php -l inc/Tasks/WorktreeCleanupChunkTask.php`
- `php -l inc/Tasks/WorkspaceRetentionCleanupTask.php`
- `php -l inc/Workspace/Workspace.php`
- `php -l tests/smoke-worktree-cleanup-chunks.php`
- `php -l data-machine-code.php`
- `homeboy lint --changed-only --errors-only`
- `homeboy test --changed-since origin/main`

## Notes
- `homeboy lint --changed-only` without `--errors-only` still reports pre-existing PHPCS warning categories in `inc/Workspace/Workspace.php`; changed-file error lint and scoped PHPStan pass.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the implementation, smoke coverage, and verification commands for Chris to review and test.

Fixes #202