### PR TITLE
Fix cleanup status child job aggregation

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -537,20 +537,25 @@ class WorkspaceCommand extends BaseCommand {
 		}
 
 		$engine_data = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		$child_jobs  = $this->get_cleanup_run_descendant_jobs( $job_id );
+		$children    = $this->cleanup_child_job_summary( $child_jobs );
+		$state       = $this->cleanup_run_state( (string) ( $job['status'] ?? '' ), $children );
 		$output      = array(
 			'success'     => true,
-			'state'       => $this->cleanup_job_state( (string) ( $job['status'] ?? '' ) ),
+			'state'       => $state,
 			'run_id'      => $this->cleanup_run_id( $job_id ),
 			'job_id'      => $job_id,
-			'status'      => $job['status'] ?? '',
+			'status'      => in_array( $state, array( 'children_processing', 'partial_failed' ), true ) ? $state : ( $job['status'] ?? '' ),
 			'created_at'  => $job['created_at'] ?? '',
 			'completed_at' => $job['completed_at'] ?? '',
+			'children'    => $children,
 		);
 
 		if ( $evidence ) {
 			$output['evidence'] = array(
 				'engine_data' => $engine_data,
 				'job'         => $job,
+				'child_jobs'  => $child_jobs,
 			);
 		} else {
 			$output['mode'] = $engine_data['cleanup_run']['mode'] ?? '';
@@ -601,6 +606,124 @@ class WorkspaceCommand extends BaseCommand {
 
 		$jobs = $result['jobs'] ?? array();
 		return is_array( $jobs ) && ! empty( $jobs[0] ) && is_array( $jobs[0] ) ? $jobs[0] : array();
+	}
+
+	/**
+	 * Return every job linked below a cleanup run job.
+	 *
+	 * @param int        $job_id Parent job ID.
+	 * @param array<int,bool> $seen Seen job IDs.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function get_cleanup_run_descendant_jobs( int $job_id, array &$seen = array() ): array {
+		$ability = wp_get_ability( 'datamachine/get-jobs' );
+		if ( ! $ability || isset( $seen[ $job_id ] ) ) {
+			return array();
+		}
+
+		$seen[ $job_id ] = true;
+		$children        = array();
+		$offset          = 0;
+		$per_page        = 100;
+
+		do {
+			$result = $ability->execute(
+				array(
+					'parent_job_id' => $job_id,
+					'per_page'      => $per_page,
+					'offset'        => $offset,
+					'orderby'       => 'j.job_id',
+					'order'         => 'ASC',
+				)
+			);
+			if ( ! ( $result['success'] ?? false ) ) {
+				break;
+			}
+
+			$page = is_array( $result['jobs'] ?? null ) ? $result['jobs'] : array();
+			foreach ( $page as $child ) {
+				if ( ! is_array( $child ) ) {
+					continue;
+				}
+				$child_id = (int) ( $child['job_id'] ?? 0 );
+				if ( $child_id <= 0 || isset( $seen[ $child_id ] ) ) {
+					continue;
+				}
+
+				$children[] = $child;
+				$children   = array_merge( $children, $this->get_cleanup_run_descendant_jobs( $child_id, $seen ) );
+			}
+
+			$offset += $per_page;
+			$total   = (int) ( $result['total'] ?? count( $page ) );
+		} while ( $offset < $total && ! empty( $page ) );
+
+		return $children;
+	}
+
+	/**
+	 * Summarize cleanup child job state for status/evidence output.
+	 *
+	 * @param array<int,array<string,mixed>> $jobs Descendant jobs.
+	 * @return array<string,mixed>
+	 */
+	private function cleanup_child_job_summary( array $jobs ): array {
+		$summary = array(
+			'total'         => count( $jobs ),
+			'running'       => 0,
+			'failed'        => 0,
+			'terminal'      => 0,
+			'by_status'     => array(),
+			'batch_job_ids' => array(),
+			'job_ids'       => array(),
+		);
+
+		foreach ( $jobs as $job ) {
+			$job_id = (int) ( $job['job_id'] ?? 0 );
+			$status = (string) ( $job['status'] ?? '' );
+			$source = (string) ( $job['source'] ?? '' );
+
+			if ( $job_id > 0 ) {
+				$summary['job_ids'][] = $job_id;
+				if ( 'batch' === $source ) {
+					$summary['batch_job_ids'][] = $job_id;
+				}
+			}
+
+			$summary['by_status'][ $status ] = (int) ( $summary['by_status'][ $status ] ?? 0 ) + 1;
+			if ( in_array( $status, array( 'pending', 'processing' ), true ) ) {
+				++$summary['running'];
+			} elseif ( str_starts_with( $status, 'failed' ) || 'cancelled' === $status ) {
+				++$summary['failed'];
+			} else {
+				++$summary['terminal'];
+			}
+		}
+
+		return $summary;
+	}
+
+	/**
+	 * Compute aggregate cleanup run state from parent and child jobs.
+	 *
+	 * @param string $status Parent job status.
+	 * @param array  $children Child summary.
+	 * @return string
+	 */
+	private function cleanup_run_state( string $status, array $children ): string {
+		$parent_state = $this->cleanup_job_state( $status );
+		if ( in_array( $parent_state, array( 'cancelled', 'partial_failure' ), true ) ) {
+			return $parent_state;
+		}
+
+		if ( (int) ( $children['failed'] ?? 0 ) > 0 ) {
+			return 'partial_failed';
+		}
+		if ( (int) ( $children['running'] ?? 0 ) > 0 ) {
+			return 'children_processing';
+		}
+
+		return $parent_state;
 	}
 
 	private function render_cleanup_control_result( array $result, array $assoc_args ): void {

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -354,6 +354,39 @@ namespace {
 
 	class FakeGetJobsAbility {
 		public function execute( array $input ): array {
+			if ( isset( $input['parent_job_id'] ) ) {
+				$children = array(
+					123 => array(
+						array(
+							'job_id'       => 124,
+							'parent_job_id' => 123,
+							'source'        => 'system',
+							'status'        => 'completed',
+							'engine_data'   => array( 'task_type' => 'workspace_retention_cleanup' ),
+						),
+					),
+					124 => array(
+						array(
+							'job_id'       => 125,
+							'parent_job_id' => 124,
+							'source'        => 'batch',
+							'status'        => 'processing',
+							'engine_data'   => array( 'task_type' => 'worktree_cleanup_chunk' ),
+						),
+					),
+					125 => array(),
+				);
+				$jobs     = $children[ (int) $input['parent_job_id'] ] ?? array();
+				$offset   = (int) ( $input['offset'] ?? 0 );
+				$per_page = (int) ( $input['per_page'] ?? 100 );
+
+				return array(
+					'success' => true,
+					'jobs'    => array_slice( $jobs, $offset, $per_page ),
+					'total'   => count( $jobs ),
+				);
+			}
+
 			return array(
 				'success' => true,
 				'jobs'    => array(
@@ -362,9 +395,9 @@ namespace {
 						'flow_id'      => null,
 						'pipeline_id'  => null,
 						'source'       => 'system',
-						'status'       => 'processing',
+						'status'       => 'completed',
 						'created_at'   => '2026-05-03 00:00:00',
-						'completed_at' => null,
+						'completed_at' => '2026-05-03 00:10:00',
 						'engine_data'  => array(
 							'cleanup_run' => array(
 								'mode'   => 'retention',
@@ -467,7 +500,10 @@ namespace {
 	WP_CLI::$successes = array();
 	$command->cleanup( array( 'status', 'cleanup-run-123' ), array( 'format' => 'json' ) );
 	$status_json = json_decode( WP_CLI::$logs[0] ?? '', true );
-	datamachine_code_cleanup_assert( 'running' === ( $status_json['state'] ?? '' ), 'cleanup status maps processing job to running state' );
+	datamachine_code_cleanup_assert( 'children_processing' === ( $status_json['state'] ?? '' ), 'cleanup status stays active while child batch is processing' );
+	datamachine_code_cleanup_assert( 'children_processing' === ( $status_json['status'] ?? '' ), 'cleanup status does not report parent completed while children run' );
+	datamachine_code_cleanup_assert( array( 125 ) === ( $status_json['children']['batch_job_ids'] ?? array() ), 'cleanup status reports child batch job ids' );
+	datamachine_code_cleanup_assert( 1 === (int) ( $status_json['children']['running'] ?? 0 ), 'cleanup status summarizes running child jobs' );
 	datamachine_code_cleanup_assert( ! isset( $status_json['flow_id'] ), 'cleanup status is not linked to a flow id' );
 
 	WP_CLI::$logs      = array();
@@ -475,6 +511,7 @@ namespace {
 	$command->cleanup( array( 'evidence', '123' ), array( 'format' => 'json' ) );
 	$evidence_json = json_decode( WP_CLI::$logs[0] ?? '', true );
 	datamachine_code_cleanup_assert( isset( $evidence_json['evidence']['engine_data'] ), 'cleanup evidence emits engine data' );
+	datamachine_code_cleanup_assert( 2 === count( $evidence_json['evidence']['child_jobs'] ?? array() ), 'cleanup evidence emits descendant child jobs' );
 
 	WP_CLI::$logs      = array();
 	WP_CLI::$successes = array();


### PR DESCRIPTION
## Summary
- Fixes cleanup run status so descendant pending/processing child jobs keep the run in `children_processing` instead of reporting parent completion.
- Adds child job status summaries and child job evidence, including batch job IDs, to cleanup status/evidence output.
- Covers the completed-parent/processing-child-batch case in the cleanup CLI smoke test.

Fixes #229.

## Tests
- `php tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-worktree-cleanup-chunks.php`
- `php tests/smoke-workspace-disk-emergency-task.php`
- `php tests/smoke-worktree-cleanup-artifacts.php`
- `php -l inc/Cli/Commands/WorkspaceCommand.php && php -l tests/smoke-worktree-cleanup-cli.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused implementation and smoke test updates; Chris remains responsible for review and merge.