### PR TITLE
fix: bound artifact cleanup apply revalidation

### DIFF
--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -4089,11 +4089,11 @@ class Workspace {
 	 * @param string $path Worktree path.
 	 * @return int|\WP_Error Dirty file count, or WP_Error when git probe failed.
 	 */
-	private function probe_worktree_dirty_count( string $path ): int|\WP_Error {
+	private function probe_worktree_dirty_count( string $path, int $timeout_seconds = 0 ): int|\WP_Error {
 		if ( '' === $path || ! is_dir( $path ) ) {
 			return new \WP_Error( 'worktree_path_missing', 'worktree path is not a directory', array( 'status' => 400 ) );
 		}
-		$result = $this->run_git( $path, 'status --porcelain' );
+		$result = $this->run_git( $path, 'status --porcelain', $timeout_seconds );
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
@@ -5772,12 +5772,10 @@ class Workspace {
 			}
 		}
 
-		// When the caller wants per-worktree dirty + unpushed probes (apply
-		// path, exhaustive dry-run), use the full git-backed worktree listing.
-		// Otherwise scan the cheap top-level inventory directly to skip the
-		// per-worktree `git status` round and `count_unpushed_commits` calls
-		// that dominate runtime on huge workspaces.
-		if ( $safety_probes ) {
+		// Exhaustive dry-run still uses the full git-backed listing. Apply-plan
+		// calls provide `only_handles`; keep those bounded by starting from cheap
+		// inventory and probing only the planned rows below.
+		if ( $safety_probes && null === $only_handles ) {
 			$listing = $this->worktree_list();
 			if ( $listing instanceof \WP_Error ) {
 				return $listing;
@@ -5814,6 +5812,10 @@ class Workspace {
 			$wt_path = (string) ( $wt['path'] ?? '' );
 			if ( $safety_probes ) {
 				$branch = (string) ( $wt['branch'] ?? '' );
+				if ( '' === $branch ) {
+					$resolved = $wt_path !== '' ? $this->resolve_worktree_branch_from_head_file( $wt_path ) : null;
+					$branch   = (string) ( $resolved ?? $wt['branch_slug'] ?? '' );
+				}
 			} else {
 				// Inventory rows only carry `branch_slug` (the directory slug,
 				// e.g. `fix-foo`). The plan apply path revalidates against the
@@ -5827,7 +5829,7 @@ class Workspace {
 			// Inventory rows don't include detected artifacts; detect them on
 			// the fly so the bounded path stays focused on artifact-bearing
 			// worktrees only.
-			if ( $safety_probes ) {
+			if ( $safety_probes && isset( $wt['artifacts'] ) ) {
 				$artifacts = array_values( array_filter( (array) ( $wt['artifacts'] ?? array() ), fn( $artifact ) => is_array( $artifact ) ) );
 			} else {
 				$artifacts = $wt_path !== '' ? $this->detect_worktree_artifacts( $repo, $wt_path ) : array();
@@ -5873,7 +5875,20 @@ class Workspace {
 			}
 
 			if ( $safety_probes ) {
-				$dirty_count = (int) ( $wt['dirty'] ?? 0 );
+				if ( null === $only_handles && null !== ( $wt['dirty'] ?? null ) ) {
+					$dirty_count = (int) ( $wt['dirty'] ?? 0 );
+				} else {
+					$dirty_probe = $this->probe_worktree_dirty_count( $wt_path, self::CLEANUP_GIT_PROBE_TIMEOUT );
+					if ( is_wp_error( $dirty_probe ) ) {
+						$skipped[] = array_merge( $base_row, array(
+							'reason_code' => 'probe_timeout',
+							'reason'      => 'artifact cleanup dirty-state probe failed - leaving artifacts in place: ' . $dirty_probe->get_error_message(),
+							'artifacts'   => $artifacts,
+						) );
+						continue;
+					}
+					$dirty_count = (int) $dirty_probe;
+				}
 				if ( $dirty_count > 0 && ! $force ) {
 					$skipped[] = array_merge( $base_row, array(
 						'reason_code' => 'dirty_worktree',

--- a/tests/smoke-worktree-cleanup-artifacts-bounded.php
+++ b/tests/smoke-worktree-cleanup-artifacts-bounded.php
@@ -120,6 +120,15 @@ namespace {
 	require __DIR__ . '/../inc/Workspace/WorktreeContextInjector.php';
 	require __DIR__ . '/../inc/Workspace/Workspace.php';
 
+	class Artifact_Bounded_Workspace extends \DataMachineCode\Workspace\Workspace {
+		public int $full_listing_calls = 0;
+
+		public function worktree_list( ?string $repo = null, ?string $state = null, array $opts = array() ): array|\WP_Error { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+			++$this->full_listing_calls;
+			return parent::worktree_list( $repo, $state, $opts );
+		}
+	}
+
 	// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
 	exec( 'git --version 2>&1', $_gv, $gv_exit );
 	if ( 0 !== $gv_exit ) {
@@ -210,7 +219,7 @@ namespace {
 		}
 	}
 
-	$workspace = new \DataMachineCode\Workspace\Workspace();
+	$workspace = new Artifact_Bounded_Workspace();
 
 	// Default bounded dry-run honors the default cap.
 	$start    = microtime( true );
@@ -233,26 +242,21 @@ namespace {
 	$assert_lt( 2.0, $elapsed, 'limit=25 page completes quickly (' . number_format( $elapsed, 3 ) . 's)' );
 
 	// only_handles surfaces from apply_plan path: passing apply_plan with a
-	// single planned candidate should restrict the scan to just that handle.
-	// Re-build the plan from a real exhaustive dry-run so the planned path
-	// matches the canonical realpath form `worktree_list` returns (`/private/...`
-	// on macOS) — we can't construct the path string by hand without recreating
-	// the symlink resolution that the apply revalidation does internally.
-	$exhaustive_plan = $workspace->worktree_cleanup_artifacts(
-		array( 'dry_run' => true, 'exhaustive' => true, 'limit' => 0 )
-	);
-	$assert( false, is_wp_error( $exhaustive_plan ), 'exhaustive scan succeeds for apply path setup' );
+	// single bounded dry-run candidate should restrict revalidation to just that
+	// handle and must not fall back to the full git-backed worktree listing.
 	$apply_plan = array( 'candidates' => array_values( array_filter(
-		(array) ( $exhaustive_plan['candidates'] ?? array() ),
+		(array) ( $page['candidates'] ?? array() ),
 		fn( $row ) => 'demo@feature-real' === ( $row['handle'] ?? '' )
 	) ) );
 	$assert( 1, count( $apply_plan['candidates'] ), 'extracted exactly one planned candidate' );
 
+	$workspace->full_listing_calls = 0;
 	$start   = microtime( true );
 	$apply   = $workspace->worktree_cleanup_artifacts( array( 'apply_plan' => $apply_plan ) );
 	$elapsed = microtime( true ) - $start;
 	$assert( false, is_wp_error( $apply ), 'apply_plan revalidation succeeds on huge workspace' );
-	$assert( 'exhaustive', $apply['pagination']['mode'] ?? '', 'apply_plan revalidation runs in exhaustive (safety_probes=true) mode' );
+	$assert( 0, $workspace->full_listing_calls, 'apply_plan revalidation does not call full worktree_list' );
+	$assert( true, (bool) ( $apply['pagination']['safety_probes'] ?? false ), 'apply_plan revalidation still runs safety probes' );
 	$assert( 1, (int) ( $apply['summary']['removed_artifacts'] ?? 0 ), 'apply_plan removes the planned artifact' );
 	$assert( false, is_dir( $tmp . '/demo@feature-real/target' ), 'apply_plan revalidation removes the target directory' );
 	$assert_lt( 5.0, $elapsed, 'apply_plan revalidation stays fast because only_handles narrows the scan (' . number_format( $elapsed, 3 ) . 's)' );


### PR DESCRIPTION
## Summary

Closes #226.

Artifact cleanup dry-run became bounded in #220, but `--apply-plan` still lost boundedness because apply-plan enabled safety probes and then rebuilt current candidates through the full git-backed `worktree_list()` before filtering planned handles. On the large `intelligence-chubes4` workspace, that made even a 50-row reviewed plan hang.

This PR keeps apply-plan revalidation scoped to the reviewed plan:

- If `only_handles` is present, candidate rebuilding starts from cheap workspace inventory instead of full `worktree_list()`.
- Branch/artifact details are resolved per planned worktree only.
- Dirty and unpushed safety probes still run, but only for planned rows, with the existing cleanup probe timeout.
- Exhaustive dry-runs without `only_handles` still use the full git-backed listing.

## Tests

```bash
php tests/smoke-worktree-cleanup-artifacts.php
php tests/smoke-worktree-cleanup-artifacts-bounded.php
```

Both passed locally.

The bounded smoke now asserts that apply-plan revalidation does **not** call full `worktree_list()`, while still running safety probes and removing the planned artifact.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Identified the boundedness regression, patched the apply-plan revalidation path, and updated focused smoke coverage. Chris reviewed the behavior through the CLI failure and requested the fix.