### PR TITLE
Surface actionable cleanup skip commands

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -2885,6 +2885,8 @@ class WorkspaceCommand extends BaseCommand {
 			WP_CLI::log( sprintf( 'Filter: %s', $only ) );
 		}
 
+		$this->render_worktree_cleanup_next_commands( (array) ( $summary['skipped_next_commands'] ?? array() ) );
+
 		if ( ! empty( $candidates ) && ( '' === $only || 'candidates' === $only ) ) {
 			WP_CLI::log( '' );
 			WP_CLI::log( $dry_run ? 'Would remove:' : 'Candidates:' );
@@ -2958,6 +2960,32 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 		WP_CLI::success( sprintf( 'Removed %d worktree(s); %d skipped.', count( $result['removed'] ?? array() ), count( $result['skipped'] ?? array() ) ) );
+	}
+
+	/**
+	 * Render compact actionable next commands for skipped cleanup buckets.
+	 *
+	 * @param array<int,array<string,mixed>> $commands Next command rows.
+	 * @return void
+	 */
+	private function render_worktree_cleanup_next_commands( array $commands ): void {
+		if ( empty( $commands ) ) {
+			return;
+		}
+
+		WP_CLI::log( '' );
+		WP_CLI::log( 'Next commands for skipped buckets:' );
+		$rows = array_map(
+			fn( $row ) => array(
+				'reason_code' => $row['reason_code'] ?? '',
+				'count'       => (int) ( $row['count'] ?? 0 ),
+				'command'     => $row['command'] ?? '',
+				'alternative' => $row['alternative'] ?? '',
+				'destructive' => ! empty( $row['destructive'] ) ? 'yes' : 'no',
+			),
+			$commands
+		);
+		$this->format_items( $rows, array( 'reason_code', 'count', 'destructive', 'command', 'alternative' ), array( 'format' => 'table' ), 'reason_code' );
 	}
 
 	/**

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -6297,6 +6297,7 @@ class Workspace {
 			'removed'               => count( $removed ),
 			'skipped'               => count( $skipped ),
 			'skipped_by_reason'     => $skipped_by_reason,
+			'skipped_next_commands' => $this->worktree_cleanup_skipped_next_commands( $skipped_by_reason ),
 			'candidates_by_signal'  => $candidates_by_signal,
 			'repair_status'         => $repair_status_counts,
 			'total_size_bytes'      => $total_size_bytes,
@@ -6313,6 +6314,55 @@ class Workspace {
 		}
 
 		return $summary;
+	}
+
+	/**
+	 * Build copy-pasteable next commands for skipped cleanup buckets.
+	 *
+	 * @param array<string,int> $skipped_by_reason Skipped reason counts.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function worktree_cleanup_skipped_next_commands( array $skipped_by_reason ): array {
+		$templates = array(
+			'missing_metadata_repaired'   => array(
+				'label'       => 'Review repaired legacy metadata with bounded safety probes',
+				'command'     => 'studio wp datamachine-code workspace cleanup run --mode=retention --older-than=7d',
+				'alternative' => 'studio wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --dry-run --limit=25 --older-than=7d',
+				'why'         => 'Queues task-backed retention cleanup so repaired rows get full safety checks before any deletion.',
+				'destructive' => true,
+			),
+			'requires_full_scan'          => array(
+				'label'       => 'Repair missing lifecycle metadata in bounded batches',
+				'command'     => 'studio wp datamachine-code workspace worktree reconcile-metadata-batch --dry-run --limit=25 --format=json',
+				'alternative' => 'studio wp datamachine-code workspace worktree reconcile-metadata-batch --limit=25',
+				'why'         => 'Bounded reconciliation writes lifecycle metadata so future inventory cleanup no longer needs a full scan for those rows.',
+				'destructive' => false,
+			),
+			'no_inventory_cleanup_signal' => array(
+				'label'       => 'Mark reviewed worktrees cleanup-eligible',
+				'command'     => 'studio wp datamachine-code workspace worktree finalize <handle> --pr=<pr-url>',
+				'alternative' => 'studio wp datamachine-code workspace worktree mark-cleanup-eligible <handle>',
+				'why'         => 'Records an explicit cleanup signal; then bounded cleanup-eligible apply can remove reviewed safe rows.',
+				'destructive' => false,
+			),
+		);
+
+		$commands = array();
+		foreach ( $templates as $reason => $template ) {
+			$count = (int) ( $skipped_by_reason[ $reason ] ?? 0 );
+			if ( $count <= 0 ) {
+				continue;
+			}
+			$commands[] = array_merge(
+				array(
+					'reason_code' => $reason,
+					'count'       => $count,
+				),
+				$template
+			);
+		}
+
+		return $commands;
 	}
 
 	/**

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -97,6 +97,31 @@ namespace {
 			'artifact_size_bytes' => 0,
 		);
 
+		$skipped[] = array(
+			'handle'      => 'repo@legacy-repaired',
+			'repo'        => 'repo',
+			'branch'      => 'legacy-repaired',
+			'path'        => '/workspace/repo@legacy-repaired',
+			'reason_code' => 'missing_metadata_repaired',
+			'reason'      => 'legacy metadata was repaired conservatively; no cleanup signal yet',
+		);
+		$skipped[] = array(
+			'handle'      => 'repo@needs-full-scan',
+			'repo'        => 'repo',
+			'branch'      => 'needs-full-scan',
+			'path'        => '/workspace/repo@needs-full-scan',
+			'reason_code' => 'requires_full_scan',
+			'reason'      => 'inventory row has no lifecycle metadata; cleanup safety requires a full scan',
+		);
+		$skipped[] = array(
+			'handle'      => 'repo@needs-review',
+			'repo'        => 'repo',
+			'branch'      => 'needs-review',
+			'path'        => '/workspace/repo@needs-review',
+			'reason_code' => 'no_inventory_cleanup_signal',
+			'reason'      => 'no explicit inventory cleanup signal - leaving in place',
+		);
+
 		return array(
 			'success'    => true,
 			'dry_run'    => true,
@@ -121,9 +146,35 @@ namespace {
 				'removed'              => 0,
 				'skipped'              => count( $skipped ),
 				'skipped_by_reason'    => array(
-					'dirty_worktree'   => 1,
-					'missing_metadata' => 1,
-					'no_merge_signal'  => 10,
+					'dirty_worktree'               => 1,
+					'missing_metadata'             => 1,
+					'missing_metadata_repaired'    => 1,
+					'no_inventory_cleanup_signal'  => 1,
+					'no_merge_signal'              => 10,
+					'requires_full_scan'           => 1,
+				),
+				'skipped_next_commands' => array(
+					array(
+						'reason_code' => 'missing_metadata_repaired',
+						'count'       => 1,
+						'command'     => 'studio wp datamachine-code workspace cleanup run --mode=retention --older-than=7d',
+						'alternative' => 'studio wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --dry-run --limit=25 --older-than=7d',
+						'destructive' => true,
+					),
+					array(
+						'reason_code' => 'requires_full_scan',
+						'count'       => 1,
+						'command'     => 'studio wp datamachine-code workspace worktree reconcile-metadata-batch --dry-run --limit=25 --format=json',
+						'alternative' => 'studio wp datamachine-code workspace worktree reconcile-metadata-batch --limit=25',
+						'destructive' => false,
+					),
+					array(
+						'reason_code' => 'no_inventory_cleanup_signal',
+						'count'       => 1,
+						'command'     => 'studio wp datamachine-code workspace worktree finalize <handle> --pr=<pr-url>',
+						'alternative' => 'studio wp datamachine-code workspace worktree mark-cleanup-eligible <handle>',
+						'destructive' => false,
+					),
 				),
 				'candidates_by_signal' => array(
 					'upstream-gone' => 1,
@@ -606,6 +657,10 @@ namespace {
 	datamachine_code_cleanup_assert( array( 'repo', 'branch', 'path' ) === ( $decoded['skipped'][11]['missing_fields'] ?? array() ), 'JSON missing_metadata includes missing fields' );
 	datamachine_code_cleanup_assert( str_contains( $decoded['skipped'][11]['hint'] ?? '', 'workspace worktree prune' ), 'JSON missing_metadata includes remediation hint' );
 	datamachine_code_cleanup_assert( 10 === (int) ( $decoded['summary']['skipped_by_reason']['no_merge_signal'] ?? 0 ), 'JSON summary includes reason counts' );
+	datamachine_code_cleanup_assert( 3 === count( $decoded['summary']['skipped_next_commands'] ?? array() ), 'JSON summary includes actionable skipped next commands' );
+	datamachine_code_cleanup_assert( str_contains( $decoded['summary']['skipped_next_commands'][0]['command'] ?? '', 'workspace cleanup run --mode=retention --older-than=7d' ), 'JSON repaired metadata command is task-backed retention cleanup' );
+	datamachine_code_cleanup_assert( str_contains( $decoded['summary']['skipped_next_commands'][1]['command'] ?? '', 'reconcile-metadata-batch --dry-run --limit=25' ), 'JSON full-scan command is bounded metadata reconciliation' );
+	datamachine_code_cleanup_assert( str_contains( $decoded['summary']['skipped_next_commands'][2]['command'] ?? '', 'finalize <handle> --pr=<pr-url>' ), 'JSON no-signal command records explicit review metadata' );
 
 	echo "\n[1b] --apply-plan decodes JSON and forbids force\n";
 	$plan_file = sys_get_temp_dir() . '/dmc-cleanup-plan-' . bin2hex( random_bytes( 3 ) ) . '.json';
@@ -633,7 +688,9 @@ namespace {
 	datamachine_code_cleanup_assert( in_array( 'table:1:handle,branch,age_days,size,artifacts,signal,reason_code', WP_CLI::$logs, true ), 'default candidate table uses compact disk fields' );
 	datamachine_code_cleanup_assert( in_array( 'table:10:handle,reason_code,age_days,size,artifacts,reason', WP_CLI::$logs, true ), 'default skipped table omits path and hint fields but keeps disk fields' );
 	datamachine_code_cleanup_assert( in_array( 'Top repos by worktree size:', WP_CLI::$logs, true ), 'human output includes top repo size summary' );
-	datamachine_code_cleanup_assert( in_array( 'Showing 10 of 12 skipped rows. Re-run with --verbose for all rows or --only=<reason_code> to filter.', WP_CLI::$logs, true ), 'human output truncates skipped rows with hint' );
+	datamachine_code_cleanup_assert( in_array( 'Next commands for skipped buckets:', WP_CLI::$logs, true ), 'human output includes actionable skipped command section' );
+	datamachine_code_cleanup_assert( in_array( 'table:3:reason_code,count,destructive,command,alternative', WP_CLI::$logs, true ), 'human output renders compact skipped command table' );
+	datamachine_code_cleanup_assert( in_array( 'Showing 10 of 15 skipped rows. Re-run with --verbose for all rows or --only=<reason_code> to filter.', WP_CLI::$logs, true ), 'human output truncates skipped rows with hint' );
 	datamachine_code_cleanup_assert( 1 === count( WP_CLI::$successes ), 'human output keeps success suffix' );
 
 	echo "\n[3] verbose output keeps detailed human fields\n";
@@ -641,7 +698,7 @@ namespace {
 	WP_CLI::$successes = array();
 	$command->worktree( array( 'cleanup' ), array( 'dry-run' => true, 'skip-github' => true, 'verbose' => true ) );
 	datamachine_code_cleanup_assert( in_array( 'table:1:handle,branch,age_days,size,artifacts,signal,reason', WP_CLI::$logs, true ), 'verbose candidate table keeps full reason field' );
-	datamachine_code_cleanup_assert( in_array( 'table:12:handle,reason_code,reason,age_days,size,artifacts,repo,branch,path,primary_path,missing,hint', WP_CLI::$logs, true ), 'verbose skipped table keeps diagnostic fields' );
+	datamachine_code_cleanup_assert( in_array( 'table:15:handle,reason_code,reason,age_days,size,artifacts,repo,branch,path,primary_path,missing,hint', WP_CLI::$logs, true ), 'verbose skipped table keeps diagnostic fields' );
 
 	echo "\n[4] --only filters rows while keeping full summary\n";
 	WP_CLI::$logs      = array();
@@ -651,7 +708,7 @@ namespace {
 	datamachine_code_cleanup_assert( array() === ( $filtered['candidates'] ?? null ), '--only reason hides candidates' );
 	datamachine_code_cleanup_assert( 1 === count( $filtered['skipped'] ?? array() ), '--only reason keeps matching skipped rows only' );
 	datamachine_code_cleanup_assert( 'missing_metadata' === ( $filtered['skipped'][0]['reason_code'] ?? '' ), '--only alias resolves to reason code' );
-	datamachine_code_cleanup_assert( 12 === (int) ( $filtered['summary']['skipped'] ?? 0 ), '--only leaves summary counts unfiltered' );
+	datamachine_code_cleanup_assert( 15 === (int) ( $filtered['summary']['skipped'] ?? 0 ), '--only leaves summary counts unfiltered' );
 
 	echo "\n[5] --only aliases resolve candidate section\n";
 	foreach ( array( 'candidates', 'would-remove', 'would_remove' ) as $alias ) {
@@ -671,7 +728,7 @@ namespace {
 	$command->worktree( array( 'cleanup' ), array( 'dry-run' => true, 'skip-github' => true, 'older-than' => '7d' ) );
 	datamachine_code_cleanup_assert( '7d' === ( $ability->last_input['older_than'] ?? null ), 'older-than forwards to cleanup ability as older_than' );
 	datamachine_code_cleanup_assert( is_callable( $ability->last_input['progress_callback'] ?? null ), 'human cleanup passes progress callback to ability' );
-	datamachine_code_cleanup_assert( in_array( 'table:10:metric,count', WP_CLI::$logs, true ), 'age filter and disk summary rows are rendered' );
+	datamachine_code_cleanup_assert( in_array( 'table:13:metric,count', WP_CLI::$logs, true ), 'age filter and disk summary rows are rendered' );
 
 	WP_CLI::$logs      = array();
 	WP_CLI::$successes = array();

--- a/tests/smoke-worktree-cleanup.php
+++ b/tests/smoke-worktree-cleanup.php
@@ -394,6 +394,10 @@ namespace {
 	$assert( 'no_inventory_cleanup_signal', $inventory_active['reason_code'] ?? '', 'inventory-only active metadata uses stable ambiguous reason' );
 	$inventory_missing = array_values( array_filter( $inventory_plan['skipped'] ?? array(), fn( $s ) => ( $s['handle'] ?? '' ) === 'demo@inventory-missing-metadata' ) )[0] ?? array();
 	$assert( 'requires_full_scan', $inventory_missing['reason_code'] ?? '', 'inventory-only missing metadata requires full scan' );
+	$inventory_next_commands = (array) ( $inventory_plan['summary']['skipped_next_commands'] ?? array() );
+	$assert( true, count( $inventory_next_commands ) >= 2, 'inventory-only summary includes actionable skipped commands' );
+	$assert( true, in_array( 'requires_full_scan', array_column( $inventory_next_commands, 'reason_code' ), true ), 'inventory-only skipped commands include full-scan remediation' );
+	$assert( true, in_array( 'no_inventory_cleanup_signal', array_column( $inventory_next_commands, 'reason_code' ), true ), 'inventory-only skipped commands include explicit review remediation' );
 	$inventory_apply = $inventory_ws->worktree_cleanup_merged( array( 'inventory_only' => true ) );
 	$assert( true, is_wp_error( $inventory_apply ), 'inventory-only cleanup refuses non-dry-run apply path' );
 


### PR DESCRIPTION
## Summary
- Add `summary.skipped_next_commands` for large cleanup skipped buckets so JSON dry-runs include copy-pasteable follow-up commands.
- Render compact human next-command rows for `missing_metadata_repaired`, `requires_full_scan`, and `no_inventory_cleanup_signal`.
- Cover the new JSON and human output in focused cleanup smoke tests.

Fixes #236.

## Tests
- `php tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-worktree-cleanup.php`
- `php -l inc/Cli/Commands/WorkspaceCommand.php && php -l inc/Workspace/Workspace.php && php -l tests/smoke-worktree-cleanup-cli.php && php -l tests/smoke-worktree-cleanup.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the cleanup output changes and focused smoke test updates; Chris remains responsible for review and merge.