### PR TITLE
feat: persist cleanup runs in database

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -26,6 +26,24 @@ define( 'DATAMACHINE_CODE_URL', plugin_dir_url( __FILE__ ) );
 require_once __DIR__ . '/vendor/autoload.php';
 
 /**
+ * Install DMC-owned database tables.
+ */
+function datamachine_code_install_schema(): void {
+	if ( class_exists( '\DataMachineCode\Storage\CleanupSchema' ) ) {
+		\DataMachineCode\Storage\CleanupSchema::install();
+	}
+}
+register_activation_hook( __FILE__, 'datamachine_code_install_schema' );
+add_action( 'plugins_loaded', function (): void {
+	$schema_version = '20260504-cleanup-runs';
+	if ( get_option( 'datamachine_code_cleanup_schema_version' ) === $schema_version ) {
+		return;
+	}
+	datamachine_code_install_schema();
+	update_option( 'datamachine_code_cleanup_schema_version', $schema_version, false );
+}, 5 );
+
+/**
  * Bootstrap the plugin after all plugins are loaded.
  *
  * Data Machine core must be active — check at plugins_loaded time

--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -15,6 +15,7 @@
 namespace DataMachineCode\Abilities;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachineCode\Workspace\CleanupRunService;
 use DataMachineCode\Workspace\Workspace;
 use DataMachineCode\Workspace\WorkspaceReader;
 use DataMachineCode\Workspace\WorkspaceWriter;
@@ -1557,8 +1558,8 @@ class WorkspaceAbilities {
 			wp_register_ability(
 				'datamachine/workspace-cleanup-plan',
 				array(
-					'label'               => 'Build Workspace Cleanup Plan Chunks',
-					'description'         => 'Freeze a non-destructive cleanup plan and optionally emit bounded chunks for artifact cleanup, worktree removal, and resolver rows.',
+					'label'               => 'Build DB-backed Workspace Cleanup Plan',
+					'description'         => 'Freeze a non-destructive cleanup plan into DMC cleanup run/item database rows and return a stable run_id. File plans are an escape hatch on lower-level commands only.',
 					'category'            => 'datamachine-code-workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
@@ -1590,6 +1591,50 @@ class WorkspaceAbilities {
 					'meta'                => array( 'show_in_rest' => false ),
 				)
 			);
+
+			wp_register_ability(
+				'datamachine/workspace-cleanup-apply',
+				array(
+					'label'               => 'Apply Workspace Cleanup Run',
+					'description'         => 'Apply pending rows from a DB-backed cleanup run by run_id after current-state revalidation.',
+					'category'            => 'datamachine-code-workspace',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'run_id' ),
+						'properties' => array(
+							'run_id' => array( 'type' => 'string' ),
+							'force'  => array( 'type' => 'boolean' ),
+						),
+					),
+					'output_schema'       => array( 'type' => 'object' ),
+					'execute_callback'    => array( self::class, 'workspaceCleanupApply' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			foreach ( array( 'status', 'evidence', 'resume', 'cancel' ) as $cleanup_operation ) {
+				wp_register_ability(
+					'datamachine/workspace-cleanup-' . $cleanup_operation,
+					array(
+						'label'               => 'Workspace Cleanup ' . ucfirst( $cleanup_operation ),
+						'description'         => 'Operate on a DB-backed workspace cleanup run by run_id.',
+						'category'            => 'datamachine-code-workspace',
+						'input_schema'        => array(
+							'type'       => 'object',
+							'required'   => array( 'run_id' ),
+							'properties' => array(
+								'run_id' => array( 'type' => 'string' ),
+								'force'  => array( 'type' => 'boolean' ),
+							),
+						),
+						'output_schema'       => array( 'type' => 'object' ),
+						'execute_callback'    => array( self::class, 'workspaceCleanup' . ucfirst( $cleanup_operation ) ),
+						'permission_callback' => fn() => PermissionHelper::can_manage(),
+						'meta'                => array( 'show_in_rest' => false ),
+					)
+				);
+			}
 		};
 
 		if ( doing_action( 'wp_abilities_api_init' ) ) {
@@ -2221,10 +2266,10 @@ class WorkspaceAbilities {
 	 * @return array<string,mixed>|\WP_Error
 	 */
 	public static function workspaceCleanupPlan( array $input ): array|\WP_Error {
-		$workspace = new Workspace();
 		$opts      = array(
 			'force_artifact_cleanup' => ! empty( $input['force_artifact_cleanup'] ),
 			'include_resolvers'      => ! empty( $input['include_resolvers'] ),
+			'mode'                   => (string) ( $input['mode'] ?? 'cleanup_plan' ),
 		);
 		foreach ( array( 'include_artifacts', 'include_worktrees' ) as $key ) {
 			if ( array_key_exists( $key, $input ) ) {
@@ -2244,9 +2289,71 @@ class WorkspaceAbilities {
 			$opts['chunk_size'] = (int) $input['chunk_size'];
 		}
 
-		return ! empty( $input['emit_chunks'] )
-			? $workspace->workspace_cleanup_plan_chunks( $opts )
-			: $workspace->workspace_cleanup_plan( $opts );
+
+		$service = new CleanupRunService();
+		$plan    = $service->plan( $opts );
+		if ( $plan instanceof \WP_Error || empty( $input['emit_chunks'] ) ) {
+			return $plan;
+		}
+
+		$workspace = new Workspace();
+		$chunks    = $workspace->workspace_cleanup_plan_chunks( array_merge( $opts, array( 'plan' => $plan ) ) );
+		if ( $chunks instanceof \WP_Error ) {
+			return $chunks;
+		}
+		$chunks['run_id']          = $plan['run_id'] ?? null;
+		$chunks['cleanup_storage'] = $plan['cleanup_storage'] ?? array();
+		return $chunks;
+	}
+
+	/**
+	 * Apply a DB-backed cleanup run.
+	 *
+	 * @param array $input Input parameters.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public static function workspaceCleanupApply( array $input ): array|\WP_Error {
+		return ( new CleanupRunService() )->apply( (string) ( $input['run_id'] ?? '' ), array( 'force' => ! empty( $input['force'] ) ) );
+	}
+
+	/**
+	 * Return DB-backed cleanup run status.
+	 *
+	 * @param array $input Input parameters.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public static function workspaceCleanupStatus( array $input ): array|\WP_Error {
+		return ( new CleanupRunService() )->status( (string) ( $input['run_id'] ?? '' ) );
+	}
+
+	/**
+	 * Return DB-backed cleanup run evidence.
+	 *
+	 * @param array $input Input parameters.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public static function workspaceCleanupEvidence( array $input ): array|\WP_Error {
+		return ( new CleanupRunService() )->evidence( (string) ( $input['run_id'] ?? '' ) );
+	}
+
+	/**
+	 * Resume pending cleanup rows.
+	 *
+	 * @param array $input Input parameters.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public static function workspaceCleanupResume( array $input ): array|\WP_Error {
+		return ( new CleanupRunService() )->resume( (string) ( $input['run_id'] ?? '' ), array( 'force' => ! empty( $input['force'] ) ) );
+	}
+
+	/**
+	 * Cancel pending cleanup rows.
+	 *
+	 * @param array $input Input parameters.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public static function workspaceCleanupCancel( array $input ): array|\WP_Error {
+		return ( new CleanupRunService() )->cancel( (string) ( $input['run_id'] ?? '' ) );
 	}
 
 	/**

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -253,11 +253,12 @@ class WorkspaceCommand extends BaseCommand {
 	 * ## OPTIONS
 	 *
 	 * <operation>
-	 * : Cleanup operation. One of: <run|status|resume|cancel|evidence>.
+	 * : Cleanup operation. One of: <plan|apply|run|status|resume|cancel|evidence>.
+	 *   Existing task-backed controls remain: <run|status|resume|cancel|evidence>.
 	 *
 	 * [<run-id>]
-	 * : Run identifier returned by `run` (currently the Data Machine job ID, or
-	 *   cleanup-run-<job_id>).
+	 * : Run identifier returned by `plan` or `run`. DB-backed plan IDs look like
+	 *   cleanup-run-<timestamp>-<nonce>; job-backed run IDs may be cleanup-run-<job_id>.
 	 *
 	 * [--mode=<mode>]
 	 * : Cleanup mode for `run`.
@@ -313,6 +314,12 @@ class WorkspaceCommand extends BaseCommand {
 	 *
 	 * ## EXAMPLES
 	 *
+	 *     # Create a DB-backed cleanup plan for review
+	 *     wp datamachine-code workspace cleanup plan --mode=retention
+	 *
+	 *     # Apply a reviewed DB-backed run
+	 *     wp datamachine-code workspace cleanup apply cleanup-run-20260504120000-abc123
+	 *
 	 *     # Start task-backed retention cleanup and return immediately
 	 *     wp datamachine-code workspace cleanup run --mode=retention
 	 *
@@ -343,17 +350,29 @@ class WorkspaceCommand extends BaseCommand {
 	public function cleanup( array $args, array $assoc_args ): void {
 		$operation = (string) ( $args[0] ?? '' );
 		if ( '' === $operation ) {
-			WP_CLI::error( 'Usage: wp datamachine-code workspace cleanup <run|status|resume|cancel|evidence> [<run-id>] [--mode=<mode>]' );
+			WP_CLI::error( 'Usage: wp datamachine-code workspace cleanup <plan|apply|run|status|resume|cancel|evidence> [<run-id>] [--mode=<mode>]' );
 			return;
 		}
 
 		switch ( $operation ) {
+			case 'plan':
+				$this->run_cleanup_plan( $assoc_args );
+				return;
+
+			case 'apply':
+				$this->run_cleanup_control_ability( 'apply', (string) ( $args[1] ?? '' ), $assoc_args );
+				return;
+
 			case 'run':
 				$this->run_cleanup_task( $assoc_args );
 				return;
 
 			case 'status':
 			case 'evidence':
+				if ( ! $this->is_job_cleanup_run_id( (string) ( $args[1] ?? '' ) ) ) {
+					$this->run_cleanup_control_ability( $operation, (string) ( $args[1] ?? '' ), $assoc_args );
+					return;
+				}
 				$job_id = $this->cleanup_run_job_id( (string) ( $args[1] ?? '' ) );
 				if ( $job_id <= 0 ) {
 					WP_CLI::error( 'Usage: wp datamachine-code workspace cleanup ' . $operation . ' <run-id>' );
@@ -364,6 +383,10 @@ class WorkspaceCommand extends BaseCommand {
 
 			case 'resume':
 			case 'cancel':
+				if ( ! $this->is_job_cleanup_run_id( (string) ( $args[1] ?? '' ) ) ) {
+					$this->run_cleanup_control_ability( $operation, (string) ( $args[1] ?? '' ), $assoc_args );
+					return;
+				}
 				$job_id = $this->cleanup_run_job_id( (string) ( $args[1] ?? '' ) );
 				if ( $job_id <= 0 ) {
 					WP_CLI::error( 'Usage: wp datamachine-code workspace cleanup ' . $operation . ' <run-id>' );
@@ -419,6 +442,60 @@ class WorkspaceCommand extends BaseCommand {
 		}
 
 		return $input;
+	}
+
+	private function run_cleanup_plan( array $assoc_args ): void {
+		$ability = wp_get_ability( 'datamachine/workspace-cleanup-plan' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'Workspace cleanup plan ability not registered.' );
+			return;
+		}
+
+		$input = array(
+			'mode'              => strtolower( preg_replace( '/[^a-z0-9_\-]/', '', (string) ( $assoc_args['mode'] ?? 'retention' ) ) ),
+			'include_resolvers' => true,
+		);
+		if ( isset( $assoc_args['older-than'] ) && '' !== trim( (string) $assoc_args['older-than'] ) ) {
+			$input['worktree_older_than'] = trim( (string) $assoc_args['older-than'] );
+		}
+		if ( isset( $assoc_args['force'] ) ) {
+			$input['force_artifact_cleanup'] = (bool) $assoc_args['force'];
+		}
+
+		$result = $ability->execute( $input );
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
+
+		$this->render_cleanup_plan_result( $result, $assoc_args );
+	}
+
+	private function run_cleanup_control_ability( string $operation, string $run_id, array $assoc_args ): void {
+		$run_id = trim( $run_id );
+		if ( '' === $run_id ) {
+			WP_CLI::error( 'Usage: wp datamachine-code workspace cleanup ' . $operation . ' <run-id>' );
+			return;
+		}
+
+		$ability = wp_get_ability( 'datamachine/workspace-cleanup-' . $operation );
+		if ( ! $ability ) {
+			WP_CLI::error( sprintf( 'Workspace cleanup %s ability not registered.', $operation ) );
+			return;
+		}
+
+		$result = $ability->execute(
+			array(
+				'run_id' => $run_id,
+				'force'  => ! empty( $assoc_args['force'] ),
+			)
+		);
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
+
+		$this->render_cleanup_control_result( $result, $assoc_args );
 	}
 
 	private function run_cleanup_review( array $assoc_args ): void {
@@ -961,6 +1038,22 @@ class WorkspaceCommand extends BaseCommand {
 		}
 	}
 
+	private function render_cleanup_plan_result( array $result, array $assoc_args ): void {
+		$format = (string) ( $assoc_args['format'] ?? 'table' );
+		if ( 'json' === $format ) {
+			WP_CLI::log( (string) wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		$summary = (array) ( $result['summary'] ?? array() );
+		WP_CLI::success( sprintf( 'Cleanup plan stored as %s.', (string) ( $result['run_id'] ?? '' ) ) );
+		WP_CLI::log( sprintf( 'Run ID: %s', (string) ( $result['run_id'] ?? '' ) ) );
+		WP_CLI::log( sprintf( 'Plan ID: %s', (string) ( $result['plan_id'] ?? '' ) ) );
+		WP_CLI::log( sprintf( 'Rows:   %d', (int) ( $summary['total_rows'] ?? 0 ) ) );
+		WP_CLI::log( sprintf( 'Bytes:  %s', $this->format_bytes( $summary['total_size_bytes'] ?? 0 ) ) );
+		WP_CLI::log( sprintf( 'Apply:  wp datamachine-code workspace cleanup apply %s', (string) ( $result['run_id'] ?? '' ) ) );
+	}
+
 	private function cleanup_run_id( int $job_id ): string {
 		return 'cleanup-run-' . $job_id;
 	}
@@ -974,6 +1067,10 @@ class WorkspaceCommand extends BaseCommand {
 			return (int) $matches[1];
 		}
 		return 0;
+	}
+
+	private function is_job_cleanup_run_id( string $run_id ): bool {
+		return $this->cleanup_run_job_id( $run_id ) > 0;
 	}
 
 	private function cleanup_job_state( string $status ): string {
@@ -1932,25 +2029,24 @@ class WorkspaceCommand extends BaseCommand {
 	 *   alongside `--task-url` (applies to `add` only). Falls back to the
 	 *   `DATAMACHINE_TASK_REF` environment variable when omitted.
 	 *
-	 * [--force]
-	 * : For `add`, explicitly bypass the disk-budget refusal threshold. For
-	 *   `remove`, force-remove a worktree even if it is dirty. For `cleanup`,
-	 *   force dirty-worktree removal but not the unpushed-commits safety.
-	 *
-	 * [--pr=<url-or-number>]
-	 * : Attach pull request metadata when finalizing or marking a worktree
-	 *   cleanup-eligible.
-	 *
-	 * [--state=<state>]
-	 * : Lifecycle state to record when finalizing a worktree.
-	 *
-	 * [--dry-run]
-	 * : Preview cleanup candidates without removing anything (cleanup only).
-	 *
-	 * [--apply-plan=<file>]
-	 * : Apply a previously reviewed cleanup JSON report. The destructive pass
-	 *   revalidates every planned row and removes only exact current matches.
-	 *   For reconcile-metadata, applies a reviewed non-destructive metadata plan.
+		 * [--force]
+		 * : For `add`, explicitly bypass the disk-budget refusal threshold. For
+		 *   `remove`, force-remove a worktree even if it is dirty. For `cleanup`,
+		 *   force dirty-worktree removal but not the unpushed-commits safety.
+		 *
+     * [--pr=<url-or-number>]
+     * : Attach pull request metadata when finalizing or marking a worktree
+     *   cleanup-eligible.
+     *
+     * [--state=<state>]
+     * : Lifecycle state to record when finalizing a worktree.
+     *
+     * [--dry-run]
+     * : Preview cleanup candidates without removing anything (cleanup only).
+     *
+     * File cleanup plan imports are an emergency escape hatch only. The normal
+     * operator workflow is `workspace cleanup plan` then
+     * `workspace cleanup apply <run-id>`.
 	 *
 	 * [--skip-github]
 	 * : Skip the GitHub API lookup and rely only on the local `upstream-gone`
@@ -2072,20 +2168,12 @@ class WorkspaceCommand extends BaseCommand {
 	 *     # Preview worktrees that would be removed (upstream gone or PR merged)
 	 *     wp datamachine-code workspace worktree cleanup --dry-run
 	 *
-	 *     # Remove all merged worktrees
-	 *     wp datamachine-code workspace worktree cleanup
-	 *
-	 *     # Review a plan, then apply only those rows after revalidation
-	 *     wp datamachine-code workspace worktree cleanup --dry-run --format=json > cleanup-plan.json
-	 *     wp datamachine-code workspace worktree cleanup --apply-plan=cleanup-plan.json
-	 *
-	 *     # Review and apply artifact-only cleanup without removing worktrees
-	 *     wp datamachine-code workspace worktree cleanup-artifacts --dry-run --format=json > artifact-plan.json
-	 *     wp datamachine-code workspace worktree cleanup-artifacts --apply-plan=artifact-plan.json
-	 *
-	 *     # Emergency disk-pressure plan: cheap inventory first, artifacts before worktrees
-	 *     wp datamachine-code workspace worktree emergency-cleanup --format=json > emergency-plan.json
-	 *     wp datamachine-code workspace worktree emergency-cleanup --apply-plan=emergency-plan.json
+		 *     # Remove all merged worktrees
+		 *     wp datamachine-code workspace worktree cleanup
+		 *
+     *     # Review a DB-backed plan, then apply only those rows after revalidation
+     *     wp datamachine-code workspace cleanup plan --mode=retention
+     *     wp datamachine-code workspace cleanup apply cleanup-run-20260504120000-abc123
 	 *
 	 *     # Bounded apply restricted to explicit lifecycle cleanup_eligible worktrees
 	 *     # (cheap inventory only — no full git worktree scan, no GitHub lookup)

--- a/inc/Storage/CleanupRunRepository.php
+++ b/inc/Storage/CleanupRunRepository.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * Cleanup run repository.
+ *
+ * @package DataMachineCode\Storage
+ */
+
+namespace DataMachineCode\Storage;
+
+defined( 'ABSPATH' ) || exit;
+
+class CleanupRunRepository {
+
+	/**
+	 * Create a cleanup run.
+	 *
+	 * @param array<string,mixed> $run Run fields.
+	 * @return string|\WP_Error
+	 */
+	public function create_run( array $run ): string|\WP_Error {
+		global $wpdb;
+
+		$run_id = (string) ( $run['run_id'] ?? $this->new_run_id() );
+		$now    = gmdate( 'Y-m-d H:i:s' );
+		$ok     = $wpdb->insert(
+			CleanupSchema::runs_table(),
+			array(
+				'run_id'                => $run_id,
+				'mode'                  => (string) ( $run['mode'] ?? 'cleanup_plan' ),
+				'status'                => (string) ( $run['status'] ?? 'planned' ),
+				'policy'                => $this->encode( $run['policy'] ?? array() ),
+				'requested_by_user_id'  => isset( $run['requested_by_user_id'] ) ? (int) $run['requested_by_user_id'] : null,
+				'requested_by_agent_id' => isset( $run['requested_by_agent_id'] ) ? (int) $run['requested_by_agent_id'] : null,
+				'parent_job_id'         => isset( $run['parent_job_id'] ) ? (int) $run['parent_job_id'] : null,
+				'batch_job_id'          => isset( $run['batch_job_id'] ) ? (int) $run['batch_job_id'] : null,
+				'created_at'            => (string) ( $run['created_at'] ?? $now ),
+				'started_at'            => $run['started_at'] ?? null,
+				'completed_at'          => $run['completed_at'] ?? null,
+				'summary'               => $this->encode( $run['summary'] ?? array() ),
+			),
+			array( '%s', '%s', '%s', '%s', '%d', '%d', '%d', '%d', '%s', '%s', '%s', '%s' )
+		);
+
+		if ( false === $ok ) {
+			return new \WP_Error( 'cleanup_run_insert_failed', 'Failed to create cleanup run.' );
+		}
+
+		return $run_id;
+	}
+
+	/**
+	 * Insert planned cleanup items.
+	 *
+	 * @param string           $run_id Run ID.
+	 * @param array<int,array> $items Items.
+	 * @return int|\WP_Error
+	 */
+	public function add_items( string $run_id, array $items ): int|\WP_Error {
+		global $wpdb;
+
+		$count = 0;
+		$now   = gmdate( 'Y-m-d H:i:s' );
+		foreach ( $items as $item ) {
+			if ( ! is_array( $item ) ) {
+				continue;
+			}
+
+			$ok = $wpdb->insert(
+				CleanupSchema::items_table(),
+				array(
+					'run_id'          => $run_id,
+					'handle'          => (string) ( $item['handle'] ?? '' ),
+					'worktree_id'     => isset( $item['worktree_id'] ) ? (int) $item['worktree_id'] : null,
+					'item_type'       => (string) ( $item['item_type'] ?? $item['row_type'] ?? 'unknown' ),
+					'planned_action'  => (string) ( $item['planned_action'] ?? $this->planned_action_for_type( (string) ( $item['item_type'] ?? $item['row_type'] ?? '' ) ) ),
+					'status'          => (string) ( $item['status'] ?? 'pending' ),
+					'reason_code'     => (string) ( $item['reason_code'] ?? '' ),
+					'reason'          => isset( $item['reason'] ) ? (string) $item['reason'] : null,
+					'bytes_reclaimed' => max( 0, (int) ( $item['bytes_reclaimed'] ?? 0 ) ),
+					'job_id'          => isset( $item['job_id'] ) ? (int) $item['job_id'] : null,
+					'chunk_index'     => isset( $item['chunk_index'] ) ? (int) $item['chunk_index'] : null,
+					'planned_at'      => (string) ( $item['planned_at'] ?? $now ),
+					'applied_at'      => $item['applied_at'] ?? null,
+					'evidence'        => $this->encode( $item['evidence'] ?? $item ),
+				),
+				array( '%s', '%s', '%d', '%s', '%s', '%s', '%s', '%s', '%d', '%d', '%d', '%s', '%s', '%s' )
+			);
+
+			if ( false === $ok ) {
+				return new \WP_Error( 'cleanup_item_insert_failed', 'Failed to create cleanup item.' );
+			}
+			++$count;
+		}
+
+		return $count;
+	}
+
+	/**
+	 * Fetch a cleanup run by ID.
+	 *
+	 * @param string $run_id Run ID.
+	 * @return array<string,mixed>|null
+	 */
+	public function get_run( string $run_id ): ?array {
+		global $wpdb;
+
+		$row = $wpdb->get_row( $wpdb->prepare( 'SELECT * FROM ' . CleanupSchema::runs_table() . ' WHERE run_id = %s', $run_id ), ARRAY_A );
+		return is_array( $row ) ? $this->decode_run( $row ) : null;
+	}
+
+	/**
+	 * Fetch items for a run.
+	 *
+	 * @param string $run_id Run ID.
+	 * @return array<int,array<string,mixed>>
+	 */
+	public function get_items( string $run_id ): array {
+		global $wpdb;
+
+		$rows = $wpdb->get_results( $wpdb->prepare( 'SELECT * FROM ' . CleanupSchema::items_table() . ' WHERE run_id = %s ORDER BY id ASC', $run_id ), ARRAY_A );
+		return array_map( fn( $row ) => $this->decode_item( (array) $row ), is_array( $rows ) ? $rows : array() );
+	}
+
+	/**
+	 * Update run fields.
+	 *
+	 * @param string              $run_id Run ID.
+	 * @param array<string,mixed> $fields Fields.
+	 * @return bool
+	 */
+	public function update_run( string $run_id, array $fields ): bool {
+		global $wpdb;
+
+		$data = array();
+		foreach ( array( 'status', 'started_at', 'completed_at', 'parent_job_id', 'batch_job_id' ) as $field ) {
+			if ( array_key_exists( $field, $fields ) ) {
+				$data[ $field ] = $fields[ $field ];
+			}
+		}
+		if ( array_key_exists( 'summary', $fields ) ) {
+			$data['summary'] = $this->encode( $fields['summary'] );
+		}
+		if ( array() === $data ) {
+			return true;
+		}
+
+		return false !== $wpdb->update( CleanupSchema::runs_table(), $data, array( 'run_id' => $run_id ) );
+	}
+
+	/**
+	 * Update one item by numeric ID.
+	 *
+	 * @param int                 $id Item ID.
+	 * @param array<string,mixed> $fields Fields.
+	 * @return bool
+	 */
+	public function update_item( int $id, array $fields ): bool {
+		global $wpdb;
+
+		$data = array();
+		foreach ( array( 'status', 'bytes_reclaimed', 'job_id', 'chunk_index', 'applied_at', 'reason_code', 'reason' ) as $field ) {
+			if ( array_key_exists( $field, $fields ) ) {
+				$data[ $field ] = $fields[ $field ];
+			}
+		}
+		if ( array_key_exists( 'evidence', $fields ) ) {
+			$data['evidence'] = $this->encode( $fields['evidence'] );
+		}
+
+		return array() === $data || false !== $wpdb->update( CleanupSchema::items_table(), $data, array( 'id' => $id ) );
+	}
+
+	private function decode_run( array $row ): array {
+		$row['policy']  = $this->decode( $row['policy'] ?? '' );
+		$row['summary'] = $this->decode( $row['summary'] ?? '' );
+		return $row;
+	}
+
+	private function decode_item( array $row ): array {
+		$row['evidence'] = $this->decode( $row['evidence'] ?? '' );
+		return $row;
+	}
+
+	private function encode( mixed $value ): string {
+		$encoded = function_exists( 'wp_json_encode' ) ? wp_json_encode( $value, JSON_UNESCAPED_SLASHES ) : json_encode( $value, JSON_UNESCAPED_SLASHES );
+		return false === $encoded ? '{}' : $encoded;
+	}
+
+	private function decode( mixed $value ): array {
+		$decoded = json_decode( (string) $value, true );
+		return is_array( $decoded ) ? $decoded : array();
+	}
+
+	private function new_run_id(): string {
+		return 'cleanup-run-' . gmdate( 'YmdHis' ) . '-' . substr( wp_generate_password( 12, false, false ), 0, 12 );
+	}
+
+	private function planned_action_for_type( string $type ): string {
+		return match ( $type ) {
+			'artifact_cleanup' => 'remove_artifacts',
+			'worktree_removal' => 'remove_worktree',
+			'resolver'         => 'resolve_signal',
+			default            => 'review',
+		};
+	}
+}

--- a/inc/Storage/CleanupSchema.php
+++ b/inc/Storage/CleanupSchema.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Cleanup run database schema.
+ *
+ * @package DataMachineCode\Storage
+ */
+
+namespace DataMachineCode\Storage;
+
+defined( 'ABSPATH' ) || exit;
+
+class CleanupSchema {
+
+	public const RUNS_TABLE  = 'datamachine_code_cleanup_runs';
+	public const ITEMS_TABLE = 'datamachine_code_cleanup_items';
+
+	/**
+	 * Install or upgrade cleanup tables.
+	 *
+	 * @return void
+	 */
+	public static function install(): void {
+		global $wpdb;
+
+		if ( ! isset( $wpdb ) ) {
+			return;
+		}
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+		$charset_collate = method_exists( $wpdb, 'get_charset_collate' ) ? $wpdb->get_charset_collate() : '';
+		$runs_table      = self::runs_table();
+		$items_table     = self::items_table();
+
+		dbDelta(
+			"CREATE TABLE {$runs_table} (
+				id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+				run_id varchar(64) NOT NULL,
+				mode varchar(64) NOT NULL,
+				status varchar(32) NOT NULL DEFAULT 'planned',
+				policy longtext NULL,
+				requested_by_user_id bigint(20) unsigned NULL,
+				requested_by_agent_id bigint(20) unsigned NULL,
+				parent_job_id bigint(20) unsigned NULL,
+				batch_job_id bigint(20) unsigned NULL,
+				created_at datetime NOT NULL,
+				started_at datetime NULL,
+				completed_at datetime NULL,
+				summary longtext NULL,
+				PRIMARY KEY  (id),
+				UNIQUE KEY run_id (run_id),
+				KEY status (status),
+				KEY mode (mode),
+				KEY created_at (created_at)
+			) {$charset_collate};"
+		);
+
+		dbDelta(
+			"CREATE TABLE {$items_table} (
+				id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+				run_id varchar(64) NOT NULL,
+				handle varchar(191) NOT NULL DEFAULT '',
+				worktree_id bigint(20) unsigned NULL,
+				item_type varchar(64) NOT NULL,
+				planned_action varchar(64) NOT NULL,
+				status varchar(32) NOT NULL DEFAULT 'pending',
+				reason_code varchar(96) NOT NULL DEFAULT '',
+				reason text NULL,
+				bytes_reclaimed bigint(20) unsigned NOT NULL DEFAULT 0,
+				job_id bigint(20) unsigned NULL,
+				chunk_index int unsigned NULL,
+				planned_at datetime NOT NULL,
+				applied_at datetime NULL,
+				evidence longtext NULL,
+				PRIMARY KEY  (id),
+				KEY run_id (run_id),
+				KEY run_status (run_id,status),
+				KEY handle (handle),
+				KEY job_id (job_id)
+			) {$charset_collate};"
+		);
+	}
+
+	/**
+	 * Resolve cleanup runs table name.
+	 *
+	 * @return string
+	 */
+	public static function runs_table(): string {
+		global $wpdb;
+		return ( $wpdb->prefix ?? '' ) . self::RUNS_TABLE;
+	}
+
+	/**
+	 * Resolve cleanup items table name.
+	 *
+	 * @return string
+	 */
+	public static function items_table(): string {
+		global $wpdb;
+		return ( $wpdb->prefix ?? '' ) . self::ITEMS_TABLE;
+	}
+}

