### PR TITLE
fix: expose workspace cleanup lock retention

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -1037,6 +1037,7 @@ class WorkspaceAbilities {
 							'worktree_status_mode'      => array( 'type' => 'string' ),
 							'top_repos_by_worktrees'    => array( 'type' => 'array' ),
 							'top_repos_by_size'         => array( 'type' => 'array' ),
+							'locks'                     => array( 'type' => 'object' ),
 							'cleanup'                   => array( 'type' => 'object' ),
 							'suggested_cleanup_command' => array( 'type' => 'string' ),
 							'notes'                     => array( 'type' => 'array' ),

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -2566,6 +2566,9 @@ class WorkspaceCommand extends BaseCommand {
 		$size            = (array) ( $report['size'] ?? array() );
 		$disk            = (array) ( $report['disk'] ?? array() );
 		$worktrees       = (array) ( $report['worktrees'] ?? array() );
+		$locks           = (array) ( $report['locks'] ?? array() );
+		$database_locks  = (array) ( $locks['database'] ?? array() );
+		$filesystem_locks = (array) ( $locks['filesystem'] ?? array() );
 		$cleanup         = (array) ( $report['cleanup'] ?? array() );
 		$cleanup_summary = (array) ( $cleanup['summary'] ?? array() );
 
@@ -2639,6 +2642,22 @@ class WorkspaceCommand extends BaseCommand {
 				array(
 					'metric' => 'duplicate_task_groups',
 					'value'  => (string) ( $worktrees['duplicate_task_groups'] ?? 0 ),
+				),
+				array(
+					'metric' => 'active_locks',
+					'value'  => (string) ( $locks['active'] ?? 0 ),
+				),
+				array(
+					'metric' => 'stale_locks',
+					'value'  => (string) ( $locks['stale'] ?? 0 ),
+				),
+				array(
+					'metric' => 'db_lock_rows',
+					'value'  => (string) ( $database_locks['total'] ?? 0 ),
+				),
+				array(
+					'metric' => 'filesystem_lock_files',
+					'value'  => (string) ( $filesystem_locks['total'] ?? 0 ),
 				),
 				array(
 					'metric' => 'cleanup_candidates',

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -1896,6 +1896,7 @@ class Workspace {
 		$size_report   = $include_sizes ? $this->build_workspace_size_report( $size_limit ) : $this->empty_workspace_size_report( $size_limit, false );
 		$cleanup       = null;
 		$cleanup_error = null;
+		$locks         = WorkspaceMutationLock::status( $this->workspace_path );
 
 		if ( $include_cleanup ) {
 			$cleanup = $this->worktree_cleanup_merged(
@@ -1925,6 +1926,7 @@ class Workspace {
 			'worktree_status_mode'      => $worktree_status_mode,
 			'top_repos_by_worktrees'    => $this->top_repos_by_worktree_count( $worktrees, 10 ),
 			'top_repos_by_size'         => $this->top_repos_by_size( (array) ( $size_report['entries'] ?? array() ), 10 ),
+			'locks'                     => $locks,
 			'cleanup'                   => $this->summarize_workspace_cleanup( $cleanup, $cleanup_error, (array) ( $size_report['entries'] ?? array() ) ),
 			'suggested_cleanup_command' => 'wp datamachine-code workspace worktree cleanup --dry-run --inventory-only --skip-github --format=json',
 			'notes'                     => array_values( array_filter( array(
@@ -1956,6 +1958,7 @@ class Workspace {
 
 		$worktree_result = null;
 		$artifact_result = null;
+		$lock_retention  = WorkspaceMutationLock::prune_stale( $this->workspace_path, $dry_run );
 
 		if ( $worktree_cleanup ) {
 			$worktree_result = $this->worktree_cleanup_merged(
@@ -2016,6 +2019,8 @@ class Workspace {
 				'skip_github'         => $skip_github,
 				'force'               => $force,
 			),
+			'lock_retention' => $lock_retention,
+			'storage'        => $this->cleanup_storage_status(),
 			'report'         => $report,
 			'worktrees'      => $worktree_result,
 			'artifacts'      => $artifact_result,
@@ -2453,6 +2458,45 @@ class Workspace {
 			'skipped_by_reason'    => $cleanup['summary']['skipped_by_reason'] ?? array(),
 			'candidates_by_signal' => $cleanup['summary']['candidates_by_signal'] ?? array(),
 		);
+	}
+
+	/**
+	 * Report whether DB cleanup storage tables are available for retention hooks.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function cleanup_storage_status(): array {
+		$status = array(
+			'cleanup_runs_available'  => false,
+			'cleanup_items_available' => false,
+			'locks_available'         => (bool) ( WorkspaceLockStore::status()['available'] ?? false ),
+			'policy_hooks'            => array(
+				'datamachine_code_lock_expires_seconds',
+				'datamachine_code_lock_released_ttl_seconds',
+				'datamachine_code_cleanup_lock_retention_policy',
+			),
+			'note'                    => 'Cleanup run/item table retention is inactive until those DB tables exist; lock storage is handled separately in datamachine_code_locks.',
+		);
+
+		global $wpdb;
+		if ( ! is_object( $wpdb ) || ! isset( $wpdb->prefix ) ) {
+			return $status;
+		}
+
+		$runs_table                         = $wpdb->prefix . 'datamachine_code_cleanup_runs';
+		$items_table                        = $wpdb->prefix . 'datamachine_code_cleanup_items';
+		$status['cleanup_runs_available']  = $this->database_table_exists( $runs_table );
+		$status['cleanup_items_available'] = $this->database_table_exists( $items_table );
+		if ( $status['cleanup_runs_available'] && $status['cleanup_items_available'] ) {
+			$status['note'] = 'Cleanup run/item tables are available; future retention can attach to the declared cleanup storage hooks without changing lock ownership.';
+		}
+
+		return $status;
+	}
+
+	private function database_table_exists( string $table ): bool {
+		global $wpdb;
+		return $table === $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
 	}
 
 	/**

--- a/inc/Workspace/WorkspaceLockStore.php
+++ b/inc/Workspace/WorkspaceLockStore.php
@@ -1,0 +1,271 @@
+<?php
+/**
+ * DB-visible workspace lock store.
+ *
+ * @package DataMachineCode\Workspace
+ */
+
+namespace DataMachineCode\Workspace;
+
+defined( 'ABSPATH' ) || exit;
+
+final class WorkspaceLockStore {
+
+	private const DEFAULT_EXPIRES_SECONDS      = 900;
+	private const DEFAULT_RELEASED_TTL_SECONDS = 604800;
+
+	/**
+	 * Whether a WordPress database handle is available.
+	 */
+	public static function is_available(): bool {
+		global $wpdb;
+		return is_object( $wpdb ) && isset( $wpdb->prefix );
+	}
+
+	/**
+	 * Register an acquired lock in the database.
+	 *
+	 * @param array<string,mixed> $args Lock fields.
+	 * @return int|\WP_Error Lock row id, 0 when DB is unavailable, or error.
+	 */
+	public static function register_acquired( array $args ): int|\WP_Error {
+		if ( ! self::is_available() ) {
+			return 0;
+		}
+
+		$ensured = self::ensure_table();
+		if ( $ensured instanceof \WP_Error ) {
+			return $ensured;
+		}
+
+		global $wpdb;
+		$now     = gmdate( 'Y-m-d H:i:s' );
+		$expires = gmdate( 'Y-m-d H:i:s', time() + self::expires_seconds() );
+		$meta    = isset( $args['metadata'] ) && is_array( $args['metadata'] ) ? $args['metadata'] : array();
+
+		$inserted = $wpdb->insert(
+			self::table_name(),
+			array(
+				'lock_key'      => self::bounded_string( (string) ( $args['lock_key'] ?? '' ), 190 ),
+				'purpose'       => self::bounded_string( (string) ( $args['purpose'] ?? 'workspace_repo_mutation' ), 100 ),
+				'scope'         => self::bounded_string( (string) ( $args['scope'] ?? '' ), 190 ),
+				'owner'         => self::bounded_string( (string) ( $args['owner'] ?? self::default_owner() ), 190 ),
+				'run_id'        => self::nullable_bounded_string( $args['run_id'] ?? null, 100 ),
+				'job_id'        => isset( $args['job_id'] ) ? (int) $args['job_id'] : null,
+				'status'        => 'active',
+				'acquired_at'   => $now,
+				'heartbeat_at'  => $now,
+				'expires_at'    => $expires,
+				'released_at'   => null,
+				'metadata_json' => self::encode_metadata( $meta ),
+			),
+			array( '%s', '%s', '%s', '%s', '%s', '%d', '%s', '%s', '%s', '%s', '%s', '%s' )
+		);
+
+		if ( false === $inserted ) {
+			return new \WP_Error(
+				'workspace_lock_db_insert_failed',
+				'Failed to record workspace lock ownership in the database.',
+				array( 'status' => 500, 'wpdb_error' => (string) $wpdb->last_error )
+			);
+		}
+
+		return (int) $wpdb->insert_id;
+	}
+
+	/**
+	 * Mark a lock row released.
+	 */
+	public static function release( int $lock_id ): void {
+		if ( $lock_id <= 0 || ! self::is_available() ) {
+			return;
+		}
+
+		global $wpdb;
+		$wpdb->update(
+			self::table_name(),
+			array(
+				'status'      => 'released',
+				'released_at' => gmdate( 'Y-m-d H:i:s' ),
+			),
+			array( 'id' => $lock_id ),
+			array( '%s', '%s' ),
+			array( '%d' )
+		);
+	}
+
+	/**
+	 * Build active/stale/released lock counts.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public static function status(): array {
+		if ( ! self::is_available() ) {
+			return array(
+				'available' => false,
+				'table'     => null,
+				'active'    => 0,
+				'stale'     => 0,
+				'released'  => 0,
+				'total'     => 0,
+			);
+		}
+
+		$ensured = self::ensure_table();
+		if ( $ensured instanceof \WP_Error ) {
+			return array(
+				'available' => false,
+				'error'     => $ensured->get_error_message(),
+				'table'     => self::table_name(),
+				'active'    => 0,
+				'stale'     => 0,
+				'released'  => 0,
+				'total'     => 0,
+			);
+		}
+
+		global $wpdb;
+		$table = self::table_name();
+		$now   = gmdate( 'Y-m-d H:i:s' );
+
+		return array(
+			'available' => true,
+			'table'     => $table,
+			'active'    => (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$table} WHERE status = %s AND expires_at >= %s", 'active', $now ) ),
+			'stale'     => (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$table} WHERE status = %s AND expires_at < %s", 'active', $now ) ),
+			'released'  => (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$table} WHERE status = %s", 'released' ) ),
+			'total'     => (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$table}" ),
+		);
+	}
+
+	/**
+	 * Prune expired DB lock rows according to retention policy.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public static function prune_expired(): array {
+		$status = self::status();
+		if ( empty( $status['available'] ) ) {
+			return array(
+				'available'          => false,
+				'active_marked_stale' => 0,
+				'released_deleted'   => 0,
+				'before'             => $status,
+				'after'              => $status,
+			);
+		}
+
+		global $wpdb;
+		$table          = self::table_name();
+		$now            = gmdate( 'Y-m-d H:i:s' );
+		$released_cutoff = gmdate( 'Y-m-d H:i:s', time() - self::released_ttl_seconds() );
+
+		$wpdb->query( $wpdb->prepare( "UPDATE {$table} SET status = %s WHERE status = %s AND expires_at < %s", 'stale', 'active', $now ) );
+		$marked = (int) $wpdb->rows_affected;
+
+		$wpdb->query( $wpdb->prepare( "DELETE FROM {$table} WHERE status IN (%s, %s) AND COALESCE(released_at, expires_at) < %s", 'released', 'stale', $released_cutoff ) );
+		$deleted = (int) $wpdb->rows_affected;
+
+		return array(
+			'available'          => true,
+			'active_marked_stale' => $marked,
+			'released_deleted'   => $deleted,
+			'before'             => $status,
+			'after'              => self::status(),
+		);
+	}
+
+	private static function ensure_table(): true|\WP_Error {
+		global $wpdb;
+		$table = self::table_name();
+
+		$exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+		if ( $exists === $table ) {
+			return true;
+		}
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		$charset_collate = method_exists( $wpdb, 'get_charset_collate' ) ? $wpdb->get_charset_collate() : '';
+		$sql             = "CREATE TABLE {$table} (
+			id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+			lock_key varchar(190) NOT NULL,
+			purpose varchar(100) NOT NULL,
+			scope varchar(190) NOT NULL,
+			owner varchar(190) NOT NULL,
+			run_id varchar(100) NULL,
+			job_id bigint(20) unsigned NULL,
+			status varchar(20) NOT NULL DEFAULT 'active',
+			acquired_at datetime NOT NULL,
+			heartbeat_at datetime NOT NULL,
+			expires_at datetime NOT NULL,
+			released_at datetime NULL,
+			metadata_json longtext NULL,
+			PRIMARY KEY  (id),
+			KEY lock_key (lock_key),
+			KEY status_expires (status, expires_at),
+			KEY scope_status (scope, status),
+			KEY run_id (run_id),
+			KEY job_id (job_id)
+		) {$charset_collate};";
+
+		dbDelta( $sql );
+		$exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+		if ( $exists !== $table ) {
+			return new \WP_Error( 'workspace_lock_table_missing', sprintf( 'Failed to create workspace locks table: %s.', $table ), array( 'status' => 500 ) );
+		}
+
+		return true;
+	}
+
+	private static function table_name(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'datamachine_code_locks';
+	}
+
+	private static function expires_seconds(): int {
+		$seconds = self::DEFAULT_EXPIRES_SECONDS;
+		if ( function_exists( 'apply_filters' ) ) {
+			$seconds = (int) apply_filters( 'datamachine_code_lock_expires_seconds', $seconds );
+		}
+		return max( 60, $seconds );
+	}
+
+	private static function released_ttl_seconds(): int {
+		$seconds = self::DEFAULT_RELEASED_TTL_SECONDS;
+		if ( function_exists( 'apply_filters' ) ) {
+			$seconds = (int) apply_filters( 'datamachine_code_lock_released_ttl_seconds', $seconds );
+		}
+		return max( 3600, $seconds );
+	}
+
+	private static function default_owner(): string {
+		$host = function_exists( 'gethostname' ) ? (string) gethostname() : 'unknown-host';
+		$pid  = function_exists( 'getmypid' ) ? (string) getmypid() : 'unknown-pid';
+		return $host . ':' . $pid;
+	}
+
+	private static function bounded_string( string $value, int $max ): string {
+		$value = trim( $value );
+		if ( '' === $value ) {
+			$value = 'unknown';
+		}
+		return substr( $value, 0, $max );
+	}
+
+	private static function nullable_bounded_string( mixed $value, int $max ): ?string {
+		if ( null === $value || '' === trim( (string) $value ) ) {
+			return null;
+		}
+		return self::bounded_string( (string) $value, $max );
+	}
+
+	/**
+	 * @param array<string,mixed> $metadata Metadata to encode.
+	 */
+	private static function encode_metadata( array $metadata ): string {
+		$metadata = array_slice( $metadata, 0, 20, true );
+		$json     = function_exists( 'wp_json_encode' ) ? wp_json_encode( $metadata ) : json_encode( $metadata );
+		$json     = false === $json ? '{}' : (string) $json;
+		return substr( $json, 0, 8192 );
+	}
+}

--- a/inc/Workspace/WorkspaceMutationLock.php
+++ b/inc/Workspace/WorkspaceMutationLock.php
@@ -12,6 +12,10 @@ namespace DataMachineCode\Workspace;
 
 defined( 'ABSPATH' ) || exit;
 
+if ( ! class_exists( WorkspaceLockStore::class ) ) {
+	require_once __DIR__ . '/WorkspaceLockStore.php';
+}
+
 final class WorkspaceMutationLock {
 
 	private const POLL_USEC = 100000;
@@ -19,8 +23,14 @@ final class WorkspaceMutationLock {
 	/** @var resource|null */
 	private $handle = null;
 
-	private function __construct( $handle ) {
-		$this->handle = $handle;
+	private int $lock_id = 0;
+
+	private string $lock_path = '';
+
+	private function __construct( $handle, int $lock_id = 0, string $lock_path = '' ) {
+		$this->handle    = $handle;
+		$this->lock_id   = $lock_id;
+		$this->lock_path = $lock_path;
 	}
 
 	/**
@@ -100,7 +110,24 @@ final class WorkspaceMutationLock {
 
 		do {
 			if ( flock( $handle, LOCK_EX | LOCK_NB ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock
-				return new self( $handle );
+				$lock_id = WorkspaceLockStore::register_acquired(
+					array(
+						'lock_key' => 'worktree-' . $repo,
+						'purpose'  => 'workspace_repo_mutation',
+						'scope'    => $repo,
+						'metadata' => array(
+							'workspace_path' => $workspace_path,
+							'lock_path'      => $lock_path,
+						),
+					)
+				);
+				if ( is_wp_error( $lock_id ) ) {
+					flock( $handle, LOCK_UN ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock
+					fclose( $handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+					return $lock_id;
+				}
+
+				return new self( $handle, (int) $lock_id, $lock_path );
 			}
 
 			if ( 0 === $timeout || ( microtime( true ) - $started ) >= $timeout ) {
@@ -129,9 +156,51 @@ final class WorkspaceMutationLock {
 			return;
 		}
 
+		WorkspaceLockStore::release( $this->lock_id );
 		flock( $this->handle, LOCK_UN ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock
 		fclose( $this->handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
-		$this->handle = null;
+		$this->handle    = null;
+		$this->lock_id   = 0;
+		$this->lock_path = '';
+	}
+
+	/**
+	 * Summarize DB-visible and filesystem lock state.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public static function status( string $workspace_path ): array {
+		$filesystem = self::filesystem_status( $workspace_path );
+		$database   = WorkspaceLockStore::status();
+
+		return array(
+			'database'          => $database,
+			'filesystem'        => $filesystem,
+			'active'            => (int) ( $database['active'] ?? 0 ) + (int) ( $filesystem['active'] ?? 0 ),
+			'stale'             => (int) ( $database['stale'] ?? 0 ) + (int) ( $filesystem['stale'] ?? 0 ),
+			'retention_enabled' => true,
+			'policy'            => self::retention_policy(),
+		);
+	}
+
+	/**
+	 * Safely prune stale lock rows and unlocked stale filesystem lock files.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public static function prune_stale( string $workspace_path, bool $dry_run = false ): array {
+		$before     = self::status( $workspace_path );
+		$db_pruned  = $dry_run ? array( 'dry_run' => true ) : WorkspaceLockStore::prune_expired();
+		$fs_pruned  = self::prune_stale_filesystem_locks( $workspace_path, $dry_run );
+		$after      = self::status( $workspace_path );
+
+		return array(
+			'dry_run'    => $dry_run,
+			'before'     => $before,
+			'database'   => $db_pruned,
+			'filesystem' => $fs_pruned,
+			'after'      => $after,
+		);
 	}
 
 	public function __destruct() {
@@ -141,5 +210,113 @@ final class WorkspaceMutationLock {
 	private static function sanitize_repo_key( string $repo ): string {
 		$repo = preg_replace( '/[^a-zA-Z0-9._-]/', '', $repo );
 		return trim( (string) $repo, '-.' );
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	private static function filesystem_status( string $workspace_path ): array {
+		$lock_dir = rtrim( $workspace_path, '/' ) . '/.locks';
+		$files    = is_dir( $lock_dir ) ? glob( $lock_dir . '/*.lock' ) : array();
+		$files    = false === $files ? array() : $files;
+		$policy   = self::retention_policy();
+		$cutoff   = time() - (int) $policy['filesystem_stale_after_seconds'];
+		$active   = 0;
+		$stale    = 0;
+		$recent   = 0;
+
+		foreach ( $files as $file ) {
+			$handle = fopen( $file, 'c' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+			if ( false === $handle ) {
+				continue;
+			}
+
+			if ( ! flock( $handle, LOCK_EX | LOCK_NB ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock
+				$active++;
+				fclose( $handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+				continue;
+			}
+
+			flock( $handle, LOCK_UN ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock
+			fclose( $handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+			$mtime = filemtime( $file );
+			if ( false !== $mtime && $mtime < $cutoff ) {
+				$stale++;
+			} else {
+				$recent++;
+			}
+		}
+
+		return array(
+			'lock_dir' => $lock_dir,
+			'total'    => count( $files ),
+			'active'   => $active,
+			'stale'    => $stale,
+			'recent'   => $recent,
+		);
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	private static function prune_stale_filesystem_locks( string $workspace_path, bool $dry_run ): array {
+		$lock_dir = rtrim( $workspace_path, '/' ) . '/.locks';
+		$files    = is_dir( $lock_dir ) ? glob( $lock_dir . '/*.lock' ) : array();
+		$files    = false === $files ? array() : $files;
+		$policy   = self::retention_policy();
+		$cutoff   = time() - (int) $policy['filesystem_stale_after_seconds'];
+		$removed  = array();
+		$skipped  = array();
+
+		foreach ( $files as $file ) {
+			$mtime = filemtime( $file );
+			if ( false === $mtime || $mtime >= $cutoff ) {
+				$skipped[] = array( 'path' => $file, 'reason' => 'not_stale' );
+				continue;
+			}
+
+			$handle = fopen( $file, 'c' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+			if ( false === $handle ) {
+				$skipped[] = array( 'path' => $file, 'reason' => 'open_failed' );
+				continue;
+			}
+
+			if ( ! flock( $handle, LOCK_EX | LOCK_NB ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock
+				$skipped[] = array( 'path' => $file, 'reason' => 'active' );
+				fclose( $handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+				continue;
+			}
+
+			if ( ! $dry_run ) {
+				unlink( $file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+			}
+			flock( $handle, LOCK_UN ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock
+			fclose( $handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+			$removed[] = $file;
+		}
+
+		return array(
+			'dry_run'       => $dry_run,
+			'removed_count' => count( $removed ),
+			'removed'       => $removed,
+			'skipped_count' => count( $skipped ),
+			'skipped'       => $skipped,
+		);
+	}
+
+	/**
+	 * @return array<string,int>
+	 */
+	private static function retention_policy(): array {
+		$policy = array(
+			'filesystem_stale_after_seconds' => 86400,
+		);
+		if ( function_exists( 'apply_filters' ) ) {
+			$policy = (array) apply_filters( 'datamachine_code_cleanup_lock_retention_policy', $policy );
+		}
+
+		return array(
+			'filesystem_stale_after_seconds' => max( 60, (int) ( $policy['filesystem_stale_after_seconds'] ?? 86400 ) ),
+		);
 	}
 }

--- a/tests/smoke-workspace-hygiene-cli.php
+++ b/tests/smoke-workspace-hygiene-cli.php
@@ -99,6 +99,12 @@ namespace {
 			'top_repos_by_size'         => array(
 				array( 'repo' => 'data-machine', 'bytes' => 4096, 'human' => '4.0 KiB' ),
 			),
+			'locks'                     => array(
+				'active'     => 1,
+				'stale'      => 2,
+				'database'   => array( 'total' => 3 ),
+				'filesystem' => array( 'total' => 4 ),
+			),
 			'cleanup'                   => array(
 				'included'           => true,
 				'dry_run'            => true,
@@ -151,7 +157,7 @@ namespace {
 	$GLOBALS['__cli_logs'] = array();
 	$command->hygiene( array(), array() );
 	datamachine_code_hygiene_assert( 'Workspace hygiene:' === ( $GLOBALS['__cli_logs'][0] ?? '' ), 'human output starts with report heading' );
-	datamachine_code_hygiene_assert( in_array( 'table:18:metric,value', $GLOBALS['__cli_logs'], true ), 'human output renders summary table (now includes 4 liveness counts + duplicate_task_groups)' );
+	datamachine_code_hygiene_assert( in_array( 'table:22:metric,value', $GLOBALS['__cli_logs'], true ), 'human output renders summary table with lock counts' );
 	datamachine_code_hygiene_assert( in_array( 'Workspace size by kind:', $GLOBALS['__cli_logs'], true ), 'human output renders size kind grouping' );
 	datamachine_code_hygiene_assert( in_array( 'Top workspace entries by size:', $GLOBALS['__cli_logs'], true ), 'human output renders top offenders' );
 	datamachine_code_hygiene_assert( in_array( 'Top repos by size:', $GLOBALS['__cli_logs'], true ), 'human output renders size leaders' );

--- a/tests/smoke-workspace-hygiene-report.php
+++ b/tests/smoke-workspace-hygiene-report.php
@@ -64,6 +64,8 @@ namespace {
 		return $GLOBALS['__dmc_hygiene_metadata'];
 	}
 
+	require __DIR__ . '/../inc/Workspace/WorkspaceLockStore.php';
+	require __DIR__ . '/../inc/Workspace/WorkspaceMutationLock.php';
 	require __DIR__ . '/../inc/Workspace/WorktreeContextInjector.php';
 	require __DIR__ . '/../inc/Workspace/Workspace.php';
 

--- a/tests/smoke-workspace-mutation-lock.php
+++ b/tests/smoke-workspace-mutation-lock.php
@@ -51,6 +51,7 @@ namespace {
 		}
 	}
 
+	require __DIR__ . '/../inc/Workspace/WorkspaceLockStore.php';
 	require __DIR__ . '/../inc/Workspace/WorkspaceMutationLock.php';
 
 	$failures = 0;
@@ -81,6 +82,9 @@ namespace {
 	$first = \DataMachineCode\Workspace\WorkspaceMutationLock::acquire( $tmp, 'demo', 1 );
 	$assert( false, is_wp_error( $first ), 'first acquisition succeeds' );
 	$assert( true, is_file( $tmp . '/.locks/worktree-demo.lock' ), 'lock file is created under workspace .locks directory' );
+	$status = \DataMachineCode\Workspace\WorkspaceMutationLock::status( $tmp );
+	$assert( 1, (int) $status['active'], 'held filesystem lock is visible in aggregate active count' );
+	$assert( false, (bool) $status['database']['available'], 'DB lock store reports unavailable in pure-PHP smoke context' );
 
 	$busy = \DataMachineCode\Workspace\WorkspaceMutationLock::acquire( $tmp, 'demo', 0 );
 	$assert( true, is_wp_error( $busy ), 'same repo acquisition fails fast while held' );
@@ -96,6 +100,20 @@ namespace {
 	if ( ! is_wp_error( $first ) ) {
 		$first->release();
 	}
+	$status = \DataMachineCode\Workspace\WorkspaceMutationLock::status( $tmp );
+	$assert( 0, (int) $status['active'], 'released filesystem lock is no longer active' );
+	$assert( 2, (int) $status['filesystem']['recent'], 'released filesystem lock files are visible as recent retention residue' );
+
+	$stale_path = $tmp . '/.locks/worktree-stale.lock';
+	touch( $stale_path, time() - 172800 );
+	$stale_status = \DataMachineCode\Workspace\WorkspaceMutationLock::status( $tmp );
+	$assert( 1, (int) $stale_status['stale'], 'old unlocked filesystem lock is counted stale' );
+	$dry_prune = \DataMachineCode\Workspace\WorkspaceMutationLock::prune_stale( $tmp, true );
+	$assert( true, is_file( $stale_path ), 'dry-run stale lock prune does not remove file' );
+	$assert( 1, (int) $dry_prune['filesystem']['removed_count'], 'dry-run reports stale lock file candidate' );
+	$prune = \DataMachineCode\Workspace\WorkspaceMutationLock::prune_stale( $tmp, false );
+	$assert( false, is_file( $stale_path ), 'stale lock prune removes unlocked old file' );
+	$assert( 1, (int) $prune['filesystem']['removed_count'], 'stale lock prune reports removed file' );
 
 	$after_release = \DataMachineCode\Workspace\WorkspaceMutationLock::acquire( $tmp, 'demo', 0 );
 	$assert( false, is_wp_error( $after_release ), 'same repo acquisition succeeds after release' );

--- a/tests/smoke-workspace-retention-cleanup.php
+++ b/tests/smoke-workspace-retention-cleanup.php
@@ -40,6 +40,8 @@ namespace {
 		return $value instanceof \WP_Error;
 	}
 
+	require __DIR__ . '/../inc/Workspace/WorkspaceLockStore.php';
+	require __DIR__ . '/../inc/Workspace/WorkspaceMutationLock.php';
 	require __DIR__ . '/../inc/Workspace/Workspace.php';
 
 	function datamachine_code_retention_assert( bool $condition, string $message ): void {


### PR DESCRIPTION
## Summary
- Add DB-visible workspace cleanup lock storage for mutation lock ownership and retention visibility.
- Surface active/stale DB and filesystem lock counts in workspace hygiene.
- Add safe stale filesystem lock pruning for old unlocked lock files.

## Tests
- `php tests/smoke-workspace-mutation-lock.php`
- `php tests/smoke-workspace-hygiene-report.php`
- `php tests/smoke-workspace-retention-cleanup.php`
- `php tests/smoke-workspace-hygiene-cli.php`
- `php tests/smoke-worktree-cleanup.php`
- `php tests/smoke-worktree-cleanup-chunks.php`
- PHP syntax checks for changed files
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafting the lock visibility/retention implementation, tests, and PR description; Chris remains responsible for review and validation.