### PR TITLE
Trigger emergency cleanup on disk pressure

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -221,11 +221,12 @@ add_action( 'plugins_loaded', 'datamachine_code_load_chat_tools', 25 );
  * Register system tasks.
  */
 add_filter( 'datamachine_tasks', function ( array $tasks ): array {
-	$tasks['github_create_issue']         = \DataMachineCode\Tasks\GitHubIssueTask::class;
-	$tasks['worktree_cleanup_chunk']      = \DataMachineCode\Tasks\WorktreeCleanupChunkTask::class;
-	$tasks['worktree_cleanup']            = \DataMachineCode\Tasks\WorktreeCleanupTask::class;
-	$tasks['workspace_retention_cleanup'] = \DataMachineCode\Tasks\WorkspaceRetentionCleanupTask::class;
-	$tasks['workspace_hygiene_report']    = \DataMachineCode\Tasks\WorkspaceHygieneReportTask::class;
+	$tasks['github_create_issue']              = \DataMachineCode\Tasks\GitHubIssueTask::class;
+	$tasks['worktree_cleanup_chunk']           = \DataMachineCode\Tasks\WorktreeCleanupChunkTask::class;
+	$tasks['worktree_cleanup']                 = \DataMachineCode\Tasks\WorktreeCleanupTask::class;
+	$tasks['workspace_disk_emergency_cleanup'] = \DataMachineCode\Tasks\WorkspaceDiskEmergencyCleanupTask::class;
+	$tasks['workspace_retention_cleanup']      = \DataMachineCode\Tasks\WorkspaceRetentionCleanupTask::class;
+	$tasks['workspace_hygiene_report']         = \DataMachineCode\Tasks\WorkspaceHygieneReportTask::class;
 	return $tasks;
 } );
 