--- a/inc/Workspace/CleanupRunService.php
+++ b/inc/Workspace/CleanupRunService.php
@@ -1,0 +1,286 @@
+<?php
+/**
+ * DB-backed cleanup run service.
+ *
+ * @package DataMachineCode\Workspace
+ */
+
+namespace DataMachineCode\Workspace;
+
+use DataMachineCode\Storage\CleanupRunRepository;
+
+defined( 'ABSPATH' ) || exit;
+
+class CleanupRunService {
+
+	public function __construct(
+		private ?CleanupRunRepository $repository = null,
+		private ?Workspace $workspace = null
+	) {
+		$this->repository ??= new CleanupRunRepository();
+		$this->workspace   ??= new Workspace();
+	}
+
+	/**
+	 * Create and persist a cleanup plan run.
+	 *
+	 * @param array<string,mixed> $opts Plan options.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function plan( array $opts = array() ): array|\WP_Error {
+		$plan = $this->workspace->workspace_cleanup_plan( $opts );
+		if ( $plan instanceof \WP_Error ) {
+			return $plan;
+		}
+
+		$items  = $this->plan_items( $plan );
+		$run_id = $this->repository->create_run(
+			array(
+				'mode'                  => (string) ( $opts['mode'] ?? $plan['mode'] ?? 'cleanup_plan' ),
+				'status'                => 'planned',
+				'policy'                => $plan['safety_policy'] ?? array(),
+				'requested_by_user_id'  => isset( $opts['user_id'] ) ? (int) $opts['user_id'] : null,
+				'requested_by_agent_id' => isset( $opts['agent_id'] ) ? (int) $opts['agent_id'] : null,
+				'summary'               => $plan['summary'] ?? array(),
+			)
+		);
+		if ( $run_id instanceof \WP_Error ) {
+			return $run_id;
+		}
+
+		$inserted = $this->repository->add_items( $run_id, $items );
+		if ( $inserted instanceof \WP_Error ) {
+			return $inserted;
+		}
+
+		$plan['run_id']          = $run_id;
+		$plan['cleanup_storage'] = array(
+			'type'        => 'database',
+			'item_count'  => $inserted,
+			'plan_id'     => $plan['plan_id'] ?? null,
+			'escape_hatch' => 'filesystem apply-plan import remains available on lower-level worktree commands only',
+		);
+
+		return $plan;
+	}
+
+	/**
+	 * Apply pending rows from a DB-backed run.
+	 *
+	 * @param string              $run_id Run ID.
+	 * @param array<string,mixed> $opts Apply options.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function apply( string $run_id, array $opts = array() ): array|\WP_Error {
+		$run = $this->repository->get_run( $run_id );
+		if ( null === $run ) {
+			return new \WP_Error( 'cleanup_run_not_found', sprintf( 'Cleanup run not found: %s', $run_id ), array( 'status' => 404 ) );
+		}
+
+		$this->repository->update_run( $run_id, array( 'status' => 'applying', 'started_at' => gmdate( 'Y-m-d H:i:s' ) ) );
+
+		$items         = $this->repository->get_items( $run_id );
+		$artifact_rows = $this->pending_rows_of_type( $items, 'artifact_cleanup' );
+		$worktree_rows = $this->pending_rows_of_type( $items, 'worktree_removal' );
+		$results       = array();
+
+		if ( array() !== $artifact_rows ) {
+			$results['artifact_cleanup'] = $this->workspace->worktree_cleanup_artifacts(
+				array(
+					'apply_plan' => array( 'candidates' => array_map( fn( $item ) => $item['evidence'], $artifact_rows ) ),
+					'force'      => ! empty( $opts['force'] ),
+					'limit'      => count( $artifact_rows ),
+				)
+			);
+			$this->record_apply_result( $artifact_rows, $results['artifact_cleanup'], 'removed' );
+		}
+
+		if ( array() !== $worktree_rows ) {
+			$results['worktree_removal'] = $this->workspace->worktree_cleanup_merged(
+				array(
+					'apply_plan'  => array( 'candidates' => array_map( fn( $item ) => $item['evidence'], $worktree_rows ) ),
+					'skip_github' => true,
+				)
+			);
+			$this->record_apply_result( $worktree_rows, $results['worktree_removal'], 'removed' );
+		}
+
+		$this->repository->update_run( $run_id, array( 'status' => 'completed', 'completed_at' => gmdate( 'Y-m-d H:i:s' ), 'summary' => $this->status( $run_id )['summary'] ?? array() ) );
+
+		return array(
+			'success' => true,
+			'state'   => 'completed',
+			'run_id'  => $run_id,
+			'status'  => 'completed',
+			'results' => $results,
+			'summary' => $this->status( $run_id )['summary'] ?? array(),
+		);
+	}
+
+	/**
+	 * Return aggregate run status.
+	 *
+	 * @param string $run_id Run ID.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function status( string $run_id ): array|\WP_Error {
+		$run = $this->repository->get_run( $run_id );
+		if ( null === $run ) {
+			return new \WP_Error( 'cleanup_run_not_found', sprintf( 'Cleanup run not found: %s', $run_id ), array( 'status' => 404 ) );
+		}
+
+		$items   = $this->repository->get_items( $run_id );
+		$summary = array(
+			'total_items'       => count( $items ),
+			'items_by_status'   => array(),
+			'items_by_type'     => array(),
+			'bytes_reclaimed'   => 0,
+			'pending_or_failed' => 0,
+		);
+		foreach ( $items as $item ) {
+			$status = (string) ( $item['status'] ?? 'unknown' );
+			$type   = (string) ( $item['item_type'] ?? 'unknown' );
+			$summary['items_by_status'][ $status ] = ( $summary['items_by_status'][ $status ] ?? 0 ) + 1;
+			$summary['items_by_type'][ $type ]     = ( $summary['items_by_type'][ $type ] ?? 0 ) + 1;
+			$summary['bytes_reclaimed']           += max( 0, (int) ( $item['bytes_reclaimed'] ?? 0 ) );
+			if ( in_array( $status, array( 'pending', 'failed' ), true ) ) {
+				++$summary['pending_or_failed'];
+			}
+		}
+		ksort( $summary['items_by_status'] );
+		ksort( $summary['items_by_type'] );
+
+		return array(
+			'success' => true,
+			'state'   => (string) ( $run['status'] ?? 'unknown' ),
+			'run_id'  => $run_id,
+			'status'  => $run['status'] ?? 'unknown',
+			'mode'    => $run['mode'] ?? '',
+			'run'     => $run,
+			'summary' => $summary,
+		);
+	}
+
+	/**
+	 * Return bounded evidence for a run.
+	 *
+	 * @param string $run_id Run ID.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function evidence( string $run_id ): array|\WP_Error {
+		$status = $this->status( $run_id );
+		if ( $status instanceof \WP_Error ) {
+			return $status;
+		}
+
+		$status['items'] = $this->repository->get_items( $run_id );
+		return $status;
+	}
+
+	/**
+	 * Mark pending rows cancelled.
+	 *
+	 * @param string $run_id Run ID.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function cancel( string $run_id ): array|\WP_Error {
+		$items = $this->repository->get_items( $run_id );
+		foreach ( $items as $item ) {
+			if ( 'pending' === (string) ( $item['status'] ?? '' ) ) {
+				$this->repository->update_item( (int) $item['id'], array( 'status' => 'cancelled' ) );
+			}
+		}
+		$this->repository->update_run( $run_id, array( 'status' => 'cancelled', 'completed_at' => gmdate( 'Y-m-d H:i:s' ) ) );
+		return $this->status( $run_id );
+	}
+
+	/**
+	 * Resume by applying pending/failed rows.
+	 *
+	 * @param string              $run_id Run ID.
+	 * @param array<string,mixed> $opts Options.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function resume( string $run_id, array $opts = array() ): array|\WP_Error {
+		return $this->apply( $run_id, $opts );
+	}
+
+	private function plan_items( array $plan ): array {
+		$items = array();
+		foreach ( (array) ( $plan['rows'] ?? array() ) as $type => $rows ) {
+			foreach ( (array) $rows as $row ) {
+				if ( ! is_array( $row ) ) {
+					continue;
+				}
+				$items[] = array(
+					'handle'         => (string) ( $row['handle'] ?? '' ),
+					'item_type'      => (string) $type,
+					'planned_action' => $this->planned_action_for_type( (string) $type ),
+					'reason_code'    => (string) ( $row['reason_code'] ?? '' ),
+					'reason'         => (string) ( $row['reason'] ?? '' ),
+					'evidence'       => $row,
+					'status'         => 'resolver' === $type ? 'blocked' : 'pending',
+				);
+			}
+		}
+		return $items;
+	}
+
+	private function pending_rows_of_type( array $items, string $type ): array {
+		return array_values( array_filter( $items, fn( $item ) => $type === (string) ( $item['item_type'] ?? '' ) && in_array( (string) ( $item['status'] ?? '' ), array( 'pending', 'failed' ), true ) ) );
+	}
+
+	private function record_apply_result( array $items, mixed $result, string $applied_key ): void {
+		if ( $result instanceof \WP_Error ) {
+			foreach ( $items as $item ) {
+				$this->repository->update_item( (int) $item['id'], array( 'status' => 'failed', 'reason_code' => $result->get_error_code(), 'reason' => $result->get_error_message() ) );
+			}
+			return;
+		}
+
+		$applied_by_handle = array();
+		foreach ( (array) ( $result[ $applied_key ] ?? array() ) as $row ) {
+			$applied_by_handle[ (string) ( $row['handle'] ?? '' ) ] = is_array( $row ) ? $row : array();
+		}
+		$skipped_by_handle = array();
+		foreach ( (array) ( $result['skipped'] ?? array() ) as $skip ) {
+			$skipped_by_handle[ (string) ( $skip['handle'] ?? '' ) ] = $skip;
+		}
+
+		foreach ( $items as $item ) {
+			$handle = (string) ( $item['handle'] ?? '' );
+			if ( isset( $applied_by_handle[ $handle ] ) ) {
+				$applied = $applied_by_handle[ $handle ];
+				$this->repository->update_item(
+					(int) $item['id'],
+					array(
+						'status'          => 'applied',
+						'applied_at'      => gmdate( 'Y-m-d H:i:s' ),
+						'bytes_reclaimed' => max( 0, (int) ( $applied['artifact_size_bytes'] ?? $applied['size_bytes'] ?? $item['evidence']['artifact_size_bytes'] ?? $item['evidence']['size_bytes'] ?? 0 ) ),
+						'evidence'        => array_merge( (array) $item['evidence'], array( 'applied' => $applied ) ),
+					)
+				);
+				continue;
+			}
+			$skip = $skipped_by_handle[ $handle ] ?? null;
+			$this->repository->update_item(
+				(int) $item['id'],
+				array(
+					'status'      => 'skipped',
+					'reason_code' => is_array( $skip ) ? (string) ( $skip['reason_code'] ?? 'apply_skipped' ) : 'apply_skipped',
+					'reason'      => is_array( $skip ) ? (string) ( $skip['reason'] ?? '' ) : 'row was not applied',
+					'evidence'    => is_array( $skip ) ? $skip : $item['evidence'],
+				)
+			);
+		}
+	}
+
+	private function planned_action_for_type( string $type ): string {
+		return match ( $type ) {
+			'artifact_cleanup' => 'remove_artifacts',
+			'worktree_removal' => 'remove_worktree',
+			'resolver'         => 'resolve_signal',
+			default            => 'review',
+		};
+	}
+}

--- a/tests/smoke-cleanup-run-storage.php
+++ b/tests/smoke-cleanup-run-storage.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Smoke test for DB-backed cleanup run storage/service.
+ *
+ * Run: php tests/smoke-cleanup-run-storage.php
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+if ( ! defined( 'ARRAY_A' ) ) {
+	define( 'ARRAY_A', 'ARRAY_A' );
+}
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code = '', private string $message = '', private mixed $data = null ) {}
+		public function get_error_code(): string { return $this->code; }
+		public function get_error_message(): string { return $this->message; }
+		public function get_error_data(): mixed { return $this->data; }
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( mixed $thing ): bool { return $thing instanceof WP_Error; }
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( mixed $value, int $flags = 0 ): string|false { return json_encode( $value, $flags ); }
+}
+
+if ( ! function_exists( 'wp_generate_password' ) ) {
+	function wp_generate_password( int $length = 12 ): string { return substr( str_repeat( 'a', $length ), 0, $length ); }
+}
+
+require __DIR__ . '/../vendor/autoload.php';
+
+class DataMachineCodeCleanupRunFakeWpdb {
+	public string $prefix = 'wp_';
+	public array $runs = array();
+	public array $items = array();
+	private int $run_id = 0;
+	private int $item_id = 0;
+
+	public function insert( string $table, array $data, array $format = array() ): int|false {
+		if ( str_contains( $table, 'cleanup_runs' ) ) {
+			$data['id'] = ++$this->run_id;
+			$this->runs[ $data['run_id'] ] = $data;
+			return 1;
+		}
+		if ( str_contains( $table, 'cleanup_items' ) ) {
+			$data['id'] = ++$this->item_id;
+			$this->items[] = $data;
+			return 1;
+		}
+		return false;
+	}
+
+	public function update( string $table, array $data, array $where ): int|false {
+		if ( str_contains( $table, 'cleanup_runs' ) ) {
+			$key = (string) ( $where['run_id'] ?? '' );
+			$this->runs[ $key ] = array_merge( $this->runs[ $key ] ?? array(), $data );
+			return 1;
+		}
+		if ( str_contains( $table, 'cleanup_items' ) ) {
+			$id = (int) ( $where['id'] ?? 0 );
+			foreach ( $this->items as &$item ) {
+				if ( (int) $item['id'] === $id ) {
+					$item = array_merge( $item, $data );
+					return 1;
+				}
+			}
+		}
+		return false;
+	}
+
+	public function prepare( string $query, mixed ...$args ): string {
+		foreach ( $args as $arg ) {
+			$query = preg_replace( '/%s|%d/', (string) $arg, $query, 1 );
+		}
+		return $query;
+	}
+
+	public function get_row( string $query, string $output = ARRAY_A ): ?array {
+		if ( preg_match( '/run_id = ([^\s]+)/', $query, $matches ) ) {
+			return $this->runs[ $matches[1] ] ?? null;
+		}
+		return null;
+	}
+
+	public function get_results( string $query, string $output = ARRAY_A ): array {
+		if ( ! preg_match( '/run_id = ([^\s]+)/', $query, $matches ) ) {
+			return array();
+		}
+		return array_values( array_filter( $this->items, fn( $item ) => (string) $item['run_id'] === $matches[1] ) );
+	}
+}
+
+class DataMachineCodeCleanupRunFakeWorkspace extends \DataMachineCode\Workspace\Workspace {
+	public function __construct() {}
+	public function workspace_cleanup_plan( array $opts = array() ): array|WP_Error {
+		return array(
+			'success'       => true,
+			'mode'          => 'cleanup_plan',
+			'plan_id'       => 'cleanup-plan-test',
+			'safety_policy' => array( 'destructive_rows_need_review' => true ),
+			'rows'          => array(
+				'artifact_cleanup' => array(
+					array( 'handle' => 'demo@old', 'row_type' => 'artifact_cleanup', 'reason_code' => 'profile_artifact', 'artifact_size_bytes' => 15 ),
+				),
+				'worktree_removal' => array(
+					array( 'handle' => 'demo@merged', 'repo' => 'demo', 'branch' => 'merged', 'path' => '/tmp/demo@merged', 'row_type' => 'worktree_removal', 'reason_code' => 'cleanup_eligible', 'size_bytes' => 20 ),
+				),
+				'resolver' => array(),
+			),
+			'summary'       => array( 'total_rows' => 2, 'total_size_bytes' => 35 ),
+		);
+	}
+	public function worktree_cleanup_artifacts( array $opts = array() ): array|WP_Error {
+		return array( 'removed' => array( array( 'handle' => 'demo@old' ) ), 'skipped' => array(), 'summary' => array() );
+	}
+	public function worktree_cleanup_merged( array $opts = array() ): array|WP_Error {
+		return array( 'removed' => array( array( 'handle' => 'demo@merged' ) ), 'skipped' => array(), 'summary' => array() );
+	}
+}
+
+function datamachine_code_cleanup_run_assert( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		fwrite( STDERR, "FAIL: {$message}\n" );
+		exit( 1 );
+	}
+	echo "ok - {$message}\n";
+}
+
+$GLOBALS['wpdb'] = new DataMachineCodeCleanupRunFakeWpdb();
+$repo = new \DataMachineCode\Storage\CleanupRunRepository();
+$service = new \DataMachineCode\Workspace\CleanupRunService( $repo, new DataMachineCodeCleanupRunFakeWorkspace() );
+
+$plan = $service->plan( array( 'mode' => 'retention' ) );
+datamachine_code_cleanup_run_assert( ! is_wp_error( $plan ), 'plan succeeds' );
+datamachine_code_cleanup_run_assert( isset( $plan['run_id'] ), 'plan returns run_id' );
+datamachine_code_cleanup_run_assert( 2 === (int) ( $plan['cleanup_storage']['item_count'] ?? 0 ), 'plan persists cleanup items' );
+
+$status = $service->status( $plan['run_id'] );
+datamachine_code_cleanup_run_assert( 2 === (int) ( $status['summary']['total_items'] ?? 0 ), 'status aggregates items' );
+datamachine_code_cleanup_run_assert( 2 === (int) ( $status['summary']['items_by_status']['pending'] ?? 0 ), 'status tracks pending items' );
+
+$apply = $service->apply( $plan['run_id'] );
+datamachine_code_cleanup_run_assert( ! is_wp_error( $apply ), 'apply succeeds' );
+
+$evidence = $service->evidence( $plan['run_id'] );
+datamachine_code_cleanup_run_assert( 2 === (int) ( $evidence['summary']['items_by_status']['applied'] ?? 0 ), 'evidence reflects applied rows' );
+datamachine_code_cleanup_run_assert( 35 === (int) ( $evidence['summary']['bytes_reclaimed'] ?? 0 ), 'evidence aggregates reclaimed bytes' );
+
+echo "DB-backed cleanup run storage smoke passed.\n";


### PR DESCRIPTION
## Summary
- Add `datamachine_code_cleanup_runs` and `datamachine_code_cleanup_items` storage.
- Add a cleanup run repository/service and wire `workspace cleanup plan|apply|status|evidence|resume|cancel` through abilities.
- Keep lower-level file plan imports as escape hatches while moving the high-level workflow to `run_id` records.

## Tests
- `php tests/smoke-cleanup-run-storage.php`
- `php tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-worktree-cleanup-chunks.php`
- `php tests/smoke-worktree-cleanup.php`
- PHP syntax checks for changed files

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafting the DB cleanup run/item implementation, tests, and PR description; Chris remains responsible for review and validation.