### PR TITLE
perf: bound artifact cleanup dry-run on huge workspaces

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -1311,7 +1311,7 @@ class WorkspaceAbilities {
 				'datamachine/workspace-worktree-cleanup-artifacts',
 				array(
 					'label'               => 'Cleanup Worktree Artifacts',
-					'description'         => 'Remove profile-derived, reconstructable artifact directories inside workspace worktrees. Requires a dry-run plan before deletion and revalidates exact paths before applying.',
+					'description'         => 'Remove profile-derived, reconstructable artifact directories inside workspace worktrees. Requires a dry-run plan before deletion and revalidates exact paths before applying. Dry-run defaults to a bounded fast scan for huge workspaces; pass exhaustive=true to enumerate every worktree.',
 					'category'            => 'datamachine-code-workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
@@ -1328,6 +1328,18 @@ class WorkspaceAbilities {
 								'type'        => 'object',
 								'description' => 'Decoded artifact cleanup dry-run report to apply after revalidating every worktree and artifact path.',
 							),
+							'limit'      => array(
+								'type'        => 'integer',
+								'description' => 'Maximum eligible worktrees to scan in the dry-run fast path. Ignored when exhaustive=true.',
+							),
+							'offset'     => array(
+								'type'        => 'integer',
+								'description' => 'Number of eligible worktrees to skip before scanning in the dry-run fast path. Use scan.next_offset to continue review.',
+							),
+							'exhaustive' => array(
+								'type'        => 'boolean',
+								'description' => 'If true, run the full per-worktree git worktree list + git status + du scan. Slow on huge workspaces; only opt in when fast-path coverage is insufficient.',
+							),
 						),
 					),
 					'output_schema'       => array(
@@ -1339,6 +1351,8 @@ class WorkspaceAbilities {
 							'removed'    => array( 'type' => 'array' ),
 							'skipped'    => array( 'type' => 'array' ),
 							'summary'    => array( 'type' => 'object' ),
+							'partial'    => array( 'type' => 'boolean' ),
+							'scan'       => array( 'type' => 'object' ),
 						),
 					),
 					'execute_callback'    => array( self::class, 'worktreeCleanupArtifacts' ),
