### PR TITLE
Fix artifact cleanup discovery fanout

### DIFF
--- a/inc/Tasks/WorkspaceRetentionCleanupTask.php
+++ b/inc/Tasks/WorkspaceRetentionCleanupTask.php
@@ -133,15 +133,16 @@ class WorkspaceRetentionCleanupTask extends SystemTask {
 	 */
 	private function schedule_job_backed_cleanup( int $jobId, Workspace $workspace, array $opts, array $params ): array|\WP_Error {
 		$started_at       = microtime( true );
-		$chunk_rows       = $this->build_cleanup_chunk_rows( $workspace, $opts );
+		$chunk_rows       = $this->build_cleanup_chunk_rows( $workspace, $opts, $params );
 		if ( $chunk_rows instanceof \WP_Error ) {
 			return $chunk_rows;
 		}
 
 		$chunk_row_counts = array(
-			'artifacts' => count( $chunk_rows['artifacts'] ),
-			'metadata'  => count( $chunk_rows['metadata'] ),
-			'worktrees' => count( $chunk_rows['worktrees'] ),
+			'artifact_discovery' => count( $chunk_rows['artifact_discovery'] ),
+			'artifacts'          => count( $chunk_rows['artifacts'] ),
+			'metadata'           => count( $chunk_rows['metadata'] ),
+			'worktrees'          => count( $chunk_rows['worktrees'] ),
 		);
 		$item_params      = $this->build_cleanup_chunk_params( $chunk_rows, $opts, $params );
 
@@ -226,30 +227,38 @@ class WorkspaceRetentionCleanupTask extends SystemTask {
 	 * Build cleanup rows from reviewed dry-run plans.
 	 *
 	 * @param Workspace $workspace Workspace service.
-	 * @param array     $opts Normalized options.
-	 * @return array{artifacts:array<int,array>,metadata:array<int,array>,worktrees:array<int,array>}|\WP_Error
+	 * @param array     $opts   Normalized options.
+	 * @param array     $params Raw task params.
+	 * @return array{artifact_discovery:array<int,array>,artifacts:array<int,array>,metadata:array<int,array>,worktrees:array<int,array>}|\WP_Error
 	 */
-	private function build_cleanup_chunk_rows( Workspace $workspace, array $opts ): array|\WP_Error {
+	private function build_cleanup_chunk_rows( Workspace $workspace, array $opts, array $params ): array|\WP_Error {
 		$rows = array(
-			'artifacts' => array(),
-			'metadata'  => array(),
-			'worktrees' => array(),
+			'artifact_discovery' => array(),
+			'artifacts'          => array(),
+			'metadata'           => array(),
+			'worktrees'          => array(),
 		);
 
 		if ( ! empty( $opts['artifact_cleanup'] ) ) {
-			// Retention chunking needs the full set of safe artifact rows, not
-			// just the bounded dry-run page CLI consumers see by default.
-			$artifact_plan = $workspace->worktree_cleanup_artifacts(
+			$page_size     = max( 1, (int) ( $params['artifact_chunk_size'] ?? 10 ) );
+			$artifact_page = $workspace->worktree_cleanup_artifacts(
 				array(
-					'dry_run'    => true,
-					'force'      => ! empty( $opts['force'] ),
-					'exhaustive' => true,
+					'dry_run' => true,
+					'force'   => ! empty( $opts['force'] ),
+					'limit'   => 1,
+					'offset'  => 0,
 				)
 			);
-			if ( $artifact_plan instanceof \WP_Error ) {
-				return $artifact_plan;
+			if ( $artifact_page instanceof \WP_Error ) {
+				return $artifact_page;
 			}
-			$rows['artifacts'] = array_values( (array) ( $artifact_plan['candidates'] ?? array() ) );
+			$total = max( 0, (int) ( $artifact_page['pagination']['total'] ?? $artifact_page['summary']['pagination']['total'] ?? 0 ) );
+			for ( $offset = 0; $offset < $total; $offset += $page_size ) {
+				$rows['artifact_discovery'][] = array(
+					'offset' => $offset,
+					'limit'  => $page_size,
+				);
+			}
 		}
 
 		if ( ! empty( $opts['metadata_repair'] ) ) {
@@ -296,6 +305,17 @@ class WorkspaceRetentionCleanupTask extends SystemTask {
 			// keep git worktree metadata mutations conservative and lock-friendly.
 			'worktrees' => 1,
 		);
+
+		foreach ( (array) ( $chunk_rows['artifact_discovery'] ?? array() ) as $index => $page ) {
+			$item_params[] = array(
+				'chunk_type'  => 'artifact_discovery',
+				'chunk_index' => $index,
+				'limit'       => max( 1, (int) ( $page['limit'] ?? $sizes['artifacts'] ) ),
+				'offset'      => max( 0, (int) ( $page['offset'] ?? 0 ) ),
+				'force'       => ! empty( $opts['force'] ),
+				'skip_github' => ! empty( $opts['skip_github'] ),
+			);
+		}
 
 		foreach ( array( 'artifacts', 'metadata', 'worktrees' ) as $type ) {
 			foreach ( array_chunk( (array) ( $chunk_rows[ $type ] ?? array() ), $sizes[ $type ] ) as $index => $rows ) {

--- a/inc/Tasks/WorktreeCleanupChunkTask.php
+++ b/inc/Tasks/WorktreeCleanupChunkTask.php
@@ -50,6 +50,11 @@ class WorktreeCleanupChunkTask extends SystemTask {
 		$chunk_type = (string) ( $params['chunk_type'] ?? '' );
 		$rows       = is_array( $params['rows'] ?? null ) ? array_values( (array) $params['rows'] ) : array();
 
+		if ( 'artifact_discovery' === $chunk_type ) {
+			$this->execute_artifact_discovery_chunk( $jobId, $params, $started_at );
+			return;
+		}
+
 		if ( '' === $chunk_type || array() === $rows ) {
 			$this->completeJob(
 				$jobId,
@@ -73,6 +78,7 @@ class WorktreeCleanupChunkTask extends SystemTask {
 				array(
 					'apply_plan' => array( 'candidates' => $rows ),
 					'force'      => ! empty( $params['force'] ),
+					'limit'      => count( $rows ),
 				)
 			),
 			'metadata'  => $workspace->worktree_reconcile_metadata(
@@ -127,6 +133,128 @@ class WorktreeCleanupChunkTask extends SystemTask {
 				array(
 					'summary' => $result['summary'] ?? array(),
 					'result'  => $this->compact_evidence_result( $result ),
+				)
+			)
+		);
+	}
+
+	/**
+	 * Discover and apply one bounded artifact cleanup page.
+	 *
+	 * @param int   $jobId      Job ID.
+	 * @param array $params     Task params.
+	 * @param float $started_at Start timestamp.
+	 * @return void
+	 */
+	private function execute_artifact_discovery_chunk( int $jobId, array $params, float $started_at ): void {
+		$limit     = max( 1, (int) ( $params['limit'] ?? 10 ) );
+		$offset    = max( 0, (int) ( $params['offset'] ?? 0 ) );
+		$force     = ! empty( $params['force'] );
+		$workspace = new Workspace();
+
+		$plan = $workspace->worktree_cleanup_artifacts(
+			array(
+				'dry_run'       => true,
+				'force'         => $force,
+				'limit'         => $limit,
+				'offset'        => $offset,
+				'safety_probes' => true,
+			)
+		);
+
+		if ( $plan instanceof \WP_Error ) {
+			$this->completeJob(
+				$jobId,
+				$this->build_chunk_result(
+					'artifact_discovery',
+					array(),
+					array(),
+					array(),
+					array(
+						array(
+							'handle'      => '',
+							'reason_code' => $plan->get_error_code(),
+							'reason'      => $plan->get_error_message(),
+						)
+					),
+					0,
+					$started_at,
+					array(
+						'offset' => $offset,
+						'limit'  => $limit,
+					)
+				)
+			);
+			return;
+		}
+
+		$planned = array_values( (array) ( $plan['candidates'] ?? array() ) );
+		$skipped = array_values( (array) ( $plan['skipped'] ?? array() ) );
+		if ( array() === $planned ) {
+			$this->completeJob(
+				$jobId,
+				$this->build_chunk_result(
+					'artifact_discovery',
+					array(),
+					array(),
+					$skipped,
+					array(),
+					0,
+					$started_at,
+					array(
+						'pagination' => $plan['pagination'] ?? null,
+						'summary'    => $plan['summary'] ?? array(),
+					)
+				)
+			);
+			return;
+		}
+
+		$result = $workspace->worktree_cleanup_artifacts(
+			array(
+				'apply_plan' => array( 'candidates' => $planned ),
+				'force'      => $force,
+				'limit'      => count( $planned ),
+			)
+		);
+
+		if ( $result instanceof \WP_Error ) {
+			$this->completeJob(
+				$jobId,
+				$this->build_chunk_result(
+					'artifact_discovery',
+					$planned,
+					array(),
+					$skipped,
+					$this->rows_to_failed( $planned, $result->get_error_code(), $result->get_error_message() ),
+					0,
+					$started_at,
+					array(
+						'pagination' => $plan['pagination'] ?? null,
+						'summary'    => $plan['summary'] ?? array(),
+					)
+				)
+			);
+			return;
+		}
+
+		$applied = $this->extract_applied_rows( 'artifacts', $result );
+		$skipped = array_merge( $skipped, array_values( (array) ( $result['skipped'] ?? array() ) ) );
+
+		$this->completeJob(
+			$jobId,
+			$this->build_chunk_result(
+				'artifact_discovery',
+				$planned,
+				$applied,
+				$skipped,
+				array(),
+				$this->bytes_reclaimed( 'artifacts', $applied, $result ),
+				$started_at,
+				array(
+					'pagination' => $plan['pagination'] ?? null,
+					'summary'    => $result['summary'] ?? array(),
+					'result'     => $this->compact_evidence_result( $result ),
 				)
 			)
 		);

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -5772,10 +5772,11 @@ class Workspace {
 			}
 		}
 
-		// Exhaustive dry-run still uses the full git-backed listing. Apply-plan
-		// calls provide `only_handles`; keep those bounded by starting from cheap
-		// inventory and probing only the planned rows below.
-		if ( $safety_probes && null === $only_handles ) {
+		// Exhaustive unbounded dry-runs still use the full git-backed listing.
+		// Bounded discovery/apply chunks start from cheap inventory and run probes
+		// only for the current page so task fanout is not blocked by full planning.
+		$uses_git_listing = $safety_probes && null === $only_handles && $limit <= 0;
+		if ( $uses_git_listing ) {
 			$listing = $this->worktree_list();
 			if ( $listing instanceof \WP_Error ) {
 				return $listing;
@@ -5937,14 +5938,14 @@ class Workspace {
 		}
 
 		$pagination = array(
-			'mode'         => $safety_probes ? 'exhaustive' : 'bounded_inventory',
-			'limit'        => $bounded ? $limit : 0,
-			'offset'       => $slice_start,
-			'scanned'      => count( $slice ),
-			'total'        => $total,
-			'complete'     => ! $bounded || $slice_end >= $total,
-			'partial'      => $bounded && $slice_end < $total,
-			'next_offset'  => ( $bounded && $slice_end < $total ) ? $slice_end : null,
+			'mode'          => $safety_probes ? ( $uses_git_listing ? 'exhaustive' : 'bounded_inventory_safety' ) : 'bounded_inventory',
+			'limit'         => $bounded ? $limit : 0,
+			'offset'        => $slice_start,
+			'scanned'       => count( $slice ),
+			'total'         => $total,
+			'complete'      => ! $bounded || $slice_end >= $total,
+			'partial'       => $bounded && $slice_end < $total,
+			'next_offset'   => ( $bounded && $slice_end < $total ) ? $slice_end : null,
 			'safety_probes' => $safety_probes,
 		);
 

--- a/tests/smoke-workspace-retention-task.php
+++ b/tests/smoke-workspace-retention-task.php
@@ -52,8 +52,33 @@ namespace DataMachine\Engine\AI\System\Tasks {
 	}
 }
 
+namespace DataMachine\Engine\Tasks {
+	class TaskScheduler {
+		public static array $batches = array();
+
+		public static function scheduleBatch( string $task_type, array $items, array $context = array() ) {
+			self::$batches[] = array(
+				'task_type' => $task_type,
+				'items'     => $items,
+				'context'   => $context,
+			);
+
+			return array(
+				'batch_job_id' => 301,
+				'job_ids'      => range( 401, 400 + count( $items ) ),
+			);
+		}
+	}
+}
+
 namespace DataMachineCode\Workspace {
 	class Workspace {
+		public static array $artifact_opts = array();
+
+		public function get_path(): string {
+			return '/tmp/dmc-retention-task-workspace';
+		}
+
 		public function workspace_retention_cleanup( array $opts = array() ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 			return array(
 				'success' => true,
@@ -65,6 +90,32 @@ namespace DataMachineCode\Workspace {
 					'remaining_disk_budget_human'  => '400.0 GiB',
 				),
 			);
+		}
+
+		public function worktree_cleanup_artifacts( array $opts = array() ): array {
+			self::$artifact_opts[] = $opts;
+			return array(
+				'success'    => true,
+				'dry_run'    => true,
+				'candidates' => array(),
+				'skipped'    => array(),
+				'summary'    => array(
+					'pagination' => array(
+						'total' => 25,
+					),
+				),
+				'pagination' => array(
+					'total' => 25,
+				),
+			);
+		}
+
+		public function worktree_reconcile_metadata( array $opts = array() ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+			return array( 'proposals' => array() );
+		}
+
+		public function worktree_cleanup_merged( array $opts = array() ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+			return array( 'candidates' => array() );
 		}
 	}
 }
@@ -117,6 +168,29 @@ namespace {
 	$completed = $task->{$completed_prop};
 	datamachine_code_retention_task_assert( empty( $completed[0][1]['skipped'] ), 'explicit CLI run bypasses disabled recurring schedule' );
 	datamachine_code_retention_task_assert( true === (bool) ( $completed[0][1]['dry_run'] ?? false ), 'explicit CLI run forwards task params' );
+
+	echo "\n[4] Artifact cleanup schedules bounded discovery chunks\n";
+	\DataMachine\Engine\Tasks\TaskScheduler::$batches = array();
+	\DataMachineCode\Workspace\Workspace::$artifact_opts = array();
+	$task = new \DataMachineCode\Tasks\WorkspaceRetentionCleanupTask();
+	$task->executeTask(
+		204,
+		array(
+			'source'              => 'workspace_cleanup_cli',
+			'artifact_cleanup'    => true,
+			'worktree_cleanup'    => false,
+			'metadata_repair'     => false,
+			'artifact_chunk_size' => 10,
+		)
+	);
+	$completed = $task->{$completed_prop};
+	$batch     = \DataMachine\Engine\Tasks\TaskScheduler::$batches[0] ?? array();
+	datamachine_code_retention_task_assert( 'worktree_cleanup_chunk' === ( $batch['task_type'] ?? '' ), 'retention task schedules cleanup chunk batch' );
+	datamachine_code_retention_task_assert( 3 === count( $batch['items'] ?? array() ), 'artifact inventory total fans out into bounded discovery pages' );
+	datamachine_code_retention_task_assert( 'artifact_discovery' === ( $batch['items'][0]['chunk_type'] ?? '' ), 'artifact cleanup uses discovery chunks instead of prebuilt artifact rows' );
+	datamachine_code_retention_task_assert( array( 0, 10, 20 ) === array_column( $batch['items'], 'offset' ), 'discovery chunks carry stable offsets' );
+	datamachine_code_retention_task_assert( empty( \DataMachineCode\Workspace\Workspace::$artifact_opts[0]['exhaustive'] ), 'parent does not run exhaustive artifact dry-run' );
+	datamachine_code_retention_task_assert( 3 === (int) ( $completed[0][1]['chunk_row_counts']['artifact_discovery'] ?? 0 ), 'completion report exposes discovery chunk count' );
 
 	echo "\nAll workspace retention task smoke tests passed.\n";
 }

--- a/tests/smoke-worktree-cleanup-chunks.php
+++ b/tests/smoke-worktree-cleanup-chunks.php
@@ -214,6 +214,16 @@ namespace {
 	$assert( 'artifact_already_removed', $retry['skipped'][0]['reason_code'] ?? '', 'missing artifact is treated as already complete' );
 	$assert( array( 'demo@clean' ), $retry['evidence']['skipped_handles'] ?? array(), 'retry evidence includes skipped handle' );
 
+	mkdir( $tmp . '/demo@clean/target', 0755, true );
+	file_put_contents( $tmp . '/demo@clean/target/artifact.bin', str_repeat( 'y', 1024 ) );
+	$task->executeTask( 103, array( 'chunk_type' => 'artifact_discovery', 'limit' => 10, 'offset' => 0 ) );
+	$discovery = $GLOBALS['datamachine_code_chunk_jobs'][103] ?? array();
+	$assert( true, (bool) ( $discovery['success'] ?? false ), 'artifact discovery chunk succeeds' );
+	$assert( 1, (int) ( $discovery['planned_count'] ?? 0 ), 'artifact discovery chunk plans bounded safe rows' );
+	$assert( 1, (int) ( $discovery['applied_count'] ?? 0 ), 'artifact discovery chunk applies planned artifact rows' );
+	$assert( false, is_dir( $tmp . '/demo@clean/target' ), 'artifact discovery chunk removes artifact directory' );
+	$assert( 'bounded_inventory_safety', $discovery['evidence']['pagination']['mode'] ?? '', 'artifact discovery chunk uses bounded inventory pagination with safety probes' );
+
 	if ( $failures > 0 ) {
 		echo "\nFAILURES: {$failures}/{$total}\n";
 		exit( 1 );


### PR DESCRIPTION
## Summary
- Fixes #228.
- Changes task-backed retention cleanup to schedule bounded artifact discovery chunks instead of doing an exhaustive artifact dry-run in the parent task.
- Adds an `artifact_discovery` cleanup chunk path that scans one paginated inventory slice with safety probes and applies safe artifact rows via the existing plan-backed ability path.

## Tests
- `php -l inc/Tasks/WorkspaceRetentionCleanupTask.php && php -l inc/Tasks/WorktreeCleanupChunkTask.php && php -l inc/Workspace/Workspace.php`
- `php tests/smoke-workspace-retention-task.php`
- `php tests/smoke-worktree-cleanup-chunks.php`
- `php tests/smoke-worktree-cleanup-artifacts.php`
- `php tests/smoke-worktree-cleanup-artifacts-bounded.php`
- `php tests/smoke-workspace-retention-cleanup.php`

## Notes
- `homeboy test --path /Users/chubes/Developer/data-machine-code@fix-artifact-cleanup-discovery-fanout` failed before tests ran because the Playground bootstrap had no `wptests_*` tables and Data Machine activation hit `get_user_by()` during setup.
- `homeboy lint --path /Users/chubes/Developer/data-machine-code@fix-artifact-cleanup-discovery-fanout` reports existing repository-wide PHPCS findings; focused PHP lint for modified files passes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation and focused smoke tests; Chris remains responsible for review and validation.