### PR TITLE
feat: bounded cleanup-eligible apply for explicit lifecycle metadata

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -1479,6 +1479,69 @@ class WorkspaceAbilities {
 			);
 
 			wp_register_ability(
+				'datamachine/workspace-worktree-bounded-cleanup-eligible-apply',
+				array(
+					'label'               => 'Bounded Cleanup Apply for Obvious Worktrees',
+					'description'         => 'Apply only worktrees with explicit lifecycle cleanup_eligible metadata in a bounded batch using cheap workspace inventory. Revalidates dirty/unpushed/missing-metadata/external/primary safety gates immediately before each removal. Optionally schedules per-candidate chunk jobs for resumable async apply. Produces evidence with processed/removed/skipped/bytes_reclaimed/continuation.',
+					'category'            => 'datamachine-code-workspace',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'dry_run'    => array(
+								'type'        => 'boolean',
+								'description' => 'Preview the bounded batch without removing anything.',
+							),
+							'limit'      => array(
+								'type'        => 'integer',
+								'description' => 'Maximum candidates to attempt this call (default 25, hard ceiling 200).',
+							),
+							'older_than' => array(
+								'type'        => 'string',
+								'description' => 'Restrict candidates to lifecycle created_at older than the duration (e.g. 7d, 24h).',
+							),
+							'sort'       => array(
+								'type'        => 'string',
+								'description' => 'Candidate ordering before bounding: size or age (default age).',
+							),
+							'force'      => array(
+								'type'        => 'boolean',
+								'description' => 'Allow apply on dirty worktrees. Unpushed-commit gate is never overridden.',
+							),
+							'via_jobs'   => array(
+								'type'        => 'boolean',
+								'description' => 'Schedule each candidate as a single-row worktree_cleanup_chunk job for resumable async apply.',
+							),
+							'source'     => array(
+								'type'        => 'string',
+								'description' => 'Caller source marker recorded in evidence.',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'         => array( 'type' => 'boolean' ),
+							'mode'            => array( 'type' => 'string' ),
+							'dry_run'         => array( 'type' => 'boolean' ),
+							'destructive'     => array( 'type' => 'boolean' ),
+							'job_backed'      => array( 'type' => 'boolean' ),
+							'workspace_path'  => array( 'type' => 'string' ),
+							'generated_at'    => array( 'type' => 'string' ),
+							'candidates'      => array( 'type' => 'array' ),
+							'removed'         => array( 'type' => 'array' ),
+							'skipped'         => array( 'type' => 'array' ),
+							'summary'         => array( 'type' => 'object' ),
+							'continuation'    => array( 'type' => 'object' ),
+							'evidence'        => array( 'type' => 'object' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'worktreeBoundedCleanupEligibleApply' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
 				'datamachine/workspace-cleanup-plan',
 				array(
 					'label'               => 'Build Workspace Cleanup Plan Chunks',
@@ -2115,6 +2178,35 @@ class WorkspaceAbilities {
 		}
 
 		return $workspace->worktree_cleanup_artifacts( $opts );
+	}
+
+	/**
+	 * Apply only worktrees with explicit lifecycle cleanup_eligible metadata in a bounded batch.
+	 *
+	 * @param array $input Input parameters (dry_run, limit, older_than, sort, force, via_jobs, source).
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public static function worktreeBoundedCleanupEligibleApply( array $input ): array|\WP_Error {
+		$workspace = new Workspace();
+		$opts      = array(
+			'dry_run'  => ! empty( $input['dry_run'] ),
+			'force'    => ! empty( $input['force'] ),
+			'via_jobs' => ! empty( $input['via_jobs'] ),
+		);
+		if ( isset( $input['limit'] ) ) {
+			$opts['limit'] = (int) $input['limit'];
+		}
+		if ( isset( $input['older_than'] ) && '' !== trim( (string) $input['older_than'] ) ) {
+			$opts['older_than'] = trim( (string) $input['older_than'] );
+		}
+		if ( isset( $input['sort'] ) && '' !== trim( (string) $input['sort'] ) ) {
+			$opts['sort'] = trim( (string) $input['sort'] );
+		}
+		if ( isset( $input['source'] ) && '' !== trim( (string) $input['source'] ) ) {
+			$opts['source'] = trim( (string) $input['source'] );
+		}
+
+		return $workspace->worktree_bounded_cleanup_eligible_apply( $opts );
 	}
 
 	/**

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1527,8 +1527,8 @@ class WorkspaceCommand extends BaseCommand {
 	 *
 	 * <operation>
 	 * : Worktree operation: add, list, remove, prune, cleanup, cleanup-artifacts,
-	 *   reconcile-metadata, reconcile-metadata-batch, refresh-context, finalize,
-	 *   mark-cleanup-eligible.
+	 *   bounded-cleanup-eligible-apply, emergency-cleanup, reconcile-metadata,
+	 *   reconcile-metadata-batch, refresh-context, finalize, mark-cleanup-eligible.
 	 *
 	 * [<repo>]
 	 * : Primary repo name (required for add and remove). For refresh-context, finalize,
@@ -1734,6 +1734,12 @@ class WorkspaceCommand extends BaseCommand {
 	 *     wp datamachine-code workspace worktree emergency-cleanup --format=json > emergency-plan.json
 	 *     wp datamachine-code workspace worktree emergency-cleanup --apply-plan=emergency-plan.json
 	 *
+	 *     # Bounded apply restricted to explicit lifecycle cleanup_eligible worktrees
+	 *     # (cheap inventory only — no full git worktree scan, no GitHub lookup)
+	 *     wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --dry-run --limit=25
+	 *     wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --limit=25
+	 *     wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --via-jobs --limit=10 --older-than=7d
+	 *
 	 *     # Local-only detection (no GitHub API call)
 	 *     wp datamachine-code workspace worktree cleanup --skip-github
 	 *
@@ -1776,24 +1782,25 @@ class WorkspaceCommand extends BaseCommand {
 		$operation = $args[0] ?? '';
 
 		if ( '' === $operation ) {
-			WP_CLI::error( 'Usage: wp datamachine-code workspace worktree <add|list|remove|prune|cleanup|cleanup-artifacts|emergency-cleanup|reconcile-metadata|reconcile-metadata-batch|refresh-context|finalize|mark-cleanup-eligible> [<repo>] [<branch>] [--flags]' );
+			WP_CLI::error( 'Usage: wp datamachine-code workspace worktree <add|list|remove|prune|cleanup|cleanup-artifacts|bounded-cleanup-eligible-apply|emergency-cleanup|reconcile-metadata|reconcile-metadata-batch|refresh-context|finalize|mark-cleanup-eligible> [<repo>] [<branch>] [--flags]' );
 			return;
 		}
 
 		$ability_name = match ( $operation ) {
-			'add'                       => 'datamachine/workspace-worktree-add',
-			'list'                      => 'datamachine/workspace-worktree-list',
-			'remove'                    => 'datamachine/workspace-worktree-remove',
-			'prune'                     => 'datamachine/workspace-worktree-prune',
-			'cleanup'                   => 'datamachine/workspace-worktree-cleanup',
-			'cleanup-artifacts'         => 'datamachine/workspace-worktree-cleanup-artifacts',
-			'emergency-cleanup'         => 'datamachine/workspace-worktree-emergency-cleanup',
-			'reconcile-metadata'        => 'datamachine/workspace-worktree-reconcile-metadata',
-			'reconcile-metadata-batch'  => 'datamachine/workspace-worktree-reconcile-metadata-batch',
-			'refresh-context'           => 'datamachine/workspace-worktree-refresh-context',
-			'finalize'                  => 'datamachine/workspace-worktree-finalize',
-			'mark-cleanup-eligible'     => 'datamachine/workspace-worktree-finalize',
-			default                     => '',
+			'add'                            => 'datamachine/workspace-worktree-add',
+			'list'                           => 'datamachine/workspace-worktree-list',
+			'remove'                         => 'datamachine/workspace-worktree-remove',
+			'prune'                          => 'datamachine/workspace-worktree-prune',
+			'cleanup'                        => 'datamachine/workspace-worktree-cleanup',
+			'cleanup-artifacts'              => 'datamachine/workspace-worktree-cleanup-artifacts',
+			'bounded-cleanup-eligible-apply' => 'datamachine/workspace-worktree-bounded-cleanup-eligible-apply',
+			'emergency-cleanup'              => 'datamachine/workspace-worktree-emergency-cleanup',
+			'reconcile-metadata'             => 'datamachine/workspace-worktree-reconcile-metadata',
+			'reconcile-metadata-batch'       => 'datamachine/workspace-worktree-reconcile-metadata-batch',
+			'refresh-context'                => 'datamachine/workspace-worktree-refresh-context',
+			'finalize'                       => 'datamachine/workspace-worktree-finalize',
+			'mark-cleanup-eligible'          => 'datamachine/workspace-worktree-finalize',
+			default                          => '',
 		};
 
 		if ( '' === $ability_name ) {
@@ -1970,6 +1977,22 @@ class WorkspaceCommand extends BaseCommand {
 					$input['apply_plan'] = $this->read_worktree_json_plan( (string) $assoc_args['apply-plan'], 'emergency cleanup' );
 				}
 				break;
+
+			case 'bounded-cleanup-eligible-apply':
+				$input['dry_run']  = ! empty( $assoc_args['dry-run'] );
+				$input['force']    = ! empty( $assoc_args['force'] );
+				$input['via_jobs'] = ! empty( $assoc_args['via-jobs'] );
+				$input['source']   = self::CLEANUP_CLI_SOURCE;
+				if ( isset( $assoc_args['limit'] ) ) {
+					$input['limit'] = (int) $assoc_args['limit'];
+				}
+				if ( isset( $assoc_args['older-than'] ) && '' !== trim( (string) $assoc_args['older-than'] ) ) {
+					$input['older_than'] = trim( (string) $assoc_args['older-than'] );
+				}
+				if ( isset( $assoc_args['sort'] ) && '' !== trim( (string) $assoc_args['sort'] ) ) {
+					$input['sort'] = trim( (string) $assoc_args['sort'] );
+				}
+				break;
 		}
 
 		$result = $ability->execute( $input );
@@ -2086,6 +2109,10 @@ class WorkspaceCommand extends BaseCommand {
 
 			case 'cleanup-artifacts':
 				$this->render_worktree_artifact_cleanup_result( $result, $assoc_args );
+				return;
+
+			case 'bounded-cleanup-eligible-apply':
+				$this->render_worktree_bounded_cleanup_eligible_apply_result( $result, $assoc_args );
 				return;
 
 			case 'emergency-cleanup':
@@ -2834,6 +2861,125 @@ class WorkspaceCommand extends BaseCommand {
 	 * @param array $assoc_args CLI args.
 	 * @return void
 	 */
+	private function render_worktree_bounded_cleanup_eligible_apply_result( array $result, array $assoc_args ): void {
+		$format = isset( $assoc_args['format'] ) ? (string) $assoc_args['format'] : 'table';
+		if ( 'json' === $format ) {
+			$json = wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+			WP_CLI::log( false === $json ? '{}' : $json );
+			return;
+		}
+
+		$summary      = (array) ( $result['summary'] ?? array() );
+		$candidates   = (array) ( $result['candidates'] ?? array() );
+		$removed      = (array) ( $result['removed'] ?? array() );
+		$skipped      = (array) ( $result['skipped'] ?? array() );
+		$continuation = (array) ( $result['continuation'] ?? array() );
+		$dry_run      = ! empty( $result['dry_run'] );
+		$job_backed   = ! empty( $result['job_backed'] );
+
+		WP_CLI::log( 'Bounded cleanup apply summary:' );
+		$summary_rows = array(
+			array(
+				'metric' => 'mode',
+				'value'  => $dry_run ? 'dry-run' : ( $job_backed ? 'job-backed apply' : 'synchronous apply' ),
+			),
+			array(
+				'metric' => 'processed',
+				'value'  => (int) ( $summary['processed'] ?? 0 ),
+			),
+			array(
+				'metric' => 'removed',
+				'value'  => (int) ( $summary['removed'] ?? 0 ),
+			),
+			array(
+				'metric' => 'skipped',
+				'value'  => (int) ( $summary['skipped'] ?? 0 ),
+			),
+			array(
+				'metric' => 'bytes_reclaimed',
+				'value'  => $this->format_bytes( $summary['bytes_reclaimed'] ?? 0 ),
+			),
+			array(
+				'metric' => 'limit',
+				'value'  => (int) ( $summary['limit'] ?? 0 ),
+			),
+		);
+		if ( $job_backed ) {
+			$summary_rows[] = array(
+				'metric' => 'scheduled_jobs',
+				'value'  => (int) ( $summary['scheduled_jobs'] ?? 0 ),
+			);
+		}
+		$this->format_items( $summary_rows, array( 'metric', 'value' ), array( 'format' => 'table' ), 'metric' );
+
+		if ( ! empty( $candidates ) && ( $dry_run || ! empty( $assoc_args['verbose'] ) ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( 'Bounded cleanup-eligible apply candidates:' );
+			$rows = array_map(
+				fn( $row ) => array(
+					'handle'      => $row['handle'] ?? '',
+					'repo'        => $row['repo'] ?? '',
+					'branch'      => $row['branch'] ?? '',
+					'reason_code' => $row['reason_code'] ?? '',
+					'pr_url'      => $row['pr_url'] ?? '',
+					'created_at'  => $row['created_at'] ?? '',
+				),
+				$candidates
+			);
+			$this->format_items( $rows, array( 'handle', 'repo', 'branch', 'reason_code', 'pr_url', 'created_at' ), array( 'format' => 'table' ), 'handle' );
+		}
+
+		if ( ! empty( $removed ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( 'Removed worktrees:' );
+			$rows = array_map(
+				fn( $row ) => array(
+					'handle' => $row['handle'] ?? '',
+					'repo'   => $row['repo'] ?? '',
+					'branch' => $row['branch'] ?? '',
+					'size'   => $this->format_bytes( $row['size_bytes'] ?? null ),
+					'path'   => $row['path'] ?? '',
+				),
+				$removed
+			);
+			$this->format_items( $rows, array( 'handle', 'repo', 'branch', 'size', 'path' ), array( 'format' => 'table' ), 'handle' );
+		}
+
+		if ( ! empty( $skipped ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( 'Skipped:' );
+			$rows = array_map(
+				fn( $row ) => array(
+					'handle'      => $row['handle'] ?? '',
+					'reason_code' => $row['reason_code'] ?? '',
+					'reason'      => $this->shorten_cleanup_reason( (string) ( $row['reason'] ?? '' ) ),
+				),
+				$skipped
+			);
+			$this->format_items( $rows, array( 'handle', 'reason_code', 'reason' ), array( 'format' => 'table' ), 'handle' );
+		}
+
+		WP_CLI::log( '' );
+		$remaining = (int) ( $continuation['remaining_total'] ?? 0 );
+		if ( $remaining > 0 ) {
+			WP_CLI::log( sprintf( 'Continuation: %d candidate(s) remaining outside this batch.', $remaining ) );
+			$hint = (string) ( $continuation['next_call_hint'] ?? '' );
+			if ( '' !== $hint ) {
+				WP_CLI::log( '  ' . $hint );
+			}
+		} else {
+			WP_CLI::log( 'Continuation: no candidates remaining outside this batch.' );
+		}
+
+		if ( $dry_run ) {
+			WP_CLI::success( 'Bounded cleanup-eligible apply dry-run complete.' );
+		} elseif ( $job_backed ) {
+			WP_CLI::success( sprintf( 'Bounded cleanup-eligible apply scheduled %d cleanup chunk job(s).', (int) ( $summary['scheduled_jobs'] ?? 0 ) ) );
+		} else {
+			WP_CLI::success( sprintf( 'Bounded cleanup-eligible apply removed %d worktree(s); reclaimed %s.', (int) ( $summary['removed'] ?? 0 ), $this->format_bytes( $summary['bytes_reclaimed'] ?? 0 ) ) );
+		}
+	}
+
 	private function render_worktree_emergency_cleanup_result( array $result, array $assoc_args ): void {
 		$format = isset( $assoc_args['format'] ) ? (string) $assoc_args['format'] : 'table';
 		if ( 'json' === $format ) {

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -5151,6 +5151,533 @@ class Workspace {
 	}
 
 	/**
+	 * Operator-safe bounded cleanup apply restricted to explicit cleanup-eligible worktrees.
+	 *
+	 * Skips the slow paths (full git worktree discovery, GitHub lookups, full
+	 * status/upstream sweep) and works only off cheap workspace inventory rows
+	 * with explicit `cleanup_eligible` lifecycle metadata. Each candidate is
+	 * revalidated at apply time — dirty/unpushed/missing-metadata/external/
+	 * primary rows stay skipped even when the inventory said they were eligible.
+	 *
+	 * Bounds:
+	 *   - `limit` caps how many candidates this batch will attempt (default 25).
+	 *   - `older_than` optionally filters by lifecycle `created_at` age.
+	 *   - `via_jobs` schedules each candidate as its own `worktree_cleanup_chunk`
+	 *     job (single-row chunks) for resumable, async apply. Synchronous mode
+	 *     is the default so operators can apply now without an Action Scheduler
+	 *     run between batch and result.
+	 *
+	 * Evidence:
+	 *   - `processed`, `removed`, `skipped`, `bytes_reclaimed`.
+	 *   - `continuation` reports remaining cleanup-eligible handles not in this
+	 *     batch so the operator can keep going (next call without changes
+	 *     re-derives the same list cheaply).
+	 *
+	 * @param array $opts Options: dry_run, limit, older_than, sort, force, via_jobs, source.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function worktree_bounded_cleanup_eligible_apply( array $opts = array() ): array|\WP_Error {
+		$started_at = microtime( true );
+		$dry_run    = ! empty( $opts['dry_run'] );
+		$force      = ! empty( $opts['force'] );
+		$via_jobs   = ! empty( $opts['via_jobs'] );
+		$older_than = isset( $opts['older_than'] ) ? trim( (string) $opts['older_than'] ) : '';
+		$sort       = isset( $opts['sort'] ) ? trim( (string) $opts['sort'] ) : 'age';
+		$source     = isset( $opts['source'] ) ? trim( (string) $opts['source'] ) : 'workspace_bounded_cleanup_eligible_apply';
+
+		$limit = isset( $opts['limit'] ) ? (int) $opts['limit'] : 25;
+		if ( $limit < 1 ) {
+			return new \WP_Error( 'invalid_bounded_cleanup_eligible_limit', 'Bounded cleanup-eligible apply limit must be a positive integer.', array( 'status' => 400 ) );
+		}
+		// Hard ceiling keeps a single bounded batch genuinely bounded — operators
+		// who want more should run multiple batches or fall through to the full
+		// retention/job-backed path.
+		$limit = min( $limit, 200 );
+
+		if ( '' !== $sort && ! in_array( $sort, array( 'size', 'age' ), true ) ) {
+			return new \WP_Error( 'invalid_cleanup_sort', 'Invalid bounded cleanup-eligible apply sort. Use size or age.', array( 'status' => 400 ) );
+		}
+
+		if ( $via_jobs && $dry_run ) {
+			return new \WP_Error( 'bounded_cleanup_eligible_apply_via_jobs_no_dry_run', 'Job-backed bounded cleanup-eligible apply cannot run as dry-run; use the synchronous dry-run path to review candidates first.', array( 'status' => 400 ) );
+		}
+
+		// Reuse the cheap inventory_only review path for candidate discovery so
+		// the bounded cleanup-eligible apply never triggers full worktree_list / fetch / GitHub
+		// API work just to plan. This intentionally does not honor `apply_plan`
+		// — bounded cleanup-eligible apply IS the apply path; no separate plan file is needed.
+		$inventory = $this->worktree_cleanup_inventory_only( $older_than, $sort );
+		if ( $inventory instanceof \WP_Error ) {
+			return $inventory;
+		}
+
+		$all_candidates = array_values( (array) ( $inventory['candidates'] ?? array() ) );
+		$inventory_skipped = array_values( (array) ( $inventory['skipped'] ?? array() ) );
+
+		$batch     = array_slice( $all_candidates, 0, $limit );
+		$deferred  = array_slice( $all_candidates, $limit );
+
+		$continuation = array(
+			'remaining_total'      => count( $deferred ),
+			'remaining_handles'    => array_values( array_filter( array_map( fn( $row ) => is_array( $row ) ? (string) ( $row['handle'] ?? '' ) : '', $deferred ) ) ),
+			'next_call_hint'       => count( $deferred ) > 0 ? sprintf( 'Run the bounded cleanup-eligible apply again to drain the next %d candidate(s).', min( $limit, count( $deferred ) ) ) : null,
+			'inventory_skipped'    => count( $inventory_skipped ),
+			'limit_applied'        => $limit,
+		);
+
+		if ( $dry_run ) {
+			return array(
+				'success'         => true,
+				'mode'            => 'bounded_cleanup_eligible_apply',
+				'dry_run'         => true,
+				'destructive'     => false,
+				'workspace_path'  => $this->workspace_path,
+				'generated_at'    => gmdate( 'c' ),
+				'candidates'      => $batch,
+				'removed'         => array(),
+				'skipped'         => array_values( $inventory_skipped ),
+				'summary'         => array(
+					'processed'       => count( $batch ),
+					'removed'         => 0,
+					'skipped'         => count( $inventory_skipped ),
+					'bytes_reclaimed' => 0,
+					'limit'           => $limit,
+				),
+				'continuation'    => $continuation,
+				'evidence'        => array(
+					'elapsed_ms'        => (int) round( ( microtime( true ) - $started_at ) * 1000 ),
+					'inventory_total'   => count( $all_candidates ),
+					'planned_handles'   => array_values( array_filter( array_map( fn( $row ) => is_array( $row ) ? (string) ( $row['handle'] ?? '' ) : '', $batch ) ) ),
+					'source'            => $source,
+				),
+			);
+		}
+
+		if ( $via_jobs ) {
+			return $this->schedule_bounded_cleanup_eligible_chunks( $batch, $deferred, $force, $source, $started_at, $continuation );
+		}
+
+		$processed       = 0;
+		$removed         = array();
+		$skipped         = array_values( $inventory_skipped );
+		$bytes_reclaimed = 0;
+
+		foreach ( $batch as $candidate ) {
+			++$processed;
+			$revalidated = $this->revalidate_bounded_cleanup_eligible_candidate( $candidate, $force );
+			if ( is_array( $revalidated ) && isset( $revalidated['skipped'] ) ) {
+				$skipped[] = $revalidated['skipped'];
+				continue;
+			}
+			if ( $revalidated instanceof \WP_Error ) {
+				$skipped[] = array(
+					'handle'      => (string) ( $candidate['handle'] ?? '' ),
+					'repo'        => (string) ( $candidate['repo'] ?? '' ),
+					'branch'      => (string) ( $candidate['branch'] ?? '' ),
+					'path'        => (string) ( $candidate['path'] ?? '' ),
+					'reason_code' => $revalidated->get_error_code(),
+					'reason'      => $revalidated->get_error_message(),
+				);
+				continue;
+			}
+
+			$validated = $revalidated;
+			$repo      = (string) ( $validated['repo'] ?? '' );
+			$branch    = (string) ( $validated['branch'] ?? '' );
+			$wt_path   = (string) ( $validated['path'] ?? '' );
+			$size      = (int) ( $validated['size_bytes'] ?? 0 );
+			if ( $size <= 0 ) {
+				$measured = $this->estimate_path_size_bytes( $wt_path );
+				$size     = null === $measured ? 0 : (int) $measured;
+			}
+
+			$remove = WorkspaceMutationLock::with_repo(
+				$this->workspace_path,
+				$repo,
+				function () use ( $repo, $branch, $wt_path, $force ) {
+					$result = $this->remove_worktree_by_path( $repo, $branch, $wt_path, $force );
+					if ( is_wp_error( $result ) ) {
+						return $result;
+					}
+
+					$primary_path = $this->get_primary_path( $repo );
+					if ( '' !== $branch ) {
+						$delete = $this->run_git( $primary_path, sprintf( 'branch -D %s', escapeshellarg( $branch ) ) );
+						if ( is_wp_error( $delete ) ) {
+							// Branch deletion failure is non-fatal: the worktree is
+							// gone, the local branch may still be useful or may have
+							// already been pruned. Bubble up the original removal.
+							return $result;
+						}
+					}
+
+					return $result;
+				}
+			);
+
+			if ( is_wp_error( $remove ) ) {
+				$skipped[] = array(
+					'handle'      => (string) ( $candidate['handle'] ?? '' ),
+					'repo'        => $repo,
+					'branch'      => $branch,
+					'path'        => $wt_path,
+					'reason_code' => 'remove_failed',
+					'reason'      => 'remove failed: ' . $remove->get_error_message(),
+				);
+				continue;
+			}
+
+			$removed[]        = array_merge(
+				array(
+					'handle'      => (string) ( $candidate['handle'] ?? '' ),
+					'repo'        => $repo,
+					'branch'      => $branch,
+					'path'        => $wt_path,
+					'size_bytes'  => $size,
+					'reason_code' => 'cleanup_eligible',
+				),
+				is_array( $candidate['metadata'] ?? null ) ? array( 'metadata' => $candidate['metadata'] ) : array()
+			);
+			$bytes_reclaimed += max( 0, $size );
+		}
+
+		// Best-effort prune in case any registry rows are now stale.
+		$this->worktree_prune();
+
+		return array(
+			'success'         => true,
+			'mode'            => 'bounded_cleanup_eligible_apply',
+			'dry_run'         => false,
+			'destructive'     => true,
+			'workspace_path'  => $this->workspace_path,
+			'generated_at'    => gmdate( 'c' ),
+			'candidates'      => $batch,
+			'removed'         => $removed,
+			'skipped'         => $skipped,
+			'summary'         => array(
+				'processed'       => $processed,
+				'removed'         => count( $removed ),
+				'skipped'         => count( $skipped ),
+				'bytes_reclaimed' => $bytes_reclaimed,
+				'limit'           => $limit,
+			),
+			'continuation'    => $continuation,
+			'evidence'        => array(
+				'elapsed_ms'      => (int) round( ( microtime( true ) - $started_at ) * 1000 ),
+				'inventory_total' => count( $all_candidates ),
+				'removed_handles' => array_values( array_filter( array_map( fn( $row ) => is_array( $row ) ? (string) ( $row['handle'] ?? '' ) : '', $removed ) ) ),
+				'skipped_handles' => array_values( array_filter( array_map( fn( $row ) => is_array( $row ) ? (string) ( $row['handle'] ?? '' ) : '', $skipped ) ) ),
+				'source'          => $source,
+			),
+		);
+	}
+
+	/**
+	 * Re-run the bounded cleanup-eligible apply safety gates against the current state.
+	 *
+	 * Returns an enriched candidate row when the worktree is still safe to
+	 * remove, or an array with a `skipped` row when a gate fires. Errors
+	 * surface as WP_Error so callers can record a remove_failed-style row.
+	 *
+	 * Gates (cheap, in priority order):
+	 *   - missing repo/branch/path metadata
+	 *   - external worktree (path outside the workspace root)
+	 *   - missing/non-directory worktree path
+	 *   - .git marker is a directory (i.e. primary checkout — never remove)
+	 *   - dirty working tree (porcelain --short)
+	 *   - unpushed commits (count_unpushed_commits)
+	 *   - missing primary checkout
+	 *
+	 * @param array $candidate Inventory candidate row.
+	 * @param bool  $force     Allow dirty worktrees.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private function revalidate_bounded_cleanup_eligible_candidate( array $candidate, bool $force ): array|\WP_Error {
+		$handle  = (string) ( $candidate['handle'] ?? '' );
+		$repo    = (string) ( $candidate['repo'] ?? '' );
+		$branch  = (string) ( $candidate['branch'] ?? '' );
+		$wt_path = (string) ( $candidate['path'] ?? '' );
+
+		$missing_fields = array();
+		foreach ( array( 'handle' => $handle, 'repo' => $repo, 'branch' => $branch, 'path' => $wt_path ) as $field => $value ) {
+			if ( '' === $value ) {
+				$missing_fields[] = $field;
+			}
+		}
+		if ( array() !== $missing_fields ) {
+			return array(
+				'skipped' => array(
+					'handle'         => $handle,
+					'repo'           => $repo,
+					'branch'         => $branch,
+					'path'           => $wt_path,
+					'reason_code'    => 'missing_metadata',
+					'reason'         => 'missing inventory metadata for bounded cleanup-eligible apply: ' . implode( ', ', $missing_fields ),
+					'missing_fields' => $missing_fields,
+				),
+			);
+		}
+
+		// Containment: path must be inside the workspace root and resolve as a
+		// real worktree marker, not a primary's `.git` directory.
+		$validation = $this->validate_containment( $wt_path, $this->workspace_path );
+		if ( ! $validation['valid'] ) {
+			return array(
+				'skipped' => array(
+					'handle'      => $handle,
+					'repo'        => $repo,
+					'branch'      => $branch,
+					'path'        => $wt_path,
+					'reason_code' => 'external_worktree',
+					'reason'      => 'inventory row is outside the workspace root and cannot be removed by bounded cleanup-eligible apply',
+				),
+			);
+		}
+
+		$real_path = (string) $validation['real_path'];
+		if ( '' === $real_path || ! is_dir( $real_path ) ) {
+			return array(
+				'skipped' => array(
+					'handle'      => $handle,
+					'repo'        => $repo,
+					'branch'      => $branch,
+					'path'        => $wt_path,
+					'reason_code' => 'path_missing',
+					'reason'      => 'worktree path no longer exists on disk',
+				),
+			);
+		}
+
+		$git_marker = rtrim( $real_path, '/' ) . '/.git';
+		if ( is_dir( $git_marker ) ) {
+			return array(
+				'skipped' => array(
+					'handle'      => $handle,
+					'repo'        => $repo,
+					'branch'      => $branch,
+					'path'        => $wt_path,
+					'reason_code' => 'primary_checkout',
+					'reason'      => 'refusing to remove a primary checkout via bounded cleanup-eligible apply',
+				),
+			);
+		}
+		if ( ! is_file( $git_marker ) ) {
+			return array(
+				'skipped' => array(
+					'handle'      => $handle,
+					'repo'        => $repo,
+					'branch'      => $branch,
+					'path'        => $wt_path,
+					'reason_code' => 'not_a_worktree',
+					'reason'      => 'worktree marker missing — refusing to apply bounded cleanup',
+				),
+			);
+		}
+
+		// Dirty gate: cheap porcelain call, bounded by the cleanup git timeout.
+		$dirty = $this->run_git( $real_path, 'status --porcelain --untracked-files=normal', self::CLEANUP_GIT_PROBE_TIMEOUT );
+		if ( $this->is_git_timeout_error( $dirty ) ) {
+			return array(
+				'skipped' => array(
+					'handle'      => $handle,
+					'repo'        => $repo,
+					'branch'      => $branch,
+					'path'        => $wt_path,
+					'reason_code' => 'probe_timeout',
+					'reason'      => 'dirty-state probe timed out — refusing bounded cleanup-eligible apply: ' . $dirty->get_error_message(),
+				),
+			);
+		}
+		if ( is_wp_error( $dirty ) ) {
+			return array(
+				'skipped' => array(
+					'handle'      => $handle,
+					'repo'        => $repo,
+					'branch'      => $branch,
+					'path'        => $wt_path,
+					'reason_code' => 'probe_failed',
+					'reason'      => 'dirty-state probe failed — refusing bounded cleanup-eligible apply: ' . $dirty->get_error_message(),
+				),
+			);
+		}
+
+		$dirty_lines = trim( (string) ( $dirty['output'] ?? '' ) );
+		$dirty_count = '' === $dirty_lines ? 0 : substr_count( $dirty_lines, "\n" ) + 1;
+		if ( $dirty_count > 0 && ! $force ) {
+			return array(
+				'skipped' => array(
+					'handle'      => $handle,
+					'repo'        => $repo,
+					'branch'      => $branch,
+					'path'        => $wt_path,
+					'reason_code' => 'dirty_worktree',
+					'reason'      => sprintf( 'working tree dirty (%d entries) — bounded cleanup-eligible apply refuses to override; rerun with force=true after review', $dirty_count ),
+					'dirty'       => $dirty_count,
+				),
+			);
+		}
+
+		// Unpushed gate: hard stop even with force=true (data loss > dirty loss).
+		$unpushed = $this->count_unpushed_commits( $real_path, self::CLEANUP_GIT_PROBE_TIMEOUT );
+		if ( $unpushed instanceof \WP_Error ) {
+			return array(
+				'skipped' => array(
+					'handle'      => $handle,
+					'repo'        => $repo,
+					'branch'      => $branch,
+					'path'        => $wt_path,
+					'reason_code' => 'probe_timeout',
+					'reason'      => 'unpushed-commit probe timed out — refusing bounded cleanup-eligible apply: ' . $unpushed->get_error_message(),
+				),
+			);
+		}
+		if ( $unpushed > 0 ) {
+			return array(
+				'skipped' => array(
+					'handle'      => $handle,
+					'repo'        => $repo,
+					'branch'      => $branch,
+					'path'        => $wt_path,
+					'reason_code' => 'unpushed_commits',
+					'reason'      => sprintf( '%d unpushed commit(s) — bounded cleanup-eligible apply refuses to remove even with force=true', $unpushed ),
+					'unpushed'    => $unpushed,
+				),
+			);
+		}
+
+		// Primary must still exist or remove_worktree_by_path will fail noisily.
+		$primary_path = $this->get_primary_path( $repo );
+		if ( ! is_dir( $primary_path . '/.git' ) ) {
+			return array(
+				'skipped' => array(
+					'handle'      => $handle,
+					'repo'        => $repo,
+					'branch'      => $branch,
+					'path'        => $wt_path,
+					'reason_code' => 'primary_missing',
+					'reason'      => 'primary checkout missing — bounded cleanup-eligible apply cannot route git worktree remove',
+				),
+			);
+		}
+
+		return array_merge( $candidate, array( 'path' => $real_path ) );
+	}
+
+	/**
+	 * Schedule each bounded-cleanup-eligible-apply candidate as its own cleanup chunk job.
+	 *
+	 * Single-row chunks keep cleanup conservative and lock-friendly while the
+	 * existing `worktree_cleanup_chunk` task handles per-row revalidation,
+	 * removal, and evidence the same way as the retention path.
+	 *
+	 * @param array<int,array<string,mixed>> $batch         Candidate rows in this bounded batch.
+	 * @param array<int,array<string,mixed>> $deferred      Candidates not in this batch.
+	 * @param bool                            $force        Whether to forward force.
+	 * @param string                          $source       Caller marker.
+	 * @param float                           $started_at   Start timestamp.
+	 * @param array<string,mixed>             $continuation Continuation envelope.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private function schedule_bounded_cleanup_eligible_chunks( array $batch, array $deferred, bool $force, string $source, float $started_at, array $continuation ): array|\WP_Error {
+		if ( ! class_exists( '\DataMachine\Engine\Tasks\TaskScheduler' ) ) {
+			return new \WP_Error( 'task_scheduler_unavailable', 'Data Machine TaskScheduler is unavailable; cannot schedule bounded cleanup-eligible apply chunks.', array( 'status' => 500 ) );
+		}
+
+		if ( array() === $batch ) {
+			return array(
+				'success'         => true,
+				'mode'            => 'bounded_cleanup_eligible_apply',
+				'dry_run'         => false,
+				'destructive'     => false,
+				'job_backed'      => true,
+				'workspace_path'  => $this->workspace_path,
+				'generated_at'    => gmdate( 'c' ),
+				'candidates'      => array(),
+				'removed'         => array(),
+				'skipped'         => array(),
+				'summary'         => array(
+					'processed'       => 0,
+					'removed'         => 0,
+					'skipped'         => 0,
+					'bytes_reclaimed' => 0,
+					'scheduled_jobs'  => 0,
+				),
+				'continuation'    => $continuation,
+				'evidence'        => array(
+					'elapsed_ms' => (int) round( ( microtime( true ) - $started_at ) * 1000 ),
+					'note'       => 'No bounded-cleanup-eligible-apply candidates eligible for scheduling.',
+					'source'     => $source,
+				),
+			);
+		}
+
+		$item_params = array();
+		foreach ( $batch as $candidate ) {
+			$row = array(
+				'handle' => (string) ( $candidate['handle'] ?? '' ),
+				'repo'   => (string) ( $candidate['repo'] ?? '' ),
+				'branch' => (string) ( $candidate['branch'] ?? '' ),
+				'path'   => (string) ( $candidate['path'] ?? '' ),
+				'signal' => (string) ( $candidate['signal'] ?? 'cleanup_eligible' ),
+			);
+			if ( isset( $candidate['size_bytes'] ) ) {
+				$row['size_bytes'] = (int) $candidate['size_bytes'];
+			}
+			if ( isset( $candidate['metadata'] ) ) {
+				$row['metadata'] = $candidate['metadata'];
+			}
+			$item_params[] = array(
+				'chunk_type'  => 'worktrees',
+				'chunk_index' => count( $item_params ),
+				'rows'        => array( $row ),
+				'force'       => $force,
+				'skip_github' => true,
+				'source'      => $source,
+			);
+		}
+
+		$batch_result = \DataMachine\Engine\Tasks\TaskScheduler::scheduleBatch(
+			'worktree_cleanup_chunk',
+			$item_params,
+			array(
+				'source' => $source,
+			)
+		);
+
+		if ( false === $batch_result ) {
+			return new \WP_Error( 'bounded_cleanup_eligible_apply_schedule_failed', 'Failed to schedule bounded cleanup-eligible apply chunk jobs.', array( 'status' => 500 ) );
+		}
+
+		return array(
+			'success'         => true,
+			'mode'            => 'bounded_cleanup_eligible_apply',
+			'dry_run'         => false,
+			'destructive'     => true,
+			'job_backed'      => true,
+			'workspace_path'  => $this->workspace_path,
+			'generated_at'    => gmdate( 'c' ),
+			'candidates'      => $batch,
+			'removed'         => array(),
+			'skipped'         => array(),
+			'summary'         => array(
+				'processed'       => count( $batch ),
+				'removed'         => 0,
+				'skipped'         => 0,
+				'bytes_reclaimed' => 0,
+				'scheduled_jobs'  => count( $item_params ),
+			),
+			'continuation'    => $continuation,
+			'evidence'        => array(
+				'elapsed_ms'      => (int) round( ( microtime( true ) - $started_at ) * 1000 ),
+				'planned_handles' => array_values( array_filter( array_map( fn( $row ) => is_array( $row ) ? (string) ( $row['handle'] ?? '' ) : '', $batch ) ) ),
+				'batch_job_id'    => (int) ( $batch_result['batch_job_id'] ?? 0 ),
+				'direct_job_ids'  => $batch_result['job_ids'] ?? array(),
+				'source'          => $source,
+			),
+		);
+	}
+
+	/**
 	 * Build current artifact cleanup candidates and safety skips.
 	 *
 	 * Two modes are supported:

--- a/tests/smoke-worktree-bounded-cleanup-eligible-apply.php
+++ b/tests/smoke-worktree-bounded-cleanup-eligible-apply.php
@@ -1,0 +1,346 @@
+<?php
+/**
+ * Integration smoke test for worktree_bounded_cleanup_eligible_apply.
+ *
+ * Builds a real workspace in a tempdir, seeds inventory rows with a mix of
+ * lifecycle states (cleanup_eligible, active, pr_opened with finalized_at,
+ * dirty, unpushed, missing-metadata, primary), then runs the bounded cleanup-eligible apply
+ * synchronously and asserts:
+ *
+ *   - Only worktrees with explicit lifecycle cleanup_eligible metadata
+ *     surface as a bounded batch.
+ *   - The cheap inventory path is used (no full git worktree_list call).
+ *   - Each candidate is revalidated immediately before mutation: dirty,
+ *     unpushed, missing-metadata, primary, and external rows are skipped.
+ *   - Evidence reports processed/removed/skipped/bytes_reclaimed/continuation
+ *     with stable shapes.
+ *   - The bounded `limit` actually bounds the batch and surfaces remaining
+ *     handles in `continuation`.
+ *
+ * Run: php tests/smoke-worktree-bounded-cleanup-eligible-apply.php
+ *
+ * Skips entirely if `git` is unavailable on $PATH.
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Core\FilesRepository {
+	if ( ! class_exists( __NAMESPACE__ . '\\FilesystemHelper' ) ) {
+		class FilesystemHelper {
+			public static function get() {
+				return null;
+			}
+		}
+	}
+}
+
+namespace DataMachineCode\Abilities {
+	if ( ! class_exists( __NAMESPACE__ . '\\GitHubAbilities' ) ) {
+		class GitHubAbilities {
+			public static function getPat(): string {
+				return '';
+			}
+			public static function apiGet( string $url, array $params, string $pat ) {
+				return array( 'data' => array() );
+			}
+		}
+	}
+}
+
+namespace {
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			public string $code;
+			public string $message;
+			public array $data;
+			public function __construct( $code = '', $message = '', $data = array() ) {
+				$this->code    = (string) $code;
+				$this->message = (string) $message;
+				$this->data    = (array) $data;
+			}
+			public function get_error_code(): string {
+				return $this->code;
+			}
+			public function get_error_message(): string {
+				return $this->message;
+			}
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $thing ): bool {
+			return $thing instanceof \WP_Error;
+		}
+	}
+
+	if ( ! function_exists( 'wp_mkdir_p' ) ) {
+		function wp_mkdir_p( string $path ): bool {
+			return is_dir( $path ) || mkdir( $path, 0755, true );
+		}
+	}
+
+	if ( ! function_exists( 'get_option' ) ) {
+		function get_option( string $name, $default_value = false ) {
+			global $datamachine_code_test_options;
+			return $datamachine_code_test_options[ $name ] ?? $default_value;
+		}
+	}
+
+	if ( ! function_exists( 'update_option' ) ) {
+		function update_option( string $name, $value, $autoload = null ): bool {
+			global $datamachine_code_test_options;
+			$datamachine_code_test_options[ $name ] = $value;
+			return true;
+		}
+	}
+
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( string $hook_name, $value ) {
+			return $value;
+		}
+	}
+
+	if ( ! function_exists( 'size_format' ) ) {
+		function size_format( $bytes ): string {
+			return (string) $bytes;
+		}
+	}
+
+	require __DIR__ . '/../inc/Support/GitHubRemote.php';
+	require __DIR__ . '/../inc/Support/GitRunner.php';
+	require __DIR__ . '/../inc/Support/PathSecurity.php';
+	require __DIR__ . '/../inc/Workspace/WorkspaceMutationLock.php';
+	require __DIR__ . '/../inc/Workspace/WorktreeDiskBudget.php';
+	require __DIR__ . '/../inc/Workspace/WorktreeContextInjector.php';
+	require __DIR__ . '/../inc/Workspace/Workspace.php';
+
+	exec( 'git --version 2>&1', $_gv, $gv_exit );
+	if ( 0 !== $gv_exit ) {
+		echo "SKIP: git not available\n";
+		exit( 0 );
+	}
+
+	$tmp = sys_get_temp_dir() . '/dmc-bounded-cleanup-eligible-apply-smoke-' . bin2hex( random_bytes( 4 ) );
+	mkdir( $tmp, 0755, true );
+	register_shutdown_function( function () use ( $tmp ) {
+		if ( is_dir( $tmp ) ) {
+			exec( 'rm -rf ' . escapeshellarg( $tmp ) );
+		}
+	} );
+
+	define( 'DATAMACHINE_WORKSPACE_PATH', realpath( $tmp ) ? realpath( $tmp ) : $tmp );
+
+	$failures = 0;
+	$total    = 0;
+	$datamachine_code_test_options = array();
+
+	$assert = function ( $expected, $actual, string $message ) use ( &$failures, &$total ): void {
+		$total++;
+		if ( $expected === $actual ) {
+			echo "  ✓ {$message}\n";
+			return;
+		}
+		$failures++;
+		echo "  ✗ {$message}\n";
+		echo "    expected: " . var_export( $expected, true ) . "\n";
+		echo "    actual:   " . var_export( $actual, true ) . "\n";
+	};
+
+	$assert_contains = function ( array $haystack, string $needle, string $message ) use ( &$failures, &$total ): void {
+		$total++;
+		foreach ( $haystack as $item ) {
+			$handle = is_array( $item ) ? ( $item['handle'] ?? '' ) : (string) $item;
+			if ( $handle === $needle ) {
+				echo "  ✓ {$message}\n";
+				return;
+			}
+		}
+		$failures++;
+		echo "  ✗ {$message}\n";
+		echo "    needle:  {$needle}\n";
+		echo "    haystack: " . implode( ', ', array_map( fn( $i ) => is_array( $i ) ? ( $i['handle'] ?? '?' ) : $i, $haystack ) ) . "\n";
+	};
+
+	$assert_skipped = function ( array $skipped, string $handle, string $reason_code, string $message ) use ( &$failures, &$total ): void {
+		$total++;
+		foreach ( $skipped as $row ) {
+			if ( ( $row['handle'] ?? '' ) === $handle && ( $row['reason_code'] ?? '' ) === $reason_code ) {
+				echo "  ✓ {$message}\n";
+				return;
+			}
+		}
+		$failures++;
+		echo "  ✗ {$message}\n";
+		echo "    needle:  {$handle} / {$reason_code}\n";
+		echo "    haystack: " . implode( ', ', array_map( fn( $r ) => sprintf( '%s/%s', $r['handle'] ?? '?', $r['reason_code'] ?? '?' ), $skipped ) ) . "\n";
+	};
+
+	$run = function ( string $cmd, string $cwd = '' ) {
+		$full = '' === $cwd ? $cmd : sprintf( 'cd %s && %s', escapeshellarg( $cwd ), $cmd );
+		exec( $full . ' 2>&1', $out, $rc );
+		return array(
+			'output' => implode( "\n", $out ),
+			'exit'   => $rc,
+		);
+	};
+
+	echo "Setting up workspace at {$tmp}\n";
+
+	$remote = $tmp . '/remote.git';
+	$run( sprintf( 'git init --bare %s', escapeshellarg( $remote ) ) );
+
+	$primary = $tmp . '/demo';
+	$run( sprintf( 'git clone %s %s', escapeshellarg( $remote ), escapeshellarg( $primary ) ) );
+	$run( 'git config user.email test@example.com', $primary );
+	$run( 'git config user.name test', $primary );
+	file_put_contents( $primary . '/README.md', "demo\n" );
+	$run( 'git add README.md && git commit -m init', $primary );
+	$run( 'git branch -M main', $primary );
+	$run( 'git push -u origin main', $primary );
+
+	$make_branch = function ( string $branch ) use ( $primary, $run ) {
+		$run( sprintf( 'git checkout -b %s', escapeshellarg( $branch ) ), $primary );
+		file_put_contents( $primary . '/' . str_replace( '/', '-', $branch ) . '.txt', $branch );
+		$run( sprintf( 'git add . && git commit -m %s', escapeshellarg( 'work on ' . $branch ) ), $primary );
+		$run( sprintf( 'git push -u origin %s', escapeshellarg( $branch ) ), $primary );
+		$run( 'git checkout main', $primary );
+	};
+
+	// Real worktree-backed branches that simulate the canonical states the
+	// bounded cleanup-eligible apply must handle.
+	foreach ( array( 'eligible-clean', 'eligible-dirty', 'eligible-unpushed', 'eligible-bounded-extra-1', 'eligible-bounded-extra-2', 'eligible-bounded-extra-3' ) as $b ) {
+		$make_branch( $b );
+	}
+
+	$run( sprintf( 'git worktree add %s eligible-clean', escapeshellarg( $tmp . '/demo@eligible-clean' ) ), $primary );
+	$run( sprintf( 'git worktree add %s eligible-dirty', escapeshellarg( $tmp . '/demo@eligible-dirty' ) ), $primary );
+	$run( sprintf( 'git worktree add %s eligible-unpushed', escapeshellarg( $tmp . '/demo@eligible-unpushed' ) ), $primary );
+	$run( sprintf( 'git worktree add %s eligible-bounded-extra-1', escapeshellarg( $tmp . '/demo@eligible-bounded-extra-1' ) ), $primary );
+	$run( sprintf( 'git worktree add %s eligible-bounded-extra-2', escapeshellarg( $tmp . '/demo@eligible-bounded-extra-2' ) ), $primary );
+	$run( sprintf( 'git worktree add %s eligible-bounded-extra-3', escapeshellarg( $tmp . '/demo@eligible-bounded-extra-3' ) ), $primary );
+
+	// Mark cleanup-eligible lifecycle metadata so the cheap inventory picks
+	// these up.
+	foreach (
+		array(
+			'demo@eligible-clean',
+			'demo@eligible-dirty',
+			'demo@eligible-unpushed',
+			'demo@eligible-bounded-extra-1',
+			'demo@eligible-bounded-extra-2',
+			'demo@eligible-bounded-extra-3',
+		) as $handle
+	) {
+		\DataMachineCode\Workspace\WorktreeContextInjector::store_lifecycle_metadata(
+			$handle,
+			array(
+				'created_at'      => '2026-04-01T00:00:00+00:00',
+				'lifecycle_state' => \DataMachineCode\Workspace\WorktreeContextInjector::STATE_CLEANUP_ELIGIBLE,
+				'pr_url'          => 'https://github.com/acme/demo/pull/42',
+				'pr_number'       => 42,
+			)
+		);
+	}
+
+	// Make eligible-dirty actually dirty so the revalidation gate kicks in.
+	file_put_contents( $tmp . '/demo@eligible-dirty/scratch.txt', 'dirty' );
+
+	// Make eligible-unpushed have an unpushed local commit (drop upstream so
+	// `count_unpushed_commits` reports >0 only when the branch is ahead of its
+	// upstream — easiest is one extra commit).
+	file_put_contents( $tmp . '/demo@eligible-unpushed/local-only.txt', 'local' );
+	$run( 'git add local-only.txt && git commit -m "unpushed change"', $tmp . '/demo@eligible-unpushed' );
+
+	// Active inventory row (no cleanup signal) — must never be a candidate.
+	mkdir( $tmp . '/demo@active-row', 0755, true );
+	\DataMachineCode\Workspace\WorktreeContextInjector::store_lifecycle_metadata(
+		'demo@active-row',
+		array(
+			'created_at'      => '2026-04-01T00:00:00+00:00',
+			'lifecycle_state' => \DataMachineCode\Workspace\WorktreeContextInjector::STATE_ACTIVE,
+		)
+	);
+
+	// Inventory row with no metadata at all — bounded cleanup-eligible apply must never act on
+	// it (inventory_only already skips it as `requires_full_scan`).
+	mkdir( $tmp . '/demo@no-metadata', 0755, true );
+
+	class Bounded_Apply_Inventory_Workspace extends \DataMachineCode\Workspace\Workspace {
+		public int $full_listing_calls = 0;
+		public function worktree_list( ?string $repo = null, ?string $state = null, array $opts = array() ): array|\WP_Error { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+			++$this->full_listing_calls;
+			return parent::worktree_list( $repo, $state, $opts );
+		}
+	}
+
+	$ws = new Bounded_Apply_Inventory_Workspace();
+
+	echo "\nDry-run scenario\n";
+	$dry = $ws->worktree_bounded_cleanup_eligible_apply( array( 'dry_run' => true, 'limit' => 2 ) );
+	$assert( true, ! is_wp_error( $dry ) && ( $dry['success'] ?? false ), 'dry-run returns success' );
+	$assert( true, $dry['dry_run'] ?? false, 'dry-run flag echoes back true' );
+	$assert( 'bounded_cleanup_eligible_apply', $dry['mode'] ?? '', 'mode is bounded_cleanup_eligible_apply' );
+	$assert( false, $dry['destructive'] ?? true, 'dry-run is non-destructive' );
+	$assert( 0, $ws->full_listing_calls, 'bounded cleanup-eligible apply dry-run does not call full worktree_list' );
+	$assert( 2, count( $dry['candidates'] ?? array() ), 'bounded limit caps dry-run candidates' );
+	$remaining = (int) ( $dry['continuation']['remaining_total'] ?? 0 );
+	$assert( true, $remaining >= 4, 'continuation reports remaining cleanup-eligible candidates' );
+
+	// Active and missing-metadata rows must never appear as candidates.
+	foreach ( $dry['candidates'] ?? array() as $cand ) {
+		$h = (string) ( $cand['handle'] ?? '' );
+		if ( 'demo@active-row' === $h || 'demo@no-metadata' === $h || 'demo' === $h ) {
+			$failures++;
+			$total++;
+			echo "  ✗ bounded cleanup-eligible apply listed unsafe candidate: {$h}\n";
+		}
+	}
+
+	echo "\nLimit validation\n";
+	$bad_limit = $ws->worktree_bounded_cleanup_eligible_apply( array( 'dry_run' => true, 'limit' => 0 ) );
+	$assert( true, is_wp_error( $bad_limit ), 'invalid limit returns WP_Error' );
+
+	$bad_via_jobs_dry_run = $ws->worktree_bounded_cleanup_eligible_apply( array( 'dry_run' => true, 'via_jobs' => true ) );
+	$assert( true, is_wp_error( $bad_via_jobs_dry_run ), 'via_jobs combined with dry_run is rejected' );
+
+	echo "\nApply scenario (synchronous)\n";
+	$apply = $ws->worktree_bounded_cleanup_eligible_apply( array( 'limit' => 10 ) );
+	$assert( true, ! is_wp_error( $apply ) && ( $apply['success'] ?? false ), 'apply returns success' );
+	$assert( false, $apply['dry_run'] ?? true, 'apply is not dry_run' );
+	$assert( true, $apply['destructive'] ?? false, 'apply marks destructive=true' );
+	$assert_contains( $apply['removed'] ?? array(), 'demo@eligible-clean', 'clean cleanup-eligible worktree was removed' );
+	$assert_contains( $apply['removed'] ?? array(), 'demo@eligible-bounded-extra-1', 'bounded-extra-1 cleanup-eligible worktree was removed' );
+
+	$assert_skipped( $apply['skipped'] ?? array(), 'demo@eligible-dirty', 'dirty_worktree', 'dirty worktree skipped on revalidation' );
+	$assert_skipped( $apply['skipped'] ?? array(), 'demo@eligible-unpushed', 'unpushed_commits', 'unpushed worktree skipped on revalidation' );
+	$assert_skipped( $apply['skipped'] ?? array(), 'demo@no-metadata', 'requires_full_scan', 'missing-metadata row skipped via inventory gate' );
+	$assert_skipped( $apply['skipped'] ?? array(), 'demo@active-row', 'no_inventory_cleanup_signal', 'active row skipped via inventory gate' );
+
+	$assert( true, is_dir( $primary . '/.git' ), 'primary survives bounded cleanup-eligible apply' );
+	$assert( false, is_dir( $tmp . '/demo@eligible-clean' ), 'clean cleanup-eligible directory removed from disk' );
+	$assert( true, is_dir( $tmp . '/demo@eligible-dirty' ), 'dirty cleanup-eligible directory survives bounded cleanup-eligible apply' );
+	$assert( true, is_dir( $tmp . '/demo@eligible-unpushed' ), 'unpushed cleanup-eligible directory survives bounded cleanup-eligible apply' );
+
+	$summary = (array) ( $apply['summary'] ?? array() );
+	$assert( true, (int) ( $summary['removed'] ?? 0 ) >= 4, 'summary records removed count' );
+	$assert( true, (int) ( $summary['skipped'] ?? 0 ) >= 4, 'summary records skipped count' );
+	$assert( true, isset( $summary['bytes_reclaimed'] ), 'summary exposes bytes_reclaimed' );
+	$assert( true, isset( $apply['continuation']['remaining_total'] ), 'apply exposes continuation envelope' );
+
+	echo "\nForce gate (dirty allowed, unpushed never allowed)\n";
+	$force_apply = $ws->worktree_bounded_cleanup_eligible_apply( array( 'limit' => 10, 'force' => true ) );
+	$assert( true, ! is_wp_error( $force_apply ) && ( $force_apply['success'] ?? false ), 'force apply returns success' );
+	// Dirty worktree should now be removed.
+	$assert_contains( $force_apply['removed'] ?? array(), 'demo@eligible-dirty', 'force=true allows dirty cleanup-eligible removal' );
+	// Unpushed worktree must still be skipped — even with force.
+	$assert_skipped( $force_apply['skipped'] ?? array(), 'demo@eligible-unpushed', 'unpushed_commits', 'unpushed gate not overridden by force=true' );
+	$assert( true, is_dir( $tmp . '/demo@eligible-unpushed' ), 'unpushed cleanup-eligible directory survives force apply' );
+
+	echo "\nResult: " . ( $total - $failures ) . "/{$total} passed\n";
+	exit( $failures > 0 ? 1 : 0 );
+}


### PR DESCRIPTION
## Summary

Adds an operator-safe **bounded cleanup-eligible apply** path for worktrees that have explicit lifecycle `cleanup_eligible` metadata. Closes the gap from #216: hundreds of worktrees pile up, full retention dry-run/apply paths time out or take too long to be useful, and there is no end-to-end way to safely reclaim the explicit `cleanup_eligible` rows in bounded batches.

This PR adds that path without touching the existing retention/artifact/emergency cleanup behaviors and without introducing any new internal pipelines or flows — purely WP-CLI wrapping a workspace ability, the same pattern as the rest of `workspace worktree *`.

## What changed

**`Workspace::worktree_bounded_cleanup_eligible_apply()`** (new public method on `inc/Workspace/Workspace.php`):

- Reuses the existing **inventory-only** path for candidate discovery, so it never triggers full `worktree_list` / `git fetch` / GitHub API work just to plan. Only worktrees whose persisted lifecycle metadata satisfies `WorktreeContextInjector::has_cleanup_signal()` are considered; rows without an explicit `cleanup_eligible` signal stay skipped via the existing inventory gate (`no_inventory_cleanup_signal`, `requires_full_scan`).
- Caps each call with `--limit` (default 25, hard ceiling 200).
- Optional `--older-than` gate against lifecycle `created_at` metadata.
- **Revalidates each candidate immediately before mutation** via cheap gates:
  - missing repo/branch/path metadata
  - external / containment violation (path outside workspace root)
  - missing or non-directory path
  - primary `.git` directory (refuses to remove primaries)
  - dirty working tree (`git status --porcelain`, bounded by `CLEANUP_GIT_PROBE_TIMEOUT`)
  - unpushed commits (hard stop — never overridden by `force`)
  - missing primary checkout
- `--via-jobs` schedules per-candidate `worktree_cleanup_chunk` jobs (single-row chunks) for resumable async apply, reusing the existing chunk task + lock flow.
- Returns evidence with `summary.processed / removed / skipped / bytes_reclaimed`, plus a `continuation` envelope (`remaining_total`, `remaining_handles`, `next_call_hint`) so operators can drain the workspace in successive bounded calls.

**Surfaces**

- New ability: `datamachine/workspace-worktree-bounded-cleanup-eligible-apply` (`inc/Abilities/WorkspaceAbilities.php`).
- New CLI subcommand:
  ```
  wp datamachine-code workspace worktree bounded-cleanup-eligible-apply \
      [--dry-run] [--limit=N] [--older-than=DUR] \
      [--sort=size|age] [--force] [--via-jobs]
  ```
  Routed through the new ability with table/JSON renderer (`inc/Cli/Commands/WorkspaceCommand.php`).

## Acceptance criteria

| Criterion | How it's met |
|---|---|
| Operator can apply explicit cleanup-eligible candidates without full scan | Inventory-only candidate discovery — no `worktree_list`, no GitHub. Only rows with explicit lifecycle `cleanup_eligible` metadata become candidates. |
| Each deletion revalidated immediately before mutation | `revalidate_bounded_cleanup_eligible_candidate()` runs the cheap safety gates per candidate at apply time. |
| Dirty/unpushed/ambiguous/missing-metadata stay protected | Each gate returns a stable `reason_code` and the worktree survives on disk; verified by smoke. |
| Job-backed/resumable where appropriate | `--via-jobs` schedules per-candidate `worktree_cleanup_chunk` jobs via `TaskScheduler::scheduleBatch`. |
| Evidence: processed / removed / skipped / bytes / continuation | Returned in `summary` + `continuation`. |

## Tests

New `tests/smoke-worktree-bounded-cleanup-eligible-apply.php` (30 assertions, all green) — builds a real workspace with a mix of cleanup-eligible / dirty / unpushed / active / missing-metadata worktrees and asserts:

- Inventory-only path is used (no full `worktree_list` calls).
- `--limit` actually bounds the batch and `continuation.remaining_total` reports the rest.
- `--dry-run` returns success without mutating anything; `--via-jobs` + `--dry-run` is rejected with a stable error.
- Synchronous apply removes only the safe rows; dirty/unpushed/missing-metadata/active rows survive on disk with the correct `reason_code`.
- `force=true` permits dirty cleanup but the unpushed-commit gate is **never** overridden.

```
tests/smoke-worktree-bounded-cleanup-eligible-apply.php  30/30 passed
tests/smoke-worktree-cleanup.php                        129/129 passed
tests/smoke-worktree-cleanup-chunks.php                  14/14 passed
tests/smoke-worktree-cleanup-artifacts.php               48/48 passed
tests/smoke-worktree-metadata-reconcile.php              32/32 passed
```

## Out of scope

- No new pipelines, flows, or recurring schedules — this stays a CLI/ability surface per the issue's "system-task/ability patterns" constraint.
- No changes to `worktree_cleanup_merged` / `worktree_cleanup_artifacts` / `worktree_emergency_cleanup` semantics.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the bounded apply method, ability registration, CLI subcommand, and smoke test based on the existing inventory-only and chunked retention cleanup patterns. Author reviewed against the issue acceptance criteria and ran the smoke + neighboring cleanup tests locally.

Closes #216