@@ -1973,11 +1987,18 @@ class WorkspaceAbilities {
 	public static function worktreeCleanupArtifacts( array $input ): array|\WP_Error {
 		$workspace = new Workspace();
 		$opts      = array(
-			'dry_run' => ! empty( $input['dry_run'] ),
-			'force'   => ! empty( $input['force'] ),
+			'dry_run'    => ! empty( $input['dry_run'] ),
+			'force'      => ! empty( $input['force'] ),
+			'exhaustive' => ! empty( $input['exhaustive'] ),
 		);
 		if ( isset( $input['apply_plan'] ) && is_array( $input['apply_plan'] ) ) {
 			$opts['apply_plan'] = $input['apply_plan'];
+		}
+		if ( isset( $input['limit'] ) && is_numeric( $input['limit'] ) ) {
+			$opts['limit'] = (int) $input['limit'];
+		}
+		if ( isset( $input['offset'] ) && is_numeric( $input['offset'] ) ) {
+			$opts['offset'] = (int) $input['offset'];
 		}
 
 		return $workspace->worktree_cleanup_artifacts( $opts );

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -280,6 +280,18 @@ class WorkspaceCommand extends BaseCommand {
 	 * [--older-than=<duration>]
 	 * : Pass an age gate such as 7d or 24h into cleanup task params.
 	 *
+	 * [--limit=<n>]
+	 * : Maximum eligible worktrees to scan for `--mode=artifacts --dry-run`. Ignored
+	 *   without `--dry-run` and ignored when `--exhaustive` is set.
+	 *
+	 * [--offset=<n>]
+	 * : Number of eligible worktrees to skip for `--mode=artifacts --dry-run`. Use
+	 *   the `scan.next_offset` field from a previous run to continue review.
+	 *
+	 * [--exhaustive]
+	 * : Force the slow per-worktree `git worktree list` + `git status` + `du`
+	 *   scan for `--mode=artifacts --dry-run`. Use sparingly on large workspaces.
+	 *
 	 * [--format=<format>]
 	 * : Output format.
 	 * ---
@@ -422,7 +434,18 @@ class WorkspaceCommand extends BaseCommand {
 
 			case 'artifacts':
 				$ability = wp_get_ability( 'datamachine/workspace-worktree-cleanup-artifacts' );
-				$result  = $ability ? $ability->execute( array( 'dry_run' => true, 'force' => ! empty( $assoc_args['force'] ) ) ) : new \WP_Error( 'artifact_cleanup_ability_missing', 'Artifact cleanup ability not registered.' );
+				$input   = array(
+					'dry_run'    => true,
+					'force'      => ! empty( $assoc_args['force'] ),
+					'exhaustive' => ! empty( $assoc_args['exhaustive'] ),
+				);
+				if ( isset( $assoc_args['limit'] ) && '' !== trim( (string) $assoc_args['limit'] ) ) {
+					$input['limit'] = (int) $assoc_args['limit'];
+				}
+				if ( isset( $assoc_args['offset'] ) && '' !== trim( (string) $assoc_args['offset'] ) ) {
+					$input['offset'] = (int) $assoc_args['offset'];
+				}
+				$result = $ability ? $ability->execute( $input ) : new \WP_Error( 'artifact_cleanup_ability_missing', 'Artifact cleanup ability not registered.' );
 				$this->render_worktree_artifact_cleanup_result_from_ability( $result, $assoc_args );
 				return;
 
@@ -1582,6 +1605,18 @@ class WorkspaceCommand extends BaseCommand {
 	 *   - age
 	 * ---
 	 *
+	 * [--limit=<n>]
+	 * : Maximum eligible worktrees to scan for cleanup-artifacts dry-run. Ignored
+	 *   when --exhaustive is set or when applying a plan.
+	 *
+	 * [--offset=<n>]
+	 * : Number of eligible worktrees to skip for cleanup-artifacts dry-run. Use
+	 *   the `scan.next_offset` from a prior partial run to continue review.
+	 *
+	 * [--exhaustive]
+	 * : Force the slow per-worktree git worktree list + git status + du scan
+	 *   for cleanup-artifacts dry-run. Use sparingly on large workspaces.
+	 *
 	 * [--stale]
 	 * : For list, show only worktrees with a stale_reason (old, dirty, or missing metadata).
 	 *
@@ -1828,8 +1863,15 @@ class WorkspaceCommand extends BaseCommand {
 				break;
 
 			case 'cleanup-artifacts':
-				$input['dry_run'] = ! empty( $assoc_args['dry-run'] );
-				$input['force']   = ! empty( $assoc_args['force'] );
+				$input['dry_run']    = ! empty( $assoc_args['dry-run'] );
+				$input['force']      = ! empty( $assoc_args['force'] );
+				$input['exhaustive'] = ! empty( $assoc_args['exhaustive'] );
+				if ( isset( $assoc_args['limit'] ) && '' !== trim( (string) $assoc_args['limit'] ) ) {
+					$input['limit'] = (int) $assoc_args['limit'];
+				}
+				if ( isset( $assoc_args['offset'] ) && '' !== trim( (string) $assoc_args['offset'] ) ) {
+					$input['offset'] = (int) $assoc_args['offset'];
+				}
 				if ( ! empty( $assoc_args['apply-plan'] ) ) {
 					$input['apply_plan'] = $this->read_worktree_cleanup_plan( (string) $assoc_args['apply-plan'] );
 				}
@@ -2615,6 +2657,25 @@ class WorkspaceCommand extends BaseCommand {
 
 		WP_CLI::log( '' );
 		if ( $dry_run ) {
+			$scan    = (array) ( $result['scan'] ?? array() );
+			$partial = ! empty( $result['partial'] );
+			if ( $partial || ( ! empty( $scan ) && 'fast' === ( $scan['mode'] ?? '' ) ) ) {
+				WP_CLI::log( sprintf(
+					'Scan: mode=%s, scanned=%d/%d worktrees, offset=%d, partial=%s.',
+					(string) ( $scan['mode'] ?? 'fast' ),
+					(int) ( $scan['scanned'] ?? 0 ),
+					(int) ( $scan['total_eligible_worktrees'] ?? 0 ),
+					(int) ( $scan['offset'] ?? 0 ),
+					$partial ? 'yes' : 'no'
+				) );
+				if ( $partial ) {
+					WP_CLI::log( sprintf(
+						'Continue review with --offset=%d, or rerun with --exhaustive to enumerate every worktree.',
+						(int) ( $scan['next_offset'] ?? 0 )
+					) );
+				}
+				WP_CLI::log( '' );
+			}
 			WP_CLI::success( sprintf( '%d artifact(s) would be removed. Save JSON and re-run with --apply-plan=<file> to apply.', (int) ( $summary['would_remove_artifacts'] ?? 0 ) ) );
 			return;
 		}

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -52,6 +52,22 @@ class Workspace {
 	private const HYGIENE_DEFAULT_SIZE_LIMIT = 1000;
 
 	/**
+	 * Default upper bound on artifact dry-run scan size before partial-result handoff.
+	 *
+	 * Sized to keep `workspace cleanup run --mode=artifacts --dry-run` returning
+	 * within a practical CLI timeout even on workspaces with hundreds of worktrees.
+	 */
+	private const ARTIFACT_DRY_RUN_DEFAULT_LIMIT = 200;
+
+	/**
+	 * Hard ceiling on the artifact dry-run scan size.
+	 *
+	 * Larger reviews must opt in to the exhaustive code path, which uses the
+	 * full `git worktree list` + per-worktree `git status` + `du` machinery.
+	 */
+	private const ARTIFACT_DRY_RUN_MAX_LIMIT = 1000;
+
+	/**
 	 * @var string Resolved workspace path.
 	 */
 	private string $workspace_path;
@@ -1879,10 +1895,15 @@ class Workspace {
 		}
 
 		if ( $artifact_cleanup ) {
+			// Retention runs orchestrate worktree-level decisions and need a
+			// complete view of artifact candidates. The fast/paginated scan
+			// is for the user-facing dry-run review, not for internal
+			// orchestration, so request the exhaustive code path here.
 			$artifact_plan = $this->worktree_cleanup_artifacts(
 				array(
-					'dry_run' => true,
-					'force'   => $force,
+					'dry_run'    => true,
+					'force'      => $force,
+					'exhaustive' => true,
 				)
 			);
 			if ( $artifact_plan instanceof \WP_Error ) {
@@ -3635,6 +3656,11 @@ class Workspace {
 		$dry_run    = ! empty( $opts['dry_run'] );
 		$force      = ! empty( $opts['force'] );
 		$apply_plan = isset( $opts['apply_plan'] ) && is_array( $opts['apply_plan'] ) ? $opts['apply_plan'] : null;
+		$exhaustive = ! empty( $opts['exhaustive'] );
+		$limit      = isset( $opts['limit'] ) && is_numeric( $opts['limit'] )
+			? max( 1, min( self::ARTIFACT_DRY_RUN_MAX_LIMIT, (int) $opts['limit'] ) )
+			: self::ARTIFACT_DRY_RUN_DEFAULT_LIMIT;
+		$offset     = isset( $opts['offset'] ) && is_numeric( $opts['offset'] ) ? max( 0, (int) $opts['offset'] ) : 0;
 
 		if ( null !== $apply_plan ) {
 			$dry_run = false;
@@ -3644,13 +3670,26 @@ class Workspace {
 			return new \WP_Error( 'artifact_cleanup_plan_required', 'Artifact cleanup requires --dry-run first and --apply-plan=<file> to delete.', array( 'status' => 400 ) );
 		}
 
-		$plan = $this->build_worktree_artifact_cleanup_plan( $force );
+		// Apply phase always revalidates against the slow exhaustive path so
+		// the planned subset is reconciled with the current authoritative
+		// `worktree list` view before deletion.
+		$use_fast_scan = $dry_run && null === $apply_plan && ! $exhaustive;
+
+		$scan_meta = null;
+		if ( $use_fast_scan ) {
+			$plan = $this->build_worktree_artifact_cleanup_plan_fast( $force, $limit, $offset );
+		} else {
+			$plan = $this->build_worktree_artifact_cleanup_plan( $force );
+		}
 		if ( $plan instanceof \WP_Error ) {
 			return $plan;
 		}
 
 		$candidates = $plan['candidates'];
 		$skipped    = $plan['skipped'];
+		if ( isset( $plan['scan'] ) && is_array( $plan['scan'] ) ) {
+			$scan_meta = $plan['scan'];
+		}
 
 		if ( null !== $apply_plan ) {
 			$planned = $this->extract_worktree_artifact_cleanup_plan_candidates( $apply_plan );
@@ -3666,7 +3705,7 @@ class Workspace {
 		$summary = $this->build_worktree_artifact_cleanup_summary( $candidates, array(), $skipped );
 
 		if ( $dry_run ) {
-			return array(
+			$result = array(
 				'success'    => true,
 				'dry_run'    => true,
 				'candidates' => $candidates,
@@ -3674,6 +3713,17 @@ class Workspace {
 				'skipped'    => $skipped,
 				'summary'    => $summary,
 			);
+			if ( null !== $scan_meta ) {
+				$result['partial'] = ! empty( $scan_meta['partial'] );
+				$result['scan']    = $scan_meta;
+			} else {
+				$result['partial'] = false;
+				$result['scan']    = array(
+					'mode'    => 'exhaustive',
+					'partial' => false,
+				);
+			}
+			return $result;
 		}
 
 		$removed = array();
@@ -3714,6 +3764,11 @@ class Workspace {
 			'removed'    => $removed,
 			'skipped'    => $skipped,
 			'summary'    => $this->build_worktree_artifact_cleanup_summary( $candidates, $removed, $skipped ),
+			'partial'    => false,
+			'scan'       => array(
+				'mode'    => 'exhaustive',
+				'partial' => false,
+			),
 		);
 	}
 
@@ -3740,10 +3795,15 @@ class Workspace {
 
 		$artifact_plan = array( 'candidates' => array(), 'skipped' => array(), 'summary' => array() );
 		if ( $inputs['include_artifacts'] ) {
+			// Frozen cleanup plans must enumerate every artifact-bearing worktree
+			// because chunked apply consumers index off the full candidate list.
+			// Use the exhaustive path; the fast/paginated scan is only for
+			// interactive dry-run review.
 			$artifact_plan = $this->worktree_cleanup_artifacts(
 				array(
-					'dry_run' => true,
-					'force'   => $inputs['force_artifact_cleanup'],
+					'dry_run'    => true,
+					'force'      => $inputs['force_artifact_cleanup'],
+					'exhaustive' => true,
 				)
 			);
 			if ( $artifact_plan instanceof \WP_Error ) {
@@ -4614,6 +4674,181 @@ class Workspace {
 			'removed'        => array(),
 			'skipped'        => $skipped,
 			'summary'        => $this->build_worktree_cleanup_summary( $candidates, array(), $skipped, $age_filter ),
+		);
+	}
+
+	/**
+	 * Build a bounded artifact cleanup dry-run plan from cheap top-level inventory.
+	 *
+	 * The fast path intentionally avoids `git worktree list --porcelain`,
+	 * per-worktree `git status`, and whole-worktree `du`. It walks the
+	 * workspace top level via `scandir`, classifies entries from their
+	 * filesystem handle, and only spends I/O on rows that actually have
+	 * profile-derived artifacts on disk:
+	 *
+	 *   1. Profile lookup is `is_file()` checks for known marker files
+	 *      (Cargo.toml, package.json, composer.json) on the worktree path.
+	 *   2. Each profile entry is probed with `is_dir()` to confirm the
+	 *      artifact directory actually exists.
+	 *   3. `du -sk` runs only on the artifact directories themselves, not
+	 *      on the entire worktree.
+	 *   4. Safety probes (`git status --porcelain`, `count_unpushed_commits`,
+	 *      symlink check) run only for rows that survive steps 1-3.
+	 *
+	 * On a workspace with hundreds of worktrees that mostly do not contain
+	 * artifact directories, this collapses an O(N) `git status`/`du` cost
+	 * into O(slice * profile_size) cheap stat calls, which keeps the dry-run
+	 * inside a normal CLI timeout.
+	 *
+	 * Results are paginated through `$offset` and `$limit`. The `scan`
+	 * metadata returned with the plan reports total worktrees, the slice
+	 * that was scanned, whether the result is partial, and a `next_offset`
+	 * the caller can pass back to continue review.
+	 *
+	 * @param bool $force  Whether to allow dirty/unpushed worktrees.
+	 * @param int  $limit  Maximum eligible worktrees to scan in this call.
+	 * @param int  $offset Number of eligible worktrees to skip before scanning.
+	 * @return array{candidates: array<int,array>, skipped: array<int,array>, scan: array<string,mixed>}|\WP_Error
+	 */
+	private function build_worktree_artifact_cleanup_plan_fast( bool $force, int $limit, int $offset ): array|\WP_Error {
+		$inventory = $this->build_workspace_inventory_rows();
+
+		// Eligible rows are non-primary worktrees inside the workspace.
+		// External worktrees can't be discovered cheaply without `git worktree
+		// list`, so the fast path simply skips them; the exhaustive path
+		// remains available for callers that need full coverage.
+		$eligible = array();
+		foreach ( $inventory as $row ) {
+			if ( empty( $row['is_worktree'] ) ) {
+				continue;
+			}
+			if ( ! empty( $row['is_primary'] ) ) {
+				continue;
+			}
+			$eligible[] = $row;
+		}
+
+		$total_eligible = count( $eligible );
+		$slice          = array_slice( $eligible, $offset, $limit );
+		$scanned        = count( $slice );
+		$next_offset    = $offset + $scanned;
+		$partial        = $next_offset < $total_eligible;
+
+		$candidates             = array();
+		$skipped                = array();
+		$without_artifact_count = 0;
+
+		foreach ( $slice as $row ) {
+			$handle  = (string) ( $row['handle'] ?? '?' );
+			$repo    = (string) ( $row['repo'] ?? '' );
+			$wt_path = (string) ( $row['path'] ?? '' );
+			// Branch is derived from the on-disk handle (`<repo>@<slug>`)
+			// instead of `git rev-parse` to keep this path stat-only. The
+			// slug is enough for review tables; apply-plan revalidates the
+			// real branch via the exhaustive path.
+			$branch  = (string) ( $row['branch_slug'] ?? '' );
+
+			$base_row = array(
+				'handle'     => $handle,
+				'repo'       => $repo,
+				'branch'     => $branch,
+				'path'       => $wt_path,
+				'created_at' => $row['created_at'] ?? null,
+			);
+
+			if ( '' === $repo || '' === $branch || '' === $wt_path || ! is_dir( $wt_path ) ) {
+				// Missing on-disk pieces are not interesting unless the
+				// worktree actually has artifacts on disk. Skip cheaply
+				// without listing them as full skip rows so the partial
+				// result stays focused on actionable review data.
+				++$without_artifact_count;
+				continue;
+			}
+
+			$artifacts = $this->detect_worktree_artifacts( $repo, $wt_path );
+			if ( empty( $artifacts ) ) {
+				++$without_artifact_count;
+				continue;
+			}
+
+			if ( $this->is_active_studio_symlink_target( $wt_path ) ) {
+				$skipped[] = array_merge( $base_row, array(
+					'reason_code' => 'active_symlink_target',
+					'reason'      => 'worktree is the target of a wp-content plugin/theme symlink - leaving artifacts in place',
+					'artifacts'   => $artifacts,
+				) );
+				continue;
+			}
+
+			$dirty_result = $this->run_git( $wt_path, 'status --porcelain', self::CLEANUP_GIT_PROBE_TIMEOUT );
+			if ( $this->is_git_timeout_error( $dirty_result ) ) {
+				$skipped[] = array_merge( $base_row, array(
+					'reason_code' => 'probe_timeout',
+					'reason'      => 'artifact cleanup dirty probe timed out - leaving artifacts in place: ' . $dirty_result->get_error_message(),
+					'artifacts'   => $artifacts,
+				) );
+				continue;
+			}
+			$dirty_count = is_wp_error( $dirty_result )
+				? 0
+				: count( array_filter( array_map( 'trim', explode( "\n", (string) ( $dirty_result['output'] ?? '' ) ) ) ) );
+			if ( $dirty_count > 0 && ! $force ) {
+				$skipped[] = array_merge( $base_row, array(
+					'reason_code' => 'dirty_worktree',
+					'reason'      => sprintf( 'working tree dirty (%d files) - pass force=true to override artifact cleanup only', $dirty_count ),
+					'dirty'       => $dirty_count,
+					'artifacts'   => $artifacts,
+				) );
+				continue;
+			}
+
+			$unpushed = $this->count_unpushed_commits( $wt_path, self::CLEANUP_GIT_PROBE_TIMEOUT );
+			if ( is_wp_error( $unpushed ) ) {
+				$skipped[] = array_merge( $base_row, array(
+					'reason_code' => 'probe_timeout',
+					'reason'      => 'artifact cleanup safety probe timed out - leaving artifacts in place: ' . $unpushed->get_error_message(),
+					'artifacts'   => $artifacts,
+				) );
+				continue;
+			}
+			if ( $unpushed > 0 && ! $force ) {
+				$skipped[] = array_merge( $base_row, array(
+					'reason_code' => 'unpushed_commits',
+					'reason'      => sprintf( '%d unpushed commit(s) - pass force=true to override artifact cleanup only', $unpushed ),
+					'unpushed'    => $unpushed,
+					'artifacts'   => $artifacts,
+				) );
+				continue;
+			}
+
+			$candidates[] = array_merge( $base_row, array(
+				'artifacts'           => $artifacts,
+				'artifact_count'      => count( $artifacts ),
+				'artifact_size_bytes' => array_sum( array_map( fn( $artifact ) => (int) ( $artifact['size_bytes'] ?? 0 ), $artifacts ) ),
+				'reason_code'         => 'profile_artifacts',
+				'reason'              => 'profile-derived reconstructable artifacts can be removed',
+			) );
+		}
+
+		$scan = array(
+			'mode'                          => 'fast',
+			'partial'                       => $partial,
+			'limit'                         => $limit,
+			'offset'                        => $offset,
+			'scanned'                       => $scanned,
+			'next_offset'                   => $partial ? $next_offset : null,
+			'total_eligible_worktrees'      => $total_eligible,
+			'remaining_worktrees'           => max( 0, $total_eligible - $next_offset ),
+			'worktrees_without_artifacts'   => $without_artifact_count,
+			'note'                          => $partial
+				? 'Bounded fast scan. Pass --offset to continue, or --exhaustive to enumerate every worktree (slow).'
+				: 'Bounded fast scan covered every eligible worktree.',
+		);
+
+		return array(
+			'candidates' => $candidates,
+			'skipped'    => $skipped,
+			'scan'       => $scan,
 		);
 	}
 

--- a/tests/smoke-worktree-cleanup-artifacts.php
+++ b/tests/smoke-worktree-cleanup-artifacts.php
@@ -195,6 +195,60 @@ namespace {
 	$assert( 'unpushed_commits', $skip_reasons['demo@unpushed'] ?? '', 'unpushed worktree is protected' );
 	$assert( 'active_symlink_target', $skip_reasons['demo@active'] ?? '', 'active plugin symlink target is protected' );
 
+	// Default dry-run uses the bounded fast scan and reports scan metadata.
+	$assert( false, ! isset( $plan['scan'] ), 'dry-run reports scan metadata' );
+	$assert( 'fast', (string) ( $plan['scan']['mode'] ?? '' ), 'default dry-run uses the fast scan path' );
+	$assert( false, (bool) ( $plan['partial'] ?? true ), 'small workspace fits in default fast-scan limit' );
+	$assert( 4, (int) ( $plan['scan']['total_eligible_worktrees'] ?? 0 ), 'fast scan counts every eligible worktree' );
+	$assert( 4, (int) ( $plan['scan']['scanned'] ?? -1 ), 'fast scan reports actual scanned count' );
+	$assert( true, array_key_exists( 'next_offset', (array) ( $plan['scan'] ?? array() ) ) && null === $plan['scan']['next_offset'], 'complete fast scan exposes null next_offset' );
+
+	// Bounded scan: limit=2 must return partial=true with next_offset for continuation.
+	$bounded = $workspace->worktree_cleanup_artifacts( array( 'dry_run' => true, 'limit' => 2, 'offset' => 0 ) );
+	$assert( false, is_wp_error( $bounded ), 'bounded dry-run returns a plan' );
+	$assert( true, (bool) ( $bounded['partial'] ?? false ), 'bounded scan reports partial=true' );
+	$assert( 2, (int) ( $bounded['scan']['scanned'] ?? -1 ), 'bounded scan honors limit' );
+	$assert( 2, (int) ( $bounded['scan']['next_offset'] ?? -1 ), 'bounded scan exposes next_offset' );
+	$assert( 4, (int) ( $bounded['scan']['total_eligible_worktrees'] ?? 0 ), 'bounded scan reports total eligible' );
+
+	// Continuation scan: offset=2, limit=2 must cover the remainder and report partial=false.
+	$continuation = $workspace->worktree_cleanup_artifacts( array( 'dry_run' => true, 'limit' => 2, 'offset' => 2 ) );
+	$assert( false, is_wp_error( $continuation ), 'continuation dry-run returns a plan' );
+	$assert( false, (bool) ( $continuation['partial'] ?? true ), 'continuation scan reaches the end' );
+	$assert( 2, (int) ( $continuation['scan']['scanned'] ?? -1 ), 'continuation scan honors limit' );
+	$assert( true, array_key_exists( 'next_offset', (array) ( $continuation['scan'] ?? array() ) ) && null === $continuation['scan']['next_offset'], 'completed continuation has null next_offset' );
+
+	// Bounded + continuation should collectively cover the same handles as the default scan.
+	$default_handles      = array_merge(
+		array_column( $plan['candidates'] ?? array(), 'handle' ),
+		array_column( $plan['skipped'] ?? array(), 'handle' )
+	);
+	$paginated_handles    = array_merge(
+		array_column( $bounded['candidates'] ?? array(), 'handle' ),
+		array_column( $bounded['skipped'] ?? array(), 'handle' ),
+		array_column( $continuation['candidates'] ?? array(), 'handle' ),
+		array_column( $continuation['skipped'] ?? array(), 'handle' )
+	);
+	sort( $default_handles );
+	sort( $paginated_handles );
+	$assert( $default_handles, $paginated_handles, 'paginated bounded scans cover the same worktrees as default scan' );
+
+	// Exhaustive opt-in still works and reports scan.mode = exhaustive.
+	$exhaustive = $workspace->worktree_cleanup_artifacts( array( 'dry_run' => true, 'exhaustive' => true ) );
+	$assert( false, is_wp_error( $exhaustive ), 'exhaustive dry-run returns a plan' );
+	$assert( 'exhaustive', (string) ( $exhaustive['scan']['mode'] ?? '' ), 'exhaustive dry-run reports exhaustive scan mode' );
+	$assert( false, (bool) ( $exhaustive['partial'] ?? true ), 'exhaustive dry-run is never partial' );
+	$assert(
+		count( $plan['candidates'] ?? array() ),
+		count( $exhaustive['candidates'] ?? array() ),
+		'fast and exhaustive scans agree on candidate count for this workspace'
+	);
+
+	// Limit is clamped to the documented hard ceiling.
+	$clamped = $workspace->worktree_cleanup_artifacts( array( 'dry_run' => true, 'limit' => 1000000 ) );
+	$assert( false, is_wp_error( $clamped ), 'oversized limit is accepted' );
+	$assert( true, (int) ( $clamped['scan']['limit'] ?? 0 ) <= 1000, 'limit is clamped to ARTIFACT_DRY_RUN_MAX_LIMIT' );
+
 	$direct_apply = $workspace->worktree_cleanup_artifacts( array() );
 	$assert( true, is_wp_error( $direct_apply ), 'direct apply without plan is rejected' );
 	$assert( 'artifact_cleanup_plan_required', $direct_apply->code ?? '', 'direct apply error is explicit' );

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -615,9 +615,16 @@ namespace {
 	WP_CLI::$logs      = array();
 	WP_CLI::$successes = array();
 	$command->worktree( array( 'cleanup-artifacts' ), array( 'dry-run' => true, 'format' => 'json' ) );
-	datamachine_code_cleanup_assert( array( 'dry_run' => true, 'force' => false ) === $artifact_ability->last_input, 'cleanup-artifacts dry-run flags forwarded to ability' );
+	datamachine_code_cleanup_assert( array( 'dry_run' => true, 'force' => false, 'exhaustive' => false ) === $artifact_ability->last_input, 'cleanup-artifacts dry-run flags forwarded to ability' );
 	$artifact_json = json_decode( WP_CLI::$logs[0] ?? '', true );
 	datamachine_code_cleanup_assert( 'target' === ( $artifact_json['candidates'][0]['artifacts'][0]['path'] ?? '' ), 'cleanup-artifacts JSON includes artifact paths' );
+
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->worktree( array( 'cleanup-artifacts' ), array( 'dry-run' => true, 'format' => 'json', 'limit' => 50, 'offset' => 25, 'exhaustive' => true ) );
+	datamachine_code_cleanup_assert( true === ( $artifact_ability->last_input['exhaustive'] ?? null ), 'cleanup-artifacts forwards --exhaustive opt-in' );
+	datamachine_code_cleanup_assert( 50 === ( $artifact_ability->last_input['limit'] ?? null ), 'cleanup-artifacts forwards --limit' );
+	datamachine_code_cleanup_assert( 25 === ( $artifact_ability->last_input['offset'] ?? null ), 'cleanup-artifacts forwards --offset' );
 
 	$artifact_plan_file = sys_get_temp_dir() . '/dmc-artifact-cleanup-plan-' . bin2hex( random_bytes( 3 ) ) . '.json';
 	file_put_contents( $artifact_plan_file, wp_json_encode( $artifact_json ) );


### PR DESCRIPTION
## Summary
- Add a bounded fast scan for `workspace cleanup run --mode=artifacts --dry-run` (and the lower-level `workspace worktree cleanup-artifacts --dry-run`) so the synchronous, ability-backed dry-run completes within a normal CLI timeout on workspaces with hundreds of worktrees.
- Default behavior now walks the workspace via cheap top-level inventory (`scandir` + parsed `<repo>@<slug>` handles), stats only known profile-derived artifact directories (`target`, `node_modules`, `.next`, `dist`, `coverage`, `vendor`), and runs `du` on those artifact directories instead of every worktree's full tree.
- Safety probes (`git status`, `count_unpushed_commits`, active-symlink detection) only run for rows that actually have artifacts on disk, which is where the answer matters.
- Pagination via `--limit`, `--offset`, and `scan.next_offset`; `--exhaustive` opt-in keeps the previous full enumeration available for callers that need it.

## Why
On a workspace with ~800 worktrees, the dry-run shelled out to `git worktree list --porcelain` once per primary, then `git status --porcelain` per worktree, then `du -sk` on the entire worktree tree, then `du -sk` on each artifact dir, then `git rev-list` per artifact-bearing candidate. That blew past the 5-minute CLI timeout on intelligence-chubes4. The new fast path collapses the dominant cost to O(slice * profile_size) cheap stat calls, with safety probes only on the artifact-bearing subset.

Closes #214

## Output contract
Dry-run results now include:
- `partial` boolean — true when the scan window did not cover every eligible worktree.
- `scan` object with `mode` (`fast` | `exhaustive`), `limit`, `offset`, `scanned`, `next_offset`, `total_eligible_worktrees`, `remaining_worktrees`, `worktrees_without_artifacts`, and a human-readable `note`.

The renderer surfaces the same info in `table` mode and tells the user how to continue review (`--offset=<n>`) or escalate to `--exhaustive`.

## Internal callers
`worktree_cleanup_merged` (retention orchestration) and `workspace_cleanup_plan` (chunked plan freezes) both still need a complete enumeration to drive whole-workspace decisions and chunk emission, so they explicitly opt into the exhaustive path. Apply-plan flows are unchanged and still revalidate against the authoritative `worktree_list` view before mutating disk.

## Limits / clamps
- Default limit: 200 (`ARTIFACT_DRY_RUN_DEFAULT_LIMIT`).
- Hard ceiling: 1000 (`ARTIFACT_DRY_RUN_MAX_LIMIT`); larger requests must use `--exhaustive`.
- Fast scan deliberately skips external worktrees (those outside the workspace root) since they can't be discovered without `git worktree list`. Operators who need them run with `--exhaustive`.

## Tests
- `tests/smoke-worktree-cleanup-artifacts.php` extended (45 assertions): default fast scan reports `scan.mode=fast`, full coverage when the workspace fits the limit, bounded scan returns `partial=true` with `next_offset`, continuation reaches the end, paginated bounded scans cover the same handles as the default scan, exhaustive opt-in reports `scan.mode=exhaustive` and is never partial, and oversized limits are clamped.
- `tests/smoke-worktree-cleanup-cli.php` extended: CLI forwards `--limit` / `--offset` / `--exhaustive` into the ability input.

Full smoke suite (`tests/smoke-*.php`) passes locally.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Profiling the slow path, designing the bounded fast scan and pagination contract, drafting the new `build_worktree_artifact_cleanup_plan_fast` method plus ability/CLI plumbing, and extending the smoke tests. Chris reviewed every change and ran the smoke suite locally.