### PR TITLE
Emit chunked workspace cleanup plans

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -53,6 +53,7 @@ function datamachine_code_bootstrap() {
 	// Load Handlers (they self-register).
 	new \DataMachineCode\Handlers\GitHub\GitHub();
 	new \DataMachineCode\Handlers\GitHub\GitHubUpsert();
+	new \DataMachineCode\Handlers\Workspace\CleanupPlan();
 
 	// Register ability categories on the correct hook (must happen during wp_abilities_api_categories_init).
 	add_action( 'wp_abilities_api_categories_init', 'datamachine_code_register_ability_categories' );

--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -1339,6 +1339,44 @@ class WorkspaceAbilities {
 					'meta'                => array( 'show_in_rest' => false ),
 				)
 			);
+
+			wp_register_ability(
+				'datamachine/workspace-cleanup-plan',
+				array(
+					'label'               => 'Build Workspace Cleanup Plan Chunks',
+					'description'         => 'Freeze a non-destructive cleanup plan and optionally emit bounded chunks for artifact cleanup, metadata repair, worktree removal, and resolver rows.',
+					'category'            => 'datamachine-code-workspace',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'emit_chunks'            => array( 'type' => 'boolean' ),
+							'chunk_size'             => array( 'type' => 'integer' ),
+							'include_artifacts'      => array( 'type' => 'boolean' ),
+							'include_metadata'       => array( 'type' => 'boolean' ),
+							'include_worktrees'      => array( 'type' => 'boolean' ),
+							'include_resolvers'      => array( 'type' => 'boolean' ),
+							'force_artifact_cleanup' => array( 'type' => 'boolean' ),
+							'worktree_older_than'    => array( 'type' => 'string' ),
+							'worktree_sort'          => array( 'type' => 'string' ),
+							'plan'                   => array( 'type' => 'object' ),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'mode'    => array( 'type' => 'string' ),
+							'plan_id' => array( 'type' => 'string' ),
+							'rows'    => array( 'type' => 'object' ),
+							'chunks'  => array( 'type' => 'array' ),
+							'summary' => array( 'type' => 'object' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'workspaceCleanupPlan' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
 		};
 
 		if ( doing_action( 'wp_abilities_api_init' ) ) {
@@ -1809,6 +1847,41 @@ class WorkspaceAbilities {
 		}
 
 		return $workspace->worktree_emergency_cleanup( $opts );
+	}
+
+	/**
+	 * Freeze a cleanup plan and optionally emit bounded chunks.
+	 *
+	 * @param array $input Input parameters (emit_chunks, chunk_size, include_*).
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public static function workspaceCleanupPlan( array $input ): array|\WP_Error {
+		$workspace = new Workspace();
+		$opts      = array(
+			'force_artifact_cleanup' => ! empty( $input['force_artifact_cleanup'] ),
+			'include_resolvers'      => ! empty( $input['include_resolvers'] ),
+		);
+		foreach ( array( 'include_artifacts', 'include_metadata', 'include_worktrees' ) as $key ) {
+			if ( array_key_exists( $key, $input ) ) {
+				$opts[ $key ] = (bool) $input[ $key ];
+			}
+		}
+		if ( isset( $input['worktree_older_than'] ) && '' !== trim( (string) $input['worktree_older_than'] ) ) {
+			$opts['worktree_older_than'] = trim( (string) $input['worktree_older_than'] );
+		}
+		if ( isset( $input['worktree_sort'] ) && '' !== trim( (string) $input['worktree_sort'] ) ) {
+			$opts['worktree_sort'] = trim( (string) $input['worktree_sort'] );
+		}
+		if ( isset( $input['plan'] ) && is_array( $input['plan'] ) ) {
+			$opts['plan'] = $input['plan'];
+		}
+		if ( isset( $input['chunk_size'] ) ) {
+			$opts['chunk_size'] = (int) $input['chunk_size'];
+		}
+
+		return ! empty( $input['emit_chunks'] )
+			? $workspace->workspace_cleanup_plan_chunks( $opts )
+			: $workspace->workspace_cleanup_plan( $opts );
 	}
 
 	/**

--- a/inc/Handlers/Workspace/CleanupPlan.php
+++ b/inc/Handlers/Workspace/CleanupPlan.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Workspace cleanup plan fetch handler.
+ *
+ * @package DataMachineCode\Handlers\Workspace
+ */
+
+namespace DataMachineCode\Handlers\Workspace;
+
+use DataMachine\Core\ExecutionContext;
+use DataMachine\Core\Steps\Fetch\Handlers\FetchHandler;
+use DataMachine\Core\Steps\HandlerRegistrationTrait;
+use DataMachineCode\Workspace\Workspace;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class CleanupPlan extends FetchHandler {
+
+	use HandlerRegistrationTrait;
+
+	public function __construct() {
+		parent::__construct( 'workspace_cleanup_plan' );
+
+		self::registerHandler(
+			'workspace_cleanup_plan',
+			'fetch',
+			self::class,
+			'Workspace Cleanup Plan',
+			'Freeze a DMC workspace cleanup plan or emit bounded cleanup chunks without applying them inline.',
+			false,
+			null,
+			CleanupPlanSettings::class,
+			null
+		);
+	}
+
+	/**
+	 * Fetch a frozen cleanup plan or bounded chunks.
+	 *
+	 * @param array            $config  Handler config.
+	 * @param ExecutionContext $context Execution context.
+	 * @return array<string,mixed>
+	 */
+	protected function executeFetch( array $config, ExecutionContext $context ): array {
+		$workspace = new Workspace();
+		$opts      = self::normalizeOptions( $config );
+		$result    = ! empty( $opts['emit_chunks'] )
+			? $workspace->workspace_cleanup_plan_chunks( $opts )
+			: $workspace->workspace_cleanup_plan( $opts );
+
+		if ( is_wp_error( $result ) ) {
+			$context->log( 'error', 'Workspace cleanup plan failed: ' . $result->get_error_message() );
+			return array();
+		}
+
+		if ( ! empty( $opts['emit_chunks'] ) ) {
+			$items = array();
+			foreach ( (array) ( $result['chunks'] ?? array() ) as $chunk ) {
+				if ( ! is_array( $chunk ) ) {
+					continue;
+				}
+				$items[] = self::buildPacketItem(
+					sprintf( 'Workspace cleanup chunk: %s', (string) ( $chunk['chunk_id'] ?? '' ) ),
+					$chunk,
+					array(
+						'source_type'     => 'workspace_cleanup_chunk',
+						'item_identifier' => (string) ( $chunk['chunk_id'] ?? '' ),
+						'plan_id'         => (string) ( $chunk['plan_id'] ?? '' ),
+						'chunk_type'      => (string) ( $chunk['type'] ?? '' ),
+						'safety_class'    => (string) ( $chunk['safety_class'] ?? '' ),
+					)
+				);
+			}
+
+			$context->log( 'info', sprintf( 'Workspace cleanup plan emitted %d chunk(s).', count( $items ) ) );
+			return array( 'items' => $items );
+		}
+
+		$context->log( 'info', sprintf( 'Workspace cleanup plan frozen: %s.', (string) ( $result['plan_id'] ?? '' ) ) );
+		return array(
+			'items' => array(
+				self::buildPacketItem(
+					sprintf( 'Workspace cleanup plan: %s', (string) ( $result['plan_id'] ?? '' ) ),
+					$result,
+					array(
+						'source_type'     => 'workspace_cleanup_plan',
+						'item_identifier' => (string) ( $result['plan_id'] ?? '' ),
+						'plan_id'         => (string) ( $result['plan_id'] ?? '' ),
+					)
+				),
+			),
+		);
+	}
+
+	/**
+	 * Normalize handler options.
+	 *
+	 * @param array<string,mixed> $config Handler config.
+	 * @return array<string,mixed>
+	 */
+	public static function normalizeOptions( array $config ): array {
+		$opts = array(
+			'emit_chunks'            => ! empty( $config['emit_chunks'] ),
+			'include_resolvers'      => ! empty( $config['include_resolvers'] ),
+			'force_artifact_cleanup' => ! empty( $config['force_artifact_cleanup'] ),
+		);
+		foreach ( array( 'include_artifacts', 'include_metadata', 'include_worktrees' ) as $key ) {
+			if ( array_key_exists( $key, $config ) ) {
+				$opts[ $key ] = (bool) $config[ $key ];
+			}
+		}
+		if ( isset( $config['chunk_size'] ) ) {
+			$opts['chunk_size'] = (int) $config['chunk_size'];
+		}
+		if ( isset( $config['worktree_older_than'] ) && '' !== trim( (string) $config['worktree_older_than'] ) ) {
+			$opts['worktree_older_than'] = trim( (string) $config['worktree_older_than'] );
+		}
+		if ( isset( $config['worktree_sort'] ) && '' !== trim( (string) $config['worktree_sort'] ) ) {
+			$opts['worktree_sort'] = trim( (string) $config['worktree_sort'] );
+		}
+
+		return $opts;
+	}
+
+	/**
+	 * Build a DataPacket-compatible item.
+	 *
+	 * @param string              $title    Item title.
+	 * @param array<string,mixed> $payload  Item payload.
+	 * @param array<string,mixed> $metadata Item metadata.
+	 * @return array<string,mixed>
+	 */
+	private static function buildPacketItem( string $title, array $payload, array $metadata ): array {
+		$encoded = function_exists( 'wp_json_encode' ) ? wp_json_encode( $payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) : json_encode( $payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+		return array(
+			'title'    => $title,
+			'content'  => $encoded ?: '',
+			'metadata' => $metadata,
+		);
+	}
+}

--- a/inc/Handlers/Workspace/CleanupPlanSettings.php
+++ b/inc/Handlers/Workspace/CleanupPlanSettings.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Workspace cleanup plan handler settings.
+ *
+ * @package DataMachineCode\Handlers\Workspace
+ */
+
+namespace DataMachineCode\Handlers\Workspace;
+
+use DataMachine\Core\Steps\Fetch\Handlers\FetchHandlerSettings;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class CleanupPlanSettings extends FetchHandlerSettings {
+
+	/**
+	 * Get settings fields for the cleanup plan fetch handler.
+	 *
+	 * @return array<string,array<string,mixed>>
+	 */
+	public static function get_fields(): array {
+		return array(
+			'emit_chunks'            => array(
+				'type'        => 'checkbox',
+				'label'       => __( 'Emit Chunks', 'data-machine-code' ),
+				'description' => __( 'Emit one DataPacket per bounded cleanup chunk instead of one frozen plan packet.', 'data-machine-code' ),
+				'default'     => true,
+			),
+			'chunk_size'             => array(
+				'type'        => 'number',
+				'label'       => __( 'Chunk Size', 'data-machine-code' ),
+				'description' => __( 'Maximum rows per chunk. Clamped to 1-50. Default: 10.', 'data-machine-code' ),
+				'default'     => 10,
+			),
+			'include_artifacts'      => array(
+				'type'        => 'checkbox',
+				'label'       => __( 'Include Artifact Cleanup Rows', 'data-machine-code' ),
+				'default'     => true,
+			),
+			'include_metadata'       => array(
+				'type'        => 'checkbox',
+				'label'       => __( 'Include Metadata Repair Rows', 'data-machine-code' ),
+				'default'     => true,
+			),
+			'include_worktrees'      => array(
+				'type'        => 'checkbox',
+				'label'       => __( 'Include Worktree Removal Rows', 'data-machine-code' ),
+				'default'     => true,
+			),
+			'include_resolvers'      => array(
+				'type'        => 'checkbox',
+				'label'       => __( 'Include Resolver Rows', 'data-machine-code' ),
+				'description' => __( 'Emit read-only resolver rows for ambiguous inventory rows that need merge/lifecycle signal resolution.', 'data-machine-code' ),
+				'default'     => false,
+			),
+			'worktree_older_than'    => array(
+				'type'        => 'text',
+				'label'       => __( 'Worktree Older Than', 'data-machine-code' ),
+				'description' => __( 'Optional age filter for inventory-only worktree removal rows, such as 14d.', 'data-machine-code' ),
+			),
+			'force_artifact_cleanup' => array(
+				'type'        => 'checkbox',
+				'label'       => __( 'Force Artifact Cleanup Planning', 'data-machine-code' ),
+				'description' => __( 'Permit dirty/unpushed artifact cleanup candidates in the frozen plan. Active symlink targets remain protected.', 'data-machine-code' ),
+				'default'     => false,
+			),
+		);
+	}
+}

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -3608,6 +3608,370 @@ class Workspace {
 	}
 
 	/**
+	 * Freeze a non-destructive workspace cleanup plan for chunked execution.
+	 *
+	 * The plan deliberately stops at reviewable data. It does not apply any
+	 * cleanup operation; later jobs can consume the emitted chunks and revalidate
+	 * each row against current state before mutating the workspace.
+	 *
+	 * @param array<string,mixed> $opts Plan options.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function workspace_cleanup_plan( array $opts = array() ): array|\WP_Error {
+		$inputs = array(
+			'force_artifact_cleanup' => ! empty( $opts['force_artifact_cleanup'] ),
+			'include_artifacts'      => array_key_exists( 'include_artifacts', $opts ) ? (bool) $opts['include_artifacts'] : true,
+			'include_metadata'       => array_key_exists( 'include_metadata', $opts ) ? (bool) $opts['include_metadata'] : true,
+			'include_worktrees'      => array_key_exists( 'include_worktrees', $opts ) ? (bool) $opts['include_worktrees'] : true,
+			'include_resolvers'      => ! empty( $opts['include_resolvers'] ),
+			'worktree_older_than'    => isset( $opts['worktree_older_than'] ) ? trim( (string) $opts['worktree_older_than'] ) : '',
+			'worktree_sort'          => isset( $opts['worktree_sort'] ) ? trim( (string) $opts['worktree_sort'] ) : '',
+		);
+
+		$artifact_plan = array( 'candidates' => array(), 'skipped' => array(), 'summary' => array() );
+		if ( $inputs['include_artifacts'] ) {
+			$artifact_plan = $this->worktree_cleanup_artifacts(
+				array(
+					'dry_run' => true,
+					'force'   => $inputs['force_artifact_cleanup'],
+				)
+			);
+			if ( $artifact_plan instanceof \WP_Error ) {
+				return $artifact_plan;
+			}
+		}
+
+		$metadata_plan = array( 'proposals' => array(), 'skipped' => array(), 'summary' => array() );
+		if ( $inputs['include_metadata'] ) {
+			$metadata_plan = $this->worktree_reconcile_metadata( array( 'dry_run' => true ) );
+			if ( $metadata_plan instanceof \WP_Error ) {
+				return $metadata_plan;
+			}
+		}
+
+		$worktree_plan = array( 'candidates' => array(), 'skipped' => array(), 'summary' => array() );
+		if ( $inputs['include_worktrees'] ) {
+			$worktree_plan = $this->worktree_cleanup_merged(
+				array(
+					'dry_run'        => true,
+					'skip_github'    => true,
+					'inventory_only' => true,
+					'older_than'     => $inputs['worktree_older_than'],
+					'sort'           => $inputs['worktree_sort'],
+				)
+			);
+			if ( $worktree_plan instanceof \WP_Error ) {
+				return $worktree_plan;
+			}
+		}
+
+		$rows = array(
+			'artifact_cleanup' => $this->prepare_cleanup_plan_rows( 'artifact_cleanup', (array) ( $artifact_plan['candidates'] ?? array() ), 'safe' ),
+			'metadata_repair'  => $this->prepare_cleanup_plan_rows( 'metadata_repair', (array) ( $metadata_plan['proposals'] ?? array() ), 'safe' ),
+			'worktree_removal' => $this->prepare_cleanup_plan_rows( 'worktree_removal', (array) ( $worktree_plan['candidates'] ?? array() ), 'reviewed_destructive' ),
+			'resolver'         => $inputs['include_resolvers'] ? $this->build_cleanup_plan_resolver_rows( (array) ( $worktree_plan['skipped'] ?? array() ) ) : array(),
+		);
+
+		$summary = $this->build_cleanup_plan_summary( $rows );
+		$plan    = array(
+			'success'        => true,
+			'mode'           => 'cleanup_plan',
+			'generated_at'   => gmdate( 'c' ),
+			'workspace_path' => $this->workspace_path,
+			'inputs'         => $inputs,
+			'safety_policy'  => array(
+				'applies_inline'               => false,
+				'artifact_cleanup'            => 'apply-plan must revalidate profile-derived artifact paths before deletion',
+				'metadata_repair'             => 'apply-plan must revalidate current handle, repo, branch, path, lifecycle state, and source map before writing metadata',
+				'worktree_removal'            => 'apply-plan must re-run dirty, unpushed, identity, lifecycle, containment, and primary protections before deletion',
+				'resolver'                    => 'resolver rows may gather merge signals but cannot delete worktrees',
+				'destructive_rows_need_review' => true,
+			),
+			'plans'          => array(
+				'artifact_cleanup' => $artifact_plan,
+				'metadata_repair'  => $metadata_plan,
+				'worktree_removal' => $worktree_plan,
+			),
+			'rows'           => $rows,
+			'summary'        => $summary,
+		);
+		$plan['plan_id'] = $this->stable_cleanup_hash( array( 'inputs' => $inputs, 'rows' => $this->cleanup_row_ids( $rows ) ), 'cleanup-plan' );
+
+		return $plan;
+	}
+
+	/**
+	 * Build bounded cleanup chunks from a frozen cleanup plan.
+	 *
+	 * @param array<string,mixed> $opts Chunk options.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function workspace_cleanup_plan_chunks( array $opts = array() ): array|\WP_Error {
+		$chunk_size = isset( $opts['chunk_size'] ) ? (int) $opts['chunk_size'] : 10;
+		$chunk_size = max( 1, min( 50, $chunk_size ) );
+		$plan       = isset( $opts['plan'] ) && is_array( $opts['plan'] ) ? $opts['plan'] : $this->workspace_cleanup_plan( $opts );
+		if ( $plan instanceof \WP_Error ) {
+			return $plan;
+		}
+
+		$plan_id = (string) ( $plan['plan_id'] ?? '' );
+		if ( '' === $plan_id ) {
+			$plan_id = $this->stable_cleanup_hash( array( 'rows' => $this->cleanup_row_ids( (array) ( $plan['rows'] ?? array() ) ) ), 'cleanup-plan' );
+			$plan['plan_id'] = $plan_id;
+		}
+
+		$chunks = array();
+		foreach ( (array) ( $plan['rows'] ?? array() ) as $type => $rows ) {
+			$groups = array();
+			foreach ( (array) $rows as $row ) {
+				if ( ! is_array( $row ) ) {
+					continue;
+				}
+				if ( empty( $row['row_id'] ) ) {
+					$row['row_id'] = $this->stable_cleanup_row_id( (string) $type, $row );
+				}
+				$class              = (string) ( $row['safety_class'] ?? 'unknown' );
+				$groups[ $class ][] = $row;
+			}
+
+			ksort( $groups );
+			foreach ( $groups as $safety_class => $group_rows ) {
+				usort( $group_rows, fn( $a, $b ) => (string) ( $a['row_id'] ?? '' ) <=> (string) ( $b['row_id'] ?? '' ) );
+				$index = 0;
+				foreach ( array_chunk( $group_rows, $chunk_size ) as $chunk_rows ) {
+					++$index;
+					$row_ids  = array_map( fn( $row ) => (string) ( $row['row_id'] ?? '' ), $chunk_rows );
+					$chunks[] = array(
+						'chunk_id'      => $this->stable_cleanup_hash( array( $plan_id, $type, $safety_class, $index, $row_ids ), 'cleanup-chunk' ),
+						'plan_id'       => $plan_id,
+						'type'          => (string) $type,
+						'safety_class'  => $safety_class,
+						'index'         => $index,
+						'chunk_size'    => count( $chunk_rows ),
+						'max_rows'      => $chunk_size,
+						'row_ids'       => $row_ids,
+						'rows'          => $chunk_rows,
+						'idempotency'   => array(
+							'key'                 => $this->stable_cleanup_hash( array( $plan_id, $row_ids ), 'cleanup-idempotency' ),
+							'revalidate_before_apply' => true,
+						),
+						'workspace_path' => $plan['workspace_path'] ?? $this->workspace_path,
+					);
+				}
+			}
+		}
+
+		return array(
+			'success'      => true,
+			'mode'         => 'cleanup_plan_chunks',
+			'generated_at' => gmdate( 'c' ),
+			'plan_id'      => $plan_id,
+			'chunk_size'   => $chunk_size,
+			'plan'         => $plan,
+			'chunks'       => $chunks,
+			'summary'      => $this->build_cleanup_chunk_summary( $chunks, $plan ),
+		);
+	}
+
+	/**
+	 * Add stable row metadata to cleanup plan rows.
+	 *
+	 * @param string             $type         Cleanup row type.
+	 * @param array<int,array>   $rows         Raw plan rows.
+	 * @param string             $safety_class Safety class.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function prepare_cleanup_plan_rows( string $type, array $rows, string $safety_class ): array {
+		$result = array();
+		foreach ( $rows as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+			$row['row_type']     = $type;
+			$row['safety_class'] = $safety_class;
+			$row['row_id']       = $this->stable_cleanup_row_id( $type, $row );
+			$result[]            = $row;
+		}
+		return $result;
+	}
+
+	/**
+	 * Build optional resolver rows from ambiguous inventory-only cleanup skips.
+	 *
+	 * @param array<int,array> $skipped Inventory skipped rows.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function build_cleanup_plan_resolver_rows( array $skipped ): array {
+		$rows = array();
+		foreach ( $skipped as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+			$reason = (string) ( $row['reason_code'] ?? '' );
+			if ( ! in_array( $reason, array( 'requires_full_scan', 'no_inventory_cleanup_signal', 'missing_metadata_repaired' ), true ) ) {
+				continue;
+			}
+
+			$resolver = array(
+				'handle'       => (string) ( $row['handle'] ?? '' ),
+				'repo'         => (string) ( $row['repo'] ?? '' ),
+				'branch'       => (string) ( $row['branch'] ?? '' ),
+				'path'         => (string) ( $row['path'] ?? '' ),
+				'created_at'   => $row['created_at'] ?? null,
+				'metadata'     => $row['metadata'] ?? null,
+				'resolver'     => 'merge_signal',
+				'reason_code'  => $reason,
+				'reason'       => 'resolve merge or lifecycle cleanup signal before any worktree removal chunk is emitted',
+				'row_type'     => 'resolver',
+				'safety_class' => 'read_only',
+			);
+			$resolver['row_id'] = $this->stable_cleanup_row_id( 'resolver', $resolver );
+			$rows[]             = $resolver;
+		}
+		return $rows;
+	}
+
+	/**
+	 * Build stable cleanup plan summary counts.
+	 *
+	 * @param array<string,array<int,array>> $rows Rows keyed by type.
+	 * @return array<string,mixed>
+	 */
+	private function build_cleanup_plan_summary( array $rows ): array {
+		$counts      = array();
+		$byte_totals = array();
+		$total_rows  = 0;
+		$total_bytes = 0;
+
+		foreach ( $rows as $type => $typed_rows ) {
+			$counts[ $type ]      = count( (array) $typed_rows );
+			$byte_totals[ $type ] = 0;
+			$total_rows          += $counts[ $type ];
+			foreach ( (array) $typed_rows as $row ) {
+				$bytes = max( 0, (int) ( $row['artifact_size_bytes'] ?? $row['size_bytes'] ?? 0 ) );
+				$byte_totals[ $type ] += $bytes;
+				$total_bytes          += $bytes;
+			}
+		}
+
+		ksort( $counts );
+		ksort( $byte_totals );
+		return array(
+			'total_rows'       => $total_rows,
+			'rows_by_type'     => $counts,
+			'byte_totals'      => $byte_totals,
+			'total_size_bytes' => $total_bytes,
+		);
+	}
+
+	/**
+	 * Build chunk summary counts.
+	 *
+	 * @param array<int,array>    $chunks Chunks.
+	 * @param array<string,mixed> $plan   Frozen plan.
+	 * @return array<string,mixed>
+	 */
+	private function build_cleanup_chunk_summary( array $chunks, array $plan ): array {
+		$chunks_by_type   = array();
+		$chunks_by_safety = array();
+		$rows_by_type     = array();
+		foreach ( $chunks as $chunk ) {
+			$type                         = (string) ( $chunk['type'] ?? 'unknown' );
+			$class                        = (string) ( $chunk['safety_class'] ?? 'unknown' );
+			$chunks_by_type[ $type ]       = ( $chunks_by_type[ $type ] ?? 0 ) + 1;
+			$chunks_by_safety[ $class ]    = ( $chunks_by_safety[ $class ] ?? 0 ) + 1;
+			$rows_by_type[ $type ]         = ( $rows_by_type[ $type ] ?? 0 ) + (int) ( $chunk['chunk_size'] ?? 0 );
+		}
+		ksort( $chunks_by_type );
+		ksort( $chunks_by_safety );
+		ksort( $rows_by_type );
+
+		return array(
+			'total_chunks'     => count( $chunks ),
+			'chunks_by_type'   => $chunks_by_type,
+			'chunks_by_safety' => $chunks_by_safety,
+			'rows_by_type'     => $rows_by_type,
+			'plan_summary'     => $plan['summary'] ?? array(),
+		);
+	}
+
+	/**
+	 * Return row IDs keyed by type for deterministic plan IDs.
+	 *
+	 * @param array<string,array<int,array>> $rows Rows keyed by type.
+	 * @return array<string,array<int,string>>
+	 */
+	private function cleanup_row_ids( array $rows ): array {
+		$ids = array();
+		foreach ( $rows as $type => $typed_rows ) {
+			$ids[ $type ] = array_map( fn( $row ) => (string) ( is_array( $row ) ? ( $row['row_id'] ?? '' ) : '' ), (array) $typed_rows );
+			sort( $ids[ $type ] );
+		}
+		ksort( $ids );
+		return $ids;
+	}
+
+	/**
+	 * Build a stable ID for one cleanup row.
+	 *
+	 * @param string             $type Row type.
+	 * @param array<string,mixed> $row Row payload.
+	 * @return string
+	 */
+	private function stable_cleanup_row_id( string $type, array $row ): string {
+		$fingerprint = array(
+			'type'      => $type,
+			'handle'    => (string) ( $row['handle'] ?? '' ),
+			'repo'      => (string) ( $row['repo'] ?? '' ),
+			'branch'    => (string) ( $row['branch'] ?? '' ),
+			'path'      => (string) ( $row['path'] ?? '' ),
+			'artifacts' => array(),
+			'fields'    => array_values( (array) ( $row['missing_fields'] ?? array() ) ),
+			'reason'    => (string) ( $row['reason_code'] ?? '' ),
+		);
+		foreach ( (array) ( $row['artifacts'] ?? array() ) as $artifact ) {
+			if ( is_array( $artifact ) ) {
+				$fingerprint['artifacts'][] = (string) ( $artifact['path'] ?? '' );
+			}
+		}
+		sort( $fingerprint['artifacts'] );
+		sort( $fingerprint['fields'] );
+
+		return $this->stable_cleanup_hash( $fingerprint, 'cleanup-row' );
+	}
+
+	/**
+	 * Hash cleanup data after stable key sorting.
+	 *
+	 * @param mixed  $value  Value to hash.
+	 * @param string $prefix Identifier prefix.
+	 * @return string
+	 */
+	private function stable_cleanup_hash( mixed $value, string $prefix ): string {
+		$this->ksort_recursive( $value );
+		$encoded = function_exists( 'wp_json_encode' ) ? wp_json_encode( $value, JSON_UNESCAPED_SLASHES ) : json_encode( $value, JSON_UNESCAPED_SLASHES );
+		return $prefix . '-' . substr( hash( 'sha256', $encoded ?: serialize( $value ) ), 0, 24 );
+	}
+
+	/**
+	 * Sort array keys recursively for stable hashing.
+	 *
+	 * @param mixed $value Value to normalize.
+	 * @return void
+	 */
+	private function ksort_recursive( mixed &$value ): void {
+		if ( ! is_array( $value ) ) {
+			return;
+		}
+		foreach ( $value as &$child ) {
+			$this->ksort_recursive( $child );
+		}
+		if ( array_keys( $value ) !== range( 0, count( $value ) - 1 ) ) {
+			ksort( $value );
+		}
+	}
+
+	/**
 	 * Build or apply a disk-pressure emergency cleanup plan.
 	 *
 	 * The dry-run path intentionally uses only top-level workspace inventory,

--- a/tests/smoke-cleanup-plan-handler.php
+++ b/tests/smoke-cleanup-plan-handler.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Smoke test for cleanup plan handler registration surface.
+ *
+ * Run: php tests/smoke-cleanup-plan-handler.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Core\Steps\Fetch\Handlers {
+	if ( ! class_exists( __NAMESPACE__ . '\\FetchHandler' ) ) {
+		abstract class FetchHandler {
+			public function __construct( string $handler_type ) {}
+		}
+	}
+	if ( ! class_exists( __NAMESPACE__ . '\\FetchHandlerSettings' ) ) {
+		abstract class FetchHandlerSettings {}
+	}
+}
+
+namespace DataMachine\Core\Steps {
+	if ( ! trait_exists( __NAMESPACE__ . '\\HandlerRegistrationTrait' ) ) {
+		trait HandlerRegistrationTrait {
+			protected static function registerHandler( string $slug, string $type, string $class_name, string $label, string $description, bool $requiresAuth = false, ?string $authClass = null, ?string $settingsClass = null, ?callable $aiToolCallback = null, ?string $authProviderKey = null, array $meta = array() ): void {
+				$GLOBALS['datamachine_code_test_registered_handlers'][ $slug ] = compact( 'slug', 'type', 'class_name', 'label', 'description', 'requiresAuth', 'authClass', 'settingsClass', 'meta' );
+			}
+		}
+	}
+}
+
+namespace DataMachine\Core {
+	if ( ! class_exists( __NAMESPACE__ . '\\ExecutionContext' ) ) {
+		class ExecutionContext {}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+	if ( ! function_exists( '__' ) ) {
+		function __( string $text, string $domain = '' ): string { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+			return $text;
+		}
+	}
+
+	require __DIR__ . '/../inc/Handlers/Workspace/CleanupPlanSettings.php';
+	require __DIR__ . '/../inc/Handlers/Workspace/CleanupPlan.php';
+
+	$failures = 0;
+	$total    = 0;
+	$assert   = function ( $expected, $actual, string $message ) use ( &$failures, &$total ): void {
+		++$total;
+		if ( $expected === $actual ) {
+			echo "  [PASS] {$message}\n";
+			return;
+		}
+		++$failures;
+		echo "  [FAIL] {$message}\n";
+		echo '    expected: ' . var_export( $expected, true ) . "\n";
+		echo '    actual:   ' . var_export( $actual, true ) . "\n";
+	};
+
+	echo "=== smoke-cleanup-plan-handler ===\n";
+
+	new \DataMachineCode\Handlers\Workspace\CleanupPlan();
+	$registered = $GLOBALS['datamachine_code_test_registered_handlers']['workspace_cleanup_plan'] ?? array();
+	$assert( 'fetch', $registered['type'] ?? '', 'cleanup plan handler registers as fetch handler' );
+	$assert( \DataMachineCode\Handlers\Workspace\CleanupPlanSettings::class, $registered['settingsClass'] ?? '', 'cleanup plan handler registers settings class' );
+
+	$options = \DataMachineCode\Handlers\Workspace\CleanupPlan::normalizeOptions(
+		array(
+			'emit_chunks'         => true,
+			'chunk_size'          => '3',
+			'include_artifacts'   => false,
+			'include_resolvers'   => true,
+			'worktree_older_than' => '14d',
+		)
+	);
+	$assert( true, $options['emit_chunks'] ?? false, 'handler options preserve chunk emission flag' );
+	$assert( 3, $options['chunk_size'] ?? 0, 'handler options normalize chunk size' );
+	$assert( false, $options['include_artifacts'] ?? true, 'handler options preserve include toggles' );
+	$assert( true, $options['include_resolvers'] ?? false, 'handler options preserve resolver flag' );
+
+	$fields = \DataMachineCode\Handlers\Workspace\CleanupPlanSettings::get_fields();
+	$assert( true, isset( $fields['chunk_size'] ), 'handler settings expose chunk_size' );
+	$assert( true, isset( $fields['include_resolvers'] ), 'handler settings expose resolver rows toggle' );
+
+	if ( $failures > 0 ) {
+		echo "\nFAILURES: {$failures}/{$total}\n";
+		exit( 1 );
+	}
+
+	echo "\nAll {$total} cleanup plan handler smoke assertions passed.\n";
+}

--- a/tests/smoke-worktree-cleanup.php
+++ b/tests/smoke-worktree-cleanup.php
@@ -416,6 +416,60 @@ namespace {
 		}
 	}
 
+	echo "\nCleanup plan chunk emission scenario\n";
+	$cleanup_plan = $ws->workspace_cleanup_plan( array( 'include_resolvers' => true ) );
+	$assert( true, ! is_wp_error( $cleanup_plan ) && ( $cleanup_plan['success'] ?? false ), 'cleanup plan freezes successfully' );
+	$cleanup_plan_again = $ws->workspace_cleanup_plan( array( 'include_resolvers' => true ) );
+	$assert( $cleanup_plan['plan_id'] ?? '', $cleanup_plan_again['plan_id'] ?? '', 'cleanup plan ID is stable for unchanged rows and inputs' );
+	$artifact_row = $cleanup_plan['rows']['artifact_cleanup'][0] ?? array();
+	$assert( true, str_starts_with( (string) ( $artifact_row['row_id'] ?? '' ), 'cleanup-row-' ), 'artifact cleanup row has stable row ID' );
+	$assert( true, isset( $cleanup_plan['rows']['metadata_repair'] ), 'cleanup plan includes metadata repair row bucket' );
+	$assert( true, isset( $cleanup_plan['rows']['worktree_removal'] ), 'cleanup plan includes worktree removal row bucket' );
+	$assert( true, isset( $cleanup_plan['rows']['resolver'] ), 'cleanup plan includes optional resolver row bucket' );
+	$chunk_report = $ws->workspace_cleanup_plan_chunks(
+		array(
+			'plan'       => $cleanup_plan,
+			'chunk_size' => 1,
+		)
+	);
+	$assert( true, ! is_wp_error( $chunk_report ) && ( $chunk_report['success'] ?? false ), 'cleanup chunks emit successfully from frozen plan' );
+	foreach ( $chunk_report['chunks'] ?? array() as $chunk ) {
+		$assert( true, (int) ( $chunk['chunk_size'] ?? 0 ) <= 1, 'chunk size respects configured bound' );
+		$assert( true, str_starts_with( (string) ( $chunk['chunk_id'] ?? '' ), 'cleanup-chunk-' ), 'chunk has stable chunk ID' );
+	}
+
+	$large_rows = array();
+	for ( $i = 0; $i < 123; ++$i ) {
+		$large_rows[] = array(
+			'row_id'       => 'cleanup-row-large-' . $i,
+			'row_type'     => 'artifact_cleanup',
+			'safety_class' => 'safe',
+			'handle'       => 'demo@large-' . $i,
+			'repo'         => 'demo',
+			'branch'       => 'large-' . $i,
+			'path'         => $tmp . '/demo@large-' . $i,
+			'artifacts'    => array( array( 'path' => 'target', 'size_bytes' => 1 ) ),
+		);
+	}
+	$large_report = $ws->workspace_cleanup_plan_chunks(
+		array(
+			'chunk_size' => 10,
+			'plan'       => array(
+				'plan_id'        => 'cleanup-plan-large',
+				'workspace_path' => $tmp,
+				'rows'           => array(
+					'artifact_cleanup' => $large_rows,
+					'metadata_repair'  => array(),
+					'worktree_removal' => array(),
+					'resolver'         => array(),
+				),
+				'summary'        => array(),
+			),
+		)
+	);
+	$assert( 13, count( $large_report['chunks'] ?? array() ), 'large cleanup plan is split into bounded chunks' );
+	$assert( 123, (int) ( $large_report['summary']['rows_by_type']['artifact_cleanup'] ?? 0 ), 'large cleanup chunk summary preserves row count' );
+
 	$size_plan = $ws->worktree_cleanup_merged(
 		array(
 			'dry_run'     => true,


### PR DESCRIPTION
## Summary
- Add a frozen workspace cleanup plan model that aggregates artifact cleanup, metadata repair, worktree removal, and optional resolver rows without applying them inline.
- Emit conservative, bounded cleanup chunks with stable plan, row, chunk, and idempotency IDs for retryable downstream jobs.
- Register a Data Machine fetch handler and ability surface for plan/chunk emission.

## Testing
- `php -l data-machine-code.php`
- `php -l inc/Abilities/WorkspaceAbilities.php`
- `php -l inc/Workspace/Workspace.php`
- `php -l inc/Handlers/Workspace/CleanupPlan.php`
- `php -l inc/Handlers/Workspace/CleanupPlanSettings.php`
- `php -l tests/smoke-worktree-cleanup.php`
- `php -l tests/smoke-cleanup-plan-handler.php`
- `php tests/smoke-cleanup-plan-handler.php`
- `php tests/smoke-worktree-cleanup.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the cleanup plan/chunk implementation, handler surface, and smoke coverage; Chris remains responsible for review and validation.