@@ -261,6 +262,17 @@ add_filter( 'datamachine_recurring_schedules', function ( array $schedules ): ar
 			'worktree_older_than' => '14d',
 			'skip_github'         => true,
 			'artifact_cleanup'    => true,
+		),
+	);
+	$schedules['workspace_disk_emergency_cleanup'] = array(
+		'task_type'       => 'workspace_disk_emergency_cleanup',
+		'interval'        => 'hourly',
+		'enabled_setting' => \DataMachineCode\Tasks\WorkspaceDiskEmergencyCleanupTask::SETTING_KEY,
+		'default_enabled' => true,
+		'label'           => 'Hourly — triggers artifact-first emergency cleanup under disk pressure',
+		'task_params'     => array(
+			'source'              => 'recurring_schedule',
+			'artifact_chunk_size' => 10,
 		),
 	);
 	$schedules['workspace_hygiene_report'] = array(

--- a/inc/Tasks/WorkspaceDiskEmergencyCleanupTask.php
+++ b/inc/Tasks/WorkspaceDiskEmergencyCleanupTask.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * Workspace Disk Emergency Cleanup System Task.
+ *
+ * @package DataMachineCode\Tasks
+ */
+
+namespace DataMachineCode\Tasks;
+
+use DataMachine\Core\PluginSettings;
+use DataMachine\Engine\AI\System\Tasks\SystemTask;
+use DataMachine\Engine\Tasks\TaskScheduler;
+use DataMachineCode\Workspace\Workspace;
+
+defined( 'ABSPATH' ) || exit;
+
+class WorkspaceDiskEmergencyCleanupTask extends SystemTask {
+
+	/**
+	 * PluginSettings key that gates threshold-triggered emergency cleanup.
+	 */
+	public const SETTING_KEY = 'workspace_disk_emergency_cleanup_enabled';
+
+	/**
+	 * Task type identifier.
+	 *
+	 * @return string
+	 */
+	public function getTaskType(): string {
+		return 'workspace_disk_emergency_cleanup';
+	}
+
+	/**
+	 * Task metadata for Data Machine system-task surfaces.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public static function getTaskMeta(): array {
+		return array(
+			'label'           => 'Workspace Disk Emergency Cleanup',
+			'description'     => 'Threshold-triggered emergency cleanup for disk pressure. Applies reconstructable artifact chunks first and reports when worktree deletion needs human approval.',
+			'setting_key'     => self::SETTING_KEY,
+			'default_enabled' => true,
+			'supports_run'    => true,
+		);
+	}
+
+	/**
+	 * Execute threshold-triggered emergency cleanup.
+	 *
+	 * @param int   $jobId  Job ID.
+	 * @param array $params Task params.
+	 * @return void
+	 */
+	public function executeTask( int $jobId, array $params ): void {
+		$enabled = (bool) PluginSettings::get( self::SETTING_KEY, true );
+		if ( ! $enabled ) {
+			$this->completeJob(
+				$jobId,
+				array(
+					'skipped' => true,
+					'reason'  => sprintf( 'Workspace disk emergency cleanup disabled (PluginSettings: %s=false).', self::SETTING_KEY ),
+				)
+			);
+			return;
+		}
+
+		$opts = array(
+			'dry_run'                           => ! empty( $params['dry_run'] ),
+			'artifact_chunk_size'               => isset( $params['artifact_chunk_size'] ) ? (int) $params['artifact_chunk_size'] : 10,
+			'allow_worktree_deletion'           => ! empty( $params['allow_worktree_deletion'] ),
+			'human_approved_worktree_deletion'  => ! empty( $params['human_approved_worktree_deletion'] ),
+			'force'                             => ! empty( $params['force'] ),
+		);
+
+		$workspace = new Workspace();
+		$result    = $workspace->workspace_disk_emergency_cleanup( array_merge( $opts, array( 'dry_run' => true ) ) );
+		if ( ! empty( $result['triggered'] ) && empty( $opts['dry_run'] ) && ! empty( $result['selected_artifact_count'] ) ) {
+			$result = $this->schedule_artifact_cleanup_chunks( $jobId, $result, $params );
+		}
+
+		if ( $result instanceof \WP_Error ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'Workspace disk emergency cleanup failed',
+				array(
+					'task'  => $this->getTaskType(),
+					'jobId' => $jobId,
+					'error' => $result->get_error_message(),
+					'code'  => $result->get_error_code(),
+				)
+			);
+			$this->failJob( $jobId, $result->get_error_message() );
+			return;
+		}
+
+		$budget  = (array) ( $result['disk_budget'] ?? array() );
+		$summary = (array) ( $result['scheduled_summary'] ?? array() );
+		$message = ! empty( $result['triggered'] )
+			? sprintf(
+				'Workspace disk emergency cleanup triggered (%s): scheduled %d artifact chunk(s) covering %d artifact row(s); action_required=%s.',
+				implode( ',', (array) ( $budget['trigger_reasons'] ?? array() ) ),
+				(int) ( $summary['scheduled_chunks'] ?? 0 ),
+				(int) ( $summary['scheduled_artifact_rows'] ?? 0 ),
+				! empty( $result['action_required'] ) ? 'yes' : 'no'
+			)
+			: 'Workspace disk emergency cleanup skipped: disk thresholds not crossed.';
+
+		do_action(
+			'datamachine_log',
+			! empty( $result['action_required'] ) ? 'warning' : 'info',
+			$message,
+			array(
+				'task'   => $this->getTaskType(),
+				'jobId'  => $jobId,
+				'report' => $result,
+			)
+		);
+
+		$this->completeJob( $jobId, $result );
+	}
+
+	/**
+	 * Enqueue selected artifact cleanup rows as child chunk jobs.
+	 *
+	 * @param int   $jobId  Parent job ID.
+	 * @param array $result Emergency cleanup dry-run result.
+	 * @param array $params Original task params.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private function schedule_artifact_cleanup_chunks( int $jobId, array $result, array $params ): array|\WP_Error {
+		if ( ! class_exists( TaskScheduler::class ) ) {
+			return new \WP_Error( 'task_scheduler_unavailable', 'Data Machine TaskScheduler is unavailable; cannot schedule emergency cleanup chunks.', array( 'status' => 500 ) );
+		}
+
+		$rows = array_values( (array) ( $result['apply_plan']['artifact_candidates'] ?? array() ) );
+		if ( array() === $rows ) {
+			$result['job_backed']        = false;
+			$result['scheduled_summary'] = array(
+				'scheduled_chunks'        => 0,
+				'scheduled_artifact_rows' => 0,
+			);
+			return $result;
+		}
+
+		$batch = TaskScheduler::scheduleBatch(
+			'worktree_cleanup_chunk',
+			array(
+				array(
+					'chunk_type'  => 'artifacts',
+					'chunk_index' => 0,
+					'rows'        => $rows,
+					'force'       => ! empty( $params['force_artifact_cleanup'] ),
+				),
+			),
+			array(
+				'parent_job_id' => $jobId,
+				'source'        => 'workspace_disk_emergency_cleanup',
+				'user_id'       => (int) ( $params['user_id'] ?? 0 ),
+				'agent_id'      => (int) ( $params['agent_id'] ?? 0 ),
+			)
+		);
+
+		if ( false === $batch ) {
+			return new \WP_Error( 'emergency_cleanup_chunk_schedule_failed', 'Failed to schedule emergency cleanup chunk jobs.', array( 'status' => 500 ) );
+		}
+
+		$result['dry_run']           = false;
+		$result['job_backed']        = true;
+		$result['chunks']            = $batch;
+		$result['scheduled_summary'] = array(
+			'scheduled_chunks'        => 1,
+			'scheduled_artifact_rows' => count( $rows ),
+			'batch_job_id'            => (int) ( $batch['batch_job_id'] ?? 0 ),
+			'direct_job_ids'          => $batch['job_ids'] ?? array(),
+		);
+
+		return $result;
+	}
+}

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -1926,6 +1926,116 @@ class Workspace {
 	}
 
 	/**
+	 * Run disk-threshold-triggered emergency cleanup orchestration.
+	 *
+	 * This is the automation-safe layer: inspect cheap disk/worktree metrics,
+	 * build the inventory-only emergency plan, and apply only reconstructable
+	 * artifact chunks by default. Whole-worktree deletion requires an explicit
+	 * cleanup-eligible plan plus human-approved escalation.
+	 *
+	 * @param array $opts Emergency automation options.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function workspace_disk_emergency_cleanup( array $opts = array() ): array|\WP_Error {
+		$dry_run                  = ! empty( $opts['dry_run'] );
+		$artifact_chunk_size      = isset( $opts['artifact_chunk_size'] ) && is_numeric( $opts['artifact_chunk_size'] ) ? max( 1, (int) $opts['artifact_chunk_size'] ) : 10;
+		$allow_worktree_deletion  = ! empty( $opts['allow_worktree_deletion'] );
+		$human_approved_deletion  = ! empty( $opts['human_approved_worktree_deletion'] );
+		$force_worktree_deletion  = ! empty( $opts['force'] ) && $human_approved_deletion;
+		$thresholds               = isset( $opts['thresholds'] ) && is_array( $opts['thresholds'] ) ? $opts['thresholds'] : WorktreeDiskBudget::thresholds( 'workspace', 'emergency-cleanup' );
+		$budget                   = WorktreeDiskBudget::inspect( $this->workspace_path, $thresholds );
+
+		$plan = $this->worktree_emergency_cleanup( array( 'dry_run' => true ) );
+		if ( $plan instanceof \WP_Error ) {
+			return $plan;
+		}
+
+		$artifact_candidates             = (array) ( $plan['artifact_candidates'] ?? array() );
+		$worktree_candidates             = (array) ( $plan['worktree_candidates'] ?? array() );
+		$top_artifact_offenders          = $this->summarize_top_worktree_rows( $artifact_candidates, 'artifact_size_bytes' );
+		$budget['top_artifact_offenders'] = $top_artifact_offenders;
+
+		$triggered = ! empty( $budget['emergency_triggered'] );
+		if ( ! $triggered ) {
+			return array(
+				'success'             => true,
+				'triggered'           => false,
+				'skipped'             => true,
+				'reason'              => 'disk thresholds not crossed',
+				'dry_run'             => $dry_run,
+				'generated_at'        => gmdate( 'c' ),
+				'workspace_path'      => $this->workspace_path,
+				'disk_budget'         => $budget,
+				'emergency_plan'      => $plan,
+				'action_required'     => false,
+				'applied'             => null,
+			);
+		}
+
+		$selected_artifacts = array_slice( $artifact_candidates, 0, $artifact_chunk_size );
+		$blocked_reasons    = array();
+		$selected_worktrees = array();
+		if ( array() === $selected_artifacts && array() !== $worktree_candidates ) {
+			if ( $allow_worktree_deletion && $human_approved_deletion ) {
+				$selected_worktrees = $worktree_candidates;
+			} else {
+				$blocked_reasons[] = 'worktree_deletion_requires_human_approval';
+			}
+		}
+
+		$apply_plan = array_merge( $plan, array(
+			'artifact_candidates' => $selected_artifacts,
+			'worktree_candidates' => $selected_worktrees,
+		) );
+
+		$applied = null;
+		if ( ! $dry_run && ( array() !== $selected_artifacts || array() !== $selected_worktrees ) ) {
+			$applied = $this->worktree_emergency_cleanup(
+				array(
+					'apply_plan' => $apply_plan,
+					'force'      => $force_worktree_deletion,
+				)
+			);
+			if ( $applied instanceof \WP_Error ) {
+				return $applied;
+			}
+		}
+
+		$apply_skipped_by_reason = (array) ( $applied['summary']['skipped_by_reason'] ?? array() );
+		foreach ( array( 'dirty_worktree', 'unpushed_commits', 'emergency_lifecycle_not_current', 'emergency_worktree_plan_not_current' ) as $reason ) {
+			if ( ! empty( $apply_skipped_by_reason[ $reason ] ) ) {
+				$blocked_reasons[] = $reason;
+			}
+		}
+		$blocked_reasons = array_values( array_unique( $blocked_reasons ) );
+
+		return array(
+			'success'                 => true,
+			'triggered'               => true,
+			'skipped'                 => false,
+			'dry_run'                 => $dry_run,
+			'generated_at'            => gmdate( 'c' ),
+			'workspace_path'          => $this->workspace_path,
+			'disk_budget'             => $budget,
+			'emergency_plan'          => $plan,
+			'apply_plan'              => $apply_plan,
+			'applied'                 => $applied,
+			'artifact_chunk_size'     => $artifact_chunk_size,
+			'selected_artifact_count' => count( $selected_artifacts ),
+			'selected_worktree_count' => count( $selected_worktrees ),
+			'action_required'         => array() !== $blocked_reasons || ( array() === $selected_artifacts && array() !== $worktree_candidates && array() === $selected_worktrees ),
+			'action_required_reasons' => $blocked_reasons,
+			'policy'                  => array(
+				'artifact_first'                      => true,
+				'allow_worktree_deletion'             => $allow_worktree_deletion,
+				'human_approved_worktree_deletion'    => $human_approved_deletion,
+				'force_requires_human_approval'       => true,
+				'force_worktree_deletion_applied'     => $force_worktree_deletion,
+			),
+		);
+	}
+
+	/**
 	 * Build cheap workspace inventory rows from top-level directory names.
 	 *
 	 * This intentionally avoids `git worktree list` and per-worktree `git status`.

--- a/inc/Workspace/WorktreeDiskBudget.php
+++ b/inc/Workspace/WorktreeDiskBudget.php
@@ -127,6 +127,15 @@ final class WorktreeDiskBudget {
 		}
 
 		$status = $refused ? 'refused' : ( empty( $warnings ) ? 'ok' : 'warning' );
+		$trigger_reasons = array();
+		if ( null !== $free_bytes && $free_bytes < $effective_refuse_bytes ) {
+			$trigger_reasons[] = 'free_space_refusal_threshold';
+		} elseif ( null !== $free_bytes && $free_bytes < $effective_warn_bytes ) {
+			$trigger_reasons[] = 'free_space_warning_threshold';
+		}
+		if ( $count > $thresholds['warn_worktree_count'] ) {
+			$trigger_reasons[] = 'worktree_count_warning_threshold';
+		}
 
 		return array(
 			'workspace_path'          => (string) ( $metrics['workspace_path'] ?? '' ),
@@ -146,14 +155,19 @@ final class WorktreeDiskBudget {
 			'refuse_free_percent'     => $thresholds['refuse_free_percent'],
 			'effective_refuse_bytes'  => $effective_refuse_bytes,
 			'effective_refuse_gib'    => round( self::bytes_to_gib( $effective_refuse_bytes ), 2 ),
+			'effective_warn_bytes'    => $effective_warn_bytes,
+			'effective_warn_gib'      => round( self::bytes_to_gib( $effective_warn_bytes ), 2 ),
 			'warn_worktree_count'     => $thresholds['warn_worktree_count'],
 			'forced'                  => $forced,
 			'status'                  => $status,
 			'warnings'                => $warnings,
-			'cleanup_dry_run_command'  => 'studio wp datamachine-code workspace worktree cleanup --dry-run',
-			'artifact_cleanup_command' => 'studio wp datamachine-code workspace worktree cleanup-artifacts --dry-run',
-			'force_override_required' => $refused,
-			'force_override_applied'  => $forced && ! empty( $warnings ),
+			'emergency_triggered'     => array() !== $trigger_reasons,
+			'trigger_reasons'         => $trigger_reasons,
+			'cleanup_dry_run_command'   => 'studio wp datamachine-code workspace worktree cleanup --dry-run',
+			'artifact_cleanup_command'  => 'studio wp datamachine-code workspace worktree cleanup-artifacts --dry-run',
+			'emergency_cleanup_command' => 'studio wp datamachine-code workspace worktree emergency-cleanup --format=json',
+			'force_override_required'   => $refused,
+			'force_override_applied'    => $forced && ! empty( $warnings ),
 		);
 	}
 

--- a/tests/smoke-workspace-disk-emergency-cleanup.php
+++ b/tests/smoke-workspace-disk-emergency-cleanup.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Smoke test for threshold-triggered workspace emergency cleanup orchestration.
+ *
+ *   php tests/smoke-workspace-disk-emergency-cleanup.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Core\FilesRepository {
+	if ( ! class_exists( __NAMESPACE__ . '\FilesystemHelper' ) ) {
+		class FilesystemHelper {
+			public static function get() {
+				return null;
+			}
+		}
+	}
+}
+
+namespace {
+	$workspace_root = sys_get_temp_dir() . '/dmc-disk-emergency-' . getmypid() . '-' . bin2hex( random_bytes( 4 ) );
+	mkdir( $workspace_root, 0755, true );
+	mkdir( $workspace_root . '/repo@one', 0755, true );
+	mkdir( $workspace_root . '/repo@two', 0755, true );
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+	if ( ! defined( 'DATAMACHINE_WORKSPACE_PATH' ) ) {
+		define( 'DATAMACHINE_WORKSPACE_PATH', $workspace_root );
+	}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			public function __construct( public string $code = '', public string $message = '', public array $data = array() ) {}
+		}
+	}
+
+	function is_wp_error( $value ): bool {
+		return $value instanceof \WP_Error;
+	}
+
+	require __DIR__ . '/../inc/Workspace/WorktreeDiskBudget.php';
+	require __DIR__ . '/../inc/Workspace/Workspace.php';
+
+	function datamachine_code_disk_emergency_assert( bool $condition, string $message ): void {
+		if ( $condition ) {
+			echo "  [PASS] {$message}\n";
+			return;
+		}
+		echo "  [FAIL] {$message}\n";
+		exit( 1 );
+	}
+
+	class Disk_Emergency_Workspace extends \DataMachineCode\Workspace\Workspace {
+		public array $apply_inputs = array();
+
+		public function worktree_emergency_cleanup( array $opts = array() ): array|\WP_Error {
+			if ( isset( $opts['apply_plan'] ) ) {
+				$this->apply_inputs[] = $opts;
+				return array(
+					'success'           => true,
+					'dry_run'           => false,
+					'removed_artifacts' => $opts['apply_plan']['artifact_candidates'] ?? array(),
+					'removed_worktrees' => $opts['apply_plan']['worktree_candidates'] ?? array(),
+					'summary'           => array(
+						'removed_artifacts'      => count( $opts['apply_plan']['artifact_candidates'] ?? array() ),
+						'removed_worktrees'      => count( $opts['apply_plan']['worktree_candidates'] ?? array() ),
+						'skipped_by_reason'      => array(),
+					),
+				);
+			}
+
+			return array(
+				'success'             => true,
+				'mode'                => 'emergency',
+				'dry_run'             => true,
+				'artifact_candidates' => array(
+					array(
+						'handle'              => 'repo@one',
+						'repo'                => 'repo',
+						'branch'              => 'one',
+						'path'                => DATAMACHINE_WORKSPACE_PATH . '/repo@one',
+						'artifact_size_bytes' => 2048,
+						'artifacts'           => array( array( 'path' => 'vendor', 'size_bytes' => 2048 ) ),
+					),
+					array(
+						'handle'              => 'repo@two',
+						'repo'                => 'repo',
+						'branch'              => 'two',
+						'path'                => DATAMACHINE_WORKSPACE_PATH . '/repo@two',
+						'artifact_size_bytes' => 1024,
+						'artifacts'           => array( array( 'path' => 'node_modules', 'size_bytes' => 1024 ) ),
+					),
+				),
+				'worktree_candidates' => array(
+					array(
+						'handle' => 'repo@two',
+						'repo'   => 'repo',
+						'branch' => 'two',
+						'path'   => DATAMACHINE_WORKSPACE_PATH . '/repo@two',
+					),
+				),
+				'skipped'             => array(),
+				'summary'             => array(),
+			);
+		}
+	}
+
+	echo "=== smoke-workspace-disk-emergency-cleanup ===\n";
+
+	try {
+		$thresholds = array(
+			'warn_free_bytes'     => 0,
+			'refuse_free_bytes'   => 0,
+			'warn_free_percent'   => 0,
+			'refuse_free_percent' => 0,
+			'warn_worktree_count' => 1,
+		);
+
+		$workspace = new Disk_Emergency_Workspace();
+		$result    = $workspace->workspace_disk_emergency_cleanup(
+			array(
+				'thresholds'          => $thresholds,
+				'artifact_chunk_size' => 1,
+			)
+		);
+
+		datamachine_code_disk_emergency_assert( ! is_wp_error( $result ), 'threshold emergency cleanup succeeds' );
+		datamachine_code_disk_emergency_assert( true === (bool) ( $result['triggered'] ?? false ), 'worktree-count threshold triggers cleanup' );
+		datamachine_code_disk_emergency_assert( 1 === count( $workspace->apply_inputs ), 'triggered cleanup applies one reviewed chunk' );
+		datamachine_code_disk_emergency_assert( 1 === count( $workspace->apply_inputs[0]['apply_plan']['artifact_candidates'] ?? array() ), 'artifact chunk is bounded' );
+		datamachine_code_disk_emergency_assert( array() === ( $workspace->apply_inputs[0]['apply_plan']['worktree_candidates'] ?? array( 'unexpected' ) ), 'worktree deletion is not automatic while artifacts remain' );
+		datamachine_code_disk_emergency_assert( 'repo@one' === ( $result['disk_budget']['top_artifact_offenders'][0]['handle'] ?? '' ), 'top artifact offenders are exposed on disk budget' );
+
+		$workspace = new Disk_Emergency_Workspace();
+		$result    = $workspace->workspace_disk_emergency_cleanup(
+			array(
+				'thresholds' => array_merge( $thresholds, array( 'warn_worktree_count' => 100 ) ),
+			)
+		);
+		datamachine_code_disk_emergency_assert( false === (bool) ( $result['triggered'] ?? true ), 'healthy threshold skips cleanup' );
+		datamachine_code_disk_emergency_assert( array() === $workspace->apply_inputs, 'skipped cleanup does not apply a plan' );
+	} finally {
+		rmdir( $workspace_root . '/repo@two' );
+		rmdir( $workspace_root . '/repo@one' );
+		rmdir( $workspace_root );
+	}
+
+	echo "\nAll workspace disk emergency cleanup smoke tests passed.\n";
+}

--- a/tests/smoke-workspace-disk-emergency-task.php
+++ b/tests/smoke-workspace-disk-emergency-task.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Smoke test for workspace disk emergency cleanup system task.
+ *
+ *   php tests/smoke-workspace-disk-emergency-task.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ );
+	}
+
+	$GLOBALS['__disk_emergency_task_logs'] = array();
+
+	function do_action( string $hook, ...$args ): void {
+		$GLOBALS['__disk_emergency_task_logs'][] = array( $hook, $args );
+	}
+}
+
+namespace DataMachine\Core {
+	class PluginSettings {
+		public static bool $enabled = true;
+
+		public static function get( string $key, $default = null ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+			return self::$enabled;
+		}
+	}
+}
+
+namespace DataMachine\Engine\AI\System\Tasks {
+	abstract class SystemTask {
+		public array $completed = array();
+		public array $failed = array();
+
+		abstract public function getTaskType(): string;
+
+		protected function completeJob( int $jobId, array $data ): void {
+			$this->completed[] = array( $jobId, $data );
+		}
+
+		protected function failJob( int $jobId, string $message ): void {
+			$this->failed[] = array( $jobId, $message );
+		}
+	}
+}
+
+namespace DataMachine\Engine\Tasks {
+	class TaskScheduler {
+		public static array $batches = array();
+
+		public static function scheduleBatch( string $task_type, array $items, array $context = array() ) {
+			self::$batches[] = array( $task_type, $items, $context );
+			return array(
+				'batch_job_id' => 900,
+				'job_ids'      => array( 901 ),
+				'task_type'    => $task_type,
+			);
+		}
+	}
+}
+
+namespace DataMachineCode\Workspace {
+	class Workspace {
+		public function workspace_disk_emergency_cleanup( array $opts = array() ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+			return array(
+				'success'                 => true,
+				'triggered'               => true,
+				'dry_run'                 => ! empty( $opts['dry_run'] ),
+				'action_required'         => true,
+				'selected_artifact_count' => 2,
+				'disk_budget'             => array(
+					'trigger_reasons' => array( 'worktree_count_warning_threshold' ),
+				),
+				'apply_plan'              => array(
+					'artifact_candidates' => array(
+						array( 'handle' => 'repo@one' ),
+						array( 'handle' => 'repo@two' ),
+					),
+				),
+			);
+		}
+	}
+}
+
+namespace {
+	require_once dirname( __DIR__ ) . '/inc/Tasks/WorkspaceDiskEmergencyCleanupTask.php';
+
+	function datamachine_code_disk_emergency_task_assert( bool $condition, string $message ): void {
+		if ( $condition ) {
+			echo "  [PASS] {$message}\n";
+			return;
+		}
+		echo "  [FAIL] {$message}\n";
+		exit( 1 );
+	}
+
+	echo "=== smoke-workspace-disk-emergency-task ===\n";
+
+	$settings_class = '\\DataMachine\\Core\\PluginSettings';
+	$enabled_prop   = 'enabled';
+	$completed_prop = 'completed';
+	$failed_prop    = 'failed';
+
+	echo "\n[1] Disabled task completes as skipped\n";
+	$settings_class::$$enabled_prop = false;
+	$task = new \DataMachineCode\Tasks\WorkspaceDiskEmergencyCleanupTask();
+	$task->executeTask( 301, array() );
+	datamachine_code_disk_emergency_task_assert( 'workspace_disk_emergency_cleanup' === $task->getTaskType(), 'task type is stable' );
+	datamachine_code_disk_emergency_task_assert( true === ( $task->{$completed_prop}[0][1]['skipped'] ?? false ), 'disabled task reports skipped completion' );
+	datamachine_code_disk_emergency_task_assert( array() === $task->{$failed_prop}, 'disabled task does not fail' );
+
+	echo "\n[2] Enabled task logs triggered cleanup\n";
+	$GLOBALS['__disk_emergency_task_logs'] = array();
+	$settings_class::$$enabled_prop = true;
+	$task = new \DataMachineCode\Tasks\WorkspaceDiskEmergencyCleanupTask();
+	$task->executeTask( 302, array( 'artifact_chunk_size' => 2 ) );
+	datamachine_code_disk_emergency_task_assert( true === (bool) ( $task->{$completed_prop}[0][1]['triggered'] ?? false ), 'enabled task stores triggered report' );
+	datamachine_code_disk_emergency_task_assert( true === (bool) ( $task->{$completed_prop}[0][1]['job_backed'] ?? false ), 'enabled task schedules chunk jobs' );
+	datamachine_code_disk_emergency_task_assert( 1 === count( \DataMachine\Engine\Tasks\TaskScheduler::$batches ), 'enabled task schedules one cleanup batch' );
+	datamachine_code_disk_emergency_task_assert( 'worktree_cleanup_chunk' === ( \DataMachine\Engine\Tasks\TaskScheduler::$batches[0][0] ?? '' ), 'scheduled batch uses cleanup chunk task' );
+	datamachine_code_disk_emergency_task_assert( 1 === count( $GLOBALS['__disk_emergency_task_logs'] ), 'enabled task emits one log event' );
+	$first_log = $GLOBALS['__disk_emergency_task_logs'][0] ?? array();
+	datamachine_code_disk_emergency_task_assert( 'warning' === (string) ( $first_log[1][0] ?? '' ), 'action-required run logs as warning' );
+	datamachine_code_disk_emergency_task_assert( str_contains( (string) ( $first_log[1][1] ?? '' ), 'scheduled 1 artifact chunk(s)' ), 'log summary includes scheduled chunk count' );
+
+	echo "\nAll workspace disk emergency task smoke tests passed.\n";
+}

--- a/tests/smoke-worktree-disk-budget.php
+++ b/tests/smoke-worktree-disk-budget.php
@@ -77,8 +77,11 @@ $budget = WorktreeDiskBudget::evaluate(
 );
 datamachine_code_budget_assert( 'refused' === $budget['status'], 'refused status below 10 GiB' );
 datamachine_code_budget_assert( true === $budget['force_override_required'], 'force required below refusal threshold' );
+datamachine_code_budget_assert( true === $budget['emergency_triggered'], 'refusal threshold triggers emergency cleanup' );
+datamachine_code_budget_assert( in_array( 'free_space_refusal_threshold', $budget['trigger_reasons'], true ), 'refusal trigger reason is stable' );
 datamachine_code_budget_assert( str_contains( $budget['cleanup_dry_run_command'], 'workspace worktree cleanup --dry-run' ), 'cleanup dry-run command is present' );
 datamachine_code_budget_assert( str_contains( $budget['artifact_cleanup_command'], 'workspace worktree cleanup-artifacts --dry-run' ), 'artifact cleanup dry-run command is present' );
+datamachine_code_budget_assert( str_contains( $budget['emergency_cleanup_command'], 'workspace worktree emergency-cleanup' ), 'emergency cleanup command is present' );
 
 echo "\n[4] force makes low-space override explicit\n";
 $budget = WorktreeDiskBudget::evaluate(
@@ -120,6 +123,7 @@ $budget = WorktreeDiskBudget::evaluate(
 	$thresholds
 );
 datamachine_code_budget_assert( 'warning' === $budget['status'], 'high worktree count warns' );
+datamachine_code_budget_assert( true === $budget['emergency_triggered'], 'worktree count warning triggers emergency cleanup' );
 datamachine_code_budget_assert( str_contains( $budget['warnings'][0], '101 worktree-like directories' ), 'worktree-count warning is descriptive' );
 
 echo "\n[7] inspect counts only worktree-like directories\n";


### PR DESCRIPTION
## Summary
- Adds a threshold-triggered `workspace_disk_emergency_cleanup` system task and hourly recurring schedule.
- Extends disk-budget evaluation with emergency trigger reasons and emergency cleanup guidance.
- Applies emergency cleanup artifact-first in bounded chunks, while requiring explicit human-approved escalation for worktree deletion.

Fixes #204.

## Tests
- `php -l inc/Workspace/WorktreeDiskBudget.php && php -l inc/Workspace/Workspace.php && php -l inc/Tasks/WorkspaceDiskEmergencyCleanupTask.php && php -l data-machine-code.php && php -l tests/smoke-workspace-disk-emergency-cleanup.php && php -l tests/smoke-workspace-disk-emergency-task.php && php tests/smoke-worktree-disk-budget.php && php tests/smoke-workspace-disk-emergency-cleanup.php && php tests/smoke-workspace-disk-emergency-task.php && php tests/smoke-workspace-retention-cleanup.php && php tests/smoke-workspace-retention-task.php`
- `git ls-files '*.php' | xargs -n 1 php -l`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the implementation and smoke tests; Chris remains responsible for review and validation.