### PR TITLE
Fix maintenance flow provision command

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -133,8 +133,8 @@ class WorkspaceCommand extends BaseCommand {
 	 *
 	 * ## OPTIONS
 	 *
-	 * provision
-	 * : Provision/update the maintenance flows.
+	 * <action>
+	 * : Maintenance flow action. Supports: provision.
 	 *
 	 * --agent=<agent>
 	 * : Agent slug or numeric agent ID that should own the flows.


### PR DESCRIPTION
## Summary
- Fixes the WP-CLI synopsis for `workspace maintenance-flows` so the `provision` action is accepted instead of rejected as an invalid positional argument.

## Testing
- `php -l inc/Cli/Commands/WorkspaceCommand.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Identified the deployed command registration failure and drafted the minimal CLI synopsis fix; Chris remains responsible for review and merge.