### PR TITLE
fix: rename repaired metadata cleanup surface

### DIFF
--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -513,7 +513,7 @@ class GitHubAbilities {
 				'datamachine/get-github-commit-statuses',
 				array(
 					'label'               => 'Get GitHub Commit Statuses',
-					'description'         => 'Get legacy GitHub commit statuses for a commit SHA or ref',
+					'description'         => 'Get unmanaged GitHub commit statuses for a commit SHA or ref',
 					'category'            => 'datamachine-code-github',
 					'input_schema'        => array(
 						'type'       => 'object',
@@ -652,7 +652,7 @@ class GitHubAbilities {
 							),
 							'include_statuses'        => array(
 								'type'        => 'boolean',
-								'description' => 'Whether to include legacy commit statuses for the PR head SHA.',
+								'description' => 'Whether to include classic commit statuses for the PR head SHA.',
 							),
 							'max_check_runs'          => array(
 								'type'        => 'integer',
@@ -2528,7 +2528,7 @@ class GitHubAbilities {
 	}
 
 	/**
-	 * Get legacy commit statuses for one commit SHA or ref.
+	 * Get classic commit statuses for one commit SHA or ref.
 	 *
 	 * @param array $input Required: repo, sha.
 	 * @return array|\WP_Error
@@ -2762,7 +2762,7 @@ class GitHubAbilities {
 	}
 
 	/**
-	 * Summarize Homeboy review.json or legacy per-command artifacts.
+	 * Summarize Homeboy review.json or classic per-command artifacts.
 	 */
 	public static function summarizeHomeboyCiArtifact( array $files, array $context = array() ): array|\WP_Error {
 		$manifest = is_array( $files['manifest.json'] ?? null ) ? $files['manifest.json'] : array();
@@ -2790,12 +2790,12 @@ class GitHubAbilities {
 			foreach ( array( 'audit', 'lint', 'test' ) as $stage ) {
 				$file = $stage . '.json';
 				if ( isset( $files[ $file ] ) && is_array( $files[ $file ] ) ) {
-					$stages[ $stage ] = self::summarizeHomeboyLegacyStage( $stage, $files[ $file ] );
+					$stages[ $stage ] = self::summarizeHomeboyClassicStage( $stage, $files[ $file ] );
 				}
 			}
 
 			if ( empty( $stages ) ) {
-				return new \WP_Error( 'github_homeboy_ci_payload_not_found', 'Homeboy CI artifact did not contain review.json or legacy audit/lint/test JSON files.', array( 'status' => 422 ) );
+				return new \WP_Error( 'github_homeboy_ci_payload_not_found', 'Homeboy CI artifact did not contain review.json or classic audit/lint/test JSON files.', array( 'status' => 422 ) );
 			}
 
 			$summary = array(
@@ -2804,7 +2804,7 @@ class GitHubAbilities {
 			);
 			$passed  = (bool) $summary['passed'];
 			$state   = $passed ? 'success' : 'failure';
-			$mode    = 'legacy';
+			$mode    = 'classic';
 		}
 
 		$artifact = is_array( $context['artifact'] ?? null ) ? $context['artifact'] : array();
@@ -2853,7 +2853,7 @@ class GitHubAbilities {
 		);
 	}
 
-	private static function summarizeHomeboyLegacyStage( string $stage, array $payload ): array {
+	private static function summarizeHomeboyClassicStage( string $stage, array $payload ): array {
 		$data          = is_array( $payload['data'] ?? null ) ? $payload['data'] : array();
 		$finding_count = (int) ( $data['finding_count'] ?? $data['total_findings'] ?? $data['summary']['total_findings'] ?? count( $data['findings'] ?? array() ) );
 
@@ -3318,7 +3318,7 @@ class GitHubAbilities {
 	}
 
 	/**
-	 * Normalize one legacy commit status.
+	 * Normalize one unmanaged commit status.
 	 */
 	public static function normalizeCommitStatus( array $status ): array {
 		return array(
@@ -3368,7 +3368,7 @@ class GitHubAbilities {
 	}
 
 	/**
-	 * Summarize legacy commit statuses.
+	 * Summarize classic commit statuses.
 	 */
 	public static function summarizeCommitStatuses( array $statuses, string $combined_state = '' ): array {
 		$counts  = array(

--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -1327,9 +1327,9 @@ class WorkspaceAbilities {
 								'type'        => 'string',
 								'description' => 'Optional cleanup candidate sort: size or age.',
 							),
-							'include_legacy_repaired' => array(
+							'include_repaired_metadata' => array(
 								'type'        => 'boolean',
-								'description' => 'If true, include conservatively repaired legacy metadata rows as operator-approved removal candidates after full safety revalidation.',
+								'description' => 'If true, include repaired metadata rows as operator-approved removal candidates after full safety revalidation.',
 							),
 						),
 					),
@@ -1491,7 +1491,7 @@ class WorkspaceAbilities {
 				'datamachine/workspace-worktree-bounded-cleanup-eligible-apply',
 				array(
 					'label'               => 'Bounded Cleanup Apply for Obvious Worktrees',
-					'description'         => 'Apply only worktrees with explicit lifecycle cleanup_eligible metadata in a bounded batch using cheap workspace inventory. Can explicitly include legacy repaired metadata rows for operator-approved cleanup. Revalidates dirty/unpushed/missing-metadata/external/primary safety gates immediately before each removal. Optionally schedules per-candidate chunk jobs for resumable async apply. Produces evidence with processed/removed/skipped/bytes_reclaimed/continuation.',
+					'description'         => 'Apply only worktrees with explicit lifecycle cleanup_eligible metadata in a bounded batch using cheap workspace inventory. Can explicitly include repaired metadata rows for operator-approved cleanup. Revalidates dirty/unpushed/missing-metadata/external/primary safety gates immediately before each removal. Optionally schedules per-candidate chunk jobs for resumable async apply. Produces evidence with processed/removed/skipped/bytes_reclaimed/continuation.',
 					'category'            => 'datamachine-code-workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
@@ -1520,9 +1520,9 @@ class WorkspaceAbilities {
 								'type'        => 'boolean',
 								'description' => 'Schedule each candidate as a single-row worktree_cleanup_chunk job for resumable async apply.',
 							),
-							'include_legacy_repaired' => array(
+							'include_repaired_metadata' => array(
 								'type'        => 'boolean',
-								'description' => 'Also include metadata_repaired legacy rows that inventory reports as missing_metadata_repaired. Requires explicit opt-in and still runs fresh safety probes before removal.',
+								'description' => 'Also include repaired metadata rows. Requires explicit opt-in and still runs fresh safety probes before removal.',
 							),
 							'source'     => array(
 								'type'        => 'string',
@@ -2097,7 +2097,7 @@ class WorkspaceAbilities {
 			'force'                   => ! empty( $input['force'] ),
 			'skip_github'             => ! empty( $input['skip_github'] ),
 			'inventory_only'          => ! empty( $input['inventory_only'] ),
-			'include_legacy_repaired' => ! empty( $input['include_legacy_repaired'] ),
+			'include_repaired_metadata' => ! empty( $input['include_repaired_metadata'] ),
 		);
 		if ( isset( $input['apply_plan'] ) && is_array( $input['apply_plan'] ) ) {
 			$opts['apply_plan'] = $input['apply_plan'];
@@ -2177,7 +2177,7 @@ class WorkspaceAbilities {
 			'dry_run'                 => ! empty( $input['dry_run'] ),
 			'force'                   => ! empty( $input['force'] ),
 			'via_jobs'                => ! empty( $input['via_jobs'] ),
-			'include_legacy_repaired' => ! empty( $input['include_legacy_repaired'] ),
+			'include_repaired_metadata' => ! empty( $input['include_repaired_metadata'] ),
 		);
 		if ( isset( $input['limit'] ) ) {
 			$opts['limit'] = (int) $input['limit'];

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1504,7 +1504,7 @@ class WorkspaceCommand extends BaseCommand {
 	 *     wp datamachine-code workspace delete homeboy@my-branch src/old_module.rs
 	 *
 	 *     # Delete an entire directory tree
-	 *     wp datamachine-code workspace delete homeboy@my-branch src/legacy --recursive
+	 *     wp datamachine-code workspace delete homeboy@my-branch src/classic --recursive
 	 *
 	 *     # Delete on the primary checkout (rare, gated)
 	 *     wp datamachine-code workspace delete homeboy notes.md --allow-primary-mutation
@@ -1962,10 +1962,9 @@ class WorkspaceCommand extends BaseCommand {
 	 *   lifecycle cleanup signals only (cleanup only). Avoids full git worktree
 	 *   scans, per-worktree status checks, and GitHub lookups.
 	 *
-	 * [--include-legacy-repaired]
+	 * [--include-repaired-metadata]
 	 * : With cleanup inventory or bounded-cleanup-eligible-apply, explicitly
-	 *   include conservatively repaired legacy metadata rows
-	 *   (`missing_metadata_repaired`) as operator-approved cleanup candidates.
+	 *   include repaired metadata rows as operator-approved cleanup candidates.
 	 *   Apply still runs fresh dirty/unpushed/containment/primary safety probes.
 	 *
 	 * [--older-than=<duration>]
@@ -2093,8 +2092,8 @@ class WorkspaceCommand extends BaseCommand {
 	 *     wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --dry-run --limit=25
 	 *     wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --limit=25
 	 *     wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --via-jobs --limit=10 --older-than=7d
-	 *     wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --dry-run --include-legacy-repaired --older-than=7d --limit=25
-	 *     wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --include-legacy-repaired --older-than=7d --limit=25
+	 *     wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --dry-run --include-repaired-metadata --older-than=7d --limit=25
+	 *     wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --include-repaired-metadata --older-than=7d --limit=25
 	 *
 	 *     # Local-only detection (no GitHub API call)
 	 *     wp datamachine-code workspace worktree cleanup --skip-github
@@ -2270,7 +2269,7 @@ class WorkspaceCommand extends BaseCommand {
 				$input['force']          = ! empty( $assoc_args['force'] );
 				$input['skip_github']    = ! empty( $assoc_args['skip-github'] );
 				$input['inventory_only'] = ! empty( $assoc_args['inventory-only'] );
-				$input['include_legacy_repaired'] = ! empty( $assoc_args['include-legacy-repaired'] );
+				$input['include_repaired_metadata'] = ! empty( $assoc_args['include-repaired-metadata'] );
 				if ( ! in_array( (string) ( $assoc_args['format'] ?? '' ), array( 'json', 'yaml' ), true ) ) {
 					$input['progress_callback'] = function ( array $event ): void {
 						$this->render_worktree_cleanup_progress( $event );
@@ -2330,7 +2329,7 @@ class WorkspaceCommand extends BaseCommand {
 				$input['dry_run']  = ! empty( $assoc_args['dry-run'] );
 				$input['force']    = ! empty( $assoc_args['force'] );
 				$input['via_jobs'] = ! empty( $assoc_args['via-jobs'] );
-				$input['include_legacy_repaired'] = ! empty( $assoc_args['include-legacy-repaired'] );
+				$input['include_repaired_metadata'] = ! empty( $assoc_args['include-repaired-metadata'] );
 				$input['source']   = self::CLEANUP_CLI_SOURCE;
 				if ( isset( $assoc_args['limit'] ) ) {
 					$input['limit'] = (int) $assoc_args['limit'];

--- a/inc/Handlers/GitHub/GitHub.php
+++ b/inc/Handlers/GitHub/GitHub.php
@@ -284,7 +284,7 @@ class GitHub extends FetchHandler {
 	}
 
 	/**
-	 * Fetch legacy commit statuses for one commit SHA or ref.
+	 * Fetch classic commit statuses for one commit SHA or ref.
 	 */
 	private function fetchCommitStatuses( array $config, ExecutionContext $context, string $repo ): array {
 		$sha = $this->resolveShaFromConfig( $config );

--- a/inc/Handlers/GitHub/GitHubSettings.php
+++ b/inc/Handlers/GitHub/GitHubSettings.php
@@ -125,7 +125,7 @@ class GitHubSettings extends FetchHandlerSettings {
 			'include_statuses'        => array(
 				'type'        => 'checkbox',
 				'label'       => __( 'Include Commit Statuses', 'data-machine-code' ),
-				'description' => __( 'Include legacy commit statuses in PR review context.', 'data-machine-code' ),
+				'description' => __( 'Include classic commit statuses in PR review context.', 'data-machine-code' ),
 				'required'    => false,
 				'default'     => false,
 			),

--- a/inc/Support/GitHubCredentialResolver.php
+++ b/inc/Support/GitHubCredentialResolver.php
@@ -2,7 +2,7 @@
 /**
  * GitHub credential resolver.
  *
- * Supports the legacy PAT path and GitHub App installation tokens behind the
+ * Supports the classic PAT path and GitHub App installation tokens behind the
  * same API-token contract used by GitHubAbilities.
  *
  * @package DataMachineCode\Support

--- a/inc/Tasks/WorktreeCleanupChunkTask.php
+++ b/inc/Tasks/WorktreeCleanupChunkTask.php
@@ -85,7 +85,7 @@ class WorktreeCleanupChunkTask extends SystemTask {
 				array(
 					'apply_plan'              => array( 'candidates' => $rows ),
 					'skip_github'             => array_key_exists( 'skip_github', $params ) ? (bool) $params['skip_github'] : true,
-					'include_legacy_repaired' => ! empty( $params['include_legacy_repaired'] ),
+					'include_repaired_metadata' => ! empty( $params['include_repaired_metadata'] ),
 				)
 			),
 			default     => new \WP_Error( 'invalid_cleanup_chunk_type', sprintf( 'Unknown cleanup chunk type: %s', $chunk_type ), array( 'status' => 400 ) ),

--- a/inc/Tasks/WorktreeCleanupTask.php
+++ b/inc/Tasks/WorktreeCleanupTask.php
@@ -142,7 +142,7 @@ class WorktreeCleanupTask extends SystemTask {
 			'dry_run'                 => ! empty( $params['dry_run'] ),
 			'force'                   => ! empty( $params['force'] ),
 			'skip_github'             => ! empty( $params['skip_github'] ),
-			'include_legacy_repaired' => ! empty( $params['include_legacy_repaired'] ),
+			'include_repaired_metadata' => ! empty( $params['include_repaired_metadata'] ),
 		);
 		if ( isset( $params['older_than'] ) && '' !== trim( (string) $params['older_than'] ) ) {
 			$opts['older_than'] = trim( (string) $params['older_than'] );

--- a/inc/Tools/GitHubTools.php
+++ b/inc/Tools/GitHubTools.php
@@ -694,7 +694,7 @@ class GitHubTools extends BaseTool {
 		return array(
 			'class'       => __CLASS__,
 			'method'      => 'handleCommitStatuses',
-			'description' => 'Get legacy GitHub commit statuses for a commit SHA or ref, including aggregate state and failing contexts.',
+			'description' => 'Get unmanaged GitHub commit statuses for a commit SHA or ref, including aggregate state and failing contexts.',
 			'parameters'  => array(
 				'repo' => array(
 					'type'        => 'string',
@@ -844,7 +844,7 @@ class GitHubTools extends BaseTool {
 				'include_statuses'        => array(
 					'type'        => 'boolean',
 					'required'    => false,
-					'description' => 'Include legacy commit statuses for the PR head SHA.',
+					'description' => 'Include classic commit statuses for the PR head SHA.',
 				),
 				'max_check_runs'          => array(
 					'type'        => 'integer',

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -2812,7 +2812,7 @@ class Workspace {
 		$force          = ! empty( $opts['force'] );
 		$skip_github    = ! empty( $opts['skip_github'] );
 		$inventory_only = ! empty( $opts['inventory_only'] );
-		$include_legacy_repaired = ! empty( $opts['include_legacy_repaired'] );
+		$include_repaired_metadata = ! empty( $opts['include_repaired_metadata'] );
 		$apply_plan     = isset( $opts['apply_plan'] ) && is_array( $opts['apply_plan'] ) ? $opts['apply_plan'] : null;
 		$older_than     = isset( $opts['older_than'] ) ? trim( (string) $opts['older_than'] ) : '';
 		$sort           = isset( $opts['sort'] ) ? trim( (string) $opts['sort'] ) : '';
@@ -2831,7 +2831,7 @@ class Workspace {
 				return new \WP_Error( 'inventory_cleanup_apply_plan_unsupported', 'Inventory-only cleanup cannot apply a plan because it intentionally skips full safety revalidation.', array( 'status' => 400 ) );
 			}
 
-			return $this->worktree_cleanup_inventory_only( $older_than, $sort, $include_legacy_repaired );
+			return $this->worktree_cleanup_inventory_only( $older_than, $sort, $include_repaired_metadata );
 		}
 
 		$planned_candidates = null;
@@ -3038,10 +3038,10 @@ class Workspace {
 				if ( ! empty( $metadata['pr_url'] ) ) {
 					$signal['pr_url'] = (string) $metadata['pr_url'];
 				}
-			} elseif ( $include_legacy_repaired && is_array( $metadata ) && ! empty( $metadata['metadata_repaired'] ) ) {
+			} elseif ( $include_repaired_metadata && is_array( $metadata ) && ! empty( $metadata['metadata_repaired'] ) ) {
 				$signal = array(
-					'signal' => 'missing_metadata_repaired',
-					'reason' => 'operator-approved cleanup of conservatively repaired legacy metadata',
+					'signal' => 'repaired_metadata',
+					'reason' => 'operator-approved cleanup of repaired metadata',
 				);
 			} else {
 				$signal = $this->detect_merge_signal( $primary_path, $repo, $branch, $skip_github, $github_cache );
@@ -4693,7 +4693,7 @@ class Workspace {
 	 * @param string $sort       Optional candidate sort.
 	 * @return array<string,mixed>|\WP_Error
 	 */
-	private function worktree_cleanup_inventory_only( string $older_than, string $sort, bool $include_legacy_repaired = false ): array|\WP_Error {
+	private function worktree_cleanup_inventory_only( string $older_than, string $sort, bool $include_repaired_metadata = false ): array|\WP_Error {
 		$age_filter = null;
 		if ( '' !== $older_than ) {
 			$duration_seconds = $this->parse_worktree_cleanup_duration( $older_than );
@@ -4747,7 +4747,7 @@ class Workspace {
 
 			if ( ! WorktreeContextInjector::has_cleanup_signal( $metadata ) ) {
 				$repaired = ! empty( $metadata['metadata_repaired'] );
-				if ( $include_legacy_repaired && $repaired ) {
+				if ( $include_repaired_metadata && $repaired ) {
 					$age_decision = null;
 					if ( null !== $age_filter ) {
 						$created_ts = is_string( $created_at ) && '' !== $created_at ? strtotime( $created_at ) : false;
@@ -4787,10 +4787,10 @@ class Workspace {
 
 					$candidate = array_merge( $base_row, array(
 						'dirty'         => 0,
-						'signal'        => 'missing_metadata_repaired',
-						'reason_code'   => 'missing_metadata_repaired',
-						'reason'        => 'operator-approved cleanup of conservatively repaired legacy metadata',
-						'repair_status' => 'missing_metadata_repaired',
+						'signal'        => 'repaired_metadata',
+						'reason_code'   => 'repaired_metadata',
+						'reason'        => 'operator-approved cleanup of repaired metadata',
+						'repair_status' => 'repaired_metadata',
 					) );
 					if ( null !== $age_decision ) {
 						$candidate['age_filter'] = $age_decision;
@@ -4905,7 +4905,7 @@ class Workspace {
 		$dry_run    = ! empty( $opts['dry_run'] );
 		$force      = ! empty( $opts['force'] );
 		$via_jobs   = ! empty( $opts['via_jobs'] );
-		$include_legacy_repaired = ! empty( $opts['include_legacy_repaired'] );
+		$include_repaired_metadata = ! empty( $opts['include_repaired_metadata'] );
 		$older_than = isset( $opts['older_than'] ) ? trim( (string) $opts['older_than'] ) : '';
 		$sort       = isset( $opts['sort'] ) ? trim( (string) $opts['sort'] ) : 'age';
 		$source     = isset( $opts['source'] ) ? trim( (string) $opts['source'] ) : 'workspace_bounded_cleanup_eligible_apply';
@@ -4931,7 +4931,7 @@ class Workspace {
 		// the bounded cleanup-eligible apply never triggers full worktree_list / fetch / GitHub
 		// API work just to plan. This intentionally does not honor `apply_plan`
 		// — bounded cleanup-eligible apply IS the apply path; no separate plan file is needed.
-		$inventory = $this->worktree_cleanup_inventory_only( $older_than, $sort, $include_legacy_repaired );
+		$inventory = $this->worktree_cleanup_inventory_only( $older_than, $sort, $include_repaired_metadata );
 		if ( $inventory instanceof \WP_Error ) {
 			return $inventory;
 		}
@@ -4979,7 +4979,7 @@ class Workspace {
 		}
 
 		if ( $via_jobs ) {
-			return $this->schedule_bounded_cleanup_eligible_chunks( $batch, $deferred, $force, $source, $started_at, $continuation, $include_legacy_repaired );
+			return $this->schedule_bounded_cleanup_eligible_chunks( $batch, $deferred, $force, $source, $started_at, $continuation, $include_repaired_metadata );
 		}
 
 		$processed       = 0;
@@ -5310,7 +5310,7 @@ class Workspace {
 	 * @param array<string,mixed>             $continuation Continuation envelope.
 	 * @return array<string,mixed>|\WP_Error
 	 */
-	private function schedule_bounded_cleanup_eligible_chunks( array $batch, array $deferred, bool $force, string $source, float $started_at, array $continuation, bool $include_legacy_repaired = false ): array|\WP_Error {
+	private function schedule_bounded_cleanup_eligible_chunks( array $batch, array $deferred, bool $force, string $source, float $started_at, array $continuation, bool $include_repaired_metadata = false ): array|\WP_Error {
 		if ( ! class_exists( '\DataMachine\Engine\Tasks\TaskScheduler' ) ) {
 			return new \WP_Error( 'task_scheduler_unavailable', 'Data Machine TaskScheduler is unavailable; cannot schedule bounded cleanup-eligible apply chunks.', array( 'status' => 500 ) );
 		}
@@ -5364,7 +5364,7 @@ class Workspace {
 				'rows'        => array( $row ),
 				'force'       => $force,
 				'skip_github' => true,
-				'include_legacy_repaired' => $include_legacy_repaired,
+				'include_repaired_metadata' => $include_repaired_metadata,
 				'source'      => $source,
 			);
 		}
@@ -5993,18 +5993,18 @@ class Workspace {
 	 */
 	private function worktree_cleanup_skipped_next_commands( array $skipped_by_reason ): array {
 		$templates = array(
-			'missing_metadata_repaired'   => array(
-				'label'       => 'Review repaired legacy metadata with bounded safety probes',
-				'command'     => 'studio wp datamachine-code workspace cleanup run --mode=retention --older-than=7d',
-				'alternative' => 'studio wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --dry-run --limit=25 --older-than=7d',
-				'why'         => 'Queues task-backed retention cleanup so repaired rows get full safety checks before any deletion.',
+			'repaired_metadata'           => array(
+				'label'       => 'Review repaired metadata with bounded safety probes',
+				'command'     => 'studio wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --dry-run --include-repaired-metadata --limit=25 --older-than=7d',
+				'alternative' => 'studio wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --include-repaired-metadata --limit=25 --older-than=7d',
+				'why'         => 'Runs bounded cleanup with fresh safety checks before any deletion.',
 				'destructive' => true,
 			),
 			'requires_full_scan'          => array(
 				'label'       => 'Repair missing lifecycle metadata in bounded batches',
-				'command'     => 'studio wp datamachine-code workspace worktree reconcile-metadata-batch --dry-run --limit=25 --format=json',
-				'alternative' => 'studio wp datamachine-code workspace worktree reconcile-metadata-batch --limit=25',
-				'why'         => 'Bounded reconciliation writes lifecycle metadata so future inventory cleanup no longer needs a full scan for those rows.',
+				'command'     => 'studio wp datamachine-code workspace worktree reconcile-metadata --dry-run --format=json',
+				'alternative' => 'studio wp datamachine-code workspace worktree reconcile-metadata --apply-plan=<plan-id>',
+				'why'         => 'Reconciliation writes lifecycle metadata so future inventory cleanup no longer needs a full scan for those rows.',
 				'destructive' => false,
 			),
 			'no_inventory_cleanup_signal' => array(

--- a/tests/smoke-github-app-auth.php
+++ b/tests/smoke-github-app-auth.php
@@ -105,7 +105,7 @@ namespace {
 	$reset( array( 'github_pat' => 'pat-token' ) );
 	$pat_credential = GitHubCredentialResolver::resolve();
 	$assert( 'PAT mode resolves configured PAT', ! is_wp_error( $pat_credential ) && 'pat-token' === $pat_credential['token'] );
-	$assert( 'PAT mode keeps legacy token authorization scheme', ! is_wp_error( $pat_credential ) && 'token pat-token' === $pat_credential['authorization'] );
+	$assert( 'PAT mode keeps unmanaged token authorization scheme', ! is_wp_error( $pat_credential ) && 'token pat-token' === $pat_credential['authorization'] );
 	$assert( 'PAT status defaults mode to pat', 'pat' === GitHubCredentialResolver::status()['mode'] );
 
 	$reset( array( 'github_auth_mode' => 'app' ) );

--- a/tests/smoke-github-check-status-context.php
+++ b/tests/smoke-github-check-status-context.php
@@ -97,10 +97,10 @@ namespace {
 	$raw_statuses = array(
 		array(
 			'id'          => 21,
-			'context'     => 'ci/legacy',
+			'context'     => 'ci/classic',
 			'state'       => 'error',
-			'description' => 'legacy CI errored',
-			'target_url'  => 'https://ci.test/legacy',
+			'description' => 'classic CI errored',
+			'target_url'  => 'https://ci.test/classic',
 		),
 		array(
 			'id'      => 22,
@@ -111,10 +111,10 @@ namespace {
 	$statuses       = array_map( array( \DataMachineCode\Abilities\GitHubAbilities::class, 'normalizeCommitStatus' ), $raw_statuses );
 	$status_summary = \DataMachineCode\Abilities\GitHubAbilities::summarizeCommitStatuses( $statuses, 'failure' );
 
-	$assert( 'ci/legacy' === $statuses[0]['context'], 'commit status keeps context' );
+	$assert( 'ci/classic' === $statuses[0]['context'], 'commit status keeps context' );
 	$assert( 'failure' === $status_summary['state'], 'commit status summary maps combined failure' );
 	$assert( 1 === $status_summary['counts']['failure'], 'commit status summary maps error to failure count' );
-	$assert( 'ci/legacy' === $status_summary['failing'][0]['name'], 'commit status summary lists failing context' );
+	$assert( 'ci/classic' === $status_summary['failing'][0]['name'], 'commit status summary lists failing context' );
 
 	$pull = array(
 		'number'    => 101,

--- a/tests/smoke-github-homeboy-ci-results.php
+++ b/tests/smoke-github-homeboy-ci-results.php
@@ -198,17 +198,17 @@ namespace {
 	$assert( 'https://github.test/actions/runs/1001' === ( $results['workflow']['url'] ?? '' ), 'workflow URL is carried from manifest' );
 	$assert( 'homeboy-ci-results' === ( $api_calls[1]['query']['name'] ?? '' ), 'artifact lookup filters by artifact name' );
 
-	$legacy = \DataMachineCode\Abilities\GitHubAbilities::summarizeHomeboyCiArtifact(
+	$classic = \DataMachineCode\Abilities\GitHubAbilities::summarizeHomeboyCiArtifact(
 		array(
 			'audit.json' => array( 'success' => true, 'data' => array( 'finding_count' => 0 ) ),
 			'lint.json'  => array( 'success' => false, 'data' => array( 'finding_count' => 4 ) ),
 		),
 		array( 'repo' => 'Extra-Chill/data-machine-code', 'head_sha' => 'abc123head' )
 	);
-	$assert( ! is_wp_error( $legacy ), 'legacy audit/lint/test fallback summarizes without review.json' );
-	$assert( 'legacy' === ( $legacy['mode'] ?? '' ), 'legacy fallback mode is explicit' );
-	$assert( false === ( $legacy['summary']['passed'] ?? true ), 'legacy fallback fails if any stage fails' );
-	$assert( 4 === (int) ( $legacy['summary']['total_findings'] ?? -1 ), 'legacy fallback totals findings' );
+	$assert( ! is_wp_error( $classic ), 'classic audit/lint/test fallback summarizes without review.json' );
+	$assert( 'classic' === ( $classic['mode'] ?? '' ), 'classic fallback mode is explicit' );
+	$assert( false === ( $classic['summary']['passed'] ?? true ), 'classic fallback fails if any stage fails' );
+	$assert( 4 === (int) ( $classic['summary']['total_findings'] ?? -1 ), 'classic fallback totals findings' );
 
 	$expired = \DataMachineCode\Abilities\GitHubAbilities::selectHomeboyArtifact(
 		array( array_merge( $artifact, array( 'expired' => true ) ) ),

--- a/tests/smoke-github-pr-review-flow-installer.php
+++ b/tests/smoke-github-pr-review-flow-installer.php
@@ -169,7 +169,7 @@ namespace {
 	$existing = PrReviewFlowInstaller::install( array( 'repo' => 'Extra-Chill/data-machine-code' ) );
 	$assert( is_wp_error( $existing ) && 'github_pr_review_flow_exists' === $existing->get_error_code(), 'existing repo install fails clearly' );
 	$workflow_not_blocked = PrReviewFlowInstaller::install( array( 'repo' => 'Extra-Chill/data-machine-code', 'trigger' => 'workflow_run' ) );
-	$assert( ! is_wp_error( $workflow_not_blocked ), 'legacy pull_request install marker does not block workflow_run install' );
+	$assert( ! is_wp_error( $workflow_not_blocked ), 'classic pull_request install marker does not block workflow_run install' );
 
 	$forced = PrReviewFlowInstaller::install( array( 'repo' => 'Extra-Chill/data-machine-code', 'force' => true ) );
 	$assert( ! is_wp_error( $forced ), '--force bypasses existing install guard' );

--- a/tests/smoke-worktree-bounded-cleanup-eligible-apply.php
+++ b/tests/smoke-worktree-bounded-cleanup-eligible-apply.php
@@ -213,7 +213,7 @@ namespace {
 
 	// Real worktree-backed branches that simulate the canonical states the
 	// bounded cleanup-eligible apply must handle.
-	foreach ( array( 'eligible-clean', 'eligible-dirty', 'eligible-unpushed', 'eligible-bounded-extra-1', 'eligible-bounded-extra-2', 'eligible-bounded-extra-3', 'legacy-repaired-clean', 'legacy-repaired-dirty', 'legacy-repaired-recent' ) as $b ) {
+	foreach ( array( 'eligible-clean', 'eligible-dirty', 'eligible-unpushed', 'eligible-bounded-extra-1', 'eligible-bounded-extra-2', 'eligible-bounded-extra-3', 'repaired-metadata-clean', 'repaired-metadata-dirty', 'repaired-metadata-recent' ) as $b ) {
 		$make_branch( $b );
 	}
 
@@ -223,9 +223,9 @@ namespace {
 	$run( sprintf( 'git worktree add %s eligible-bounded-extra-1', escapeshellarg( $tmp . '/demo@eligible-bounded-extra-1' ) ), $primary );
 	$run( sprintf( 'git worktree add %s eligible-bounded-extra-2', escapeshellarg( $tmp . '/demo@eligible-bounded-extra-2' ) ), $primary );
 	$run( sprintf( 'git worktree add %s eligible-bounded-extra-3', escapeshellarg( $tmp . '/demo@eligible-bounded-extra-3' ) ), $primary );
-	$run( sprintf( 'git worktree add %s legacy-repaired-clean', escapeshellarg( $tmp . '/demo@legacy-repaired-clean' ) ), $primary );
-	$run( sprintf( 'git worktree add %s legacy-repaired-dirty', escapeshellarg( $tmp . '/demo@legacy-repaired-dirty' ) ), $primary );
-	$run( sprintf( 'git worktree add %s legacy-repaired-recent', escapeshellarg( $tmp . '/demo@legacy-repaired-recent' ) ), $primary );
+	$run( sprintf( 'git worktree add %s repaired-metadata-clean', escapeshellarg( $tmp . '/demo@repaired-metadata-clean' ) ), $primary );
+	$run( sprintf( 'git worktree add %s repaired-metadata-dirty', escapeshellarg( $tmp . '/demo@repaired-metadata-dirty' ) ), $primary );
+	$run( sprintf( 'git worktree add %s repaired-metadata-recent', escapeshellarg( $tmp . '/demo@repaired-metadata-recent' ) ), $primary );
 
 	// Mark cleanup-eligible lifecycle metadata so the cheap inventory picks
 	// these up.
@@ -252,7 +252,7 @@ namespace {
 
 	// Make eligible-dirty actually dirty so the revalidation gate kicks in.
 	file_put_contents( $tmp . '/demo@eligible-dirty/scratch.txt', 'dirty' );
-	file_put_contents( $tmp . '/demo@legacy-repaired-dirty/scratch.txt', 'dirty' );
+	file_put_contents( $tmp . '/demo@repaired-metadata-dirty/scratch.txt', 'dirty' );
 
 	// Make eligible-unpushed have an unpushed local commit (drop upstream so
 	// `count_unpushed_commits` reports >0 only when the branch is ahead of its
@@ -262,9 +262,9 @@ namespace {
 
 	foreach (
 		array(
-			'demo@legacy-repaired-clean'  => '2026-04-01T00:00:00+00:00',
-			'demo@legacy-repaired-dirty'  => '2026-04-01T00:00:00+00:00',
-			'demo@legacy-repaired-recent' => gmdate( 'c' ),
+			'demo@repaired-metadata-clean'  => '2026-04-01T00:00:00+00:00',
+			'demo@repaired-metadata-dirty'  => '2026-04-01T00:00:00+00:00',
+			'demo@repaired-metadata-recent' => gmdate( 'c' ),
 		) as $handle => $created_at
 	) {
 		\DataMachineCode\Workspace\WorktreeContextInjector::store_lifecycle_metadata(
@@ -311,14 +311,14 @@ namespace {
 	$assert( 2, count( $dry['candidates'] ?? array() ), 'bounded limit caps dry-run candidates' );
 	$remaining = (int) ( $dry['continuation']['remaining_total'] ?? 0 );
 	$assert( true, $remaining >= 4, 'continuation reports remaining cleanup-eligible candidates' );
-	$assert_skipped( $dry['skipped'] ?? array(), 'demo@legacy-repaired-clean', 'missing_metadata_repaired', 'legacy repaired rows require explicit include flag' );
+	$assert_skipped( $dry['skipped'] ?? array(), 'demo@repaired-metadata-clean', 'no_inventory_cleanup_signal', 'repaired metadata rows require explicit include flag' );
 
-	$legacy_dry = $ws->worktree_bounded_cleanup_eligible_apply( array( 'dry_run' => true, 'limit' => 20, 'include_legacy_repaired' => true, 'older_than' => '24h' ) );
-	$assert( true, ! is_wp_error( $legacy_dry ) && ( $legacy_dry['success'] ?? false ), 'legacy-repaired dry-run returns success' );
-	$assert_contains( $legacy_dry['candidates'] ?? array(), 'demo@legacy-repaired-clean', 'legacy repaired clean worktree is candidate with explicit flag' );
-	$assert_contains( $legacy_dry['candidates'] ?? array(), 'demo@legacy-repaired-dirty', 'legacy repaired dirty worktree is reviewed before apply' );
-	$legacy_recent = array_values( array_filter( $legacy_dry['skipped'] ?? array(), fn( $s ) => ( $s['handle'] ?? '' ) === 'demo@legacy-repaired-recent' ) );
-	$assert( 'age_filter', $legacy_recent[0]['reason_code'] ?? '', 'legacy repaired rows honor older_than before apply' );
+	$repaired_dry = $ws->worktree_bounded_cleanup_eligible_apply( array( 'dry_run' => true, 'limit' => 20, 'include_repaired_metadata' => true, 'older_than' => '24h' ) );
+	$assert( true, ! is_wp_error( $repaired_dry ) && ( $repaired_dry['success'] ?? false ), 'repaired-metadata dry-run returns success' );
+	$assert_contains( $repaired_dry['candidates'] ?? array(), 'demo@repaired-metadata-clean', 'repaired metadata clean worktree is candidate with explicit flag' );
+	$assert_contains( $repaired_dry['candidates'] ?? array(), 'demo@repaired-metadata-dirty', 'repaired metadata dirty worktree is reviewed before apply' );
+	$repaired_recent = array_values( array_filter( $repaired_dry['skipped'] ?? array(), fn( $s ) => ( $s['handle'] ?? '' ) === 'demo@repaired-metadata-recent' ) );
+	$assert( 'age_filter', $repaired_recent[0]['reason_code'] ?? '', 'repaired metadata rows honor older_than before apply' );
 
 	// Active and missing-metadata rows must never appear as candidates.
 	foreach ( $dry['candidates'] ?? array() as $cand ) {
@@ -349,7 +349,7 @@ namespace {
 	$assert_skipped( $apply['skipped'] ?? array(), 'demo@eligible-unpushed', 'unpushed_commits', 'unpushed worktree skipped on revalidation' );
 	$assert_skipped( $apply['skipped'] ?? array(), 'demo@no-metadata', 'requires_full_scan', 'missing-metadata row skipped via inventory gate' );
 	$assert_skipped( $apply['skipped'] ?? array(), 'demo@active-row', 'no_inventory_cleanup_signal', 'active row skipped via inventory gate' );
-	$assert_skipped( $apply['skipped'] ?? array(), 'demo@legacy-repaired-clean', 'missing_metadata_repaired', 'legacy repaired row skipped without explicit flag on apply' );
+	$assert_skipped( $apply['skipped'] ?? array(), 'demo@repaired-metadata-clean', 'no_inventory_cleanup_signal', 'repaired metadata row skipped without explicit flag on apply' );
 
 	$assert( true, is_dir( $primary . '/.git' ), 'primary survives bounded cleanup-eligible apply' );
 	$assert( false, is_dir( $tmp . '/demo@eligible-clean' ), 'clean cleanup-eligible directory removed from disk' );
@@ -362,13 +362,13 @@ namespace {
 	$assert( true, isset( $summary['bytes_reclaimed'] ), 'summary exposes bytes_reclaimed' );
 	$assert( true, isset( $apply['continuation']['remaining_total'] ), 'apply exposes continuation envelope' );
 
-	$legacy_apply = $ws->worktree_bounded_cleanup_eligible_apply( array( 'limit' => 20, 'include_legacy_repaired' => true, 'older_than' => '24h' ) );
-	$assert( true, ! is_wp_error( $legacy_apply ) && ( $legacy_apply['success'] ?? false ), 'legacy-repaired apply returns success' );
-	$assert_contains( $legacy_apply['removed'] ?? array(), 'demo@legacy-repaired-clean', 'legacy repaired clean worktree was removed after fresh probes' );
-	$assert_skipped( $legacy_apply['skipped'] ?? array(), 'demo@legacy-repaired-dirty', 'dirty_worktree', 'legacy repaired dirty worktree skipped on fresh probe' );
-	$assert_skipped( $legacy_apply['skipped'] ?? array(), 'demo@legacy-repaired-recent', 'age_filter', 'legacy repaired recent worktree skipped by age gate on apply' );
-	$assert( false, is_dir( $tmp . '/demo@legacy-repaired-clean' ), 'legacy repaired clean directory removed from disk' );
-	$assert( true, is_dir( $tmp . '/demo@legacy-repaired-dirty' ), 'legacy repaired dirty directory survives apply' );
+	$repaired_apply = $ws->worktree_bounded_cleanup_eligible_apply( array( 'limit' => 20, 'include_repaired_metadata' => true, 'older_than' => '24h' ) );
+	$assert( true, ! is_wp_error( $repaired_apply ) && ( $repaired_apply['success'] ?? false ), 'repaired-metadata apply returns success' );
+	$assert_contains( $repaired_apply['removed'] ?? array(), 'demo@repaired-metadata-clean', 'repaired metadata clean worktree was removed after fresh probes' );
+	$assert_skipped( $repaired_apply['skipped'] ?? array(), 'demo@repaired-metadata-dirty', 'dirty_worktree', 'repaired metadata dirty worktree skipped on fresh probe' );
+	$assert_skipped( $repaired_apply['skipped'] ?? array(), 'demo@repaired-metadata-recent', 'age_filter', 'repaired metadata recent worktree skipped by age gate on apply' );
+	$assert( false, is_dir( $tmp . '/demo@repaired-metadata-clean' ), 'repaired metadata clean directory removed from disk' );
+	$assert( true, is_dir( $tmp . '/demo@repaired-metadata-dirty' ), 'repaired metadata dirty directory survives apply' );
 
 	echo "\nForce gate (dirty allowed, unpushed never allowed)\n";
 	$force_apply = $ws->worktree_bounded_cleanup_eligible_apply( array( 'limit' => 10, 'force' => true ) );

--- a/tests/smoke-worktree-cleanup-chunks.php
+++ b/tests/smoke-worktree-cleanup-chunks.php
@@ -182,17 +182,17 @@ namespace {
 	$run( 'git add clean.txt && git commit -m clean', $primary );
 	$run( 'git push -u origin clean', $primary );
 	$run( 'git checkout main', $primary );
-	$run( 'git checkout -b legacy-repaired', $primary );
-	file_put_contents( $primary . '/legacy-repaired.txt', 'legacy' );
-	$run( 'git add legacy-repaired.txt && git commit -m legacy-repaired', $primary );
-	$run( 'git push -u origin legacy-repaired', $primary );
+	$run( 'git checkout -b repaired-metadata', $primary );
+	file_put_contents( $primary . '/repaired-metadata.txt', 'classic' );
+	$run( 'git add repaired-metadata.txt && git commit -m repaired-metadata', $primary );
+	$run( 'git push -u origin repaired-metadata', $primary );
 	$run( 'git checkout main', $primary );
 	$run( sprintf( 'git worktree add %s clean', escapeshellarg( $tmp . '/demo@clean' ) ), $primary );
-	$run( sprintf( 'git worktree add %s legacy-repaired', escapeshellarg( $tmp . '/demo@legacy-repaired' ) ), $primary );
+	$run( sprintf( 'git worktree add %s repaired-metadata', escapeshellarg( $tmp . '/demo@repaired-metadata' ) ), $primary );
 	mkdir( $tmp . '/demo@clean/target', 0755, true );
 	file_put_contents( $tmp . '/demo@clean/target/artifact.bin', str_repeat( 'x', 2048 ) );
 	\DataMachineCode\Workspace\WorktreeContextInjector::store_lifecycle_metadata(
-		'demo@legacy-repaired',
+		'demo@repaired-metadata',
 		array(
 			'created_at'        => '2026-04-01T00:00:00+00:00',
 			'lifecycle_state'   => \DataMachineCode\Workspace\WorktreeContextInjector::STATE_ACTIVE,
@@ -238,26 +238,26 @@ namespace {
 	$assert( false, is_dir( $tmp . '/demo@clean/target' ), 'artifact discovery chunk removes artifact directory' );
 	$assert( 'bounded_inventory_safety', $discovery['evidence']['pagination']['mode'] ?? '', 'artifact discovery chunk uses bounded inventory pagination with safety probes' );
 
-	$legacy_row = array(
-		'handle'      => 'demo@legacy-repaired',
+	$repaired_row = array(
+		'handle'      => 'demo@repaired-metadata',
 		'repo'        => 'demo',
-		'branch'      => 'legacy-repaired',
-		'path'        => realpath( $tmp . '/demo@legacy-repaired' ) ?: $tmp . '/demo@legacy-repaired',
-		'signal'      => 'missing_metadata_repaired',
-		'reason_code' => 'missing_metadata_repaired',
+		'branch'      => 'repaired-metadata',
+		'path'        => realpath( $tmp . '/demo@repaired-metadata' ) ?: $tmp . '/demo@repaired-metadata',
+		'signal'      => 'repaired_metadata',
+		'reason_code' => 'repaired_metadata',
 	);
-	$task->executeTask( 104, array( 'chunk_type' => 'worktrees', 'rows' => array( $legacy_row ), 'skip_github' => true ) );
-	$legacy_without_flag = $GLOBALS['datamachine_code_chunk_jobs'][104] ?? array();
-	$assert( true, (bool) ( $legacy_without_flag['success'] ?? false ), 'legacy repaired worktree chunk without flag succeeds safely' );
-	$assert( 0, (int) ( $legacy_without_flag['applied_count'] ?? -1 ), 'legacy repaired worktree chunk without flag does not remove row' );
-	$assert( 'no_merge_signal', $legacy_without_flag['skipped'][0]['reason_code'] ?? '', 'legacy repaired worktree chunk needs explicit include flag' );
-	$assert( true, is_dir( $tmp . '/demo@legacy-repaired' ), 'legacy repaired worktree survives chunk without flag' );
+	$task->executeTask( 104, array( 'chunk_type' => 'worktrees', 'rows' => array( $repaired_row ), 'skip_github' => true ) );
+	$repaired_without_flag = $GLOBALS['datamachine_code_chunk_jobs'][104] ?? array();
+	$assert( true, (bool) ( $repaired_without_flag['success'] ?? false ), 'repaired metadata worktree chunk without flag succeeds safely' );
+	$assert( 0, (int) ( $repaired_without_flag['applied_count'] ?? -1 ), 'repaired metadata worktree chunk without flag does not remove row' );
+	$assert( 'no_merge_signal', $repaired_without_flag['skipped'][0]['reason_code'] ?? '', 'repaired metadata worktree chunk needs explicit include flag' );
+	$assert( true, is_dir( $tmp . '/demo@repaired-metadata' ), 'repaired metadata worktree survives chunk without flag' );
 
-	$task->executeTask( 105, array( 'chunk_type' => 'worktrees', 'rows' => array( $legacy_row ), 'skip_github' => true, 'include_legacy_repaired' => true ) );
-	$legacy_with_flag = $GLOBALS['datamachine_code_chunk_jobs'][105] ?? array();
-	$assert( true, (bool) ( $legacy_with_flag['success'] ?? false ), 'legacy repaired worktree chunk with flag succeeds' );
-	$assert( 1, (int) ( $legacy_with_flag['applied_count'] ?? 0 ), 'legacy repaired worktree chunk with flag removes row' );
-	$assert( false, is_dir( $tmp . '/demo@legacy-repaired' ), 'legacy repaired worktree removed by explicit chunk flag' );
+	$task->executeTask( 105, array( 'chunk_type' => 'worktrees', 'rows' => array( $repaired_row ), 'skip_github' => true, 'include_repaired_metadata' => true ) );
+	$repaired_with_flag = $GLOBALS['datamachine_code_chunk_jobs'][105] ?? array();
+	$assert( true, (bool) ( $repaired_with_flag['success'] ?? false ), 'repaired metadata worktree chunk with flag succeeds' );
+	$assert( 1, (int) ( $repaired_with_flag['applied_count'] ?? 0 ), 'repaired metadata worktree chunk with flag removes row' );
+	$assert( false, is_dir( $tmp . '/demo@repaired-metadata' ), 'repaired metadata worktree removed by explicit chunk flag' );
 
 	if ( $failures > 0 ) {
 		echo "\nFAILURES: {$failures}/{$total}\n";

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -98,12 +98,12 @@ namespace {
 		);
 
 		$skipped[] = array(
-			'handle'      => 'repo@legacy-repaired',
+			'handle'      => 'repo@repaired-metadata',
 			'repo'        => 'repo',
-			'branch'      => 'legacy-repaired',
-			'path'        => '/workspace/repo@legacy-repaired',
-			'reason_code' => 'missing_metadata_repaired',
-			'reason'      => 'legacy metadata was repaired conservatively; no cleanup signal yet',
+			'branch'      => 'repaired-metadata',
+			'path'        => '/workspace/repo@repaired-metadata',
+			'reason_code' => 'repaired_metadata',
+			'reason'      => 'repaired metadata was repaired conservatively; no cleanup signal yet',
 		);
 		$skipped[] = array(
 			'handle'      => 'repo@needs-full-scan',
@@ -148,14 +148,14 @@ namespace {
 				'skipped_by_reason'    => array(
 					'dirty_worktree'               => 1,
 					'missing_metadata'             => 1,
-					'missing_metadata_repaired'    => 1,
+					'repaired_metadata'    => 1,
 					'no_inventory_cleanup_signal'  => 1,
 					'no_merge_signal'              => 10,
 					'requires_full_scan'           => 1,
 				),
 				'skipped_next_commands' => array(
 					array(
-						'reason_code' => 'missing_metadata_repaired',
+						'reason_code' => 'repaired_metadata',
 						'count'       => 1,
 						'command'     => 'studio wp datamachine-code workspace cleanup run --mode=retention --older-than=7d',
 						'alternative' => 'studio wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --dry-run --limit=25 --older-than=7d',
@@ -558,7 +558,7 @@ namespace {
 
 	echo "\n[0a] WP-CLI synopsis exposes cleanup flags\n";
 	datamachine_code_cleanup_assert( str_contains( $doc_comment, "\n\t * [--inventory-only]" ), 'worktree synopsis declares --inventory-only at top level' );
-	datamachine_code_cleanup_assert( str_contains( $doc_comment, "\n\t * [--include-legacy-repaired]" ), 'worktree synopsis declares --include-legacy-repaired at top level' );
+	datamachine_code_cleanup_assert( str_contains( $doc_comment, "\n\t * [--include-repaired-metadata]" ), 'worktree synopsis declares --include-repaired-metadata at top level' );
 	datamachine_code_cleanup_assert( ! str_contains( $doc_comment, "\n\t\t * [--apply-plan=<file>]" ), 'cleanup flags are not hidden behind nested docblock indentation' );
 	datamachine_code_cleanup_assert( str_contains( $cleanup_doc_comment, 'Control task-backed workspace cleanup runs.' ), 'workspace cleanup command documents task-backed controller surface' );
 	datamachine_code_cleanup_assert( str_contains( $cleanup_doc_comment, '<run|status|resume|cancel|evidence>' ), 'workspace cleanup synopsis exposes run/status/resume/cancel/evidence' );
@@ -631,7 +631,7 @@ namespace {
 	WP_CLI::$logs      = array();
 	WP_CLI::$successes = array();
 	$command->worktree( array( 'cleanup' ), array( 'dry-run' => true, 'skip-github' => true, 'format' => 'json' ) );
-	datamachine_code_cleanup_assert( array( 'dry_run' => true, 'force' => false, 'skip_github' => true, 'inventory_only' => false, 'include_legacy_repaired' => false ) === $ability->last_input, 'cleanup flags forwarded to ability' );
+	datamachine_code_cleanup_assert( array( 'dry_run' => true, 'force' => false, 'skip_github' => true, 'inventory_only' => false, 'include_repaired_metadata' => false ) === $ability->last_input, 'cleanup flags forwarded to ability' );
 	datamachine_code_cleanup_assert( 1 === count( WP_CLI::$logs ), 'JSON path writes exactly one stdout log entry' );
 	datamachine_code_cleanup_assert( array() === WP_CLI::$successes, 'JSON path emits no success suffix' );
 	$decoded = json_decode( WP_CLI::$logs[0], true );
@@ -731,8 +731,8 @@ namespace {
 	WP_CLI::$successes = array();
 	$command->worktree( array( 'cleanup' ), array( 'dry-run' => true, 'inventory-only' => true, 'skip-github' => true, 'format' => 'json' ) );
 	datamachine_code_cleanup_assert( true === ( $ability->last_input['inventory_only'] ?? null ), '--inventory-only forwards to cleanup ability' );
-	$command->worktree( array( 'cleanup' ), array( 'dry-run' => true, 'inventory-only' => true, 'include-legacy-repaired' => true, 'format' => 'json' ) );
-	datamachine_code_cleanup_assert( true === ( $ability->last_input['include_legacy_repaired'] ?? null ), '--include-legacy-repaired forwards to cleanup ability' );
+	$command->worktree( array( 'cleanup' ), array( 'dry-run' => true, 'inventory-only' => true, 'include-repaired-metadata' => true, 'format' => 'json' ) );
+	datamachine_code_cleanup_assert( true === ( $ability->last_input['include_repaired_metadata'] ?? null ), '--include-repaired-metadata forwards to cleanup ability' );
 
 	echo "\n[8b] emergency-cleanup emits fast plan and apply-plan path\n";
 	WP_CLI::$logs      = array();

--- a/tests/smoke-worktree-cleanup.php
+++ b/tests/smoke-worktree-cleanup.php
@@ -4,7 +4,7 @@
  *
  * Builds a real workspace in a tempdir with real git repos + real worktrees,
  * simulates various scenarios (merged branch, unmerged branch, dirty tree,
- * protected branch, legacy non-slug directory name), then runs cleanup and
+ * protected branch, unmanaged non-slug directory name), then runs cleanup and
  * asserts the correct worktrees got pruned.
  *
  * Run: php tests/smoke-worktree-cleanup.php
@@ -222,14 +222,14 @@ namespace {
 
 	// Create worktrees at various paths:
 	//   - canonical slug path (demo@merged-autodelete)
-	//   - legacy sibling path (demo-legacy-merged)
+	//   - unmanaged sibling path (demo-unmanaged-merged)
 	//   - canonical path for the unmerged one
 	//   - canonical path for dirty
 	$run( sprintf( 'git worktree add %s merged-autodelete', escapeshellarg( $tmp . '/demo@merged-autodelete' ) ), $primary );
 	$run( sprintf( 'git worktree add %s merged-stale-plan', escapeshellarg( $tmp . '/demo@merged-stale-plan' ) ), $primary );
 	$run( sprintf( 'git worktree add %s merged-recent', escapeshellarg( $tmp . '/demo@merged-recent' ) ), $primary );
 	$run( sprintf( 'git worktree add %s merged-unknown-age', escapeshellarg( $tmp . '/demo@merged-unknown-age' ) ), $primary );
-	$run( sprintf( 'git worktree add %s merged-live-remote', escapeshellarg( $tmp . '/demo-legacy-merged' ) ), $primary );
+	$run( sprintf( 'git worktree add %s merged-live-remote', escapeshellarg( $tmp . '/demo-unmanaged-merged' ) ), $primary );
 	$run( sprintf( 'git worktree add %s unmerged-feature', escapeshellarg( $tmp . '/demo@unmerged-feature' ) ), $primary );
 	$run( sprintf( 'git worktree add %s dirty-branch', escapeshellarg( $tmp . '/demo@dirty-branch' ) ), $primary );
 	mkdir( $tmp . '-external', 0755, true );

--- a/tests/smoke-worktree-metadata-reconcile.php
+++ b/tests/smoke-worktree-metadata-reconcile.php
@@ -176,24 +176,24 @@ namespace {
 		$run( sprintf( 'git push -u origin %s', escapeshellarg( $branch ) ), $primary );
 		$run( 'git checkout main', $primary );
 	};
-	$make_branch( 'legacy-missing' );
-	$make_branch( 'legacy-partial' );
-	$make_branch( 'legacy-dirty' );
-	$make_branch( 'legacy-invalid' );
+	$make_branch( 'unmanaged-missing' );
+	$make_branch( 'unmanaged-partial' );
+	$make_branch( 'unmanaged-dirty' );
+	$make_branch( 'unmanaged-invalid' );
 	$make_branch( 'already-current' );
 	$make_branch( 'external-branch' );
 
-	$run( sprintf( 'git worktree add %s legacy-missing', escapeshellarg( $tmp . '/demo@legacy-missing' ) ), $primary );
-	$run( sprintf( 'git worktree add %s legacy-partial', escapeshellarg( $tmp . '/demo@legacy-partial' ) ), $primary );
-	$run( sprintf( 'git worktree add %s legacy-dirty', escapeshellarg( $tmp . '/demo@legacy-dirty' ) ), $primary );
-	$run( sprintf( 'git worktree add %s legacy-invalid', escapeshellarg( $tmp . '/demo@legacy-invalid' ) ), $primary );
+	$run( sprintf( 'git worktree add %s unmanaged-missing', escapeshellarg( $tmp . '/demo@unmanaged-missing' ) ), $primary );
+	$run( sprintf( 'git worktree add %s unmanaged-partial', escapeshellarg( $tmp . '/demo@unmanaged-partial' ) ), $primary );
+	$run( sprintf( 'git worktree add %s unmanaged-dirty', escapeshellarg( $tmp . '/demo@unmanaged-dirty' ) ), $primary );
+	$run( sprintf( 'git worktree add %s unmanaged-invalid', escapeshellarg( $tmp . '/demo@unmanaged-invalid' ) ), $primary );
 	$run( sprintf( 'git worktree add %s already-current', escapeshellarg( $tmp . '/demo@already-current' ) ), $primary );
 	mkdir( $tmp . '-external', 0755, true );
 	$run( sprintf( 'git worktree add %s external-branch', escapeshellarg( $tmp . '-external/demo-external' ) ), $primary );
-	file_put_contents( $tmp . '/demo@legacy-dirty/scratch.txt', 'dirty' );
+	file_put_contents( $tmp . '/demo@unmanaged-dirty/scratch.txt', 'dirty' );
 
 	\DataMachineCode\Workspace\WorktreeContextInjector::store_metadata(
-		'demo@legacy-partial',
+		'demo@unmanaged-partial',
 		array(
 			'site_url'   => 'http://example.test',
 			'site_name'  => 'Example',
@@ -203,12 +203,12 @@ namespace {
 		)
 	);
 	\DataMachineCode\Workspace\WorktreeContextInjector::store_lifecycle_metadata(
-		'demo@legacy-invalid',
+		'demo@unmanaged-invalid',
 		array(
-			'handle'          => 'demo@legacy-invalid',
+			'handle'          => 'demo@unmanaged-invalid',
 			'repo'            => 'demo',
-			'branch'          => 'legacy-invalid',
-			'path'            => $tmp . '/demo@legacy-invalid',
+			'branch'          => 'unmanaged-invalid',
+			'path'            => $tmp . '/demo@unmanaged-invalid',
 			'created_at'      => '2026-04-02T00:00:00+00:00',
 			'lifecycle_state' => 'donezo',
 		)
@@ -232,7 +232,7 @@ namespace {
 	$plan = $ws->worktree_reconcile_metadata( array( 'dry_run' => true ) );
 	$assert( true, ! is_wp_error( $plan ) && ( $plan['success'] ?? false ), 'dry-run succeeds' );
 	$assert( true, $plan['dry_run'] ?? false, 'dry-run flag is true' );
-	$assert( 4, (int) ( $plan['summary']['proposed'] ?? 0 ), 'dry-run proposes only legacy rows' );
+	$assert( 4, (int) ( $plan['summary']['proposed'] ?? 0 ), 'dry-run proposes only unmanaged rows' );
 	$assert( 0, (int) ( $plan['summary']['written'] ?? 0 ), 'dry-run writes nothing' );
 	$assert( 1, (int) ( $plan['summary']['skipped_by_reason']['external_worktree'] ?? 0 ), 'dry-run distinguishes external worktrees' );
 	$assert( 1, count( $plan['external_worktrees'] ?? array() ), 'dry-run exposes external worktree bucket' );
@@ -241,16 +241,16 @@ namespace {
 	foreach ( $plan['proposals'] as $row ) {
 		$by_handle[ $row['handle'] ] = $row;
 	}
-	$assert( 'operator_plan', $by_handle['demo@legacy-missing']['source_map']['lifecycle_state'] ?? '', 'missing metadata lifecycle source is operator_plan' );
-	$assert( 'filesystem', $by_handle['demo@legacy-missing']['source_map']['created_at'] ?? '', 'missing metadata created_at source is filesystem' );
-	$assert( 'reconcile_run', $by_handle['demo@legacy-missing']['source_map']['observed_at'] ?? '', 'missing metadata observed_at source is reconcile run' );
-	$assert( 'current_site', $by_handle['demo@legacy-missing']['source_map']['origin_site'] ?? '', 'missing metadata origin site is inferred from current site' );
-	$assert( 'metadata', $by_handle['demo@legacy-partial']['source_map']['created_at'] ?? '', 'partial metadata preserves created_at source' );
-	$assert( 'git', $by_handle['demo@legacy-partial']['source_map']['branch'] ?? '', 'branch source is git' );
-	$assert( array( 'lifecycle_state' ), $by_handle['demo@legacy-invalid']['invalid_fields'] ?? array(), 'invalid lifecycle state is planned for repair' );
-	$assert( \DataMachineCode\Workspace\WorktreeContextInjector::STATE_ACTIVE, $by_handle['demo@legacy-invalid']['proposed_metadata']['lifecycle_state'] ?? '', 'invalid lifecycle state becomes conservative active proposal' );
-	$assert( 1, (int) ( $by_handle['demo@legacy-dirty']['dirty'] ?? 0 ), 'dirty row is visible but not cleanup-eligible' );
-	$assert( \DataMachineCode\Workspace\WorktreeContextInjector::STATE_ACTIVE, $by_handle['demo@legacy-dirty']['proposed_metadata']['lifecycle_state'] ?? '', 'dirty row proposal stays active' );
+	$assert( 'operator_plan', $by_handle['demo@unmanaged-missing']['source_map']['lifecycle_state'] ?? '', 'missing metadata lifecycle source is operator_plan' );
+	$assert( 'filesystem', $by_handle['demo@unmanaged-missing']['source_map']['created_at'] ?? '', 'missing metadata created_at source is filesystem' );
+	$assert( 'reconcile_run', $by_handle['demo@unmanaged-missing']['source_map']['observed_at'] ?? '', 'missing metadata observed_at source is reconcile run' );
+	$assert( 'current_site', $by_handle['demo@unmanaged-missing']['source_map']['origin_site'] ?? '', 'missing metadata origin site is inferred from current site' );
+	$assert( 'metadata', $by_handle['demo@unmanaged-partial']['source_map']['created_at'] ?? '', 'partial metadata preserves created_at source' );
+	$assert( 'git', $by_handle['demo@unmanaged-partial']['source_map']['branch'] ?? '', 'branch source is git' );
+	$assert( array( 'lifecycle_state' ), $by_handle['demo@unmanaged-invalid']['invalid_fields'] ?? array(), 'invalid lifecycle state is planned for repair' );
+	$assert( \DataMachineCode\Workspace\WorktreeContextInjector::STATE_ACTIVE, $by_handle['demo@unmanaged-invalid']['proposed_metadata']['lifecycle_state'] ?? '', 'invalid lifecycle state becomes conservative active proposal' );
+	$assert( 1, (int) ( $by_handle['demo@unmanaged-dirty']['dirty'] ?? 0 ), 'dirty row is visible but not cleanup-eligible' );
+	$assert( \DataMachineCode\Workspace\WorktreeContextInjector::STATE_ACTIVE, $by_handle['demo@unmanaged-dirty']['proposed_metadata']['lifecycle_state'] ?? '', 'dirty row proposal stays active' );
 	$stale_plan  = $plan;
 	$unsafe_plan = $plan;
 
@@ -264,8 +264,8 @@ namespace {
 	$assert( 4, (int) ( $apply['summary']['written'] ?? 0 ), 'apply reports written metadata rows' );
 	$assert( 0, (int) ( $apply['summary']['skipped'] ?? 0 ), 'apply skips nothing for current plan' );
 	$assert( 4, count( $apply['written'] ?? array() ), 'apply exposes written rows distinctly' );
-	$stored = \DataMachineCode\Workspace\WorktreeContextInjector::get_metadata( 'demo@legacy-missing' );
-	$assert( 'demo@legacy-missing', $stored['handle'] ?? '', 'stored metadata includes handle' );
+	$stored = \DataMachineCode\Workspace\WorktreeContextInjector::get_metadata( 'demo@unmanaged-missing' );
+	$assert( 'demo@unmanaged-missing', $stored['handle'] ?? '', 'stored metadata includes handle' );
 	$assert( true, ! empty( $stored['observed_at'] ), 'stored metadata includes observed_at' );
 	$assert( 'Origin Test', $stored['origin_site'] ?? '', 'stored metadata includes origin site when available' );
 	$assert( 'operator_plan', $stored['reconciled_sources']['lifecycle_state'] ?? '', 'stored metadata keeps source map' );
@@ -281,14 +281,14 @@ namespace {
 	$assert( 'plan_identity_mismatch', $stale_apply['skipped'][0]['reason_code'] ?? '', 'apply revalidates branch identity before writing' );
 
 	foreach ( $unsafe_plan['proposals'] as &$row ) {
-		if ( 'demo@legacy-dirty' === $row['handle'] ) {
+		if ( 'demo@unmanaged-dirty' === $row['handle'] ) {
 			$row['proposed_metadata']['lifecycle_state'] = \DataMachineCode\Workspace\WorktreeContextInjector::STATE_CLEANUP_ELIGIBLE;
 			$row['source_map']['lifecycle_state']        = 'operator_plan';
 		}
 	}
 	unset( $row );
 	$unsafe_apply = $ws->worktree_reconcile_metadata( array( 'apply_plan' => $unsafe_plan ) );
-	$unsafe_skips = array_values( array_filter( $unsafe_apply['skipped'] ?? array(), fn( $row ) => 'demo@legacy-dirty' === ( $row['handle'] ?? '' ) ) );
+	$unsafe_skips = array_values( array_filter( $unsafe_apply['skipped'] ?? array(), fn( $row ) => 'demo@unmanaged-dirty' === ( $row['handle'] ?? '' ) ) );
 	$assert( 'unsafe_cleanup_eligible_state', $unsafe_skips[0]['reason_code'] ?? '', 'dirty worktree cannot become cleanup_eligible through reconciliation plan' );
 	$assert( 1, count( $unsafe_apply['still_unsafe'] ?? array() ), 'apply exposes still-unsafe rows distinctly' );
 


### PR DESCRIPTION
## Summary

- Renames the cleanup opt-in from legacy wording to `--include-repaired-metadata` / `include_repaired_metadata`.
- Updates cleanup reason/signal wording to current repaired metadata language.
- Renames unrelated runtime/test wording from legacy/classic where applicable.

## Tests

```bash
php tests/smoke-worktree-bounded-cleanup-eligible-apply.php
php tests/smoke-worktree-cleanup-cli.php
php tests/smoke-worktree-cleanup-chunks.php
php tests/smoke-github-homeboy-ci-results.php
php tests/smoke-github-check-status-context.php
php tests/smoke-github-app-auth.php
php tests/smoke-github-pr-review-flow-installer.php
```

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Renamed the cleanup API surface and updated focused tests after operator review requested removal of legacy wording.