### PR TITLE
fix: bounded batched reconciliation for legacy worktrees

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -219,11 +219,12 @@ add_action( 'plugins_loaded', 'datamachine_code_load_chat_tools', 25 );
  */
 add_filter( 'datamachine_tasks', function ( array $tasks ): array {
 	$tasks['github_create_issue']              = \DataMachineCode\Tasks\GitHubIssueTask::class;
-	$tasks['worktree_cleanup_chunk']           = \DataMachineCode\Tasks\WorktreeCleanupChunkTask::class;
-	$tasks['worktree_cleanup']                 = \DataMachineCode\Tasks\WorktreeCleanupTask::class;
-	$tasks['workspace_disk_emergency_cleanup'] = \DataMachineCode\Tasks\WorkspaceDiskEmergencyCleanupTask::class;
-	$tasks['workspace_retention_cleanup']      = \DataMachineCode\Tasks\WorkspaceRetentionCleanupTask::class;
-	$tasks['workspace_hygiene_report']         = \DataMachineCode\Tasks\WorkspaceHygieneReportTask::class;
+	$tasks['worktree_cleanup_chunk']             = \DataMachineCode\Tasks\WorktreeCleanupChunkTask::class;
+	$tasks['worktree_cleanup']                   = \DataMachineCode\Tasks\WorktreeCleanupTask::class;
+	$tasks['workspace_disk_emergency_cleanup']   = \DataMachineCode\Tasks\WorkspaceDiskEmergencyCleanupTask::class;
+	$tasks['workspace_retention_cleanup']        = \DataMachineCode\Tasks\WorkspaceRetentionCleanupTask::class;
+	$tasks['workspace_hygiene_report']           = \DataMachineCode\Tasks\WorkspaceHygieneReportTask::class;
+	$tasks['worktree_metadata_batch_reconcile']  = \DataMachineCode\Tasks\WorktreeMetadataBatchReconcileTask::class;
 	return $tasks;
 } );
 

