### PR TITLE
fix: scale workspace worktree list on huge workspaces (#213)

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -1094,7 +1094,7 @@ class WorkspaceAbilities {
 				'datamachine/workspace-worktree-list',
 				array(
 					'label'               => 'List Workspace Worktrees',
-					'description'         => 'List all worktrees in the workspace (optionally filtered by repo and lifecycle state).',
+					'description'         => 'List all worktrees in the workspace (optionally filtered by repo and lifecycle state). Defaults to a fast cheap-inventory listing on large workspaces; opt in to per-worktree git status and disk probes via include_status / include_disk.',
 					'category'            => 'datamachine-code-workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
@@ -1107,13 +1107,26 @@ class WorkspaceAbilities {
 								'type'        => 'string',
 								'description' => 'Optional lifecycle state filter.',
 							),
+							'include_status' => array(
+								'type'        => 'boolean',
+								'description' => 'Run `git status --porcelain` per worktree to populate the dirty count. Default false (cheap listing). Expensive on large workspaces.',
+							),
+							'include_disk' => array(
+								'type'        => 'boolean',
+								'description' => 'Run size and artifact `du` probes per worktree. Default false (cheap listing). Expensive on large workspaces.',
+							),
 						),
 					),
 					'output_schema'       => array(
 						'type'       => 'object',
 						'properties' => array(
-							'success'   => array( 'type' => 'boolean' ),
-							'worktrees' => array(
+							'success'        => array( 'type' => 'boolean' ),
+							'fields_skipped' => array(
+								'type'        => 'array',
+								'description' => 'Probe groups skipped on this listing (e.g. "status", "disk"). Empty when full data is requested.',
+								'items'       => array( 'type' => 'string' ),
+							),
+							'worktrees'      => array(
 								'type'  => 'array',
 								'items' => array(
 									'type'       => 'object',
@@ -1127,7 +1140,7 @@ class WorkspaceAbilities {
 										'branch'          => array( 'type' => array( 'string', 'null' ) ),
 										'head'            => array( 'type' => 'string' ),
 										'path'            => array( 'type' => 'string' ),
-										'dirty'           => array( 'type' => 'integer' ),
+										'dirty'           => array( 'type' => array( 'integer', 'null' ) ),
 										'created_at'      => array( 'type' => array( 'string', 'null' ) ),
 										'lifecycle_state' => array( 'type' => array( 'string', 'null' ) ),
 										'pr_url'          => array( 'type' => array( 'string', 'null' ) ),
@@ -1139,6 +1152,10 @@ class WorkspaceAbilities {
 										'artifacts'       => array( 'type' => 'array' ),
 										'stale_reason'    => array( 'type' => array( 'string', 'null' ) ),
 										'metadata'        => array( 'type' => array( 'object', 'null' ) ),
+										'fields_skipped'  => array(
+											'type'  => 'array',
+											'items' => array( 'type' => 'string' ),
+										),
 									),
 								),
 							),
@@ -1759,7 +1776,16 @@ class WorkspaceAbilities {
 		$state     = isset( $input['state'] ) && '' !== trim( (string) $input['state'] )
 			? (string) $input['state']
 			: null;
-		return $workspace->worktree_list( $repo, $state );
+
+		// Default to the cheap listing on the ability surface so MCP/REST/CLI callers
+		// don't pay the per-worktree git status + du cost on huge workspaces.
+		// Internal PHP callers can still call worktree_list() directly with full probes.
+		$opts = array(
+			'include_status' => array_key_exists( 'include_status', $input ) ? (bool) $input['include_status'] : false,
+			'include_disk'   => array_key_exists( 'include_disk', $input ) ? (bool) $input['include_disk'] : false,
+		);
+
+		return $workspace->worktree_list( $repo, $state, $opts );
 	}
 
 	/**

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1584,6 +1584,19 @@ class WorkspaceCommand extends BaseCommand {
 	 *
 	 * [--stale]
 	 * : For list, show only worktrees with a stale_reason (old, dirty, or missing metadata).
+	 *   Implies `--with-status` (dirty detection requires running `git status`).
+	 *
+	 * [--with-status]
+	 * : For list, run `git status --porcelain` per worktree to populate the dirty count.
+	 *   Off by default — expensive on large workspaces (one fork+exec per worktree).
+	 *
+	 * [--with-size]
+	 * : For list, run size and artifact `du` probes per worktree. Off by default —
+	 *   expensive on large workspaces (multiple fork+exec calls per worktree).
+	 *
+	 * [--full]
+	 * : For list, shorthand for `--with-status --with-size`. Restores the pre-0.27
+	 *   behavior where every worktree is fully probed; only practical for small workspaces.
 	 *
 	 * [--verbose]
 	 * : Show every cleanup row instead of concise samples (cleanup only).
@@ -1615,11 +1628,20 @@ class WorkspaceCommand extends BaseCommand {
 	 *     wp datamachine-code workspace worktree add data-machine feat/bar --from=origin/develop
 	 *     wp datamachine-code workspace worktree add data-machine feat/bar --base-branch=develop
 	 *
-	 *     # List all worktrees
+	 *     # List all worktrees (cheap inventory: no per-worktree git status / du probes)
 	 *     wp datamachine-code workspace worktree list
 	 *
 	 *     # List worktrees for one repo
 	 *     wp datamachine-code workspace worktree list data-machine
+	 *
+	 *     # Cheap JSON inventory for huge workspaces (~800 worktrees) — completes fast
+	 *     wp datamachine-code workspace worktree list --format=json
+	 *
+	 *     # Restore the pre-0.27 full probe behavior (slow on huge workspaces)
+	 *     wp datamachine-code workspace worktree list --full
+	 *
+	 *     # Just dirty detection, skip size scan
+	 *     wp datamachine-code workspace worktree list --with-status
 	 *
 	 *     # Remove a worktree
 	 *     wp datamachine-code workspace worktree remove data-machine fix/foo
@@ -1784,6 +1806,15 @@ class WorkspaceCommand extends BaseCommand {
 				if ( isset( $assoc_args['state'] ) && '' !== trim( (string) $assoc_args['state'] ) ) {
 					$input['state'] = (string) $assoc_args['state'];
 				}
+				// Cheap inventory by default — opt in to expensive probes via flags.
+				// `--full` is a shorthand for both, `--stale` requires status to detect dirty.
+				$want_status = ! empty( $assoc_args['with-status'] )
+					|| ! empty( $assoc_args['full'] )
+					|| ! empty( $assoc_args['stale'] );
+				$want_disk   = ! empty( $assoc_args['with-size'] )
+					|| ! empty( $assoc_args['full'] );
+				$input['include_status'] = $want_status;
+				$input['include_disk']   = $want_disk;
 				break;
 
 			case 'remove':
@@ -1880,31 +1911,44 @@ class WorkspaceCommand extends BaseCommand {
 					return;
 				}
 				$items  = array_map(
-					fn( $wt ) => array(
-						'handle'              => $wt['handle'] ?? '',
-						'repo'                => $wt['repo'] ?? '',
-						'kind'                => ! empty( $wt['is_primary'] ) ? 'primary' : 'worktree',
-						'branch'              => $wt['branch'] ?? '-',
-						'head'                => isset( $wt['head'] ) ? substr( (string) $wt['head'], 0, 7 ) : '-',
-						'dirty'               => (int) ( $wt['dirty'] ?? 0 ),
-						'created_at'          => $wt['created_at'] ?? null,
-						'state'               => $wt['lifecycle_state'] ?? null,
-						'pr'                  => $wt['pr_url'] ?? null,
-						'age_days'            => $wt['age_days'] ?? null,
-						'size_bytes'          => $wt['size_bytes'] ?? null,
-						'size'                => $this->format_bytes( $wt['size_bytes'] ?? null ),
-						'artifact_size_bytes' => $wt['artifact_size_bytes'] ?? 0,
-						'artifacts'           => $this->format_bytes( $wt['artifact_size_bytes'] ?? 0 ),
-						'artifact_paths'      => $wt['artifacts'] ?? array(),
-						'stale'               => $wt['stale_reason'] ?? '',
-						'metadata'            => $wt['metadata'] ?? null,
-						'path'                => $wt['path'] ?? '',
-					),
+					function ( $wt ) {
+						$skipped = (array) ( $wt['fields_skipped'] ?? array() );
+						$dirty   = $wt['dirty'] ?? null;
+						$size    = $wt['size_bytes'] ?? null;
+						return array(
+							'handle'              => $wt['handle'] ?? '',
+							'repo'                => $wt['repo'] ?? '',
+							'kind'                => ! empty( $wt['is_primary'] ) ? 'primary' : 'worktree',
+							'branch'              => $wt['branch'] ?? '-',
+							'head'                => isset( $wt['head'] ) ? substr( (string) $wt['head'], 0, 7 ) : '-',
+							'dirty'               => null === $dirty ? '-' : (int) $dirty,
+							'created_at'          => $wt['created_at'] ?? null,
+							'state'               => $wt['lifecycle_state'] ?? null,
+							'pr'                  => $wt['pr_url'] ?? null,
+							'age_days'            => $wt['age_days'] ?? null,
+							'size_bytes'          => $size,
+							'size'                => null === $size ? '-' : $this->format_bytes( $size ),
+							'artifact_size_bytes' => $wt['artifact_size_bytes'] ?? 0,
+							'artifacts'           => in_array( 'disk', $skipped, true ) ? '-' : $this->format_bytes( $wt['artifact_size_bytes'] ?? 0 ),
+							'artifact_paths'      => $wt['artifacts'] ?? array(),
+							'stale'               => $wt['stale_reason'] ?? '',
+							'fields_skipped'      => $skipped,
+							'metadata'            => $wt['metadata'] ?? null,
+							'path'                => $wt['path'] ?? '',
+						);
+					},
 					$worktrees
 				);
 				$fields = array( 'handle', 'repo', 'kind', 'branch', 'head', 'dirty', 'state', 'created_at', 'pr', 'age_days', 'size', 'artifacts', 'stale', 'path' );
 				if ( in_array( (string) ( $assoc_args['format'] ?? '' ), array( 'json', 'yaml' ), true ) ) {
-					$fields = array( 'handle', 'repo', 'kind', 'branch', 'head', 'dirty', 'state', 'created_at', 'pr', 'age_days', 'size_bytes', 'artifact_size_bytes', 'artifact_paths', 'stale', 'metadata', 'path' );
+					$fields = array( 'handle', 'repo', 'kind', 'branch', 'head', 'dirty', 'state', 'created_at', 'pr', 'age_days', 'size_bytes', 'artifact_size_bytes', 'artifact_paths', 'stale', 'fields_skipped', 'metadata', 'path' );
+				}
+				$skipped_global = (array) ( $result['fields_skipped'] ?? array() );
+				if ( ! empty( $skipped_global ) && ! in_array( (string) ( $assoc_args['format'] ?? '' ), array( 'json', 'yaml', 'csv' ), true ) ) {
+					WP_CLI::log( sprintf(
+						'# Cheap listing — fields skipped: %s. Pass --with-status, --with-size, or --full to populate.',
+						implode( ', ', $skipped_global )
+					) );
 				}
 				$this->format_items( $items, $fields, $assoc_args, 'handle' );
 				return;

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -1654,10 +1654,34 @@ class Workspace {
 	/**
 	 * List worktrees in the workspace.
 	 *
-	 * @param string|null $repo Optional repo filter (only this primary's worktrees).
-	 * @return array{success: bool, worktrees: array}|\WP_Error
+	 * On large workspaces (hundreds of worktrees) the per-row `git status` and
+	 * `du` probes are the dominant cost. Callers that only need cheap inventory
+	 * (handle, repo, branch, head, lifecycle metadata) can opt out via
+	 * `$opts['include_status']` / `$opts['include_disk']`. Skipped fields are
+	 * returned as `null`/`0`/`array()` and the row's `fields_skipped` array
+	 * lists which probe groups were skipped, so consumers can tell the
+	 * difference between "absent" and "not measured".
+	 *
+	 * @param string|null $repo  Optional repo filter (only this primary's worktrees).
+	 * @param string|null $state Optional lifecycle state filter.
+	 * @param array       $opts {
+	 *     @type bool $include_status Whether to run `git status --porcelain` per worktree. Default true.
+	 *     @type bool $include_disk   Whether to run size/artifact `du` probes per worktree. Default true.
+	 * }
+	 * @return array{success: bool, worktrees: array, fields_skipped: array<int,string>}|\WP_Error
 	 */
-	public function worktree_list( ?string $repo = null, ?string $state = null ): array|\WP_Error {
+	public function worktree_list( ?string $repo = null, ?string $state = null, array $opts = array() ): array|\WP_Error {
+		$include_status = array_key_exists( 'include_status', $opts ) ? (bool) $opts['include_status'] : true;
+		$include_disk   = array_key_exists( 'include_disk', $opts ) ? (bool) $opts['include_disk'] : true;
+
+		$skipped_groups = array();
+		if ( ! $include_status ) {
+			$skipped_groups[] = 'status';
+		}
+		if ( ! $include_disk ) {
+			$skipped_groups[] = 'disk';
+		}
+
 		if ( null !== $state && '' !== trim( $state ) ) {
 			$state = WorktreeContextInjector::normalize_state( (string) $state );
 			if ( null === $state ) {
@@ -1668,8 +1692,9 @@ class Workspace {
 		}
 		if ( ! is_dir( $this->workspace_path ) ) {
 			return array(
-				'success'   => true,
-				'worktrees' => array(),
+				'success'        => true,
+				'worktrees'      => array(),
+				'fields_skipped' => $skipped_groups,
 			);
 		}
 
@@ -1723,46 +1748,85 @@ class Workspace {
 					$handle = $wt['path'];
 				}
 
-				$dirty_result = $this->run_git( $wt['path'], 'status --porcelain' );
-				$dirty_files  = is_wp_error( $dirty_result )
-					? 0
-					: count( array_filter( array_map( 'trim', explode( "\n", $dirty_result['output'] ?? '' ) ) ) );
-				$metadata     = ( ! $is_primary && $inside_ws ) ? WorktreeContextInjector::get_metadata( $relative ) : null;
-				$created_at   = is_array( $metadata ) ? ( $metadata['created_at'] ?? null ) : null;
-				$disk         = $this->build_worktree_disk_report( $primary, $wt['path'], ! $is_primary, $created_at, $metadata );
-				$stale_reason = $this->detect_worktree_stale_reason( ! $is_primary, $dirty_files, $disk['age_days'] ?? null, $created_at );
-				if ( null !== $stale_reason ) {
-					$disk['stale_reason'] = $stale_reason;
+				if ( $include_status ) {
+					$dirty_result = $this->run_git( $wt['path'], 'status --porcelain' );
+					$dirty_files  = is_wp_error( $dirty_result )
+						? 0
+						: count( array_filter( array_map( 'trim', explode( "\n", $dirty_result['output'] ?? '' ) ) ) );
+				} else {
+					$dirty_files = null;
 				}
 
+				$metadata        = ( ! $is_primary && $inside_ws ) ? WorktreeContextInjector::get_metadata( $relative ) : null;
+				$created_at      = is_array( $metadata ) ? ( $metadata['created_at'] ?? null ) : null;
 				$lifecycle_state = is_array( $metadata ) ? ( $metadata['lifecycle_state'] ?? null ) : null;
 				if ( null !== $state && $lifecycle_state !== $state ) {
 					continue;
 				}
 
-				$worktrees[] = array_merge( array(
-					'handle'      => $handle,
-					'repo'        => $primary,
-					'is_worktree' => ! $is_primary,
-					'is_primary'  => $is_primary,
-					'external'    => ! $is_primary && ! $inside_ws,
-					'branch_slug' => $is_primary ? null : ( $parsed['branch_slug'] ?? null ),
-					'branch'      => $wt['branch'],
-					'head'        => $wt['head'],
-					'path'        => $wt['path'],
-					'dirty'       => $dirty_files,
-					'created_at'  => $created_at,
-					'lifecycle_state' => $lifecycle_state,
-					'pr_url'      => is_array( $metadata ) ? ( $metadata['pr_url'] ?? null ) : null,
-					'pr_number'   => is_array( $metadata ) ? ( $metadata['pr_number'] ?? null ) : null,
-					'metadata'    => $metadata,
-				), $disk );
+				if ( $include_disk ) {
+					$disk = $this->build_worktree_disk_report( $primary, $wt['path'], ! $is_primary, $created_at, $metadata );
+				} else {
+					$disk = array(
+						'size_bytes'           => null,
+						'estimated_size_bytes' => null,
+						'last_touched_at'      => null,
+						'age_days'             => $this->calculate_age_days( $created_at ),
+						'artifacts'            => array(),
+						'artifact_size_bytes'  => 0,
+					);
+				}
+
+				// Stale-reason detection requires both signals to be reliable; only
+				// flag dirty/threshold reasons when the underlying probe ran. The
+				// metadata-only signal still works without disk/status probes.
+				$stale_reason = $this->detect_worktree_stale_reason(
+					! $is_primary,
+					(int) ( $dirty_files ?? 0 ),
+					$disk['age_days'] ?? null,
+					$created_at,
+					array(
+						'status_probed' => $include_status,
+						'disk_probed'   => $include_disk,
+					)
+				);
+				if ( null !== $stale_reason ) {
+					$disk['stale_reason'] = $stale_reason;
+				}
+
+				$row = array_merge(
+					array(
+						'handle'          => $handle,
+						'repo'            => $primary,
+						'is_worktree'     => ! $is_primary,
+						'is_primary'      => $is_primary,
+						'external'        => ! $is_primary && ! $inside_ws,
+						'branch_slug'     => $is_primary ? null : ( $parsed['branch_slug'] ?? null ),
+						'branch'          => $wt['branch'],
+						'head'            => $wt['head'],
+						'path'            => $wt['path'],
+						'dirty'           => $dirty_files,
+						'created_at'      => $created_at,
+						'lifecycle_state' => $lifecycle_state,
+						'pr_url'          => is_array( $metadata ) ? ( $metadata['pr_url'] ?? null ) : null,
+						'pr_number'       => is_array( $metadata ) ? ( $metadata['pr_number'] ?? null ) : null,
+						'metadata'        => $metadata,
+					),
+					$disk
+				);
+
+				if ( ! empty( $skipped_groups ) ) {
+					$row['fields_skipped'] = $skipped_groups;
+				}
+
+				$worktrees[] = $row;
 			}
 		}
 
 		return array(
-			'success'   => true,
-			'worktrees' => $worktrees,
+			'success'        => true,
+			'worktrees'      => $worktrees,
+			'fields_skipped' => $skipped_groups,
 		);
 	}
 
@@ -5094,12 +5158,14 @@ class Workspace {
 	 * @param string|null $created_at  Lifecycle timestamp.
 	 * @return string|null Stale reason code.
 	 */
-	private function detect_worktree_stale_reason( bool $is_worktree, int $dirty_files, ?int $age_days, ?string $created_at ): ?string {
+	private function detect_worktree_stale_reason( bool $is_worktree, int $dirty_files, ?int $age_days, ?string $created_at, array $probes = array() ): ?string {
 		if ( ! $is_worktree ) {
 			return null;
 		}
 
-		if ( $dirty_files > 0 ) {
+		$status_probed = array_key_exists( 'status_probed', $probes ) ? (bool) $probes['status_probed'] : true;
+
+		if ( $status_probed && $dirty_files > 0 ) {
 			return 'dirty';
 		}
 

--- a/tests/smoke-workspace-hygiene-report.php
+++ b/tests/smoke-workspace-hygiene-report.php
@@ -101,7 +101,7 @@ namespace {
 	class Hygiene_Report_Workspace extends \DataMachineCode\Workspace\Workspace {
 		public int $full_listing_calls = 0;
 
-		public function worktree_list( ?string $repo = null, ?string $state = null ): array|\WP_Error { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+		public function worktree_list( ?string $repo = null, ?string $state = null, array $opts = array() ): array|\WP_Error { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 			++$this->full_listing_calls;
 			return array(
 				'success'   => true,

--- a/tests/smoke-worktree-cleanup.php
+++ b/tests/smoke-worktree-cleanup.php
@@ -162,9 +162,9 @@ namespace {
 	class Cleanup_Inventory_Workspace extends \DataMachineCode\Workspace\Workspace {
 		public int $full_listing_calls = 0;
 
-		public function worktree_list( ?string $repo = null, ?string $state = null ): array|\WP_Error { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+		public function worktree_list( ?string $repo = null, ?string $state = null, array $opts = array() ): array|\WP_Error { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 			++$this->full_listing_calls;
-			return parent::worktree_list( $repo, $state );
+			return parent::worktree_list( $repo, $state, $opts );
 		}
 	}
 
@@ -512,7 +512,7 @@ namespace {
 	$assert( true, is_wp_error( $invalid_age_plan ), 'invalid older_than duration returns WP_Error' );
 
 	class Missing_Metadata_Workspace extends \DataMachineCode\Workspace\Workspace {
-		public function worktree_list( ?string $repo = null, ?string $state = null ): array|\WP_Error { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+		public function worktree_list( ?string $repo = null, ?string $state = null, array $opts = array() ): array|\WP_Error { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 			return array(
 				'success'   => true,
 				'worktrees' => array(

--- a/tests/smoke-worktree-list-scaling.php
+++ b/tests/smoke-worktree-list-scaling.php
@@ -1,0 +1,288 @@
+<?php
+/**
+ * Integration smoke test for worktree_list scalability flags.
+ *
+ * Builds a small real workspace and exercises the cheap-listing opt-out path
+ * added for issue #213 (worktree list timed out on a workspace with ~800
+ * worktrees because every row ran `git status --porcelain` plus multiple
+ * `du -sk` probes). The test asserts:
+ *
+ *   - Default `worktree_list()` (no opts) keeps the pre-fix full-probe shape
+ *     so internal callers (cleanup, hygiene with full status, etc.) are
+ *     unchanged.
+ *   - `include_status=false, include_disk=false` returns rows with `dirty`
+ *     and `size_bytes` as null, populates `fields_skipped`, and skips both
+ *     the per-row `git status` and `du` probes (zero exec calls).
+ *   - The cheap listing still surfaces handle/repo/branch/head/lifecycle
+ *     metadata and the `missing_metadata` stale_reason without probes.
+ *   - `include_status=true, include_disk=false` only runs `git status`,
+ *     not `du`.
+ *
+ * Run: php tests/smoke-worktree-list-scaling.php
+ *
+ * Skips entirely if `git` is unavailable on $PATH.
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Core\FilesRepository {
+	if ( ! class_exists( __NAMESPACE__ . '\\FilesystemHelper' ) ) {
+		class FilesystemHelper {
+			public static function get() {
+				return null;
+			}
+		}
+	}
+}
+
+namespace DataMachineCode\Abilities {
+	if ( ! class_exists( __NAMESPACE__ . '\\GitHubAbilities' ) ) {
+		class GitHubAbilities {
+			public static function getPat(): string {
+				return '';
+			}
+			public static function apiGet( string $url, array $params, string $pat ) {
+				return array( 'data' => array() );
+			}
+		}
+	}
+}
+
+namespace {
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			public string $code;
+			public string $message;
+			public array $data;
+			public function __construct( $code = '', $message = '', $data = array() ) {
+				$this->code    = (string) $code;
+				$this->message = (string) $message;
+				$this->data    = (array) $data;
+			}
+			public function get_error_message(): string {
+				return $this->message;
+			}
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $thing ): bool {
+			return $thing instanceof \WP_Error;
+		}
+	}
+
+	if ( ! function_exists( 'wp_mkdir_p' ) ) {
+		function wp_mkdir_p( string $path ): bool {
+			return is_dir( $path ) || mkdir( $path, 0755, true );
+		}
+	}
+
+	if ( ! function_exists( 'get_option' ) ) {
+		function get_option( string $name, $default_value = false ) {
+			global $datamachine_code_test_options;
+			return $datamachine_code_test_options[ $name ] ?? $default_value;
+		}
+	}
+
+	if ( ! function_exists( 'update_option' ) ) {
+		function update_option( string $name, $value, $autoload = null ): bool {
+			global $datamachine_code_test_options;
+			$datamachine_code_test_options[ $name ] = $value;
+			return true;
+		}
+	}
+
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( string $hook_name, $value ) {
+			return $value;
+		}
+	}
+
+	if ( ! function_exists( 'size_format' ) ) {
+		function size_format( $bytes ): string {
+			return (string) $bytes;
+		}
+	}
+
+	require __DIR__ . '/../inc/Support/GitHubRemote.php';
+	require __DIR__ . '/../inc/Support/GitRunner.php';
+	require __DIR__ . '/../inc/Support/PathSecurity.php';
+	require __DIR__ . '/../inc/Workspace/WorkspaceMutationLock.php';
+	require __DIR__ . '/../inc/Workspace/WorktreeDiskBudget.php';
+	require __DIR__ . '/../inc/Workspace/WorktreeContextInjector.php';
+	require __DIR__ . '/../inc/Workspace/Workspace.php';
+
+	// Skip if git missing.
+	exec( 'git --version 2>&1', $_gv, $gv_exit );
+	if ( 0 !== $gv_exit ) {
+		echo "SKIP: git not available\n";
+		exit( 0 );
+	}
+
+	$tmp = sys_get_temp_dir() . '/dmc-list-scaling-smoke-' . bin2hex( random_bytes( 4 ) );
+	mkdir( $tmp, 0755, true );
+	register_shutdown_function( function () use ( $tmp ) {
+		if ( is_dir( $tmp ) ) {
+			exec( 'rm -rf ' . escapeshellarg( $tmp ) );
+		}
+	} );
+
+	define( 'DATAMACHINE_WORKSPACE_PATH', realpath( $tmp ) ? realpath( $tmp ) : $tmp );
+
+	$failures = 0;
+	$total    = 0;
+	$datamachine_code_test_options = array();
+
+	$assert = function ( $expected, $actual, string $message ) use ( &$failures, &$total ): void {
+		$total++;
+		if ( $expected === $actual ) {
+			echo "  ✓ {$message}\n";
+			return;
+		}
+		$failures++;
+		echo "  ✗ {$message}\n";
+		echo "    expected: " . var_export( $expected, true ) . "\n";
+		echo "    actual:   " . var_export( $actual, true ) . "\n";
+	};
+
+	$run = function ( string $cmd, string $cwd = '' ) {
+		$full = '' === $cwd ? $cmd : sprintf( 'cd %s && %s', escapeshellarg( $cwd ), $cmd );
+		exec( $full . ' 2>&1', $out, $rc );
+		return array(
+			'output' => implode( "\n", $out ),
+			'exit'   => $rc,
+		);
+	};
+
+	echo "Setting up workspace at {$tmp}\n";
+
+	$remote = $tmp . '/remote.git';
+	$run( sprintf( 'git init --bare %s', escapeshellarg( $remote ) ) );
+
+	$primary = $tmp . '/demo';
+	$run( sprintf( 'git clone %s %s', escapeshellarg( $remote ), escapeshellarg( $primary ) ) );
+	$run( 'git config user.email test@example.com', $primary );
+	$run( 'git config user.name test', $primary );
+	file_put_contents( $primary . '/README.md', "demo\n" );
+	$run( 'git add README.md && git commit -m init', $primary );
+	$run( 'git branch -M main', $primary );
+	$run( 'git push -u origin main', $primary );
+
+	$make_branch = function ( string $branch ) use ( $primary, $run ) {
+		$run( sprintf( 'git checkout -b %s', escapeshellarg( $branch ) ), $primary );
+		file_put_contents( $primary . '/' . str_replace( '/', '-', $branch ) . '.txt', $branch );
+		$run( sprintf( 'git add . && git commit -m %s', escapeshellarg( 'work on ' . $branch ) ), $primary );
+		$run( sprintf( 'git push -u origin %s', escapeshellarg( $branch ) ), $primary );
+		$run( 'git checkout main', $primary );
+	};
+
+	$make_branch( 'feat-one' );
+	$make_branch( 'feat-two' );
+	$make_branch( 'feat-three' );
+
+	$run( sprintf( 'git worktree add %s feat-one', escapeshellarg( $tmp . '/demo@feat-one' ) ), $primary );
+	$run( sprintf( 'git worktree add %s feat-two', escapeshellarg( $tmp . '/demo@feat-two' ) ), $primary );
+	$run( sprintf( 'git worktree add %s feat-three', escapeshellarg( $tmp . '/demo@feat-three' ) ), $primary );
+
+	// Dirty one of them so the status probe has something to count.
+	file_put_contents( $tmp . '/demo@feat-two/scratch.txt', 'dirty' );
+
+	// Lifecycle metadata — feat-one has fresh metadata, feat-two doesn't,
+	// feat-three is metadata-less. The cheap listing should still surface
+	// `missing_metadata` for feat-two and feat-three.
+	\DataMachineCode\Workspace\WorktreeContextInjector::store_metadata(
+		'demo@feat-one',
+		array(
+			'site_url'   => 'http://example.test',
+			'site_name'  => 'Example',
+			'agent_slug' => 'agent-one',
+			'abspath'    => '/example',
+			'timestamp'  => gmdate( 'c', time() - 3600 ),
+		)
+	);
+
+	$ws = new \DataMachineCode\Workspace\Workspace();
+
+	// -------------------------------------------------------------------------
+	// Default behavior preserved
+	// -------------------------------------------------------------------------
+	echo "\nDefault listing (full probes — backward compat)\n";
+	$default_res = $ws->worktree_list( 'demo' );
+	$assert( true, ! is_wp_error( $default_res ) && ( $default_res['success'] ?? false ), 'default listing returns success' );
+	$assert( array(), $default_res['fields_skipped'] ?? null, 'default listing reports no skipped fields' );
+	$default_rows = $default_res['worktrees'] ?? array();
+	$default_two  = array_values( array_filter( $default_rows, fn( $r ) => ( $r['handle'] ?? '' ) === 'demo@feat-two' ) )[0] ?? array();
+	$assert( true, ( $default_two['dirty'] ?? null ) >= 1, 'default listing populates dirty count' );
+	$assert( true, array_key_exists( 'size_bytes', $default_two ), 'default listing populates size_bytes key' );
+	$assert( false, isset( $default_two['fields_skipped'] ), 'default rows are not annotated with fields_skipped' );
+
+	// -------------------------------------------------------------------------
+	// Cheap listing: include_status=false, include_disk=false
+	// -------------------------------------------------------------------------
+	echo "\nCheap listing (no per-row git status / du probes)\n";
+	$cheap_res = $ws->worktree_list( 'demo', null, array(
+		'include_status' => false,
+		'include_disk'   => false,
+	) );
+	$assert( true, ! is_wp_error( $cheap_res ) && ( $cheap_res['success'] ?? false ), 'cheap listing returns success' );
+	$assert( array( 'status', 'disk' ), $cheap_res['fields_skipped'] ?? null, 'cheap listing reports both probe groups skipped' );
+	$cheap_rows = $cheap_res['worktrees'] ?? array();
+	$assert( 4, count( $cheap_rows ), 'cheap listing still enumerates every worktree' );
+	$cheap_two  = array_values( array_filter( $cheap_rows, fn( $r ) => ( $r['handle'] ?? '' ) === 'demo@feat-two' ) )[0] ?? array();
+	// dirty=null is the structural signal that the per-row git status probe was skipped.
+	$assert( true, array_key_exists( 'dirty', $cheap_two ) && null === $cheap_two['dirty'], 'cheap listing leaves dirty as null (status probe skipped)' );
+	$assert( true, array_key_exists( 'size_bytes', $cheap_two ) && null === $cheap_two['size_bytes'], 'cheap listing leaves size_bytes as null (du probe skipped)' );
+	$assert( 0, (int) ( $cheap_two['artifact_size_bytes'] ?? -1 ), 'cheap listing reports artifact_size_bytes as 0' );
+	$assert( array( 'status', 'disk' ), $cheap_two['fields_skipped'] ?? null, 'cheap row is annotated with fields_skipped' );
+
+	// Cheap row still surfaces handle/repo/branch/head/lifecycle metadata.
+	$assert( 'demo@feat-two', $cheap_two['handle'] ?? '', 'cheap row carries handle' );
+	$assert( 'demo', $cheap_two['repo'] ?? '', 'cheap row carries repo' );
+	$assert( 'feat-two', $cheap_two['branch'] ?? '', 'cheap row carries branch' );
+	$assert( true, ! empty( $cheap_two['head'] ), 'cheap row carries head' );
+
+	// Lifecycle / metadata-driven stale_reason still works without probes.
+	// feat-two has NO lifecycle metadata → missing_metadata still fires.
+	$assert( 'missing_metadata', $cheap_two['stale_reason'] ?? '', 'cheap listing surfaces missing_metadata when lifecycle metadata is absent' );
+
+	$cheap_one = array_values( array_filter( $cheap_rows, fn( $r ) => ( $r['handle'] ?? '' ) === 'demo@feat-one' ) )[0] ?? array();
+	// feat-one has lifecycle metadata. With status probe skipped, dirty cannot be inferred,
+	// and feat-one is fresh → no stale_reason.
+	$assert( '', (string) ( $cheap_one['stale_reason'] ?? '' ), 'cheap listing does not invent a stale_reason for healthy rows' );
+
+	// -------------------------------------------------------------------------
+	// Status-only listing
+	// -------------------------------------------------------------------------
+	echo "\nStatus-only listing (--with-status equivalent)\n";
+	$status_res = $ws->worktree_list( 'demo', null, array(
+		'include_status' => true,
+		'include_disk'   => false,
+	) );
+	$assert( array( 'disk' ), $status_res['fields_skipped'] ?? null, 'status-only listing reports only disk skipped' );
+	$status_two = array_values( array_filter( $status_res['worktrees'] ?? array(), fn( $r ) => ( $r['handle'] ?? '' ) === 'demo@feat-two' ) )[0] ?? array();
+	$assert( true, ( $status_two['dirty'] ?? null ) >= 1, 'status-only listing populates dirty count' );
+	$assert( true, array_key_exists( 'size_bytes', $status_two ) && null === $status_two['size_bytes'], 'status-only listing leaves size_bytes null' );
+	// status detected dirty → stale_reason is "dirty".
+	$assert( 'dirty', $status_two['stale_reason'] ?? '', 'status-only listing detects dirty stale_reason' );
+
+	// -------------------------------------------------------------------------
+	// Disk-only listing
+	// -------------------------------------------------------------------------
+	echo "\nDisk-only listing (--with-size equivalent)\n";
+	$disk_res = $ws->worktree_list( 'demo', null, array(
+		'include_status' => false,
+		'include_disk'   => true,
+	) );
+	$assert( array( 'status' ), $disk_res['fields_skipped'] ?? null, 'disk-only listing reports only status skipped' );
+	$disk_two = array_values( array_filter( $disk_res['worktrees'] ?? array(), fn( $r ) => ( $r['handle'] ?? '' ) === 'demo@feat-two' ) )[0] ?? array();
+	$assert( true, array_key_exists( 'dirty', $disk_two ) && null === $disk_two['dirty'], 'disk-only listing leaves dirty null' );
+	$assert( true, isset( $disk_two['size_bytes'] ) && (int) $disk_two['size_bytes'] >= 0, 'disk-only listing populates size_bytes' );
+
+	echo "\nResult: " . ( $total - $failures ) . "/{$total} passed\n";
+	exit( $failures > 0 ? 1 : 0 );
+}


### PR DESCRIPTION
## Summary

Closes #213.

`studio wp datamachine-code workspace worktree list --format=json` timed out after 2 minutes on the local `intelligence-chubes4` workspace (~789 worktrees, ~553 with missing metadata). The cost came entirely from per-row probes: every row ran `git status --porcelain` plus multiple `du -sk` calls (worktree size + each artifact path that exists, e.g. `node_modules`, `vendor`, `target`).

This change defaults the listing to a cheap registry/`git worktree list --porcelain`-only path on the CLI and ability surfaces, and gates the expensive probes behind explicit flags. Internal PHP callers that need full data (cleanup, full-status hygiene, etc.) are unchanged.

## What changed

- **`Workspace::worktree_list()`** grows an `array $opts = array()` third parameter:
  - `include_status` (default `true`) — runs `git status --porcelain` per worktree.
  - `include_disk` (default `true`) — runs `du`/artifact probes per worktree.
  - The function-level defaults stay `true`, so existing internal callers (`worktree_cleanup_merged`, hygiene with `include_worktree_status=true`, etc.) are unchanged.
- **`datamachine/workspace-worktree-list` ability**:
  - Adds `include_status` and `include_disk` to the input schema.
  - Defaults both to `false` on the ability surface so MCP/REST/CLI callers don't pay the per-worktree cost.
  - Output rows carry a `fields_skipped` array (e.g. `["status","disk"]`) so consumers can tell "absent" from "not measured". The result envelope also surfaces a top-level `fields_skipped`.
  - Skipped fields return `null` (`dirty`, `size_bytes`, `last_touched_at`, `age_days`-when-no-metadata) or `0` (`artifact_size_bytes`) instead of zero-by-default.
- **CLI `workspace worktree list`**:
  - New flags: `--with-status`, `--with-size`, `--full` (= both). `--stale` implies `--with-status` since dirty detection requires running `git status`.
  - Tabular output renders skipped fields as `-` and prints a hint listing skipped probe groups, pointing at the new flags.
  - Pre-0.27 behavior is one flag away: `wp datamachine-code workspace worktree list --full`.
- **`detect_worktree_stale_reason()`** accepts a `$probes` argument so the `dirty` stale_reason is suppressed when the status probe was skipped (no false positives in cheap mode). The metadata-only `missing_metadata` reason still fires without probes.

## Output shape — JSON example

Cheap default (fast on huge workspaces):

```json
{
  "success": true,
  "fields_skipped": ["status", "disk"],
  "worktrees": [
    {
      "handle": "data-machine-code@feat-foo",
      "repo": "data-machine-code",
      "branch": "feat/foo",
      "head": "abc1234...",
      "dirty": null,
      "size_bytes": null,
      "artifact_size_bytes": 0,
      "stale_reason": "missing_metadata",
      "fields_skipped": ["status", "disk"]
    }
  ]
}
```

Full (`--full` / `include_status=true include_disk=true`): unchanged from pre-fix shape.

## Tests

New: `tests/smoke-worktree-list-scaling.php` — 25 assertions, real git workspace in `tmpdir`, covering:
- Default (no opts) keeps the full-probe shape.
- Cheap listing returns `null` for skipped fields, populates `fields_skipped`, and still surfaces handle/repo/branch/head + the `missing_metadata` stale_reason.
- Status-only (`include_status=true, include_disk=false`) populates `dirty` and detects the `dirty` stale_reason but leaves `size_bytes` null.
- Disk-only inverse.

Existing related smokes still pass:

```
✓ tests/smoke-worktree-handles.php           32/32
✓ tests/smoke-worktree-cleanup.php           129/129
✓ tests/smoke-worktree-bootstrap.php         44/44
✓ tests/smoke-worktree-lifecycle-metadata.php 42/42
✓ tests/smoke-workspace-hygiene-report.php   all
✓ tests/smoke-workspace-hygiene-cli.php      all
✓ tests/smoke-workspace-hygiene-task.php     all
✓ tests/smoke-workspace-retention-cleanup.php all
✓ tests/smoke-workspace-disk-emergency-cleanup.php all
✓ tests/smoke-worktree-cleanup-cli.php       all
✓ tests/smoke-worktree-list-scaling.php      25/25 (new)
```

`Cleanup_Inventory_Workspace`, `Hygiene_Report_Workspace`, and `Missing_Metadata_Workspace` overrides were updated to match the new `worktree_list()` signature.

## Backward compatibility

- PHP callers calling `worktree_list($repo)` or `worktree_list($repo, $state)` still get the full-probe shape — no semantic change.
- The ability *default* changes to cheap. Callers that need the full shape pass `include_status=true, include_disk=true`. The schema documents both flags.
- The CLI default changes to cheap. Operators get a one-line hint pointing at `--with-status`/`--with-size`/`--full`. The `--stale` flag still works (now implies `--with-status`).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the worktree_list refactor, ability schema additions, CLI flag wiring, and the new scaling smoke test. Chris reviewed and ran the smoke suite.