### PR TITLE
feat: surface agent/session liveness on worktrees (#221)

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -831,6 +831,14 @@ class WorkspaceAbilities {
 								'type'        => 'boolean',
 								'description' => 'Explicitly bypass the disk-budget refusal threshold. The disk-budget report still appears in output so the override is visible.',
 							),
+							'task_url'       => array(
+								'type'        => 'string',
+								'description' => 'Optional task/issue URL (e.g. GitHub issue link) to record on the worktree for ownership/duplicate detection. Falls back to DATAMACHINE_TASK_URL env when omitted.',
+							),
+							'task_ref'       => array(
+								'type'        => 'string',
+								'description' => 'Optional short task/issue reference (e.g. `org/repo#123`) recorded alongside task_url. Falls back to DATAMACHINE_TASK_REF env when omitted.',
+							),
 						),
 						'required'   => array( 'repo', 'branch' ),
 					),
@@ -1145,6 +1153,42 @@ class WorkspaceAbilities {
 										'lifecycle_state' => array( 'type' => array( 'string', 'null' ) ),
 										'pr_url'          => array( 'type' => array( 'string', 'null' ) ),
 										'pr_number'       => array( 'type' => array( 'integer', 'null' ) ),
+										'last_seen_at'    => array( 'type' => array( 'string', 'null' ) ),
+										'liveness'        => array(
+											'type'        => 'string',
+											'description' => 'Owner/agent liveness: live, stopped, stale, or unknown. Distinct from lifecycle_state.',
+										),
+										'liveness_reason' => array(
+											'type'        => 'string',
+											'description' => 'Reason code for the liveness classification (e.g. heartbeat_fresh, heartbeat_stale, lifecycle_pr_opened, metadata_missing).',
+										),
+										'heartbeat_age_seconds' => array( 'type' => array( 'integer', 'null' ) ),
+										'owner'           => array(
+											'type'       => 'object',
+											'description' => 'Owner snapshot recorded at worktree creation. Unknown-safe defaults: site, agent, user default to the literal string "unknown".',
+											'properties' => array(
+												'site'     => array( 'type' => 'string' ),
+												'site_url' => array( 'type' => array( 'string', 'null' ) ),
+												'agent'    => array( 'type' => 'string' ),
+												'user'     => array( 'type' => 'string' ),
+											),
+										),
+										'session'         => array(
+											'type'       => 'object',
+											'description' => 'Captured session identifiers (kimaki/opencode). Fields default to null when the corresponding env was not present at worktree creation.',
+											'properties' => array(
+												'primary_id'         => array( 'type' => array( 'string', 'null' ) ),
+												'kimaki_session_id'  => array( 'type' => array( 'string', 'null' ) ),
+												'kimaki_thread_id'   => array( 'type' => array( 'string', 'null' ) ),
+												'kimaki_thread_url'  => array( 'type' => array( 'string', 'null' ) ),
+												'opencode_session_id' => array( 'type' => array( 'string', 'null' ) ),
+												'opencode_run_id'    => array( 'type' => array( 'string', 'null' ) ),
+											),
+										),
+										'task'            => array(
+											'type'       => array( 'object', 'null' ),
+											'description' => 'Optional task/issue reference recorded at creation, when supplied via input or DATAMACHINE_TASK_URL/DATAMACHINE_TASK_REF env.',
+										),
 										'last_touched_at' => array( 'type' => array( 'string', 'null' ) ),
 										'age_days'        => array( 'type' => array( 'integer', 'null' ) ),
 										'size_bytes'      => array( 'type' => array( 'integer', 'null' ) ),
@@ -1153,6 +1197,21 @@ class WorkspaceAbilities {
 										'stale_reason'    => array( 'type' => array( 'string', 'null' ) ),
 										'metadata'        => array( 'type' => array( 'object', 'null' ) ),
 										'fields_skipped'  => array(
+											'type'  => 'array',
+											'items' => array( 'type' => 'string' ),
+										),
+									),
+								),
+							),
+							'duplicates' => array(
+								'type'       => 'array',
+								'description' => 'Groups of worktrees sharing a task_url, task_ref, pr_url, or pr_repo#pr_number. Reported only — never used to drive deletions.',
+								'items'      => array(
+									'type'       => 'object',
+									'properties' => array(
+										'kind'    => array( 'type' => 'string' ),
+										'key'     => array( 'type' => 'string' ),
+										'handles' => array(
 											'type'  => 'array',
 											'items' => array( 'type' => 'string' ),
 										),
@@ -1795,6 +1854,13 @@ class WorkspaceAbilities {
 		// Default rebase_base=false; only true when explicitly requested.
 		$rebase_base = array_key_exists( 'rebase_base', $input ) ? (bool) $input['rebase_base'] : false;
 		$force       = ! empty( $input['force'] );
+		$task        = array();
+		if ( isset( $input['task_url'] ) && '' !== trim( (string) $input['task_url'] ) ) {
+			$task['task_url'] = (string) $input['task_url'];
+		}
+		if ( isset( $input['task_ref'] ) && '' !== trim( (string) $input['task_ref'] ) ) {
+			$task['task_ref'] = (string) $input['task_ref'];
+		}
 		return $workspace->worktree_add(
 			$input['repo'] ?? '',
 			$input['branch'] ?? '',
@@ -1803,7 +1869,8 @@ class WorkspaceAbilities {
 			$bootstrap,
 			$allow_stale,
 			$rebase_base,
-			$force
+			$force,
+			$task
 		);
 	}
 

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1584,6 +1584,18 @@ class WorkspaceCommand extends BaseCommand {
 	 *   `--allow-stale` bypass. The ability-level input is
 	 *   `rebase_base=true`.
 	 *
+	 * [--task-url=<url>]
+	 * : Optional task/issue URL recorded on the worktree at creation time
+	 *   for ownership/duplicate detection (applies to `add` only). Falls
+	 *   back to the `DATAMACHINE_TASK_URL` environment variable when
+	 *   omitted. Used by `worktree list` and the hygiene report to flag
+	 *   multiple worktrees pointing at the same task.
+	 *
+	 * [--task-ref=<ref>]
+	 * : Optional short task/issue reference (e.g. `org/repo#123`) recorded
+	 *   alongside `--task-url` (applies to `add` only). Falls back to the
+	 *   `DATAMACHINE_TASK_REF` environment variable when omitted.
+	 *
 	 * [--force]
 	 * : For `add`, explicitly bypass the disk-budget refusal threshold. For
 	 *   `remove`, force-remove a worktree even if it is dirty. For `cleanup`,
@@ -1770,6 +1782,9 @@ class WorkspaceCommand extends BaseCommand {
 	 *     wp datamachine-code workspace worktree finalize data-machine@fix-foo --pr=https://github.com/org/repo/pull/123
 	 *     wp datamachine-code workspace worktree mark-cleanup-eligible data-machine@fix-foo
 	 *
+	 *     # Record a task/issue URL on a worktree for ownership tracking
+	 *     wp datamachine-code workspace worktree add data-machine fix/foo --task-url=https://github.com/org/repo/issues/42
+	 *
 	 * @subcommand worktree
 	 */
 	public function worktree( array $args, array $assoc_args ): void {
@@ -1836,6 +1851,12 @@ class WorkspaceCommand extends BaseCommand {
 				$input['rebase_base'] = ! empty( $assoc_args['rebase-base'] );
 				// --force is an explicit disk-budget override for add.
 				$input['force'] = ! empty( $assoc_args['force'] );
+				if ( isset( $assoc_args['task-url'] ) && '' !== trim( (string) $assoc_args['task-url'] ) ) {
+					$input['task_url'] = (string) $assoc_args['task-url'];
+				}
+				if ( isset( $assoc_args['task-ref'] ) && '' !== trim( (string) $assoc_args['task-ref'] ) ) {
+					$input['task_ref'] = (string) $assoc_args['task-ref'];
+				}
 				break;
 
 			case 'refresh-context':
@@ -2004,6 +2025,10 @@ class WorkspaceCommand extends BaseCommand {
 				}
 				if ( empty( $worktrees ) ) {
 					WP_CLI::log( 'No worktrees found.' );
+					$duplicates = (array) ( $result['duplicates'] ?? array() );
+					if ( ! empty( $duplicates ) ) {
+						WP_CLI::log( sprintf( 'Duplicate task ownership groups: %d', count( $duplicates ) ) );
+					}
 					return;
 				}
 				$items  = array_map(
@@ -2020,6 +2045,14 @@ class WorkspaceCommand extends BaseCommand {
 							'dirty'               => null === $dirty ? '-' : (int) $dirty,
 							'created_at'          => $wt['created_at'] ?? null,
 							'state'               => $wt['lifecycle_state'] ?? null,
+							'liveness'            => $wt['liveness'] ?? 'unknown',
+							'liveness_reason'     => $wt['liveness_reason'] ?? '',
+							'last_seen_at'        => $wt['last_seen_at'] ?? null,
+							'owner'               => isset( $wt['owner']['user'] ) ? (string) $wt['owner']['user'] : 'unknown',
+							'agent'               => isset( $wt['owner']['agent'] ) ? (string) $wt['owner']['agent'] : 'unknown',
+							'site'                => isset( $wt['owner']['site'] ) ? (string) $wt['owner']['site'] : 'unknown',
+							'session'             => isset( $wt['session']['primary_id'] ) && null !== $wt['session']['primary_id'] ? (string) $wt['session']['primary_id'] : '',
+							'task'                => is_array( $wt['task'] ?? null ) ? (string) ( $wt['task']['task_url'] ?? $wt['task']['task_ref'] ?? '' ) : '',
 							'pr'                  => $wt['pr_url'] ?? null,
 							'age_days'            => $wt['age_days'] ?? null,
 							'size_bytes'          => $size,
@@ -2030,14 +2063,17 @@ class WorkspaceCommand extends BaseCommand {
 							'stale'               => $wt['stale_reason'] ?? '',
 							'fields_skipped'      => $skipped,
 							'metadata'            => $wt['metadata'] ?? null,
+							'session_full'        => $wt['session'] ?? null,
+							'owner_full'          => $wt['owner'] ?? null,
+							'task_full'           => $wt['task'] ?? null,
 							'path'                => $wt['path'] ?? '',
 						);
 					},
 					$worktrees
 				);
-				$fields = array( 'handle', 'repo', 'kind', 'branch', 'head', 'dirty', 'state', 'created_at', 'pr', 'age_days', 'size', 'artifacts', 'stale', 'path' );
+				$fields = array( 'handle', 'repo', 'kind', 'branch', 'head', 'dirty', 'state', 'liveness', 'last_seen_at', 'owner', 'agent', 'session', 'task', 'pr', 'age_days', 'size', 'artifacts', 'stale', 'path' );
 				if ( in_array( (string) ( $assoc_args['format'] ?? '' ), array( 'json', 'yaml' ), true ) ) {
-					$fields = array( 'handle', 'repo', 'kind', 'branch', 'head', 'dirty', 'state', 'created_at', 'pr', 'age_days', 'size_bytes', 'artifact_size_bytes', 'artifact_paths', 'stale', 'fields_skipped', 'metadata', 'path' );
+					$fields = array( 'handle', 'repo', 'kind', 'branch', 'head', 'dirty', 'state', 'created_at', 'liveness', 'liveness_reason', 'last_seen_at', 'owner_full', 'session_full', 'task_full', 'pr', 'age_days', 'size_bytes', 'artifact_size_bytes', 'artifact_paths', 'stale', 'fields_skipped', 'metadata', 'path' );
 				}
 				$skipped_global = (array) ( $result['fields_skipped'] ?? array() );
 				if ( ! empty( $skipped_global ) && ! in_array( (string) ( $assoc_args['format'] ?? '' ), array( 'json', 'yaml', 'csv' ), true ) ) {
@@ -2047,6 +2083,13 @@ class WorkspaceCommand extends BaseCommand {
 					) );
 				}
 				$this->format_items( $items, $fields, $assoc_args, 'handle' );
+				$duplicates = (array) ( $result['duplicates'] ?? array() );
+				if ( ! empty( $duplicates ) && ! in_array( (string) ( $assoc_args['format'] ?? '' ), array( 'json', 'yaml' ), true ) ) {
+					WP_CLI::log( sprintf( 'Duplicate task ownership groups: %d', count( $duplicates ) ) );
+					foreach ( $duplicates as $group ) {
+						WP_CLI::log( sprintf( '  - [%s=%s] %s', (string) ( $group['kind'] ?? '' ), (string) ( $group['key'] ?? '' ), implode( ', ', (array) ( $group['handles'] ?? array() ) ) ) );
+					}
+				}
 				return;
 
 			case 'prune':
@@ -2243,6 +2286,26 @@ class WorkspaceCommand extends BaseCommand {
 					'value'  => (string) ( $worktrees['external'] ?? 0 ),
 				),
 				array(
+					'metric' => 'liveness_live',
+					'value'  => (string) ( $worktrees['by_liveness']['live'] ?? 0 ),
+				),
+				array(
+					'metric' => 'liveness_stopped',
+					'value'  => (string) ( $worktrees['by_liveness']['stopped'] ?? 0 ),
+				),
+				array(
+					'metric' => 'liveness_stale',
+					'value'  => (string) ( $worktrees['by_liveness']['stale'] ?? 0 ),
+				),
+				array(
+					'metric' => 'liveness_unknown',
+					'value'  => (string) ( $worktrees['by_liveness']['unknown'] ?? 0 ),
+				),
+				array(
+					'metric' => 'duplicate_task_groups',
+					'value'  => (string) ( $worktrees['duplicate_task_groups'] ?? 0 ),
+				),
+				array(
 					'metric' => 'cleanup_candidates',
 					'value'  => (string) ( $cleanup_summary['would_remove'] ?? 0 ),
 				),
@@ -2251,6 +2314,20 @@ class WorkspaceCommand extends BaseCommand {
 			array( 'format' => 'table' ),
 			'metric'
 		);
+
+		$duplicates = (array) ( $worktrees['duplicates'] ?? array() );
+		if ( array() !== $duplicates ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( 'Duplicate task ownership groups (reported only — never auto-deleted):' );
+			foreach ( $duplicates as $group ) {
+				WP_CLI::log( sprintf(
+					'  - [%s=%s] %s',
+					(string) ( $group['kind'] ?? '' ),
+					(string) ( $group['key'] ?? '' ),
+					implode( ', ', (array) ( $group['handles'] ?? array() ) )
+				) );
+			}
+		}
 
 		$top_size = array_slice( (array) ( $report['top_repos_by_size'] ?? array() ), 0, 10 );
 		$by_kind  = array_slice( (array) ( $size['by_kind'] ?? array() ), 0, 10 );

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -1252,7 +1252,7 @@ class Workspace {
 	 * @param bool        $force          Bypass the disk-budget refusal threshold (default false).
 	 * @return array{success: bool, handle: string, path: string, branch: string, slug: string, created_branch: bool, message: string, disk_budget?: array, context_injected?: bool, context_files?: string[], context_skip_reason?: string, bootstrap?: array, fetch_failed?: bool, fetch_error?: string, stale_commits_behind?: int, upstream?: string, base_stale_commits_behind?: int, base_upstream?: string, gate_threshold?: int, rebase_attempted?: bool, rebase_succeeded?: bool, rebase_error?: string, rebase_target?: string}|\WP_Error
 	 */
-	public function worktree_add( string $repo, string $branch, ?string $from = null, bool $inject_context = true, bool $bootstrap = true, bool $allow_stale = false, bool $rebase_base = false, bool $force = false ): array|\WP_Error {
+	public function worktree_add( string $repo, string $branch, ?string $from = null, bool $inject_context = true, bool $bootstrap = true, bool $allow_stale = false, bool $rebase_base = false, bool $force = false, array $task = array() ): array|\WP_Error {
 		$visible = $this->require_workspace_visible();
 		if ( null !== $visible ) {
 			return $visible;
@@ -1319,7 +1319,8 @@ class Workspace {
 				$slug,
 				$wt_handle,
 				$wt_path,
-				$primary_path
+				$primary_path,
+				$task
 			)
 		);
 
@@ -1361,7 +1362,8 @@ class Workspace {
 		string $slug,
 		string $wt_handle,
 		string $wt_path,
-		string $primary_path
+		string $primary_path,
+		array $task = array()
 	): array|\WP_Error {
 		if ( is_dir( $wt_path ) ) {
 			return new \WP_Error( 'worktree_exists', sprintf( 'Worktree handle "%s" already exists.', $wt_handle ), array( 'status' => 400 ) );
@@ -1518,6 +1520,8 @@ class Workspace {
 				'branch'      => $branch,
 				'base_ref'    => $created_branch ? $resolved_base : null,
 				'base_source' => $created_branch ? ( null !== $from && '' !== trim( $from ) ? 'requested_ref' : 'default_base' ) : 'existing_local_branch',
+				'task_url'    => isset( $task['task_url'] ) ? (string) $task['task_url'] : '',
+				'task_ref'    => isset( $task['task_ref'] ) ? (string) $task['task_ref'] : '',
 			)
 		);
 		WorktreeContextInjector::store_lifecycle_metadata( $wt_handle, $lifecycle_metadata );
@@ -1579,9 +1583,11 @@ class Workspace {
 		$metadata = WorktreeContextInjector::build_finalizer_metadata( $normalized_state, $pr );
 		$metadata = array_merge(
 			array(
-				'handle' => $parsed['dir_name'],
-				'path'   => $wt_path,
-				'repo'   => $parsed['repo'],
+				'handle'       => $parsed['dir_name'],
+				'path'         => $wt_path,
+				'repo'         => $parsed['repo'],
+				// Finalize is itself an explicit liveness signal from the owner.
+				'last_seen_at' => gmdate( 'c' ),
 			),
 			$metadata
 		);
@@ -1645,6 +1651,9 @@ class Workspace {
 		}
 
 		WorktreeContextInjector::store_metadata( $parsed['dir_name'], $payload );
+		// refresh-context is a deliberate liveness signal: the originating site
+		// (and therefore some agent process there) just touched this worktree.
+		WorktreeContextInjector::record_heartbeat( $parsed['dir_name'] );
 
 		return array(
 			'success'      => true,
@@ -1800,23 +1809,35 @@ class Workspace {
 					$disk['stale_reason'] = $stale_reason;
 				}
 
+				$liveness     = WorktreeContextInjector::classify_liveness( is_array( $metadata ) ? $metadata : null );
+				$owner        = WorktreeContextInjector::summarize_owner( is_array( $metadata ) ? $metadata : null );
+				$session_view = WorktreeContextInjector::summarize_session( is_array( $metadata ) ? $metadata : null );
+				$task_view    = is_array( $metadata ) && is_array( $metadata['origin_task'] ?? null ) ? $metadata['origin_task'] : null;
+
 				$row = array_merge(
 					array(
-						'handle'          => $handle,
-						'repo'            => $primary,
-						'is_worktree'     => ! $is_primary,
-						'is_primary'      => $is_primary,
-						'external'        => ! $is_primary && ! $inside_ws,
-						'branch_slug'     => $is_primary ? null : ( $parsed['branch_slug'] ?? null ),
-						'branch'          => $wt['branch'],
-						'head'            => $wt['head'],
-						'path'            => $wt['path'],
-						'dirty'           => $dirty_files,
-						'created_at'      => $created_at,
-						'lifecycle_state' => $lifecycle_state,
-						'pr_url'          => is_array( $metadata ) ? ( $metadata['pr_url'] ?? null ) : null,
-						'pr_number'       => is_array( $metadata ) ? ( $metadata['pr_number'] ?? null ) : null,
-						'metadata'        => $metadata,
+						'handle'                => $handle,
+						'repo'                  => $primary,
+						'is_worktree'           => ! $is_primary,
+						'is_primary'            => $is_primary,
+						'external'              => ! $is_primary && ! $inside_ws,
+						'branch_slug'           => $is_primary ? null : ( $parsed['branch_slug'] ?? null ),
+						'branch'                => $wt['branch'],
+						'head'                  => $wt['head'],
+						'path'                  => $wt['path'],
+						'dirty'                 => $dirty_files,
+						'created_at'            => $created_at,
+						'lifecycle_state'       => $lifecycle_state,
+						'pr_url'                => is_array( $metadata ) ? ( $metadata['pr_url'] ?? null ) : null,
+						'pr_number'             => is_array( $metadata ) ? ( $metadata['pr_number'] ?? null ) : null,
+						'last_seen_at'          => is_array( $metadata ) ? ( $metadata['last_seen_at'] ?? null ) : null,
+						'liveness'              => $liveness['liveness'],
+						'liveness_reason'       => $liveness['reason'],
+						'heartbeat_age_seconds' => $liveness['heartbeat_age_seconds'],
+						'owner'                 => $owner,
+						'session'               => $session_view,
+						'task'                  => $task_view,
+						'metadata'              => $metadata,
 					),
 					$disk
 				);
@@ -1829,9 +1850,12 @@ class Workspace {
 			}
 		}
 
+		$duplicates = WorktreeContextInjector::find_duplicate_task_ownership( $worktrees );
+
 		return array(
 			'success'        => true,
 			'worktrees'      => $worktrees,
+			'duplicates'     => $duplicates,
 			'fields_skipped' => $skipped_groups,
 		);
 	}
@@ -2144,6 +2168,11 @@ class Workspace {
 			$is_worktree = 'worktree' === $kind;
 			$metadata    = $is_worktree ? WorktreeContextInjector::get_metadata( $parsed['dir_name'] ) : null;
 
+			$liveness     = WorktreeContextInjector::classify_liveness( is_array( $metadata ) ? $metadata : null );
+			$owner        = WorktreeContextInjector::summarize_owner( is_array( $metadata ) ? $metadata : null );
+			$session_view = WorktreeContextInjector::summarize_session( is_array( $metadata ) ? $metadata : null );
+			$task_view    = is_array( $metadata ) && is_array( $metadata['origin_task'] ?? null ) ? $metadata['origin_task'] : null;
+
 			$rows[] = array(
 				'handle'           => $parsed['dir_name'],
 				'repo'             => $parsed['repo'],
@@ -2158,6 +2187,13 @@ class Workspace {
 				'lifecycle_state'  => is_array( $metadata ) ? ( $metadata['lifecycle_state'] ?? null ) : null,
 				'pr_url'           => is_array( $metadata ) ? ( $metadata['pr_url'] ?? null ) : null,
 				'pr_number'        => is_array( $metadata ) ? ( $metadata['pr_number'] ?? null ) : null,
+				'last_seen_at'     => is_array( $metadata ) ? ( $metadata['last_seen_at'] ?? null ) : null,
+				'liveness'         => $liveness['liveness'],
+				'liveness_reason'  => $liveness['reason'],
+				'heartbeat_age_seconds' => $liveness['heartbeat_age_seconds'],
+				'owner'            => $owner,
+				'session'          => $session_view,
+				'task'             => $task_view,
 				'missing_metadata' => $is_worktree && ! is_array( $metadata ),
 				'metadata'         => $metadata,
 			);
@@ -2318,6 +2354,13 @@ class Workspace {
 			'protected_dirty'    => 0,
 			'protected_unpushed' => 0,
 			'missing_metadata'   => 0,
+			'by_liveness'        => array(
+				WorktreeContextInjector::LIVENESS_LIVE    => 0,
+				WorktreeContextInjector::LIVENESS_STOPPED => 0,
+				WorktreeContextInjector::LIVENESS_STALE   => 0,
+				WorktreeContextInjector::LIVENESS_UNKNOWN => 0,
+			),
+			'duplicate_task_groups' => 0,
 		);
 
 		foreach ( $worktrees as $row ) {
@@ -2340,7 +2383,19 @@ class Workspace {
 			if ( ! empty( $row['missing_metadata'] ) ) {
 				++$summary['missing_metadata'];
 			}
+
+			if ( ! empty( $row['is_worktree'] ) ) {
+				$liveness = (string) ( $row['liveness'] ?? WorktreeContextInjector::LIVENESS_UNKNOWN );
+				if ( ! isset( $summary['by_liveness'][ $liveness ] ) ) {
+					$summary['by_liveness'][ $liveness ] = 0;
+				}
+				++$summary['by_liveness'][ $liveness ];
+			}
 		}
+
+		$duplicates = WorktreeContextInjector::find_duplicate_task_ownership( $worktrees );
+		$summary['duplicate_task_groups'] = count( $duplicates );
+		$summary['duplicates']            = $duplicates;
 
 		if ( null !== $cleanup ) {
 			$by_reason                     = (array) ( $cleanup['summary']['skipped_by_reason'] ?? array() );

--- a/inc/Workspace/WorktreeContextInjector.php
+++ b/inc/Workspace/WorktreeContextInjector.php
@@ -56,6 +56,26 @@ class WorktreeContextInjector {
 	);
 
 	/**
+	 * Liveness classification labels surfaced alongside lifecycle state.
+	 *
+	 * These describe owner/agent liveness, not lifecycle. They are separate
+	 * from {@see self::VALID_STATES} so a worktree can be in `active` lifecycle
+	 * but `stale` liveness when its session heartbeat has lapsed.
+	 */
+	public const LIVENESS_LIVE = 'live';
+	public const LIVENESS_STOPPED = 'stopped';
+	public const LIVENESS_STALE = 'stale';
+	public const LIVENESS_UNKNOWN = 'unknown';
+
+	/**
+	 * Default heartbeat TTL for liveness classification, in seconds.
+	 *
+	 * 24 hours intentionally errs toward "stale, not dead": a heartbeat older
+	 * than this only changes the surfaced liveness, never causes deletion.
+	 */
+	public const DEFAULT_HEARTBEAT_TTL_SECONDS = 86400;
+
+	/**
 	 * Site option key used to persist per-worktree metadata.
 	 *
 	 * Shape: array<string, array<string,mixed>> keyed by workspace handle.
@@ -93,12 +113,14 @@ class WorktreeContextInjector {
 		$user      = self::resolve_origin_user();
 		$agent     = self::resolve_origin_agent();
 		$session   = self::resolve_origin_session();
+		$task      = self::resolve_origin_task( $args );
 
 		$created_at = gmdate( 'c' );
 
 		$metadata = array(
 			'created_at'       => $created_at,
 			'observed_at'      => $created_at,
+			'last_seen_at'     => $created_at,
 			'lifecycle_state'  => self::STATE_ACTIVE,
 			'handle'           => isset( $args['handle'] ) && '' !== (string) $args['handle'] ? (string) $args['handle'] : null,
 			'path'             => isset( $args['path'] ) && '' !== (string) $args['path'] ? (string) $args['path'] : null,
@@ -108,6 +130,7 @@ class WorktreeContextInjector {
 			'origin_agent'     => $agent,
 			'origin_session'   => $session,
 			'origin_user'      => $user,
+			'origin_task'      => $task,
 			'base_ref'         => isset( $args['base_ref'] ) && '' !== (string) $args['base_ref'] ? (string) $args['base_ref'] : null,
 			'base_source'      => isset( $args['base_source'] ) && '' !== (string) $args['base_source'] ? (string) $args['base_source'] : null,
 			'branch'           => isset( $args['branch'] ) && '' !== (string) $args['branch'] ? (string) $args['branch'] : null,
@@ -120,6 +143,290 @@ class WorktreeContextInjector {
 		$metadata['agent_slug'] = is_string( $agent ) ? $agent : '';
 
 		return array_filter( $metadata, fn( $value ) => null !== $value );
+	}
+
+	/**
+	 * Update the heartbeat (`last_seen_at`) for a worktree handle.
+	 *
+	 * Bounded helper used by lifecycle write paths (`refresh-context`,
+	 * `finalize`) so listing surfaces can distinguish live vs stale ownership
+	 * without touching destructive flows.
+	 *
+	 * @param string      $handle Workspace handle.
+	 * @param string|null $now    ISO-8601 timestamp; defaults to current time.
+	 * @return string|null The persisted heartbeat timestamp, or null when no
+	 *                     metadata record exists for the handle.
+	 */
+	public static function record_heartbeat( string $handle, ?string $now = null ): ?string {
+		$existing = self::get_metadata( $handle );
+		if ( null === $existing ) {
+			return null;
+		}
+		$timestamp = $now ?? gmdate( 'c' );
+		self::store_lifecycle_metadata( $handle, array( 'last_seen_at' => $timestamp ) );
+		return $timestamp;
+	}
+
+	/**
+	 * Classify the liveness of a worktree from its persisted lifecycle metadata.
+	 *
+	 * Returns a stable shape the listing/hygiene surfaces can render directly.
+	 * The classification is intentionally non-destructive: callers must not
+	 * derive cleanup actions from `liveness` alone — combine with dirtiness
+	 * and unpushed-commit checks before acting.
+	 *
+	 * Reason codes:
+	 *   - `metadata_missing`     — no metadata record at all
+	 *   - `lifecycle_pr_opened`  — PR has been opened (live owner irrelevant)
+	 *   - `lifecycle_finalized`  — merged/closed/abandoned/cleanup_eligible
+	 *   - `heartbeat_fresh`      — last_seen within TTL
+	 *   - `heartbeat_stale`      — last_seen older than TTL
+	 *   - `heartbeat_unknown`    — no last_seen recorded
+	 *
+	 * @param array<string,mixed>|null $metadata Worktree lifecycle metadata.
+	 * @param int|null                 $now      Override "now" for tests. Unix timestamp.
+	 * @param int                      $ttl      Heartbeat TTL in seconds.
+	 * @return array{liveness:string,reason:string,heartbeat_age_seconds:?int,last_seen_at:?string}
+	 */
+	public static function classify_liveness( ?array $metadata, ?int $now = null, int $ttl = self::DEFAULT_HEARTBEAT_TTL_SECONDS ): array {
+		if ( ! is_array( $metadata ) || empty( $metadata ) ) {
+			return array(
+				'liveness'              => self::LIVENESS_UNKNOWN,
+				'reason'                => 'metadata_missing',
+				'heartbeat_age_seconds' => null,
+				'last_seen_at'          => null,
+			);
+		}
+
+		$state = isset( $metadata['lifecycle_state'] ) ? self::normalize_state( (string) $metadata['lifecycle_state'] ) : null;
+		if ( self::STATE_PR_OPENED === $state ) {
+			return array(
+				'liveness'              => self::LIVENESS_STOPPED,
+				'reason'                => 'lifecycle_pr_opened',
+				'heartbeat_age_seconds' => null,
+				'last_seen_at'          => isset( $metadata['last_seen_at'] ) ? (string) $metadata['last_seen_at'] : null,
+			);
+		}
+		if ( null !== $state && in_array( $state, array( self::STATE_MERGED, self::STATE_CLOSED, self::STATE_ABANDONED, self::STATE_CLEANUP_ELIGIBLE ), true ) ) {
+			return array(
+				'liveness'              => self::LIVENESS_STOPPED,
+				'reason'                => 'lifecycle_finalized',
+				'heartbeat_age_seconds' => null,
+				'last_seen_at'          => isset( $metadata['last_seen_at'] ) ? (string) $metadata['last_seen_at'] : null,
+			);
+		}
+
+		$last_seen_raw = isset( $metadata['last_seen_at'] ) ? (string) $metadata['last_seen_at'] : '';
+		if ( '' === $last_seen_raw ) {
+			$last_seen_raw = isset( $metadata['created_at'] ) ? (string) $metadata['created_at'] : '';
+		}
+
+		if ( '' === $last_seen_raw ) {
+			return array(
+				'liveness'              => self::LIVENESS_UNKNOWN,
+				'reason'                => 'heartbeat_unknown',
+				'heartbeat_age_seconds' => null,
+				'last_seen_at'          => null,
+			);
+		}
+
+		$last_seen_ts = strtotime( $last_seen_raw );
+		if ( false === $last_seen_ts ) {
+			return array(
+				'liveness'              => self::LIVENESS_UNKNOWN,
+				'reason'                => 'heartbeat_unknown',
+				'heartbeat_age_seconds' => null,
+				'last_seen_at'          => $last_seen_raw,
+			);
+		}
+
+		$now_ts = null === $now ? time() : $now;
+		$age    = max( 0, $now_ts - $last_seen_ts );
+
+		if ( $age <= max( 0, $ttl ) ) {
+			return array(
+				'liveness'              => self::LIVENESS_LIVE,
+				'reason'                => 'heartbeat_fresh',
+				'heartbeat_age_seconds' => $age,
+				'last_seen_at'          => $last_seen_raw,
+			);
+		}
+
+		return array(
+			'liveness'              => self::LIVENESS_STALE,
+			'reason'                => 'heartbeat_stale',
+			'heartbeat_age_seconds' => $age,
+			'last_seen_at'          => $last_seen_raw,
+		);
+	}
+
+	/**
+	 * Detect duplicate task ownership across a worktree listing.
+	 *
+	 * Two worktrees are duplicates when they share a normalized task key:
+	 *   - origin_task.task_url (preferred, e.g. https://github.com/o/r/issues/N)
+	 *   - origin_task.task_ref
+	 *   - pr_url
+	 *   - pr_repo:pr_number
+	 *
+	 * Bounded by listing size; intentionally returns groups rather than
+	 * deletion candidates so callers can decide whether to act.
+	 *
+	 * @param array<int,array<string,mixed>> $worktrees Worktree rows. Each row
+	 *        must expose `handle` and `metadata` (or top-level pr_url/pr_number/
+	 *        origin_task fields).
+	 * @return array<int,array{key:string,kind:string,handles:array<int,string>}>
+	 */
+	public static function find_duplicate_task_ownership( array $worktrees ): array {
+		$buckets = array();
+
+		foreach ( $worktrees as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+			$handle = (string) ( $row['handle'] ?? '' );
+			if ( '' === $handle ) {
+				continue;
+			}
+			$metadata = is_array( $row['metadata'] ?? null ) ? $row['metadata'] : array();
+
+			$keys = self::extract_task_keys( $row, $metadata );
+			foreach ( $keys as $kind => $key ) {
+				$bucket_key                       = $kind . '|' . $key;
+				$buckets[ $bucket_key ]['kind']   = $kind;
+				$buckets[ $bucket_key ]['key']    = $key;
+				$buckets[ $bucket_key ]['handles'][] = $handle;
+			}
+		}
+
+		$duplicates = array();
+		foreach ( $buckets as $bucket ) {
+			$handles = array_values( array_unique( (array) ( $bucket['handles'] ?? array() ) ) );
+			if ( count( $handles ) < 2 ) {
+				continue;
+			}
+			$duplicates[] = array(
+				'kind'    => (string) $bucket['kind'],
+				'key'     => (string) $bucket['key'],
+				'handles' => $handles,
+			);
+		}
+
+		return $duplicates;
+	}
+
+	/**
+	 * Summarize the owner side of persisted metadata for listing surfaces.
+	 *
+	 * Returns a stable shape with `unknown` defaults so renderers don't need
+	 * null-coalescing for every field. Sensitive user fields are excluded.
+	 *
+	 * @param array<string,mixed>|null $metadata Persisted metadata.
+	 * @return array{site:string,site_url:?string,agent:string,user:string}
+	 */
+	public static function summarize_owner( ?array $metadata ): array {
+		$site     = 'unknown';
+		$site_url = null;
+		$agent    = 'unknown';
+		$user     = 'unknown';
+
+		if ( is_array( $metadata ) ) {
+			$origin_site = trim( (string) ( $metadata['origin_site'] ?? $metadata['site_name'] ?? '' ) );
+			if ( '' !== $origin_site ) {
+				$site = $origin_site;
+			}
+
+			$origin_site_url = trim( (string) ( $metadata['origin_site_url'] ?? $metadata['site_url'] ?? '' ) );
+			if ( '' !== $origin_site_url ) {
+				$site_url = $origin_site_url;
+			}
+
+			$origin_agent = trim( (string) ( $metadata['origin_agent'] ?? $metadata['agent_slug'] ?? '' ) );
+			if ( '' !== $origin_agent ) {
+				$agent = $origin_agent;
+			}
+
+			$origin_user = is_array( $metadata['origin_user'] ?? null ) ? $metadata['origin_user'] : array();
+			$display     = trim( (string) ( $origin_user['display_name'] ?? '' ) );
+			$login       = trim( (string) ( $origin_user['login'] ?? '' ) );
+			if ( '' !== $login ) {
+				$user = $login;
+			} elseif ( '' !== $display ) {
+				$user = $display;
+			}
+		}
+
+		return array(
+			'site'     => $site,
+			'site_url' => $site_url,
+			'agent'    => $agent,
+			'user'     => $user,
+		);
+	}
+
+	/**
+	 * Summarize the session side of persisted metadata for listing surfaces.
+	 *
+	 * Returns the recorded runtime IDs along with a single stable
+	 * `primary_id` field renderers can show in narrow tables.
+	 *
+	 * @param array<string,mixed>|null $metadata Persisted metadata.
+	 * @return array{primary_id:?string,kimaki_session_id:?string,kimaki_thread_id:?string,kimaki_thread_url:?string,opencode_session_id:?string,opencode_run_id:?string}
+	 */
+	public static function summarize_session( ?array $metadata ): array {
+		$session = is_array( $metadata['origin_session'] ?? null ) ? $metadata['origin_session'] : array();
+
+		$kimaki_session_id   = isset( $session['kimaki_session_id'] ) ? (string) $session['kimaki_session_id'] : null;
+		$kimaki_thread_id    = isset( $session['kimaki_thread_id'] ) ? (string) $session['kimaki_thread_id'] : null;
+		$kimaki_thread_url   = isset( $session['kimaki_thread_url'] ) ? (string) $session['kimaki_thread_url'] : null;
+		$opencode_session_id = isset( $session['opencode_session_id'] ) ? (string) $session['opencode_session_id'] : null;
+		$opencode_run_id     = isset( $session['opencode_run_id'] ) ? (string) $session['opencode_run_id'] : null;
+
+		// Pick the most descriptive identifier as the renderer-friendly primary.
+		$primary = $kimaki_session_id ?? $opencode_session_id ?? $opencode_run_id ?? $kimaki_thread_id;
+
+		return array(
+			'primary_id'         => '' === $primary ? null : $primary,
+			'kimaki_session_id'  => '' === $kimaki_session_id ? null : $kimaki_session_id,
+			'kimaki_thread_id'   => '' === $kimaki_thread_id ? null : $kimaki_thread_id,
+			'kimaki_thread_url'  => '' === $kimaki_thread_url ? null : $kimaki_thread_url,
+			'opencode_session_id' => '' === $opencode_session_id ? null : $opencode_session_id,
+			'opencode_run_id'    => '' === $opencode_run_id ? null : $opencode_run_id,
+		);
+	}
+
+	/**
+	 * Extract normalized task keys for duplicate detection from a worktree row.
+	 *
+	 * @param array<string,mixed> $row      Listing row.
+	 * @param array<string,mixed> $metadata Persisted metadata.
+	 * @return array<string,string> Map of kind => normalized key.
+	 */
+	private static function extract_task_keys( array $row, array $metadata ): array {
+		$keys = array();
+
+		$task = is_array( $metadata['origin_task'] ?? null ) ? $metadata['origin_task'] : array();
+		$task_url = trim( (string) ( $task['task_url'] ?? '' ) );
+		if ( '' !== $task_url ) {
+			$keys['task_url'] = strtolower( $task_url );
+		}
+		$task_ref = trim( (string) ( $task['task_ref'] ?? '' ) );
+		if ( '' === $task_url && '' !== $task_ref ) {
+			$keys['task_ref'] = strtolower( $task_ref );
+		}
+
+		$pr_url = trim( (string) ( $row['pr_url'] ?? $metadata['pr_url'] ?? '' ) );
+		if ( '' !== $pr_url ) {
+			$keys['pr_url'] = strtolower( $pr_url );
+		}
+
+		$pr_repo   = trim( (string) ( $metadata['pr_repo'] ?? '' ) );
+		$pr_number = (int) ( $row['pr_number'] ?? $metadata['pr_number'] ?? 0 );
+		if ( '' !== $pr_repo && $pr_number > 0 ) {
+			$keys['pr_ref'] = strtolower( $pr_repo . '#' . $pr_number );
+		}
+
+		return $keys;
 	}
 
 	/**
@@ -583,6 +890,11 @@ class WorktreeContextInjector {
 	/**
 	 * Resolve non-sensitive runtime/session hints from the creating process.
 	 *
+	 * Reads identifiers exposed by the surrounding agent runtime (OpenCode,
+	 * Kimaki/Discord) and the originating site URL. Cross-machine federation
+	 * is intentionally out of scope: only the env that the creator process
+	 * exposes is captured. Missing fields stay missing — never invent IDs.
+	 *
 	 * @return array<string,mixed>|null
 	 */
 	private static function resolve_origin_session(): ?array {
@@ -591,6 +903,11 @@ class WorktreeContextInjector {
 		$opencode_run_id = getenv( 'OPENCODE_RUN_ID' );
 		if ( is_string( $opencode_run_id ) && '' !== trim( $opencode_run_id ) ) {
 			$session['opencode_run_id'] = trim( $opencode_run_id );
+		}
+
+		$opencode_session_id = getenv( 'OPENCODE_SESSION_ID' );
+		if ( is_string( $opencode_session_id ) && '' !== trim( $opencode_session_id ) ) {
+			$session['opencode_session_id'] = trim( $opencode_session_id );
 		}
 
 		$opencode_pid = getenv( 'OPENCODE_PID' );
@@ -608,12 +925,63 @@ class WorktreeContextInjector {
 			$session['kimaki_thread_id'] = trim( $kimaki_thread_id );
 		}
 
+		$kimaki_channel_id = getenv( 'KIMAKI_CHANNEL_ID' );
+		if ( is_string( $kimaki_channel_id ) && '' !== trim( $kimaki_channel_id ) ) {
+			$session['kimaki_channel_id'] = trim( $kimaki_channel_id );
+		}
+
+		$kimaki_guild_id = getenv( 'KIMAKI_GUILD_ID' );
+		if ( is_string( $kimaki_guild_id ) && '' !== trim( $kimaki_guild_id ) ) {
+			$session['kimaki_guild_id'] = trim( $kimaki_guild_id );
+		}
+
 		$kimaki_thread_url = getenv( 'KIMAKI_THREAD_URL' );
-		if ( is_string( $kimaki_thread_url ) && preg_match( '#^https?://#', $kimaki_thread_url ) ) {
+		if ( is_string( $kimaki_thread_url ) && preg_match( '#^https?://#', (string) $kimaki_thread_url ) ) {
 			$session['kimaki_thread_url'] = trim( $kimaki_thread_url );
 		}
 
 		return empty( $session ) ? null : $session;
+	}
+
+	/**
+	 * Resolve a task/issue reference for the worktree, when available.
+	 *
+	 * Sources, in order:
+	 *   1. Caller-supplied `task_url` / `task_ref` in `$args` (explicit wins).
+	 *   2. `DATAMACHINE_TASK_URL` / `DATAMACHINE_TASK_REF` env vars exposed
+	 *      by the surrounding orchestrator.
+	 *
+	 * Cross-machine inference is intentionally out of scope.
+	 *
+	 * @param array<string,mixed> $args Worktree creation context.
+	 * @return array<string,mixed>|null
+	 */
+	private static function resolve_origin_task( array $args = array() ): ?array {
+		$task = array();
+
+		$task_url = isset( $args['task_url'] ) && '' !== trim( (string) $args['task_url'] ) ? trim( (string) $args['task_url'] ) : '';
+		if ( '' === $task_url ) {
+			$env_task_url = getenv( 'DATAMACHINE_TASK_URL' );
+			if ( is_string( $env_task_url ) && '' !== trim( $env_task_url ) ) {
+				$task_url = trim( $env_task_url );
+			}
+		}
+		if ( '' !== $task_url && preg_match( '#^https?://#', $task_url ) ) {
+			$task['task_url'] = $task_url;
+		}
+
+		$task_ref = isset( $args['task_ref'] ) && '' !== trim( (string) $args['task_ref'] ) ? trim( (string) $args['task_ref'] ) : '';
+		if ( '' === $task_ref ) {
+			$env_task_ref = getenv( 'DATAMACHINE_TASK_REF' );
+			if ( is_string( $env_task_ref ) && '' !== trim( $env_task_ref ) ) {
+				$task_ref = trim( $env_task_ref );
+			}
+		}
+		if ( '' !== $task_ref ) {
+			$task['task_ref'] = $task_ref;
+		}
+
+		return empty( $task ) ? null : $task;
 	}
 
 	/**

--- a/tests/smoke-workspace-hygiene-cli.php
+++ b/tests/smoke-workspace-hygiene-cli.php
@@ -151,7 +151,7 @@ namespace {
 	$GLOBALS['__cli_logs'] = array();
 	$command->hygiene( array(), array() );
 	datamachine_code_hygiene_assert( 'Workspace hygiene:' === ( $GLOBALS['__cli_logs'][0] ?? '' ), 'human output starts with report heading' );
-	datamachine_code_hygiene_assert( in_array( 'table:13:metric,value', $GLOBALS['__cli_logs'], true ), 'human output renders summary table' );
+	datamachine_code_hygiene_assert( in_array( 'table:18:metric,value', $GLOBALS['__cli_logs'], true ), 'human output renders summary table (now includes 4 liveness counts + duplicate_task_groups)' );
 	datamachine_code_hygiene_assert( in_array( 'Workspace size by kind:', $GLOBALS['__cli_logs'], true ), 'human output renders size kind grouping' );
 	datamachine_code_hygiene_assert( in_array( 'Top workspace entries by size:', $GLOBALS['__cli_logs'], true ), 'human output renders top offenders' );
 	datamachine_code_hygiene_assert( in_array( 'Top repos by size:', $GLOBALS['__cli_logs'], true ), 'human output renders size leaders' );

--- a/tests/smoke-worktree-agent-session-lifecycle.php
+++ b/tests/smoke-worktree-agent-session-lifecycle.php
@@ -1,0 +1,365 @@
+<?php
+/**
+ * Smoke test for DMC agent/session lifecycle tracking on worktrees.
+ *
+ * Covers:
+ *  - liveness classification (live / stale / stopped / unknown) with reason codes
+ *  - heartbeat updates persisted to lifecycle metadata
+ *  - duplicate task ownership detection (task_url, task_ref, pr_url, pr_repo#pr_number)
+ *  - owner/session/task summary helpers exposing unknown-safe defaults
+ *  - env-driven session and task capture from build_lifecycle_metadata
+ *
+ * Run: php tests/smoke-worktree-agent-session-lifecycle.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Core\FilesRepository {
+	if ( ! class_exists( __NAMESPACE__ . '\FilesystemHelper' ) ) {
+		class FilesystemHelper {
+			public static function get() {
+				return null;
+			}
+		}
+	}
+
+	if ( ! class_exists( __NAMESPACE__ . '\DirectoryManager' ) ) {
+		class DirectoryManager {
+			public function get_effective_user_id( int $fallback ): int {
+				return 7;
+			}
+
+			public function resolve_agent_slug( array $args ): string {
+				return 'minion-franklin';
+			}
+		}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			public string $code;
+			public string $message;
+			public array $data;
+
+			public function __construct( $code = '', $message = '', $data = array() ) {
+				$this->code    = (string) $code;
+				$this->message = (string) $message;
+				$this->data    = (array) $data;
+			}
+
+			public function get_error_message(): string {
+				return $this->message;
+			}
+
+			public function get_error_data() {
+				return $this->data;
+			}
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $thing ): bool {
+			return $thing instanceof \WP_Error;
+		}
+	}
+
+	if ( ! function_exists( 'get_option' ) ) {
+		function get_option( string $name, $default = false ) {
+			global $datamachine_code_test_options;
+			return $datamachine_code_test_options[ $name ] ?? $default;
+		}
+	}
+
+	if ( ! function_exists( 'update_option' ) ) {
+		function update_option( string $name, $value, $autoload = null ): bool {
+			global $datamachine_code_test_options;
+			$datamachine_code_test_options[ $name ] = $value;
+			return true;
+		}
+	}
+
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( string $hook_name, $value, ...$args ) {
+			return $value;
+		}
+	}
+
+	if ( ! function_exists( 'home_url' ) ) {
+		function home_url(): string {
+			return 'https://intelligence.example.test';
+		}
+	}
+
+	if ( ! function_exists( 'get_bloginfo' ) ) {
+		function get_bloginfo( string $show ): string {
+			return 'Intelligence';
+		}
+	}
+
+	if ( ! function_exists( 'get_current_user_id' ) ) {
+		function get_current_user_id(): int {
+			return 7;
+		}
+	}
+
+	if ( ! function_exists( 'get_userdata' ) ) {
+		function get_userdata( int $user_id ): object {
+			return (object) array(
+				'user_login'   => 'chris',
+				'display_name' => 'Chris Huber',
+			);
+		}
+	}
+
+	if ( ! function_exists( 'wp_mkdir_p' ) ) {
+		function wp_mkdir_p( string $path ): bool {
+			return is_dir( $path ) || mkdir( $path, 0755, true );
+		}
+	}
+
+	require __DIR__ . '/../inc/Workspace/WorktreeContextInjector.php';
+
+	$assertions = 0;
+	$failures   = 0;
+
+	$assert = function ( $expected, $actual, string $message ) use ( &$assertions, &$failures ): void {
+		++$assertions;
+		if ( $expected === $actual ) {
+			echo "  [PASS] {$message}\n";
+			return;
+		}
+		++$failures;
+		echo "  [FAIL] {$message}\n";
+		echo '         expected: ' . var_export( $expected, true ) . "\n";
+		echo '         actual:   ' . var_export( $actual, true ) . "\n";
+	};
+
+	echo "=== smoke-worktree-agent-session-lifecycle ===\n";
+
+	// Reset option state for this run.
+	$GLOBALS['datamachine_code_test_options'] = array();
+
+	// --- 1) build_lifecycle_metadata captures env-driven session + task fields ---
+	putenv( 'OPENCODE_SESSION_ID=ses_smoke_42' );
+	putenv( 'OPENCODE_RUN_ID=run-smoke-1' );
+	putenv( 'KIMAKI_SESSION_ID=kim-ses-99' );
+	putenv( 'KIMAKI_THREAD_ID=thr_111' );
+	putenv( 'KIMAKI_CHANNEL_ID=chan_222' );
+	putenv( 'KIMAKI_THREAD_URL=https://discord.com/channels/1/2/3' );
+	putenv( 'DATAMACHINE_TASK_URL=https://github.com/Extra-Chill/data-machine-code/issues/221' );
+	putenv( 'DATAMACHINE_TASK_REF=Extra-Chill/data-machine-code#221' );
+
+	$built = \DataMachineCode\Workspace\WorktreeContextInjector::build_lifecycle_metadata( array(
+		'handle' => 'demo@feature-x',
+		'path'   => '/tmp/demo@feature-x',
+		'repo'   => 'demo',
+		'branch' => 'feature/x',
+	) );
+
+	$assert( 'active', $built['lifecycle_state'] ?? null, 'new metadata defaults lifecycle to active' );
+	$assert( true, isset( $built['last_seen_at'] ) && '' !== $built['last_seen_at'], 'last_seen_at heartbeat is set at creation' );
+	$assert( $built['created_at'] ?? '', $built['last_seen_at'] ?? '_none_', 'last_seen_at matches created_at on first record' );
+	$assert( 'minion-franklin', $built['origin_agent'] ?? null, 'origin agent recorded' );
+	$assert( 'Intelligence', $built['origin_site'] ?? null, 'origin site name recorded' );
+	$assert( 'https://intelligence.example.test', $built['origin_site_url'] ?? null, 'origin site URL recorded' );
+	$assert( 'chris', $built['origin_user']['login'] ?? null, 'origin user login recorded' );
+	$assert( 'ses_smoke_42', $built['origin_session']['opencode_session_id'] ?? null, 'opencode session id captured' );
+	$assert( 'kim-ses-99', $built['origin_session']['kimaki_session_id'] ?? null, 'kimaki session id captured' );
+	$assert( 'chan_222', $built['origin_session']['kimaki_channel_id'] ?? null, 'kimaki channel id captured' );
+	$assert( 'https://discord.com/channels/1/2/3', $built['origin_session']['kimaki_thread_url'] ?? null, 'kimaki thread URL captured' );
+	$assert( 'https://github.com/Extra-Chill/data-machine-code/issues/221', $built['origin_task']['task_url'] ?? null, 'task URL captured from env' );
+	$assert( 'Extra-Chill/data-machine-code#221', $built['origin_task']['task_ref'] ?? null, 'task ref captured from env' );
+
+	// Caller-supplied task_url/task_ref override env.
+	putenv( 'DATAMACHINE_TASK_URL=https://github.com/some/other/issues/9999' );
+	$built_explicit = \DataMachineCode\Workspace\WorktreeContextInjector::build_lifecycle_metadata( array(
+		'handle'   => 'demo@bug-fix',
+		'task_url' => 'https://github.com/Extra-Chill/data-machine-code/issues/221',
+		'task_ref' => 'EC/dmc#221',
+	) );
+	$assert( 'https://github.com/Extra-Chill/data-machine-code/issues/221', $built_explicit['origin_task']['task_url'] ?? null, 'explicit task_url wins over env' );
+	$assert( 'EC/dmc#221', $built_explicit['origin_task']['task_ref'] ?? null, 'explicit task_ref wins over env' );
+
+	// Clear env so subsequent assertions get unknown-safe defaults.
+	putenv( 'OPENCODE_SESSION_ID' );
+	putenv( 'OPENCODE_RUN_ID' );
+	putenv( 'KIMAKI_SESSION_ID' );
+	putenv( 'KIMAKI_THREAD_ID' );
+	putenv( 'KIMAKI_CHANNEL_ID' );
+	putenv( 'KIMAKI_THREAD_URL' );
+	putenv( 'DATAMACHINE_TASK_URL' );
+	putenv( 'DATAMACHINE_TASK_REF' );
+
+	// --- 2) Liveness classification ---
+	$now = strtotime( '2026-05-10T12:00:00Z' );
+
+	$missing = \DataMachineCode\Workspace\WorktreeContextInjector::classify_liveness( null, $now );
+	$assert( 'unknown', $missing['liveness'], 'null metadata classifies as unknown' );
+	$assert( 'metadata_missing', $missing['reason'], 'null metadata has metadata_missing reason' );
+
+	$fresh = \DataMachineCode\Workspace\WorktreeContextInjector::classify_liveness(
+		array(
+			'lifecycle_state' => 'active',
+			'last_seen_at'    => gmdate( 'c', $now - 600 ),
+		),
+		$now,
+		3600
+	);
+	$assert( 'live', $fresh['liveness'], 'recent heartbeat classifies as live' );
+	$assert( 'heartbeat_fresh', $fresh['reason'], 'live carries heartbeat_fresh reason' );
+	$assert( 600, $fresh['heartbeat_age_seconds'], 'heartbeat age computed in seconds' );
+
+	$stale = \DataMachineCode\Workspace\WorktreeContextInjector::classify_liveness(
+		array(
+			'lifecycle_state' => 'active',
+			'last_seen_at'    => gmdate( 'c', $now - ( 2 * 86400 ) ),
+		),
+		$now,
+		86400
+	);
+	$assert( 'stale', $stale['liveness'], 'heartbeat older than TTL classifies as stale' );
+	$assert( 'heartbeat_stale', $stale['reason'], 'stale carries heartbeat_stale reason' );
+
+	$pr_opened = \DataMachineCode\Workspace\WorktreeContextInjector::classify_liveness(
+		array( 'lifecycle_state' => 'pr_opened' ),
+		$now
+	);
+	$assert( 'stopped', $pr_opened['liveness'], 'pr_opened lifecycle classifies as stopped liveness' );
+	$assert( 'lifecycle_pr_opened', $pr_opened['reason'], 'pr_opened liveness carries explicit reason' );
+
+	$cleanup_eligible = \DataMachineCode\Workspace\WorktreeContextInjector::classify_liveness(
+		array( 'lifecycle_state' => 'cleanup_eligible' ),
+		$now
+	);
+	$assert( 'stopped', $cleanup_eligible['liveness'], 'cleanup_eligible classifies as stopped' );
+	$assert( 'lifecycle_finalized', $cleanup_eligible['reason'], 'cleanup_eligible carries lifecycle_finalized reason' );
+
+	$no_heartbeat = \DataMachineCode\Workspace\WorktreeContextInjector::classify_liveness(
+		array( 'lifecycle_state' => 'active' ),
+		$now
+	);
+	$assert( 'unknown', $no_heartbeat['liveness'], 'active without heartbeat or created_at is unknown' );
+	$assert( 'heartbeat_unknown', $no_heartbeat['reason'], 'unknown liveness reports heartbeat_unknown' );
+
+	$bad_timestamp = \DataMachineCode\Workspace\WorktreeContextInjector::classify_liveness(
+		array(
+			'lifecycle_state' => 'active',
+			'last_seen_at'    => 'not-a-date',
+		),
+		$now
+	);
+	$assert( 'unknown', $bad_timestamp['liveness'], 'unparseable last_seen_at degrades to unknown rather than crashing' );
+
+	// --- 3) Heartbeat persistence ---
+	\DataMachineCode\Workspace\WorktreeContextInjector::store_lifecycle_metadata(
+		'demo@feature-heartbeat',
+		array(
+			'lifecycle_state' => 'active',
+			'created_at'      => gmdate( 'c', $now - 3600 ),
+			'last_seen_at'    => gmdate( 'c', $now - 3600 ),
+		)
+	);
+	$bumped = \DataMachineCode\Workspace\WorktreeContextInjector::record_heartbeat( 'demo@feature-heartbeat', gmdate( 'c', $now ) );
+	$assert( gmdate( 'c', $now ), $bumped, 'record_heartbeat returns persisted timestamp' );
+	$reloaded = \DataMachineCode\Workspace\WorktreeContextInjector::get_metadata( 'demo@feature-heartbeat' );
+	$assert( gmdate( 'c', $now ), $reloaded['last_seen_at'] ?? null, 'heartbeat is persisted to metadata' );
+
+	$missing_handle = \DataMachineCode\Workspace\WorktreeContextInjector::record_heartbeat( 'demo@does-not-exist' );
+	$assert( null, $missing_handle, 'record_heartbeat returns null when handle has no metadata (does not invent records)' );
+
+	// --- 4) Owner / session summaries with unknown-safe defaults ---
+	$owner_unknown = \DataMachineCode\Workspace\WorktreeContextInjector::summarize_owner( null );
+	$assert( 'unknown', $owner_unknown['site'], 'summarize_owner defaults site to unknown' );
+	$assert( 'unknown', $owner_unknown['agent'], 'summarize_owner defaults agent to unknown' );
+	$assert( 'unknown', $owner_unknown['user'], 'summarize_owner defaults user to unknown' );
+	$assert( null, $owner_unknown['site_url'], 'summarize_owner site_url is null when missing' );
+
+	$owner_filled = \DataMachineCode\Workspace\WorktreeContextInjector::summarize_owner( $built );
+	$assert( 'Intelligence', $owner_filled['site'], 'summarize_owner reflects origin site' );
+	$assert( 'minion-franklin', $owner_filled['agent'], 'summarize_owner reflects origin agent' );
+	$assert( 'chris', $owner_filled['user'], 'summarize_owner prefers user_login over display_name' );
+
+	$session_unknown = \DataMachineCode\Workspace\WorktreeContextInjector::summarize_session( null );
+	$assert( null, $session_unknown['primary_id'], 'summarize_session primary_id null on missing metadata' );
+	$assert( null, $session_unknown['kimaki_session_id'], 'summarize_session kimaki id null on missing metadata' );
+
+	$session_filled = \DataMachineCode\Workspace\WorktreeContextInjector::summarize_session( $built );
+	$assert( 'kim-ses-99', $session_filled['primary_id'], 'summarize_session prefers kimaki session id as primary' );
+	$assert( 'ses_smoke_42', $session_filled['opencode_session_id'], 'summarize_session exposes opencode session id' );
+
+	// --- 5) Duplicate task ownership detection ---
+	$rows = array(
+		array(
+			'handle'   => 'a@one',
+			'metadata' => array(
+				'origin_task' => array( 'task_url' => 'https://github.com/Extra-Chill/data-machine-code/issues/221' ),
+			),
+		),
+		array(
+			'handle'   => 'a@two',
+			'metadata' => array(
+				'origin_task' => array( 'task_url' => 'https://github.com/Extra-Chill/data-machine-code/issues/221' ),
+			),
+		),
+		array(
+			'handle'   => 'a@three',
+			'metadata' => array(
+				'pr_url'   => 'https://github.com/foo/bar/pull/42',
+				'pr_repo'  => 'foo/bar',
+				'pr_number' => 42,
+			),
+		),
+		array(
+			'handle'   => 'a@four',
+			'metadata' => array(
+				'pr_url'    => 'https://github.com/foo/bar/pull/42',
+				'pr_repo'   => 'foo/bar',
+				'pr_number' => 42,
+			),
+		),
+		array(
+			'handle'   => 'a@five',
+			'metadata' => array(
+				'origin_task' => array( 'task_ref' => 'org/repo#7' ),
+			),
+		),
+	);
+
+	$dups = \DataMachineCode\Workspace\WorktreeContextInjector::find_duplicate_task_ownership( $rows );
+	$dup_kinds = array_map( fn( $g ) => $g['kind'], $dups );
+	$assert( true, in_array( 'task_url', $dup_kinds, true ), 'duplicate detection flags task_url collisions' );
+	$assert( true, in_array( 'pr_url', $dup_kinds, true ), 'duplicate detection flags pr_url collisions' );
+	$assert( true, in_array( 'pr_ref', $dup_kinds, true ), 'duplicate detection flags pr_repo#pr_number collisions' );
+	$assert( false, in_array( 'task_ref', $dup_kinds, true ), 'a single task_ref does not produce a duplicate group' );
+
+	$task_url_group = array_values( array_filter( $dups, fn( $g ) => 'task_url' === $g['kind'] ) )[0] ?? array();
+	$assert( true, in_array( 'a@one', (array) $task_url_group['handles'], true ) && in_array( 'a@two', (array) $task_url_group['handles'], true ), 'task_url group lists both handles' );
+
+	// Single row: no duplicates.
+	$single = \DataMachineCode\Workspace\WorktreeContextInjector::find_duplicate_task_ownership(
+		array(
+			array(
+				'handle'   => 'solo@one',
+				'metadata' => array(
+					'origin_task' => array( 'task_url' => 'https://example.test/issues/1' ),
+				),
+			),
+		)
+	);
+	$assert( 0, count( $single ), 'single worktree never produces duplicate group' );
+
+	if ( $failures > 0 ) {
+		echo "\n{$failures} failure(s) across {$assertions} assertion(s).\n";
+		exit( 1 );
+	}
+
+	echo "\nAll {$assertions} agent/session lifecycle assertions passed.\n";
+}

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -490,7 +490,7 @@ namespace {
 	WP_CLI::$logs      = array();
 	WP_CLI::$successes = array();
 	$command->worktree( array( 'list' ), array( 'stale' => true ) );
-	datamachine_code_cleanup_assert( in_array( 'table:2:handle,repo,kind,branch,head,dirty,state,created_at,pr,age_days,size,artifacts,stale,path', WP_CLI::$logs, true ), 'worktree list --stale filters to stale rows and includes disk fields' );
+	datamachine_code_cleanup_assert( in_array( 'table:2:handle,repo,kind,branch,head,dirty,state,liveness,last_seen_at,owner,agent,session,task,pr,age_days,size,artifacts,stale,path', WP_CLI::$logs, true ), 'worktree list --stale filters to stale rows and includes disk + liveness fields' );
 
 	echo "\n[1] JSON output is one parseable document\n";
 	WP_CLI::$logs      = array();

--- a/tests/smoke-worktree-finalizer-cli.php
+++ b/tests/smoke-worktree-finalizer-cli.php
@@ -138,8 +138,8 @@ namespace {
 	WP_CLI::$logs      = array();
 	WP_CLI::$successes = array();
 	$command->worktree( array( 'list' ), array( 'state' => 'cleanup_eligible' ) );
-	datamachine_code_finalizer_assert( array( 'state' => 'cleanup_eligible' ) === $list->last_input, 'list forwards lifecycle state filter' );
-	datamachine_code_finalizer_assert( in_array( 'table:1:handle,repo,kind,branch,head,dirty,state,created_at,pr,age_days,size,artifacts,stale,path', WP_CLI::$logs, true ), 'list human table exposes state and PR columns' );
+	datamachine_code_finalizer_assert( array( 'state' => 'cleanup_eligible', 'include_status' => false, 'include_disk' => false ) === $list->last_input, 'list forwards lifecycle state filter and the cheap-listing defaults from #217' );
+	datamachine_code_finalizer_assert( in_array( 'table:1:handle,repo,kind,branch,head,dirty,state,liveness,last_seen_at,owner,agent,session,task,pr,age_days,size,artifacts,stale,path', WP_CLI::$logs, true ), 'list human table exposes state, liveness, owner/session/task, and PR columns' );
 
 	echo "\nAll worktree finalizer CLI smoke tests passed.\n";
 }


### PR DESCRIPTION
## Summary

- Smallest useful slice of agent/session lifecycle tracking for dead-worktree detection: record more ownership/session context at worktree creation, expose liveness/owner/session/task fields on listing and hygiene surfaces, and add bounded reason-coded classification helpers.
- **No new destructive cleanup behavior.** Liveness and duplicate detection are reporting surfaces only — they never trigger deletions. Existing dirty/unpushed/missing-metadata safety gates remain authoritative.
- Closes the immediate part of #221: classify and surface ownership; deletion policy stays out of scope here.

## What's new

### Lifecycle metadata

- New `last_seen_at` heartbeat field on worktree metadata records.
- Extra Kimaki/OpenCode session env captured at creation: `kimaki_channel_id`, `kimaki_guild_id`, `opencode_session_id` (in addition to the existing run-id/thread-id/session-id fields).
- New `origin_task` block (`task_url`, `task_ref`) populated from explicit input or `DATAMACHINE_TASK_URL` / `DATAMACHINE_TASK_REF` env.
- `WorktreeContextInjector::record_heartbeat()` updates `last_seen_at`. Wired into `refresh-context` and `finalize` so the heartbeat tracks real owner activity rather than passive scans.

### Liveness classification (reporting only)

`WorktreeContextInjector::classify_liveness()` returns one of `live | stopped | stale | unknown` plus a reason code:

| Liveness | Reason code | When |
|---|---|---|
| `unknown` | `metadata_missing` | No metadata record at all |
| `unknown` | `heartbeat_unknown` | Active state but no parsable `last_seen_at`/`created_at` |
| `live` | `heartbeat_fresh` | `last_seen_at` within TTL (default 24h) |
| `stale` | `heartbeat_stale` | `last_seen_at` older than TTL |
| `stopped` | `lifecycle_pr_opened` | `lifecycle_state=pr_opened` |
| `stopped` | `lifecycle_finalized` | merged / closed / abandoned / cleanup_eligible |

### Duplicate task ownership detection (reporting only)

`WorktreeContextInjector::find_duplicate_task_ownership()` groups worktrees sharing a normalized key:

- `task_url`
- `task_ref` (when no task_url)
- `pr_url`
- `pr_repo#pr_number`

Single-row task_refs never produce a group. Result is exposed on `worktree list` (`duplicates` field) and as `duplicate_task_groups` count plus a list section in the hygiene report.

### Surfaced output

- `workspace-worktree-list` ability output now includes `last_seen_at`, `liveness`, `liveness_reason`, `heartbeat_age_seconds`, `owner` (`site`/`site_url`/`agent`/`user`), `session` (`primary_id`/`kimaki_*`/`opencode_*`), `task`, and a top-level `duplicates` list.
- Owner/session helpers return unknown-safe defaults (`'unknown'` strings, `null` for absent IDs) so renderers don't need null guards.
- CLI `worktree list` table adds `liveness`, `last_seen_at`, `owner`, `agent`, `session`, `task` columns and prints duplicate groups below the table.
- Workspace hygiene summary table adds `liveness_live` / `liveness_stopped` / `liveness_stale` / `liveness_unknown` / `duplicate_task_groups` rows plus a duplicate ownership listing.
- New `--task-url=<url>` / `--task-ref=<ref>` CLI flags on `worktree add` map straight to the ability input.

### Tests

- New `tests/smoke-worktree-agent-session-lifecycle.php` — 49 assertions across env capture, classification (incl. unparseable timestamps), heartbeat persistence, owner/session summaries, and duplicate detection.
- Updated `smoke-workspace-hygiene-cli`, `smoke-worktree-cleanup-cli`, `smoke-worktree-finalizer-cli` to reflect the new list/hygiene field set.
- Existing `smoke-worktree-lifecycle-metadata` (42 assertions) still passes.
- Full smoke sweep: 45/46 pass; remaining failure (`smoke-agents-md-marker.php`) is pre-existing on `main` and unrelated.

## Constraints honored

- No `dm_` shorthand introduced in code identifiers.
- CLI commands stay as thin wrappers around abilities (`workspace-worktree-add`, `workspace-worktree-list`).
- No Data Machine pipelines/flows added for internal maintenance.
- No destructive cleanup behavior changes; `cleanup` and finalizer flows unaffected.
- Cross-machine federation remains explicitly out of scope.

## Acceptance criteria mapping (#221)

- ✅ DMC records agent/session identifiers in worktree lifecycle metadata when available.
- ✅ DMC surfaces live/stopped/stale/unknown ownership in `worktree list` and hygiene output.
- ✅ Bounded classification path with reason codes (`heartbeat_*`, `lifecycle_*`, `metadata_missing`).
- ✅ Duplicate task/issue detection reports multiple active worktrees or PRs for the same task.
- ✅ Cleanup never deletes anything new based on liveness — deletion behavior is unchanged.

## Out of scope (likely follow-ups, single PR is enough for #221's core ask)

- TTL-based auto-eligibility transitions (deciding when `stale` becomes `cleanup_eligible`). Intentionally not addressed here — it's the destructive policy half and deserves separate review.
- Cross-machine session reachability checks (Discord/Kimaki/OpenCode liveness probes).
- Explicit `abandoned` heuristics from PR state (closed-without-merge, etc.).

These can each ship as their own PR. The current change is sufficient for #221's stated reporting goal and keeps the surface area small.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the lifecycle/classification helpers, list/hygiene surface plumbing, and smoke tests; Chris reviewed the diff and ran the smoke suite locally on `intelligence-chubes4`.