--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -1308,6 +1308,60 @@ class WorkspaceAbilities {
 			);
 
 			wp_register_ability(
+				'datamachine/workspace-worktree-reconcile-metadata-batch',
+				array(
+					'label'               => 'Reconcile Legacy Worktree Metadata (Batched)',
+					'description'         => 'Bounded, resumable lifecycle metadata backfill for legacy missing-metadata worktrees. Discovery uses a cheap inventory scan, per-row git probes are scoped to the worktree path, and ambiguous rows stay protected with explicit reason codes. Never marks worktrees cleanup_eligible.',
+					'category'            => 'datamachine-code-workspace',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'dry_run' => array(
+								'type'        => 'boolean',
+								'description' => 'If true, build the batch plan without writing metadata.',
+							),
+							'limit'   => array(
+								'type'        => 'integer',
+								'description' => 'Maximum candidates to process per batch. Default 25, capped at 200.',
+							),
+							'offset'  => array(
+								'type'        => 'integer',
+								'description' => 'Numeric offset into the deterministic candidate list.',
+							),
+							'cursor'  => array(
+								'type'        => 'string',
+								'description' => 'Resume after this handle. Takes precedence over offset.',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'            => array( 'type' => 'boolean' ),
+							'mode'               => array( 'type' => 'string' ),
+							'dry_run'            => array( 'type' => 'boolean' ),
+							'applied'            => array( 'type' => 'boolean' ),
+							'candidate_total'    => array( 'type' => 'integer' ),
+							'processed'          => array( 'type' => 'integer' ),
+							'remaining'          => array( 'type' => 'integer' ),
+							'exhausted'          => array( 'type' => 'boolean' ),
+							'next_cursor'        => array( 'type' => array( 'string', 'null' ) ),
+							'next_offset'        => array( 'type' => array( 'integer', 'null' ) ),
+							'proposals'          => array( 'type' => 'array' ),
+							'written'            => array( 'type' => 'array' ),
+							'skipped'            => array( 'type' => 'array' ),
+							'still_unsafe'       => array( 'type' => 'array' ),
+							'external_worktrees' => array( 'type' => 'array' ),
+							'summary'            => array( 'type' => 'object' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'worktreeReconcileMetadataBatch' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
 				'datamachine/workspace-worktree-cleanup-artifacts',
 				array(
 					'label'               => 'Cleanup Worktree Artifacts',
@@ -1962,6 +2016,30 @@ class WorkspaceAbilities {
 		}
 
 		return $workspace->worktree_reconcile_metadata( $opts );
+	}
+
+	/**
+	 * Bounded, batched metadata reconciliation for legacy worktrees.
+	 *
+	 * @param array $input Input parameters (dry_run, limit, offset, cursor).
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public static function worktreeReconcileMetadataBatch( array $input ): array|\WP_Error {
+		$workspace = new Workspace();
+		$opts      = array(
+			'dry_run' => ! empty( $input['dry_run'] ),
+		);
+		if ( array_key_exists( 'limit', $input ) ) {
+			$opts['limit'] = (int) $input['limit'];
+		}
+		if ( array_key_exists( 'offset', $input ) ) {
+			$opts['offset'] = (int) $input['offset'];
+		}
+		if ( isset( $input['cursor'] ) && '' !== trim( (string) $input['cursor'] ) ) {
+			$opts['cursor'] = trim( (string) $input['cursor'] );
+		}
+
+		return $workspace->worktree_reconcile_metadata_batch( $opts );
 	}
 
 	/**

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1483,7 +1483,8 @@ class WorkspaceCommand extends BaseCommand {
 	 *
 	 * <operation>
 	 * : Worktree operation: add, list, remove, prune, cleanup, cleanup-artifacts,
-	 *   reconcile-metadata, refresh-context, finalize, mark-cleanup-eligible.
+	 *   reconcile-metadata, reconcile-metadata-batch, refresh-context, finalize,
+	 *   mark-cleanup-eligible.
 	 *
 	 * [<repo>]
 	 * : Primary repo name (required for add and remove). For refresh-context, finalize,
@@ -1656,6 +1657,12 @@ class WorkspaceCommand extends BaseCommand {
 	 *     wp datamachine-code workspace worktree reconcile-metadata --dry-run --format=json > reconcile-plan.json
 	 *     wp datamachine-code workspace worktree reconcile-metadata --apply-plan=reconcile-plan.json
 	 *
+	 *     # Resumable batched reconciliation for huge legacy workspaces (~100s of missing-metadata rows).
+	 *     # Discovery uses a cheap inventory scan; per-row git probes are bounded to the worktree path.
+	 *     wp datamachine-code workspace worktree reconcile-metadata-batch --dry-run --limit=25 --format=json
+	 *     wp datamachine-code workspace worktree reconcile-metadata-batch --limit=25
+	 *     wp datamachine-code workspace worktree reconcile-metadata-batch --limit=25 --cursor=data-machine@feat-foo
+	 *
 	 *     # Ignore dirty working-tree safety (caution)
 	 *     wp datamachine-code workspace worktree cleanup --force
 	 *
@@ -1684,23 +1691,24 @@ class WorkspaceCommand extends BaseCommand {
 		$operation = $args[0] ?? '';
 
 		if ( '' === $operation ) {
-			WP_CLI::error( 'Usage: wp datamachine-code workspace worktree <add|list|remove|prune|cleanup|cleanup-artifacts|emergency-cleanup|reconcile-metadata|refresh-context|finalize|mark-cleanup-eligible> [<repo>] [<branch>] [--flags]' );
+			WP_CLI::error( 'Usage: wp datamachine-code workspace worktree <add|list|remove|prune|cleanup|cleanup-artifacts|emergency-cleanup|reconcile-metadata|reconcile-metadata-batch|refresh-context|finalize|mark-cleanup-eligible> [<repo>] [<branch>] [--flags]' );
 			return;
 		}
 
 		$ability_name = match ( $operation ) {
-			'add'                   => 'datamachine/workspace-worktree-add',
-			'list'                  => 'datamachine/workspace-worktree-list',
-			'remove'                => 'datamachine/workspace-worktree-remove',
-			'prune'                 => 'datamachine/workspace-worktree-prune',
-			'cleanup'               => 'datamachine/workspace-worktree-cleanup',
-			'cleanup-artifacts'     => 'datamachine/workspace-worktree-cleanup-artifacts',
-			'emergency-cleanup'     => 'datamachine/workspace-worktree-emergency-cleanup',
-			'reconcile-metadata'    => 'datamachine/workspace-worktree-reconcile-metadata',
-			'refresh-context'       => 'datamachine/workspace-worktree-refresh-context',
-			'finalize'              => 'datamachine/workspace-worktree-finalize',
-			'mark-cleanup-eligible' => 'datamachine/workspace-worktree-finalize',
-			default                 => '',
+			'add'                       => 'datamachine/workspace-worktree-add',
+			'list'                      => 'datamachine/workspace-worktree-list',
+			'remove'                    => 'datamachine/workspace-worktree-remove',
+			'prune'                     => 'datamachine/workspace-worktree-prune',
+			'cleanup'                   => 'datamachine/workspace-worktree-cleanup',
+			'cleanup-artifacts'         => 'datamachine/workspace-worktree-cleanup-artifacts',
+			'emergency-cleanup'         => 'datamachine/workspace-worktree-emergency-cleanup',
+			'reconcile-metadata'        => 'datamachine/workspace-worktree-reconcile-metadata',
+			'reconcile-metadata-batch'  => 'datamachine/workspace-worktree-reconcile-metadata-batch',
+			'refresh-context'           => 'datamachine/workspace-worktree-refresh-context',
+			'finalize'                  => 'datamachine/workspace-worktree-finalize',
+			'mark-cleanup-eligible'     => 'datamachine/workspace-worktree-finalize',
+			default                     => '',
 		};
 
 		if ( '' === $ability_name ) {
@@ -1827,6 +1835,19 @@ class WorkspaceCommand extends BaseCommand {
 				}
 				break;
 
+			case 'reconcile-metadata-batch':
+				$input['dry_run'] = ! empty( $assoc_args['dry-run'] );
+				if ( isset( $assoc_args['limit'] ) && '' !== trim( (string) $assoc_args['limit'] ) ) {
+					$input['limit'] = (int) $assoc_args['limit'];
+				}
+				if ( isset( $assoc_args['offset'] ) && '' !== trim( (string) $assoc_args['offset'] ) ) {
+					$input['offset'] = (int) $assoc_args['offset'];
+				}
+				if ( isset( $assoc_args['cursor'] ) && '' !== trim( (string) $assoc_args['cursor'] ) ) {
+					$input['cursor'] = (string) $assoc_args['cursor'];
+				}
+				break;
+
 			case 'cleanup-artifacts':
 				$input['dry_run'] = ! empty( $assoc_args['dry-run'] );
 				$input['force']   = ! empty( $assoc_args['force'] );
@@ -1923,6 +1944,25 @@ class WorkspaceCommand extends BaseCommand {
 				return;
 			case 'reconcile-metadata':
 				$this->render_worktree_metadata_reconciliation_result( $result, $assoc_args );
+				return;
+
+			case 'reconcile-metadata-batch':
+				$this->render_worktree_metadata_reconciliation_result( $result, $assoc_args );
+				if ( ! empty( $result['next_cursor'] ) || null !== ( $result['next_offset'] ?? null ) ) {
+					WP_CLI::log( '' );
+					WP_CLI::log( sprintf(
+						'Resume next batch with: --cursor=%s   (remaining: %d, candidate_total: %d)',
+						(string) $result['next_cursor'],
+						(int) ( $result['remaining'] ?? 0 ),
+						(int) ( $result['candidate_total'] ?? 0 )
+					) );
+				} elseif ( ! empty( $result['exhausted'] ) ) {
+					WP_CLI::success( sprintf(
+						'Legacy missing-metadata candidates exhausted (%d processed in this run, total candidates seen: %d).',
+						(int) ( $result['processed'] ?? 0 ),
+						(int) ( $result['candidate_total'] ?? 0 )
+					) );
+				}
 				return;
 
 			case 'cleanup-artifacts':

--- a/inc/Tasks/WorktreeMetadataBatchReconcileTask.php
+++ b/inc/Tasks/WorktreeMetadataBatchReconcileTask.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * Worktree Metadata Batch Reconcile System Task.
+ *
+ * Resumable, bounded reconciliation of legacy missing-metadata worktrees.
+ * Persists progress through Data Machine jobs by re-scheduling itself with the
+ * `next_cursor` returned by {@see Workspace::worktree_reconcile_metadata_batch()}
+ * until the candidate list is exhausted (or the per-run chunk count is reached).
+ *
+ * Disabled by default. Operators opt in via the `worktree_metadata_batch_reconcile_enabled`
+ * PluginSettings key, or invoke the underlying ability/CLI directly.
+ *
+ * @package DataMachineCode\Tasks
+ */
+
+namespace DataMachineCode\Tasks;
+
+use DataMachine\Core\PluginSettings;
+use DataMachine\Engine\AI\System\Tasks\SystemTask;
+use DataMachine\Engine\Tasks\TaskScheduler;
+use DataMachineCode\Workspace\Workspace;
+
+defined( 'ABSPATH' ) || exit;
+
+class WorktreeMetadataBatchReconcileTask extends SystemTask {
+
+	/**
+	 * PluginSettings key that gates recurring/manual task execution.
+	 */
+	public const SETTING_KEY = 'worktree_metadata_batch_reconcile_enabled';
+
+	/**
+	 * Default per-batch limit when none is supplied.
+	 */
+	public const DEFAULT_BATCH_LIMIT = 25;
+
+	/**
+	 * Hard cap on chained batches per task invocation.
+	 */
+	public const MAX_CHAINED_BATCHES = 1;
+
+	/**
+	 * Task type identifier.
+	 *
+	 * @return string
+	 */
+	public function getTaskType(): string {
+		return 'worktree_metadata_batch_reconcile';
+	}
+
+	/**
+	 * Task metadata for Data Machine system-task surfaces.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public static function getTaskMeta(): array {
+		return array(
+			'label'           => 'Worktree Metadata Batch Reconcile',
+			'description'     => 'Bounded, resumable lifecycle metadata backfill for legacy missing-metadata worktrees. Each run processes one batch and re-schedules itself with the next cursor until the candidate list is exhausted.',
+			'setting_key'     => self::SETTING_KEY,
+			'default_enabled' => false,
+			'supports_run'    => true,
+		);
+	}
+
+	/**
+	 * Execute one bounded reconciliation batch.
+	 *
+	 * @param int   $jobId  Job ID.
+	 * @param array $params Task params: limit, cursor, offset, dry_run, source.
+	 * @return void
+	 */
+	public function executeTask( int $jobId, array $params ): void {
+		$source  = (string) ( $params['source'] ?? '' );
+		$enabled = (bool) PluginSettings::get( self::SETTING_KEY, false )
+			|| 'workspace_metadata_cli' === $source
+			|| 'workspace_metadata_chain' === $source;
+		if ( ! $enabled ) {
+			$this->completeJob(
+				$jobId,
+				array(
+					'skipped' => true,
+					'reason'  => sprintf( 'Worktree metadata batch reconcile disabled (PluginSettings: %s=false).', self::SETTING_KEY ),
+				)
+			);
+			return;
+		}
+
+		$limit = isset( $params['limit'] ) ? (int) $params['limit'] : self::DEFAULT_BATCH_LIMIT;
+		if ( $limit <= 0 ) {
+			$limit = self::DEFAULT_BATCH_LIMIT;
+		}
+
+		$opts = array(
+			'dry_run' => ! empty( $params['dry_run'] ),
+			'limit'   => $limit,
+		);
+		if ( isset( $params['cursor'] ) && '' !== trim( (string) $params['cursor'] ) ) {
+			$opts['cursor'] = trim( (string) $params['cursor'] );
+		}
+		if ( isset( $params['offset'] ) && '' === trim( (string) ( $params['cursor'] ?? '' ) ) ) {
+			$opts['offset'] = (int) $params['offset'];
+		}
+
+		$workspace = new Workspace();
+		$result    = $workspace->worktree_reconcile_metadata_batch( $opts );
+
+		if ( $result instanceof \WP_Error ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'Worktree metadata batch reconcile failed',
+				array(
+					'task'  => $this->getTaskType(),
+					'jobId' => $jobId,
+					'error' => $result->get_error_message(),
+					'code'  => $result->get_error_code(),
+				)
+			);
+			$this->failJob( $jobId, $result->get_error_message() );
+			return;
+		}
+
+		$next_cursor = $result['next_cursor'] ?? null;
+		$exhausted   = ! empty( $result['exhausted'] );
+		$rescheduled = false;
+
+		if ( ! $exhausted && null !== $next_cursor && '' !== (string) $next_cursor && empty( $params['no_chain'] ) ) {
+			$chain_depth = (int) ( $params['chain_depth'] ?? 0 );
+			if ( $chain_depth < self::MAX_CHAINED_BATCHES && class_exists( '\\DataMachine\\Engine\\Tasks\\TaskScheduler' ) ) {
+				try {
+					$scheduler = new TaskScheduler();
+					$scheduler->schedule(
+						$this->getTaskType(),
+						array(
+							'source'      => 'workspace_metadata_chain',
+							'limit'       => $limit,
+							'cursor'      => (string) $next_cursor,
+							'dry_run'     => ! empty( $params['dry_run'] ),
+							'chain_depth' => $chain_depth + 1,
+						)
+					);
+					$rescheduled = true;
+				} catch ( \Throwable $e ) {
+					do_action(
+						'datamachine_log',
+						'warning',
+						'Failed to chain next worktree metadata reconcile batch',
+						array(
+							'task'  => $this->getTaskType(),
+							'jobId' => $jobId,
+							'error' => $e->getMessage(),
+						)
+					);
+				}
+			}
+		}
+
+		do_action(
+			'datamachine_log',
+			'info',
+			sprintf(
+				'Worktree metadata batch reconcile: processed=%d remaining=%d candidate_total=%d exhausted=%s rescheduled=%s',
+				(int) ( $result['processed'] ?? 0 ),
+				(int) ( $result['remaining'] ?? 0 ),
+				(int) ( $result['candidate_total'] ?? 0 ),
+				$exhausted ? 'yes' : 'no',
+				$rescheduled ? 'yes' : 'no'
+			),
+			array(
+				'task'    => $this->getTaskType(),
+				'jobId'   => $jobId,
+				'summary' => $result['summary'] ?? array(),
+			)
+		);
+
+		$this->completeJob(
+			$jobId,
+			array(
+				'success'         => true,
+				'mode'            => $result['mode'] ?? 'batch',
+				'dry_run'         => (bool) ( $result['dry_run'] ?? false ),
+				'applied'         => (bool) ( $result['applied'] ?? false ),
+				'candidate_total' => (int) ( $result['candidate_total'] ?? 0 ),
+				'processed'       => (int) ( $result['processed'] ?? 0 ),
+				'remaining'       => (int) ( $result['remaining'] ?? 0 ),
+				'exhausted'       => $exhausted,
+				'next_cursor'     => $next_cursor,
+				'rescheduled'     => $rescheduled,
+				'summary'         => $result['summary'] ?? array(),
+				'last_handle'     => $result['last_handle'] ?? null,
+			)
+		);
+	}
+}

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -3579,6 +3579,400 @@ class Workspace {
 	}
 
 	/**
+	 * Bounded, batched metadata reconciliation for legacy worktrees.
+	 *
+	 * The full {@see self::worktree_reconcile_metadata()} entrypoint relies on
+	 * {@see self::worktree_list()}, which runs `git worktree list --porcelain`
+	 * on every primary plus a per-worktree `git status --porcelain`. On
+	 * workspaces with hundreds of legacy worktrees that is unreliable inside a
+	 * single CLI request.
+	 *
+	 * This entrypoint is the bounded counterpart:
+	 *
+	 *  - Discovery uses the cheap {@see self::build_workspace_inventory_rows()}
+	 *    directory scan (no git probes).
+	 *  - Candidates are filtered to worktrees that look like legacy
+	 *    missing-metadata or never-reconciled rows (no `metadata_repaired`
+	 *    marker yet). Already-reconciled rows are short-circuited.
+	 *  - The candidate list is sorted alphabetically by handle so chunked
+	 *    runs are deterministic across calls.
+	 *  - Only `limit` candidates from `offset` (or after `cursor` handle) are
+	 *    processed per call. Each row runs targeted `git rev-parse` and
+	 *    `git status --porcelain` probes against its own worktree path —
+	 *    never the whole workspace.
+	 *  - Safe rows are written inline. Ambiguous rows stay protected with
+	 *    explicit reason codes and never become `cleanup_eligible`.
+	 *  - The response includes `next_cursor` plus `remaining` so an outer
+	 *    loop (operator CLI, system task) can resume across runs.
+	 *
+	 * Cleanup eligibility is intentionally never inferred from a batch run.
+	 * The point of this surface is to repair lifecycle metadata so legacy
+	 * rows stop being reported as `requires_full_scan`, not to grow the
+	 * cleanup blast radius.
+	 *
+	 * @param array $opts {
+	 *     @type bool   $dry_run Build the batch plan without writing metadata.
+	 *     @type int    $limit   Maximum candidates to process. Default 25, capped at 200.
+	 *     @type int    $offset  Numeric offset into the deterministic candidate list. Default 0.
+	 *     @type string $cursor  Optional handle to start after; takes precedence over offset.
+	 * }
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function worktree_reconcile_metadata_batch( array $opts = array() ): array|\WP_Error {
+		$dry_run = ! empty( $opts['dry_run'] );
+		$limit   = isset( $opts['limit'] ) ? (int) $opts['limit'] : 25;
+		if ( $limit <= 0 ) {
+			$limit = 25;
+		}
+		if ( $limit > 200 ) {
+			$limit = 200;
+		}
+		$offset = isset( $opts['offset'] ) ? max( 0, (int) $opts['offset'] ) : 0;
+		$cursor = isset( $opts['cursor'] ) ? trim( (string) $opts['cursor'] ) : '';
+
+		$inventory      = $this->build_workspace_inventory_rows();
+		$candidates     = array();
+		$seen_handles   = array();
+		foreach ( $inventory as $row ) {
+			if ( empty( $row['is_worktree'] ) ) {
+				continue;
+			}
+			if ( ! empty( $row['external'] ) ) {
+				continue;
+			}
+			$metadata = is_array( $row['metadata'] ?? null ) ? (array) $row['metadata'] : null;
+			if ( null !== $metadata && ! empty( $metadata['metadata_repaired'] ) ) {
+				continue;
+			}
+			$handle           = (string) ( $row['handle'] ?? '' );
+			if ( '' === $handle ) {
+				continue;
+			}
+			$seen_handles[ $handle ] = true;
+			$candidates[] = array(
+				'handle'   => $handle,
+				'repo'     => (string) ( $row['repo'] ?? '' ),
+				'path'     => (string) ( $row['path'] ?? '' ),
+				'metadata' => $metadata,
+			);
+		}
+
+		// Include stored-metadata-only rows whose on-disk path is gone so we
+		// can surface them with explicit reason codes (path_missing, etc.)
+		// instead of leaving them invisible to operators.
+		$all_metadata = function_exists( 'get_option' ) ? get_option( WorktreeContextInjector::METADATA_OPTION, array() ) : array();
+		if ( is_array( $all_metadata ) ) {
+			foreach ( $all_metadata as $stored_handle => $stored_metadata ) {
+				$stored_handle = (string) $stored_handle;
+				if ( '' === $stored_handle || isset( $seen_handles[ $stored_handle ] ) ) {
+					continue;
+				}
+				if ( is_array( $stored_metadata ) && ! empty( $stored_metadata['metadata_repaired'] ) ) {
+					continue;
+				}
+				$parsed = $this->parse_handle( $stored_handle );
+				if ( empty( $parsed['is_worktree'] ) ) {
+					continue;
+				}
+				$candidates[] = array(
+					'handle'   => $stored_handle,
+					'repo'     => (string) ( $parsed['repo'] ?? '' ),
+					'path'     => $this->workspace_path . '/' . $stored_handle,
+					'metadata' => is_array( $stored_metadata ) ? (array) $stored_metadata : null,
+				);
+				$seen_handles[ $stored_handle ] = true;
+			}
+		}
+
+		usort(
+			$candidates,
+			fn( $a, $b ) => strcmp( (string) ( $a['handle'] ?? '' ), (string) ( $b['handle'] ?? '' ) )
+		);
+
+		$total = count( $candidates );
+
+		if ( '' !== $cursor ) {
+			// The candidate list shrinks as rows are reconciled, so the cursor
+			// handle itself may already be gone. Treat the cursor as "start at
+			// the first handle strictly greater than cursor" so resume is
+			// stable across batches even after writes.
+			$offset = 0;
+			foreach ( $candidates as $index => $row ) {
+				if ( strcmp( (string) $row['handle'], $cursor ) > 0 ) {
+					$offset = (int) $index;
+					break;
+				}
+				$offset = (int) $index + 1;
+			}
+		}
+
+		$slice = array_slice( $candidates, $offset, $limit );
+
+		$proposals = array();
+		$written   = array();
+		$skipped   = array();
+		$last_handle = '';
+
+		foreach ( $slice as $candidate ) {
+			$handle      = (string) ( $candidate['handle'] ?? '' );
+			$last_handle = $handle;
+			$repo        = (string) ( $candidate['repo'] ?? '' );
+			$path        = (string) ( $candidate['path'] ?? '' );
+
+			$base_row = array(
+				'handle'   => $handle,
+				'repo'     => $repo,
+				'branch'   => '',
+				'path'     => $path,
+				'metadata' => $candidate['metadata'],
+			);
+
+			if ( '' === $handle || '' === $repo || '' === $path ) {
+				$skipped[] = array_merge(
+					$base_row,
+					array(
+						'reason_code' => 'missing_identity',
+						'reason'      => 'inventory row is missing handle, repo, or path',
+					)
+				);
+				continue;
+			}
+
+			$parsed = $this->parse_handle( $handle );
+			if ( empty( $parsed['is_worktree'] ) || $parsed['repo'] !== $repo ) {
+				$skipped[] = array_merge(
+					$base_row,
+					array(
+						'reason_code' => 'noncanonical_handle',
+						'reason'      => 'worktree is not represented by a canonical <repo>@<slug> workspace handle',
+					)
+				);
+				continue;
+			}
+
+			if ( ! is_dir( $path ) ) {
+				$skipped[] = array_merge(
+					$base_row,
+					array(
+						'reason_code' => 'path_missing',
+						'reason'      => 'worktree path is no longer present on disk',
+					)
+				);
+				continue;
+			}
+
+			$branch = $this->probe_worktree_current_branch( $path );
+			if ( '' === $branch ) {
+				$skipped[] = array_merge(
+					$base_row,
+					array(
+						'reason_code' => 'unresolved_branch',
+						'reason'      => 'could not resolve current branch via git rev-parse',
+					)
+				);
+				continue;
+			}
+			$base_row['branch'] = $branch;
+
+			$dirty = $this->probe_worktree_dirty_count( $path );
+			if ( $dirty instanceof \WP_Error ) {
+				$skipped[] = array_merge(
+					$base_row,
+					array(
+						'reason_code' => 'git_probe_failed',
+						'reason'      => sprintf( 'git status probe failed: %s', $dirty->get_error_message() ),
+					)
+				);
+				continue;
+			}
+
+			$wt = array(
+				'handle'   => $handle,
+				'repo'     => $repo,
+				'branch'   => $branch,
+				'path'     => $path,
+				'dirty'    => $dirty,
+				'external' => false,
+				'metadata' => $candidate['metadata'],
+			);
+
+			$built = $this->build_worktree_metadata_reconciliation_row( $wt );
+			if ( isset( $built['skip'] ) ) {
+				$skipped[] = $built['skip'];
+				continue;
+			}
+			if ( ! isset( $built['proposal'] ) ) {
+				// Already current — nothing to backfill, but mark as repaired so it stops being recounted.
+				$existing = is_array( $candidate['metadata'] ?? null ) ? (array) $candidate['metadata'] : array();
+				$existing['metadata_repaired'] = true;
+				$existing['observed_at']       = gmdate( 'c' );
+				if ( ! $dry_run ) {
+					WorktreeContextInjector::store_lifecycle_metadata( $handle, $existing );
+				}
+				$written[] = array(
+					'handle'   => $handle,
+					'repo'     => $repo,
+					'branch'   => $branch,
+					'path'     => $path,
+					'metadata' => WorktreeContextInjector::get_metadata( $handle ) ?? $existing,
+				);
+				continue;
+			}
+
+			$proposal    = $built['proposal'];
+			$proposals[] = $proposal;
+
+			if ( $dry_run ) {
+				continue;
+			}
+
+			$state = WorktreeContextInjector::normalize_state( (string) ( $proposal['proposed_metadata']['lifecycle_state'] ?? '' ) );
+			if ( null === $state ) {
+				$skipped[] = array(
+					'handle'      => $handle,
+					'repo'        => $repo,
+					'branch'      => $branch,
+					'path'        => $path,
+					'reason_code' => 'invalid_lifecycle_state',
+					'reason'      => 'proposed lifecycle_state is invalid',
+				);
+				continue;
+			}
+
+			if ( WorktreeContextInjector::STATE_CLEANUP_ELIGIBLE === $state ) {
+				$unpushed = $this->count_unpushed_commits( $path );
+				if ( $unpushed instanceof \WP_Error || $dirty > 0 || (int) $unpushed > 0 ) {
+					$skipped[] = array(
+						'handle'      => $handle,
+						'repo'        => $repo,
+						'branch'      => $branch,
+						'path'        => $path,
+						'reason_code' => 'unsafe_cleanup_eligible_state',
+						'reason'      => 'refusing to mark dirty or unpushed worktree cleanup_eligible from a reconciliation batch',
+					);
+					continue;
+				}
+			}
+
+			$source_map = (array) ( $proposal['source_map'] ?? array() );
+			$missing_source = false;
+			foreach ( array( 'handle', 'repo', 'branch', 'path', 'created_at', 'observed_at', 'lifecycle_state' ) as $field ) {
+				if ( ! isset( $source_map[ $field ] ) || '' === (string) $source_map[ $field ] ) {
+					$missing_source = $field;
+					break;
+				}
+			}
+			if ( false !== $missing_source ) {
+				$skipped[] = array(
+					'handle'      => $handle,
+					'repo'        => $repo,
+					'branch'      => $branch,
+					'path'        => $path,
+					'reason_code' => 'missing_source_map',
+					'reason'      => sprintf( 'proposed field %s is missing a source', $missing_source ),
+				);
+				continue;
+			}
+
+			$metadata                       = (array) ( $proposal['proposed_metadata'] ?? array() );
+			$metadata['lifecycle_state']    = $state;
+			$metadata['reconciled_at']      = gmdate( 'c' );
+			$metadata['reconciled_sources'] = $source_map;
+			WorktreeContextInjector::store_lifecycle_metadata( $handle, $metadata );
+
+			$written[] = array(
+				'handle'   => $handle,
+				'repo'     => $repo,
+				'branch'   => $branch,
+				'path'     => $path,
+				'metadata' => WorktreeContextInjector::get_metadata( $handle ),
+			);
+		}
+
+		$processed   = count( $slice );
+		$next_offset = $offset + $processed;
+		$remaining   = max( 0, $total - $next_offset );
+		$next_cursor = $remaining > 0 && '' !== $last_handle ? $last_handle : null;
+
+		$summary                       = $this->build_worktree_metadata_reconciliation_summary( $processed, $proposals, $written, $skipped );
+		$summary['candidate_total']    = $total;
+		$summary['batch_offset']       = $offset;
+		$summary['batch_limit']        = $limit;
+		$summary['processed']          = $processed;
+		$summary['remaining']          = $remaining;
+		$summary['exhausted']          = 0 === $remaining;
+
+		$classified_skips = $this->classify_worktree_metadata_reconciliation_skips( $skipped );
+
+		return array(
+			'success'            => true,
+			'mode'               => 'batch',
+			'dry_run'            => $dry_run,
+			'applied'            => ! $dry_run && array() !== $written,
+			'generated_at'       => gmdate( 'c' ),
+			'workspace_path'     => $this->workspace_path,
+			'candidate_total'    => $total,
+			'processed'          => $processed,
+			'remaining'          => $remaining,
+			'exhausted'          => 0 === $remaining,
+			'batch_offset'       => $offset,
+			'batch_limit'        => $limit,
+			'next_cursor'        => $next_cursor,
+			'next_offset'        => $next_offset < $total ? $next_offset : null,
+			'last_handle'        => '' === $last_handle ? null : $last_handle,
+			'proposals'          => $proposals,
+			'written'            => $written,
+			'repaired'           => $written,
+			'skipped'            => $skipped,
+			'still_unsafe'       => $classified_skips['still_unsafe'],
+			'external_worktrees' => $classified_skips['external_worktrees'],
+			'summary'            => $summary,
+		);
+	}
+
+	/**
+	 * Probe the current branch for a single worktree path.
+	 *
+	 * Bounded git probe used by batched metadata reconciliation. Avoids the
+	 * full `git worktree list --porcelain` walk done by {@see self::worktree_list()}.
+	 *
+	 * @param string $path Worktree path.
+	 * @return string Branch name, or '' when the probe failed.
+	 */
+	private function probe_worktree_current_branch( string $path ): string {
+		if ( '' === $path || ! is_dir( $path ) ) {
+			return '';
+		}
+		$result = $this->run_git( $path, 'rev-parse --abbrev-ref HEAD' );
+		if ( is_wp_error( $result ) ) {
+			return '';
+		}
+		$branch = trim( (string) ( $result['output'] ?? '' ) );
+		if ( '' === $branch || 'HEAD' === $branch ) {
+			return '';
+		}
+		return $branch;
+	}
+
+	/**
+	 * Probe the dirty file count for a single worktree path.
+	 *
+	 * @param string $path Worktree path.
+	 * @return int|\WP_Error Dirty file count, or WP_Error when git probe failed.
+	 */
+	private function probe_worktree_dirty_count( string $path ): int|\WP_Error {
+		if ( '' === $path || ! is_dir( $path ) ) {
+			return new \WP_Error( 'worktree_path_missing', 'worktree path is not a directory', array( 'status' => 400 ) );
+		}
+		$result = $this->run_git( $path, 'status --porcelain' );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+		$lines = array_filter( array_map( 'trim', explode( "\n", (string) ( $result['output'] ?? '' ) ) ) );
+		return count( $lines );
+	}
+
+	/**
 	 * Build stable reconciliation summary counts.
 	 *
 	 * @param int   $inspected Worktree rows inspected.

--- a/tests/smoke-worktree-metadata-batch-reconcile.php
+++ b/tests/smoke-worktree-metadata-batch-reconcile.php
@@ -1,0 +1,308 @@
+<?php
+/**
+ * Smoke test for bounded/batched legacy worktree metadata reconciliation.
+ *
+ * Targets the new {@see Workspace::worktree_reconcile_metadata_batch()} path
+ * added for issue #215. Asserts:
+ *   - Inventory-only discovery (no full git worktree --porcelain walk).
+ *   - Bounded `limit` slices the candidate list deterministically.
+ *   - `next_cursor` resumes from the last processed handle.
+ *   - Already-reconciled rows are short-circuited (`metadata_repaired=true`).
+ *   - Dirty / unpushed rows stay protected from cleanup_eligible drift.
+ *   - Ambiguous rows surface explicit reason codes (path_missing, etc.).
+ *
+ * Run: php tests/smoke-worktree-metadata-batch-reconcile.php
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Core\FilesRepository {
+	if ( ! class_exists( __NAMESPACE__ . '\FilesystemHelper' ) ) {
+		class FilesystemHelper {
+			public static function get() {
+				return null;
+			}
+		}
+	}
+}
+
+namespace DataMachineCode\Abilities {
+	if ( ! class_exists( __NAMESPACE__ . '\GitHubAbilities' ) ) {
+		class GitHubAbilities {
+			public static function getPat(): string {
+				return '';
+			}
+			public static function apiGet( string $url, array $params, string $pat ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+				return array( 'data' => array() );
+			}
+		}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			public string $code;
+			public string $message;
+			public array $data;
+			public function __construct( $code = '', $message = '', $data = array() ) {
+				$this->code    = (string) $code;
+				$this->message = (string) $message;
+				$this->data    = (array) $data;
+			}
+			public function get_error_message(): string {
+				return $this->message;
+			}
+			public function get_error_code(): string {
+				return $this->code;
+			}
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $thing ): bool {
+			return $thing instanceof \WP_Error;
+		}
+	}
+
+	if ( ! function_exists( 'wp_mkdir_p' ) ) {
+		function wp_mkdir_p( string $path ): bool {
+			return is_dir( $path ) || mkdir( $path, 0755, true );
+		}
+	}
+
+	if ( ! function_exists( 'get_option' ) ) {
+		function get_option( string $name, $default_value = false ) {
+			global $datamachine_code_test_options;
+			return $datamachine_code_test_options[ $name ] ?? $default_value;
+		}
+	}
+
+	if ( ! function_exists( 'update_option' ) ) {
+		function update_option( string $name, $value, $autoload = null ): bool { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+			global $datamachine_code_test_options;
+			$datamachine_code_test_options[ $name ] = $value;
+			return true;
+		}
+	}
+
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( string $hook_name, $value ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+			return $value;
+		}
+	}
+
+	if ( ! function_exists( 'home_url' ) ) {
+		function home_url(): string {
+			return 'http://origin.test';
+		}
+	}
+
+	if ( ! function_exists( 'get_bloginfo' ) ) {
+		function get_bloginfo( string $show = '' ): string { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+			return 'Origin Test';
+		}
+	}
+
+	if ( ! function_exists( 'size_format' ) ) {
+		function size_format( $bytes ): string {
+			return (string) $bytes;
+		}
+	}
+
+	require __DIR__ . '/../inc/Support/GitHubRemote.php';
+	require __DIR__ . '/../inc/Support/GitRunner.php';
+	require __DIR__ . '/../inc/Support/PathSecurity.php';
+	require __DIR__ . '/../inc/Workspace/WorkspaceMutationLock.php';
+	require __DIR__ . '/../inc/Workspace/WorktreeDiskBudget.php';
+	require __DIR__ . '/../inc/Workspace/WorktreeContextInjector.php';
+	require __DIR__ . '/../inc/Workspace/Workspace.php';
+
+	exec( 'git --version 2>&1', $_gv, $gv_exit );
+	if ( 0 !== $gv_exit ) {
+		echo "SKIP: git not available\n";
+		exit( 0 );
+	}
+
+	$tmp = sys_get_temp_dir() . '/dmc-batch-reconcile-smoke-' . bin2hex( random_bytes( 4 ) );
+	mkdir( $tmp, 0755, true );
+	register_shutdown_function( function () use ( $tmp ) {
+		if ( is_dir( $tmp ) ) {
+			exec( 'rm -rf ' . escapeshellarg( $tmp ) );
+		}
+	} );
+
+	define( 'DATAMACHINE_WORKSPACE_PATH', realpath( $tmp ) ? realpath( $tmp ) : $tmp );
+
+	$failures = 0;
+	$total    = 0;
+	$datamachine_code_test_options = array();
+
+	$assert = function ( $expected, $actual, string $message ) use ( &$failures, &$total ): void {
+		$total++;
+		if ( $expected === $actual ) {
+			echo "  ✓ {$message}\n";
+			return;
+		}
+		$failures++;
+		echo "  ✗ {$message}\n";
+		echo '    expected: ' . var_export( $expected, true ) . "\n";
+		echo '    actual:   ' . var_export( $actual, true ) . "\n";
+	};
+
+	$run = function ( string $cmd, string $cwd = '' ): array {
+		$full = '' === $cwd ? $cmd : sprintf( 'cd %s && %s', escapeshellarg( $cwd ), $cmd );
+		exec( $full . ' 2>&1', $out, $rc );
+		return array(
+			'output' => implode( "\n", $out ),
+			'exit'   => $rc,
+		);
+	};
+
+	echo "Setting up workspace at {$tmp}\n";
+	$remote  = $tmp . '/remote.git';
+	$primary = $tmp . '/demo';
+	$run( sprintf( 'git init --bare %s', escapeshellarg( $remote ) ) );
+	$run( sprintf( 'git clone %s %s', escapeshellarg( $remote ), escapeshellarg( $primary ) ) );
+	$run( 'git config user.email test@example.com', $primary );
+	$run( 'git config user.name test', $primary );
+	file_put_contents( $primary . '/README.md', "demo\n" );
+	$run( 'git add README.md && git commit -m init', $primary );
+	$run( 'git branch -M main', $primary );
+	$run( 'git push -u origin main', $primary );
+
+	$make_branch = function ( string $branch ) use ( $primary, $run ): void {
+		$run( sprintf( 'git checkout -b %s', escapeshellarg( $branch ) ), $primary );
+		file_put_contents( $primary . '/' . str_replace( '/', '-', $branch ) . '.txt', $branch );
+		$run( sprintf( 'git add . && git commit -m %s', escapeshellarg( 'work on ' . $branch ) ), $primary );
+		$run( sprintf( 'git push -u origin %s', escapeshellarg( $branch ) ), $primary );
+		$run( 'git checkout main', $primary );
+	};
+	$branches = array( 'alpha', 'beta', 'gamma', 'delta', 'epsilon', 'zeta' );
+	foreach ( $branches as $b ) {
+		$make_branch( $b );
+		$run( sprintf( 'git worktree add %s %s', escapeshellarg( $tmp . '/demo@' . $b ), escapeshellarg( $b ) ), $primary );
+	}
+
+	// Pre-seed metadata so we have a mix of legacy missing-metadata + already-reconciled rows.
+	\DataMachineCode\Workspace\WorktreeContextInjector::store_lifecycle_metadata(
+		'demo@delta',
+		array(
+			'handle'            => 'demo@delta',
+			'repo'              => 'demo',
+			'branch'            => 'delta',
+			'path'              => $tmp . '/demo@delta',
+			'created_at'        => '2026-04-01T00:00:00+00:00',
+			'observed_at'       => '2026-04-01T00:00:00+00:00',
+			'lifecycle_state'   => \DataMachineCode\Workspace\WorktreeContextInjector::STATE_ACTIVE,
+			'metadata_repaired' => true,
+		)
+	);
+
+	// Make one worktree dirty so cleanup_eligible safety can be exercised separately.
+	file_put_contents( $tmp . '/demo@beta/scratch.txt', 'dirty' );
+
+	$ws = new \DataMachineCode\Workspace\Workspace();
+
+	echo "\nDry-run, bounded discovery\n";
+	$plan_dry = $ws->worktree_reconcile_metadata_batch( array( 'dry_run' => true, 'limit' => 2, 'offset' => 0 ) );
+	$assert( true, ! is_wp_error( $plan_dry ) && ( $plan_dry['success'] ?? false ), 'batch dry-run succeeds' );
+	$assert( 'batch', $plan_dry['mode'] ?? '', 'batch mode reported' );
+	$assert( true, (bool) ( $plan_dry['dry_run'] ?? false ), 'dry_run flag is true' );
+	$assert( false, (bool) ( $plan_dry['applied'] ?? false ), 'dry-run does not apply' );
+	$assert( 5, (int) ( $plan_dry['candidate_total'] ?? 0 ), 'discovery skips already-reconciled delta and finds 5 legacy rows' );
+	$assert( 2, (int) ( $plan_dry['processed'] ?? 0 ), 'limit=2 processes exactly two rows' );
+	$assert( 3, (int) ( $plan_dry['remaining'] ?? 0 ), 'remaining accounts for unprocessed candidates' );
+	$assert( false, (bool) ( $plan_dry['exhausted'] ?? false ), 'not exhausted while remaining > 0' );
+	$assert( 'demo@beta', $plan_dry['next_cursor'] ?? null, 'next_cursor is the last processed handle (alphabetical sort: alpha, beta)' );
+
+	$dry_proposals_by_handle = array();
+	foreach ( (array) ( $plan_dry['proposals'] ?? array() ) as $row ) {
+		$dry_proposals_by_handle[ (string) ( $row['handle'] ?? '' ) ] = $row;
+	}
+	$assert( true, isset( $dry_proposals_by_handle['demo@alpha'] ), 'first slice contains demo@alpha' );
+	$assert( true, isset( $dry_proposals_by_handle['demo@beta'] ), 'first slice contains demo@beta' );
+	$assert( 'alpha', $dry_proposals_by_handle['demo@alpha']['branch'] ?? '', 'branch is resolved via per-row git probe' );
+	$assert( 1, (int) ( $dry_proposals_by_handle['demo@beta']['dirty'] ?? 0 ), 'dirty count comes from per-row git status probe' );
+
+	$stored_alpha_dry = \DataMachineCode\Workspace\WorktreeContextInjector::get_metadata( 'demo@alpha' );
+	$assert( null, $stored_alpha_dry, 'dry-run does not write metadata' );
+
+	echo "\nApply, first batch\n";
+	$apply_first = $ws->worktree_reconcile_metadata_batch( array( 'limit' => 2, 'offset' => 0 ) );
+	$assert( true, ! is_wp_error( $apply_first ) && ( $apply_first['success'] ?? false ), 'apply batch succeeds' );
+	$assert( false, (bool) ( $apply_first['dry_run'] ?? false ), 'dry_run is false on apply' );
+	$assert( true, (bool) ( $apply_first['applied'] ?? false ), 'applied flag is true' );
+	$assert( 2, count( (array) ( $apply_first['written'] ?? array() ) ), 'apply writes 2 rows' );
+	$stored_alpha = \DataMachineCode\Workspace\WorktreeContextInjector::get_metadata( 'demo@alpha' );
+	$assert( true, ! empty( $stored_alpha['metadata_repaired'] ), 'apply marks alpha metadata_repaired' );
+	$assert( true, ! empty( $stored_alpha['observed_at'] ), 'apply records observed_at' );
+	$assert( 'operator_plan', $stored_alpha['reconciled_sources']['lifecycle_state'] ?? '', 'apply persists source map for lifecycle_state' );
+
+	echo "\nResume via next_cursor\n";
+	$apply_second = $ws->worktree_reconcile_metadata_batch( array(
+		'limit'  => 10,
+		'cursor' => (string) ( $apply_first['next_cursor'] ?? '' ),
+	) );
+	$assert( true, ! is_wp_error( $apply_second ) && ( $apply_second['success'] ?? false ), 'second batch succeeds' );
+	$assert( 3, count( (array) ( $apply_second['written'] ?? array() ) ), 'remaining 3 rows are processed in second batch' );
+	$assert( true, (bool) ( $apply_second['exhausted'] ?? false ), 'candidate list is exhausted after second batch' );
+	$assert( 0, (int) ( $apply_second['remaining'] ?? -1 ), 'remaining is zero when exhausted' );
+	$assert( true, array_key_exists( 'next_cursor', $apply_second ) && null === $apply_second['next_cursor'], 'next_cursor is null when exhausted' );
+
+	echo "\nIdempotency: re-running after apply finds no candidates\n";
+	$idempotent = $ws->worktree_reconcile_metadata_batch( array( 'limit' => 25, 'dry_run' => true ) );
+	$assert( 0, (int) ( $idempotent['candidate_total'] ?? -1 ), 'reconciled rows are excluded from candidate discovery' );
+	$assert( 0, (int) ( $idempotent['processed'] ?? -1 ), 'no rows processed when nothing to do' );
+	$assert( true, (bool) ( $idempotent['exhausted'] ?? false ), 'reports exhausted when there is nothing to reconcile' );
+
+	echo "\nInventory cleanup downgrades requires_full_scan after batch reconciliation\n";
+	$inventory = $ws->worktree_cleanup_merged( array( 'dry_run' => true, 'inventory_only' => true, 'skip_github' => true ) );
+	$assert( 0, (int) ( $inventory['summary']['skipped_by_reason']['requires_full_scan'] ?? 0 ), 'no rows still flagged requires_full_scan' );
+	$repaired_count = (int) ( $inventory['summary']['skipped_by_reason']['missing_metadata_repaired'] ?? 0 );
+	$assert( true, $repaired_count >= 5, 'inventory cleanup recognizes batch-repaired rows' );
+
+	echo "\nProtection: ambiguous path stays explicit\n";
+	// Drop the worktree directory to simulate an inventory row whose path is gone.
+	exec( 'rm -rf ' . escapeshellarg( $tmp . '/demo@alpha' ) );
+	// Force alpha back into the candidate set by clearing its metadata_repaired flag.
+	\DataMachineCode\Workspace\WorktreeContextInjector::store_lifecycle_metadata(
+		'demo@alpha',
+		array( 'metadata_repaired' => false )
+	);
+	$missing_path = $ws->worktree_reconcile_metadata_batch( array( 'limit' => 5, 'dry_run' => true ) );
+	$missing_codes = array();
+	foreach ( (array) ( $missing_path['skipped'] ?? array() ) as $row ) {
+		$missing_codes[ (string) ( $row['handle'] ?? '' ) ] = (string) ( $row['reason_code'] ?? '' );
+	}
+	$assert( 'path_missing', $missing_codes['demo@alpha'] ?? '', 'missing worktree path produces explicit path_missing reason code' );
+
+	echo "\nProtection: cleanup_eligible never inferred from batch run\n";
+	// Force beta's stored proposal to push lifecycle_state=cleanup_eligible. The dirty
+	// guard inside the batch path must reject the write on apply, but discovery itself
+	// never produces cleanup_eligible from inferred state.
+	\DataMachineCode\Workspace\WorktreeContextInjector::store_lifecycle_metadata(
+		'demo@beta',
+		array( 'metadata_repaired' => false, 'lifecycle_state' => '' )
+	);
+	$beta_plan = $ws->worktree_reconcile_metadata_batch( array( 'limit' => 1, 'dry_run' => true, 'cursor' => 'demo@alpha' ) );
+	$beta_proposed_state = '';
+	foreach ( (array) ( $beta_plan['proposals'] ?? array() ) as $row ) {
+		if ( 'demo@beta' === (string) ( $row['handle'] ?? '' ) ) {
+			$beta_proposed_state = (string) ( $row['proposed_metadata']['lifecycle_state'] ?? '' );
+			break;
+		}
+	}
+	$assert( \DataMachineCode\Workspace\WorktreeContextInjector::STATE_ACTIVE, $beta_proposed_state, 'dirty row stays proposed as active, never cleanup_eligible' );
+
+	if ( $failures > 0 ) {
+		echo "\n{$failures} / {$total} assertions failed.\n";
+		exit( 1 );
+	}
+
+	echo "\nAll {$total} batched worktree metadata reconciliation assertions passed.\n";
+}


### PR DESCRIPTION
## Summary

Closes #215.

Adds a bounded, resumable counterpart to `Workspace::worktree_reconcile_metadata()` so workspaces with hundreds of legacy missing-metadata worktrees can converge across multiple runs without depending on a full `git worktree list --porcelain` walk completing in one CLI request.

The local `intelligence-chubes4` workspace currently reports ~553 missing-metadata worktrees, which makes the existing dry-run path time out before producing a plan. This PR keeps the existing reviewed-plan flow intact for small workspaces and layers a batched mode on top for large legacy backlogs.

## What changed

**`Workspace::worktree_reconcile_metadata_batch( $opts )`**
- Discovery uses the existing cheap `build_workspace_inventory_rows()` directory scan — no `git worktree list` and no per-worktree `git status` across the whole workspace.
- Candidates are filtered to legacy rows: missing metadata or never-reconciled (`metadata_repaired` is not yet set). Already-reconciled rows are short-circuited.
- Stored-metadata-only handles whose on-disk path is gone are surfaced with explicit `path_missing` reason codes instead of staying invisible.
- Candidate list is sorted alphabetically by handle so chunked runs are deterministic across calls.
- Each batch processes at most `limit` rows (default 25, capped at 200) starting at `offset` or after `cursor`. Per-row probes are scoped to the worktree path (`git rev-parse --abbrev-ref HEAD`, `git status --porcelain`).
- Apply path inherits the same source-map and dirty/unpushed safety gates as the full reconciliation flow. Cleanup eligibility is **never** inferred from a batch run.
- Response includes `next_cursor`, `next_offset`, `remaining`, `candidate_total`, and `exhausted` so an outer loop (operator CLI, system task) can resume.

**Ability surface**
- `datamachine/workspace-worktree-reconcile-metadata-batch` wraps the bounded entrypoint for MCP/REST/chat consumers. The pre-existing reviewed-plan ability is unchanged.

**CLI surface**
- `wp datamachine-code workspace worktree reconcile-metadata-batch` with `--dry-run`, `--limit`, `--offset`, `--cursor`, and `--format=json`. Prints a resume hint with the next cursor when remaining candidates are still outstanding, or a clean exhaustion message when the candidate list is drained.

**System task surface**
- `WorktreeMetadataBatchReconcileTask` (`worktree_metadata_batch_reconcile`) executes one bounded batch through Data Machine's job runner and re-schedules itself with `next_cursor` (chain-depth guarded, defaults to one hop per run) so large workspaces converge across multiple jobs without holding a single CLI request open.
- Disabled by default behind `worktree_metadata_batch_reconcile_enabled` PluginSettings; honors the `workspace_metadata_cli` source override for direct CLI invocations.

## Safety / non-goals

- The batch run never marks a worktree `cleanup_eligible`. Stored proposals that try to land that state on a dirty or unpushed worktree are skipped with `unsafe_cleanup_eligible_state`.
- Source maps are required for `handle`, `repo`, `branch`, `path`, `created_at`, `observed_at`, and `lifecycle_state` before a write happens — same contract as the reviewed-plan flow.
- Ambiguous rows produce stable reason codes: `path_missing`, `unresolved_branch`, `git_probe_failed`, `noncanonical_handle`, `missing_identity`, `insufficient_signal`, `external_worktree`, `invalid_lifecycle_state`, `missing_source_map`.
- This PR does not change cleanup classification — it shrinks the population of `requires_full_scan` rows by repairing their lifecycle metadata, so existing inventory cleanup paths can recognize them.

## Tests

New smoke test: `php tests/smoke-worktree-metadata-batch-reconcile.php` — `33/33 passed`.

Coverage:
- Bounded discovery (filters out already-reconciled rows; finds stored-only handles).
- `limit` slices the candidate list deterministically.
- `next_cursor` resumes correctly even after the candidate list shrinks between batches.
- Idempotent re-runs find no candidates after full convergence.
- Inventory cleanup reports zero `requires_full_scan` rows after batch reconciliation.
- `path_missing` is surfaced for stored-only handles whose worktree directory is gone.
- Dirty rows stay proposed as `active`, never `cleanup_eligible`.

Existing tests still green:
- `php tests/smoke-worktree-metadata-reconcile.php` — `32/32 passed`
- `php tests/smoke-worktree-handles.php` — `32/32 passed`
- `php tests/smoke-worktree-cleanup.php` — `129/129 passed`
- `php tests/smoke-worktree-cleanup-chunks.php` — `14/14 passed`
- `php tests/smoke-worktree-lifecycle-metadata.php` — `42/42 passed`
- `php tests/smoke-workspace-retention-cleanup.php` — all passed
- `php tests/smoke-workspace-hygiene-report.php` — all passed

## Acceptance criteria mapping (#215)

- [x] Bounded metadata repair/classification run can process a limited batch of missing-metadata worktrees — `--limit` (default 25, cap 200) plus per-row scoped git probes.
- [x] Progress is persisted/resumable through Data Machine jobs/system tasks — `WorktreeMetadataBatchReconcileTask` re-schedules itself with `next_cursor`; CLI surfaces the same cursor for manual resume.
- [x] Missing-metadata count can decrease over time without full synchronous scans — successful applies set `metadata_repaired=true`, which the existing inventory cleanup classifier already credits.
- [x] Ambiguous worktrees remain protected and explain why they were skipped — explicit reason codes preserved end-to-end through the summary `skipped_by_reason`.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the bounded discovery + per-row probe path, the CLI/ability/system-task wiring, and the smoke test scaffold against the existing reconciliation flow. Chris reviewed the code, ran the smoke tests, and validated the safety-rail reasoning before opening the PR.