### PR TITLE
feat: add DB-backed worktree inventory

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -26,6 +26,27 @@ define( 'DATAMACHINE_CODE_URL', plugin_dir_url( __FILE__ ) );
 require_once __DIR__ . '/vendor/autoload.php';
 
 /**
+ * Install DMC-owned database tables.
+ */
+function datamachine_code_install_schema(): void {
+	if ( class_exists( '\DataMachineCode\Storage\WorktreeInventoryRepository' ) ) {
+		\DataMachineCode\Storage\WorktreeInventoryRepository::install_schema();
+	}
+}
+register_activation_hook( __FILE__, 'datamachine_code_install_schema' );
+
+/**
+ * Keep schema current for already-active installs after deploy/update.
+ */
+function datamachine_code_maybe_upgrade_schema(): void {
+	$installed = function_exists( 'get_option' ) ? (string) get_option( 'datamachine_code_worktrees_schema_version', '' ) : '';
+	if ( '1' !== $installed ) {
+		datamachine_code_install_schema();
+	}
+}
+add_action( 'plugins_loaded', 'datamachine_code_maybe_upgrade_schema', 5 );
+
+/**
  * Bootstrap the plugin after all plugins are loaded.
  *
  * Data Machine core must be active — check at plugins_loaded time

--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -1018,6 +1018,10 @@ class WorkspaceAbilities {
 								'type'        => 'boolean',
 								'description' => 'Include full per-worktree git status. Default false for huge-workspace safety.',
 							),
+							'refresh_inventory' => array(
+								'type'        => 'boolean',
+								'description' => 'Refresh the DB-backed worktree inventory before reporting freshness. Default false.',
+							),
 							'size_limit'      => array(
 								'type'        => 'integer',
 								'description' => 'Maximum top-level workspace entries to size. Default 1000.',
@@ -1033,6 +1037,7 @@ class WorkspaceAbilities {
 							'destructive'               => array( 'type' => 'boolean' ),
 							'size'                      => array( 'type' => 'object' ),
 							'disk'                      => array( 'type' => 'object' ),
+							'inventory'                 => array( 'type' => 'object' ),
 							'worktrees'                 => array( 'type' => 'object' ),
 							'worktree_status_mode'      => array( 'type' => 'string' ),
 							'top_repos_by_worktrees'    => array( 'type' => 'array' ),
@@ -1043,6 +1048,32 @@ class WorkspaceAbilities {
 						),
 					),
 					'execute_callback'    => array( self::class, 'workspaceHygieneReport' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/workspace-worktree-inventory-refresh',
+				array(
+					'label'               => 'Refresh Worktree Inventory',
+					'description'         => 'Reconcile the DB-backed worktree inventory from the current filesystem/git worktree view. Current rows are upserted; stale known rows are marked missing_path.',
+					'category'            => 'datamachine-code-workspace',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'        => array( 'type' => 'boolean' ),
+							'refreshed_at'   => array( 'type' => 'string' ),
+							'upserted'       => array( 'type' => 'array' ),
+							'marked_missing' => array( 'type' => 'array' ),
+							'summary'        => array( 'type' => 'object' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'worktreeInventoryRefresh' ),
 					'permission_callback' => fn() => PermissionHelper::can_manage(),
 					'meta'                => array( 'show_in_rest' => false ),
 				)
@@ -1960,11 +1991,25 @@ class WorkspaceAbilities {
 		if ( array_key_exists( 'include_worktree_status', $input ) ) {
 			$opts['include_worktree_status'] = (bool) $input['include_worktree_status'];
 		}
+		if ( array_key_exists( 'refresh_inventory', $input ) ) {
+			$opts['refresh_inventory'] = (bool) $input['refresh_inventory'];
+		}
 		if ( isset( $input['size_limit'] ) ) {
 			$opts['size_limit'] = (int) $input['size_limit'];
 		}
 
 		return $workspace->workspace_hygiene_report( $opts );
+	}
+
+	/**
+	 * Refresh DB-backed worktree inventory from the filesystem/git view.
+	 *
+	 * @param array $input Unused input.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public static function worktreeInventoryRefresh( array $input ): array|\WP_Error { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+		$workspace = new Workspace();
+		return $workspace->worktree_inventory_refresh();
 	}
 
 	/**

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1067,6 +1067,9 @@ class WorkspaceCommand extends BaseCommand {
 	 * [--include-worktree-status]
 	 * : Include full per-worktree git status. This can be expensive on huge workspaces.
 	 *
+	 * [--refresh-inventory]
+	 * : Refresh the DB-backed worktree inventory before reporting freshness.
+	 *
 	 * [--size-limit=<count>]
 	 * : Maximum top-level workspace entries to size.
 	 * ---
@@ -1091,6 +1094,7 @@ class WorkspaceCommand extends BaseCommand {
 			'include_cleanup'         => empty( $assoc_args['skip-cleanup'] ),
 			'include_sizes'           => empty( $assoc_args['skip-sizes'] ),
 			'include_worktree_status' => ! empty( $assoc_args['include-worktree-status'] ),
+			'refresh_inventory'       => ! empty( $assoc_args['refresh-inventory'] ),
 		);
 		if ( isset( $assoc_args['size-limit'] ) ) {
 			$input['size_limit'] = (int) $assoc_args['size-limit'];
@@ -1103,6 +1107,58 @@ class WorkspaceCommand extends BaseCommand {
 		}
 
 		$this->render_workspace_hygiene_report( $result, $assoc_args );
+	}
+
+	/**
+	 * Manage the DB-backed workspace inventory.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <operation>
+	 * : Inventory operation. Currently: refresh.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-code workspace inventory refresh --format=json
+	 *
+	 * @subcommand inventory
+	 */
+	public function inventory( array $args, array $assoc_args ): void {
+		$operation = $args[0] ?? '';
+		if ( 'refresh' !== $operation ) {
+			WP_CLI::error( 'Usage: wp datamachine-code workspace inventory refresh [--format=<format>]' );
+			return;
+		}
+
+		$ability = wp_get_ability( 'datamachine/workspace-worktree-inventory-refresh' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'Workspace inventory refresh ability not available.' );
+			return;
+		}
+
+		$result = $ability->execute( array() );
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
+
+		if ( 'json' === (string) ( $assoc_args['format'] ?? '' ) ) {
+			$json = wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+			WP_CLI::log( false === $json ? '{}' : $json );
+			return;
+		}
+
+		$summary = (array) ( $result['summary'] ?? array() );
+		WP_CLI::success( sprintf( 'Inventory refreshed: %d upserted, %d marked missing.', (int) ( $summary['upserted'] ?? 0 ), (int) ( $summary['marked_missing'] ?? 0 ) ) );
 	}
 
 	/**
@@ -2566,12 +2622,25 @@ class WorkspaceCommand extends BaseCommand {
 		$size            = (array) ( $report['size'] ?? array() );
 		$disk            = (array) ( $report['disk'] ?? array() );
 		$worktrees       = (array) ( $report['worktrees'] ?? array() );
+		$inventory       = (array) ( $report['inventory']['freshness'] ?? array() );
 		$cleanup         = (array) ( $report['cleanup'] ?? array() );
 		$cleanup_summary = (array) ( $cleanup['summary'] ?? array() );
 
 		WP_CLI::log( 'Workspace hygiene:' );
 		$this->format_items(
 			array(
+				array(
+					'metric' => 'inventory_rows',
+					'value'  => (string) ( $inventory['total_rows'] ?? 0 ),
+				),
+				array(
+					'metric' => 'inventory_missing_paths',
+					'value'  => (string) ( $inventory['missing_paths'] ?? 0 ),
+				),
+				array(
+					'metric' => 'inventory_last_probe_at',
+					'value'  => (string) ( $inventory['last_probe_at'] ?? '-' ),
+				),
 				array(
 					'metric' => 'workspace_path',
 					'value'  => (string) ( $report['workspace_path'] ?? '' ),

--- a/inc/Storage/WorktreeInventoryRepository.php
+++ b/inc/Storage/WorktreeInventoryRepository.php
@@ -1,0 +1,300 @@
+<?php
+/**
+ * DB-backed workspace worktree inventory.
+ *
+ * @package DataMachineCode\Storage
+ */
+
+namespace DataMachineCode\Storage;
+
+defined( 'ABSPATH' ) || exit;
+
+class WorktreeInventoryRepository {
+
+	public const TABLE = 'datamachine_code_worktrees';
+
+	/**
+	 * Install or upgrade the worktree inventory table.
+	 */
+	public static function install_schema(): void {
+		global $wpdb;
+
+		if ( ! isset( $wpdb ) ) {
+			return;
+		}
+
+		$table           = self::table_name();
+		$charset_collate = method_exists( $wpdb, 'get_charset_collate' ) ? $wpdb->get_charset_collate() : '';
+		$sql             = "CREATE TABLE {$table} (
+			id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+			handle varchar(191) NOT NULL,
+			repo varchar(191) NOT NULL DEFAULT '',
+			branch varchar(191) DEFAULT NULL,
+			path text NOT NULL,
+			primary_path text DEFAULT NULL,
+			is_primary tinyint(1) NOT NULL DEFAULT 0,
+			lifecycle_state varchar(64) DEFAULT NULL,
+			origin_site varchar(191) DEFAULT NULL,
+			origin_agent varchar(191) DEFAULT NULL,
+			origin_session varchar(191) DEFAULT NULL,
+			task_url text DEFAULT NULL,
+			task_ref varchar(191) DEFAULT NULL,
+			pr_url text DEFAULT NULL,
+			created_at datetime DEFAULT NULL,
+			last_seen_at datetime DEFAULT NULL,
+			last_probe_at datetime DEFAULT NULL,
+			last_probe_status varchar(64) DEFAULT NULL,
+			dirty_count int(11) DEFAULT NULL,
+			unpushed_count int(11) DEFAULT NULL,
+			artifact_count int(11) DEFAULT NULL,
+			artifact_size_bytes bigint(20) unsigned DEFAULT NULL,
+			size_bytes bigint(20) unsigned DEFAULT NULL,
+			cleanup_signal varchar(64) DEFAULT NULL,
+			missing_path tinyint(1) NOT NULL DEFAULT 0,
+			metadata longtext DEFAULT NULL,
+			updated_at datetime NOT NULL,
+			PRIMARY KEY  (id),
+			UNIQUE KEY handle (handle),
+			KEY repo (repo),
+			KEY lifecycle_state (lifecycle_state),
+			KEY last_seen_at (last_seen_at),
+			KEY missing_path (missing_path)
+		) {$charset_collate};";
+
+		if ( ! function_exists( 'dbDelta' ) && defined( 'ABSPATH' ) && file_exists( ABSPATH . 'wp-admin/includes/upgrade.php' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		}
+
+		if ( function_exists( 'dbDelta' ) ) {
+			dbDelta( $sql );
+		} else {
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Static schema string.
+			$wpdb->query( $sql );
+		}
+
+		if ( function_exists( 'update_option' ) ) {
+			update_option( 'datamachine_code_worktrees_schema_version', '1' );
+		}
+	}
+
+	/**
+	 * Return the prefixed table name.
+	 */
+	public static function table_name(): string {
+		global $wpdb;
+		$prefix = isset( $wpdb->prefix ) ? (string) $wpdb->prefix : '';
+		return $prefix . self::TABLE;
+	}
+
+	/**
+	 * Upsert one inventory row.
+	 *
+	 * @param array<string,mixed> $row Inventory row.
+	 * @return bool
+	 */
+	public function upsert( array $row ): bool {
+		global $wpdb;
+
+		if ( ! isset( $wpdb ) ) {
+			return false;
+		}
+
+		$data = $this->normalize_row( $row );
+		if ( '' === $data['handle'] ) {
+			return false;
+		}
+
+		if ( method_exists( $wpdb, 'replace' ) ) {
+			$result = $wpdb->replace( self::table_name(), $data );
+			return false !== $result;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Delete one inventory row by handle.
+	 */
+	public function delete( string $handle ): bool {
+		global $wpdb;
+
+		$handle = trim( $handle );
+		if ( '' === $handle || ! isset( $wpdb ) || ! method_exists( $wpdb, 'delete' ) ) {
+			return false;
+		}
+
+		$result = $wpdb->delete( self::table_name(), array( 'handle' => $handle ) );
+		return false !== $result;
+	}
+
+	/**
+	 * Mark a known row as missing on disk instead of dropping it silently.
+	 */
+	public function mark_missing( string $handle ): bool {
+		global $wpdb;
+
+		$handle = trim( $handle );
+		if ( '' === $handle || ! isset( $wpdb ) || ! method_exists( $wpdb, 'update' ) ) {
+			return false;
+		}
+
+		$result = $wpdb->update(
+			self::table_name(),
+			array(
+				'missing_path'      => 1,
+				'last_probe_at'     => current_time( 'mysql', true ),
+				'last_probe_status' => 'missing_path',
+				'updated_at'        => current_time( 'mysql', true ),
+			),
+			array( 'handle' => $handle )
+		);
+
+		return false !== $result;
+	}
+
+	/**
+	 * Fetch all rows, optionally filtered by repo.
+	 *
+	 * @return array<int,array<string,mixed>>
+	 */
+	public function list( ?string $repo = null ): array {
+		global $wpdb;
+
+		if ( ! isset( $wpdb ) || ! method_exists( $wpdb, 'get_results' ) ) {
+			return array();
+		}
+
+		$table = self::table_name();
+		if ( null !== $repo && '' !== trim( $repo ) && method_exists( $wpdb, 'prepare' ) ) {
+			$sql = $wpdb->prepare( "SELECT * FROM {$table} WHERE repo = %s ORDER BY handle ASC", $repo );
+		} else {
+			$sql = "SELECT * FROM {$table} ORDER BY handle ASC";
+		}
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Prepared above when dynamic input is present.
+		$rows = $wpdb->get_results( $sql, ARRAY_A );
+		return is_array( $rows ) ? array_map( array( $this, 'decode_row' ), $rows ) : array();
+	}
+
+	/**
+	 * Summarize inventory freshness for hygiene output.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public function freshness(): array {
+		$rows       = $this->list();
+		$total      = count( $rows );
+		$missing    = 0;
+		$last_probe = null;
+		foreach ( $rows as $row ) {
+			if ( ! empty( $row['missing_path'] ) ) {
+				++$missing;
+			}
+			if ( ! empty( $row['last_probe_at'] ) && ( null === $last_probe || strcmp( (string) $row['last_probe_at'], (string) $last_probe ) > 0 ) ) {
+				$last_probe = $row['last_probe_at'];
+			}
+		}
+
+		return array(
+			'table'         => self::table_name(),
+			'total_rows'    => $total,
+			'missing_paths' => $missing,
+			'last_probe_at' => $last_probe,
+			'fresh'         => 0 < $total && null !== $last_probe,
+		);
+	}
+
+	/**
+	 * Normalize runtime/listing rows for DB storage.
+	 *
+	 * @param array<string,mixed> $row Input row.
+	 * @return array<string,mixed>
+	 */
+	private function normalize_row( array $row ): array {
+		$metadata = is_array( $row['metadata'] ?? null ) ? (array) $row['metadata'] : array();
+		$owner    = is_array( $row['owner'] ?? null ) ? (array) $row['owner'] : array();
+		$session  = is_array( $row['session'] ?? null ) ? (array) $row['session'] : array();
+		$task     = is_array( $row['task'] ?? null ) ? (array) $row['task'] : ( is_array( $metadata['origin_task'] ?? null ) ? (array) $metadata['origin_task'] : array() );
+
+		return array(
+			'handle'              => (string) ( $row['handle'] ?? $metadata['handle'] ?? '' ),
+			'repo'                => (string) ( $row['repo'] ?? $metadata['repo'] ?? '' ),
+			'branch'              => isset( $row['branch'] ) ? (string) $row['branch'] : ( isset( $metadata['branch'] ) ? (string) $metadata['branch'] : null ),
+			'path'                => (string) ( $row['path'] ?? $metadata['path'] ?? '' ),
+			'primary_path'        => isset( $row['primary_path'] ) ? (string) $row['primary_path'] : null,
+			'is_primary'          => ! empty( $row['is_primary'] ) ? 1 : 0,
+			'lifecycle_state'     => isset( $row['lifecycle_state'] ) ? (string) $row['lifecycle_state'] : ( isset( $metadata['lifecycle_state'] ) ? (string) $metadata['lifecycle_state'] : null ),
+			'origin_site'         => (string) ( $owner['site'] ?? $metadata['origin_site'] ?? $metadata['origin_site_name'] ?? '' ),
+			'origin_agent'        => (string) ( $owner['agent'] ?? $metadata['origin_agent'] ?? '' ),
+			'origin_session'      => isset( $session['primary_id'] ) ? (string) $session['primary_id'] : ( isset( $metadata['origin_session'] ) ? (string) $metadata['origin_session'] : null ),
+			'task_url'            => isset( $task['task_url'] ) ? (string) $task['task_url'] : null,
+			'task_ref'            => isset( $task['task_ref'] ) ? (string) $task['task_ref'] : null,
+			'pr_url'              => isset( $row['pr_url'] ) ? (string) $row['pr_url'] : ( isset( $metadata['pr_url'] ) ? (string) $metadata['pr_url'] : null ),
+			'created_at'          => $this->datetime( $row['created_at'] ?? $metadata['created_at'] ?? null ),
+			'last_seen_at'        => $this->datetime( $row['last_seen_at'] ?? $metadata['last_seen_at'] ?? null ),
+			'last_probe_at'       => current_time( 'mysql', true ),
+			'last_probe_status'   => ! empty( $row['missing_path'] ) ? 'missing_path' : 'present',
+			'dirty_count'         => isset( $row['dirty'] ) ? ( null === $row['dirty'] ? null : (int) $row['dirty'] ) : ( isset( $row['dirty_count'] ) ? (int) $row['dirty_count'] : null ),
+			'unpushed_count'      => isset( $row['unpushed_count'] ) ? (int) $row['unpushed_count'] : null,
+			'artifact_count'      => isset( $row['artifacts'] ) && is_array( $row['artifacts'] ) ? count( $row['artifacts'] ) : ( isset( $row['artifact_count'] ) ? (int) $row['artifact_count'] : null ),
+			'artifact_size_bytes' => isset( $row['artifact_size_bytes'] ) ? (int) $row['artifact_size_bytes'] : null,
+			'size_bytes'          => isset( $row['size_bytes'] ) ? ( null === $row['size_bytes'] ? null : (int) $row['size_bytes'] ) : null,
+			'cleanup_signal'      => $this->cleanup_signal( $row, $metadata ),
+			'missing_path'        => ! empty( $row['missing_path'] ) ? 1 : 0,
+			'metadata'            => wp_json_encode( $metadata ),
+			'updated_at'          => current_time( 'mysql', true ),
+		);
+	}
+
+	/**
+	 * Decode JSON columns in DB rows.
+	 *
+	 * @param array<string,mixed> $row DB row.
+	 * @return array<string,mixed>
+	 */
+	private function decode_row( array $row ): array {
+		$decoded = isset( $row['metadata'] ) && is_string( $row['metadata'] ) ? json_decode( $row['metadata'], true ) : null;
+		$row['metadata'] = is_array( $decoded ) ? $decoded : null;
+		foreach ( array( 'id', 'is_primary', 'dirty_count', 'unpushed_count', 'artifact_count', 'artifact_size_bytes', 'size_bytes', 'missing_path' ) as $key ) {
+			if ( isset( $row[ $key ] ) ) {
+				$row[ $key ] = (int) $row[ $key ];
+			}
+		}
+		return $row;
+	}
+
+	/**
+	 * Normalize ISO or MySQL dates to GMT MySQL format.
+	 */
+	private function datetime( mixed $value ): ?string {
+		if ( ! is_string( $value ) || '' === trim( $value ) ) {
+			return null;
+		}
+
+		$timestamp = strtotime( $value );
+		if ( false === $timestamp ) {
+			return null;
+		}
+
+		return gmdate( 'Y-m-d H:i:s', $timestamp );
+	}
+
+	/**
+	 * Derive the explicit cleanup signal stored in the inventory row.
+	 *
+	 * @param array<string,mixed> $row      Inventory row.
+	 * @param array<string,mixed> $metadata Lifecycle metadata.
+	 */
+	private function cleanup_signal( array $row, array $metadata ): ?string {
+		if ( ! empty( $row['cleanup_signal'] ) ) {
+			return (string) $row['cleanup_signal'];
+		}
+
+		$state = (string) ( $row['lifecycle_state'] ?? $metadata['lifecycle_state'] ?? '' );
+		if ( in_array( $state, array( 'cleanup_eligible', 'pr_opened', 'merged', 'closed', 'abandoned' ), true ) ) {
+			return $state;
+		}
+
+		return null;
+	}
+}

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -16,6 +16,7 @@ use DataMachine\Core\FilesRepository\FilesystemHelper;
 use DataMachineCode\Support\GitHubRemote;
 use DataMachineCode\Support\GitRunner;
 use DataMachineCode\Support\PathSecurity;
+use DataMachineCode\Storage\WorktreeInventoryRepository;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -64,6 +65,17 @@ class Workspace {
 
 	public function __construct() {
 		$this->workspace_path = self::resolve_workspace_directory();
+	}
+
+	/**
+	 * Worktree inventory repository factory.
+	 */
+	private function worktree_inventory(): WorktreeInventoryRepository {
+		if ( ! class_exists( WorktreeInventoryRepository::class ) ) {
+			require_once dirname( __DIR__ ) . '/Storage/WorktreeInventoryRepository.php';
+		}
+
+		return new WorktreeInventoryRepository();
 	}
 
 	/**
@@ -626,6 +638,7 @@ class Workspace {
 					fn() => $this->run_git( $primary_path, 'worktree prune' )
 				);
 			}
+			$this->worktree_inventory()->delete( $parsed['dir_name'] );
 		}
 
 		return array(
@@ -1334,6 +1347,8 @@ class Workspace {
 			$response['bootstrap'] = WorktreeBootstrapper::bootstrap( $wt_path );
 		}
 
+		$this->worktree_inventory()->upsert( $this->build_worktree_inventory_row_from_handle( $wt_handle ) );
+
 		return $response;
 	}
 
@@ -1594,6 +1609,7 @@ class Workspace {
 		WorktreeContextInjector::store_lifecycle_metadata( $parsed['dir_name'], $metadata );
 
 		$stored = WorktreeContextInjector::get_metadata( $parsed['dir_name'] ) ?? array();
+		$this->worktree_inventory()->upsert( $this->build_worktree_inventory_row_from_handle( $parsed['dir_name'] ) );
 		return array(
 			'success'         => true,
 			'handle'          => $parsed['dir_name'],
@@ -1654,6 +1670,7 @@ class Workspace {
 		// refresh-context is a deliberate liveness signal: the originating site
 		// (and therefore some agent process there) just touched this worktree.
 		WorktreeContextInjector::record_heartbeat( $parsed['dir_name'] );
+		$this->worktree_inventory()->upsert( $this->build_worktree_inventory_row_from_handle( $parsed['dir_name'] ) );
 
 		return array(
 			'success'      => true,
@@ -1861,6 +1878,110 @@ class Workspace {
 	}
 
 	/**
+	 * Refresh the DB-backed worktree inventory from the current filesystem/git view.
+	 *
+	 * Current rows are upserted. Previously known rows missing from the current
+	 * scan are marked `missing_path` so operators can see drift explicitly.
+	 *
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function worktree_inventory_refresh(): array|\WP_Error {
+		$listing = $this->worktree_list(
+			null,
+			null,
+			array(
+				'include_status' => false,
+				'include_disk'   => false,
+			)
+		);
+		if ( $listing instanceof \WP_Error ) {
+			return $listing;
+		}
+
+		$repository      = $this->worktree_inventory();
+		$current_handles = array();
+		$upserted        = array();
+		$marked_missing  = array();
+
+		foreach ( (array) ( $listing['worktrees'] ?? array() ) as $row ) {
+			$handle = (string) ( $row['handle'] ?? '' );
+			if ( '' === $handle || ! empty( $row['external'] ) ) {
+				continue;
+			}
+
+			$current_handles[ $handle ] = true;
+			if ( $repository->upsert( $row ) ) {
+				$upserted[] = $handle;
+			}
+		}
+
+		foreach ( $repository->list() as $stored ) {
+			$handle = (string) ( $stored['handle'] ?? '' );
+			if ( '' === $handle || isset( $current_handles[ $handle ] ) ) {
+				continue;
+			}
+
+			if ( $repository->mark_missing( $handle ) ) {
+				$marked_missing[] = $handle;
+			}
+		}
+
+		return array(
+			'success'        => true,
+			'refreshed_at'   => gmdate( 'c' ),
+			'upserted'       => $upserted,
+			'marked_missing' => $marked_missing,
+			'summary'        => array(
+				'upserted'       => count( $upserted ),
+				'marked_missing' => count( $marked_missing ),
+			),
+		);
+	}
+
+	/**
+	 * Build a single inventory row for a known workspace handle.
+	 *
+	 * @param string $handle Workspace handle.
+	 * @return array<string,mixed>
+	 */
+	private function build_worktree_inventory_row_from_handle( string $handle ): array {
+		$parsed   = $this->parse_handle( $handle );
+		$path     = $this->workspace_path . '/' . $parsed['dir_name'];
+		$metadata = $parsed['is_worktree'] ? WorktreeContextInjector::get_metadata( $parsed['dir_name'] ) : null;
+		$metadata = is_array( $metadata ) ? $metadata : array();
+		$liveness = WorktreeContextInjector::classify_liveness( $metadata );
+		$owner    = WorktreeContextInjector::summarize_owner( $metadata );
+		$session  = WorktreeContextInjector::summarize_session( $metadata );
+		$task     = is_array( $metadata['origin_task'] ?? null ) ? (array) $metadata['origin_task'] : null;
+
+		return array(
+			'handle'                => $parsed['dir_name'],
+			'repo'                  => $parsed['repo'],
+			'is_worktree'           => $parsed['is_worktree'],
+			'is_primary'            => ! $parsed['is_worktree'],
+			'external'              => false,
+			'branch_slug'           => $parsed['branch_slug'],
+			'branch'                => $metadata['branch'] ?? $parsed['branch_slug'],
+			'path'                  => $path,
+			'primary_path'          => $this->get_primary_path( $parsed['repo'] ),
+			'dirty'                 => null,
+			'created_at'            => $metadata['created_at'] ?? null,
+			'lifecycle_state'       => $metadata['lifecycle_state'] ?? null,
+			'pr_url'                => $metadata['pr_url'] ?? null,
+			'pr_number'             => $metadata['pr_number'] ?? null,
+			'last_seen_at'          => $metadata['last_seen_at'] ?? null,
+			'liveness'              => $liveness['liveness'],
+			'liveness_reason'       => $liveness['reason'],
+			'heartbeat_age_seconds' => $liveness['heartbeat_age_seconds'],
+			'owner'                 => $owner,
+			'session'               => $session,
+			'task'                  => $task,
+			'missing_path'          => ! is_dir( $path ),
+			'metadata'              => $metadata,
+		);
+	}
+
+	/**
 	 * Build a non-destructive workspace hygiene report.
 	 *
 	 * The report intentionally defaults to local-only cleanup detection so an
@@ -1879,7 +2000,16 @@ class Workspace {
 		$include_cleanup         = array_key_exists( 'include_cleanup', $opts ) ? (bool) $opts['include_cleanup'] : true;
 		$include_sizes           = array_key_exists( 'include_sizes', $opts ) ? (bool) $opts['include_sizes'] : true;
 		$include_worktree_status = array_key_exists( 'include_worktree_status', $opts ) ? (bool) $opts['include_worktree_status'] : false;
+		$refresh_inventory       = ! empty( $opts['refresh_inventory'] );
 		$size_limit              = isset( $opts['size_limit'] ) ? max( 0, (int) $opts['size_limit'] ) : self::HYGIENE_DEFAULT_SIZE_LIMIT;
+
+		$inventory_refresh = null;
+		if ( $refresh_inventory ) {
+			$inventory_refresh = $this->worktree_inventory_refresh();
+			if ( $inventory_refresh instanceof \WP_Error ) {
+				return $inventory_refresh;
+			}
+		}
 
 		if ( $include_worktree_status ) {
 			$listing = $this->worktree_list();
@@ -1921,6 +2051,10 @@ class Workspace {
 			'destructive'               => false,
 			'size'                      => $size_report,
 			'disk'                      => $this->build_workspace_disk_report(),
+			'inventory'                 => array(
+				'freshness' => $this->worktree_inventory()->freshness(),
+				'refresh'   => $inventory_refresh,
+			),
 			'worktrees'                 => $this->summarize_workspace_worktrees( $worktrees, $cleanup ),
 			'worktree_status_mode'      => $worktree_status_mode,
 			'top_repos_by_worktrees'    => $this->top_repos_by_worktree_count( $worktrees, 10 ),
@@ -2714,6 +2848,7 @@ class Workspace {
 				}
 
 				WorktreeContextInjector::forget_metadata( $wt_handle );
+				$this->worktree_inventory()->delete( $wt_handle );
 				return $result;
 			}
 		);
@@ -2764,9 +2899,15 @@ class Workspace {
 			$pruned[] = $entry;
 		}
 
+		$refresh = $this->worktree_inventory_refresh();
+		if ( $refresh instanceof \WP_Error ) {
+			return $refresh;
+		}
+
 		return array(
 			'success' => true,
 			'pruned'  => $pruned,
+			'inventory' => $refresh,
 		);
 	}
 
@@ -6512,6 +6653,7 @@ class Workspace {
 		}
 
 		WorktreeContextInjector::forget_metadata( basename( $wt_path ) );
+		$this->worktree_inventory()->delete( basename( $wt_path ) );
 
 		return array(
 			'success' => true,

--- a/tests/smoke-workspace-hygiene-cli.php
+++ b/tests/smoke-workspace-hygiene-cli.php
@@ -84,6 +84,13 @@ namespace {
 			'disk'                      => array(
 				'free_human' => '1.1 GiB',
 			),
+			'inventory'                 => array(
+				'freshness' => array(
+					'total_rows'    => 42,
+					'missing_paths' => 4,
+					'last_probe_at' => '2026-05-04 12:00:00',
+				),
+			),
 			'worktrees'                 => array(
 				'worktrees'          => 42,
 				'artifacts'          => 1,
@@ -123,18 +130,35 @@ namespace {
 		}
 	}
 
+	class FakeInventoryRefreshAbility {
+		public int $calls = 0;
+
+		public function execute( array $input ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+			++$this->calls;
+			return array(
+				'success' => true,
+				'summary' => array(
+					'upserted'       => 3,
+					'marked_missing' => 1,
+				),
+			);
+		}
+	}
+
 	echo "=== smoke-workspace-hygiene-cli ===\n";
 
 	$ability                 = new FakeHygieneAbility();
+	$inventory_ability       = new FakeInventoryRefreshAbility();
 	$GLOBALS['__abilities'] = array(
-		'datamachine/workspace-hygiene-report' => $ability,
+		'datamachine/workspace-hygiene-report'             => $ability,
+		'datamachine/workspace-worktree-inventory-refresh' => $inventory_ability,
 	);
 	$command = new \DataMachineCode\Cli\Commands\WorkspaceCommand();
 
 	echo "\n[1] JSON output is parseable and forwards bounded flags\n";
 	$GLOBALS['__cli_logs'] = array();
 	$command->hygiene( array(), array( 'format' => 'json', 'skip-cleanup' => true, 'skip-sizes' => true, 'size-limit' => '25' ) );
-	datamachine_code_hygiene_assert( array( 'include_cleanup' => false, 'include_sizes' => false, 'include_worktree_status' => false, 'size_limit' => 25 ) === $ability->last_input, 'CLI forwards skip flags, status mode, and size limit' );
+	datamachine_code_hygiene_assert( array( 'include_cleanup' => false, 'include_sizes' => false, 'include_worktree_status' => false, 'refresh_inventory' => false, 'size_limit' => 25 ) === $ability->last_input, 'CLI forwards skip flags, status mode, inventory mode, and size limit' );
 	datamachine_code_hygiene_assert( 1 === count( $GLOBALS['__cli_logs'] ), 'JSON path writes one stdout document' );
 	$decoded = json_decode( (string) $GLOBALS['__cli_logs'][0], true );
 	datamachine_code_hygiene_assert( JSON_ERROR_NONE === json_last_error(), 'JSON output parses cleanly' );
@@ -146,18 +170,26 @@ namespace {
 	$GLOBALS['__cli_logs'] = array();
 	$command->hygiene( array(), array( 'format' => 'json', 'include-worktree-status' => true ) );
 	datamachine_code_hygiene_assert( true === ( $ability->last_input['include_worktree_status'] ?? false ), 'CLI forwards explicit worktree status opt-in' );
+	$command->hygiene( array(), array( 'format' => 'json', 'refresh-inventory' => true ) );
+	datamachine_code_hygiene_assert( true === ( $ability->last_input['refresh_inventory'] ?? false ), 'CLI forwards explicit inventory refresh opt-in' );
 
 	echo "\n[3] Human output is summary-first and includes actionable sections\n";
 	$GLOBALS['__cli_logs'] = array();
 	$command->hygiene( array(), array() );
 	datamachine_code_hygiene_assert( 'Workspace hygiene:' === ( $GLOBALS['__cli_logs'][0] ?? '' ), 'human output starts with report heading' );
-	datamachine_code_hygiene_assert( in_array( 'table:18:metric,value', $GLOBALS['__cli_logs'], true ), 'human output renders summary table (now includes 4 liveness counts + duplicate_task_groups)' );
+	datamachine_code_hygiene_assert( in_array( 'table:21:metric,value', $GLOBALS['__cli_logs'], true ), 'human output renders summary table with inventory freshness metrics' );
 	datamachine_code_hygiene_assert( in_array( 'Workspace size by kind:', $GLOBALS['__cli_logs'], true ), 'human output renders size kind grouping' );
 	datamachine_code_hygiene_assert( in_array( 'Top workspace entries by size:', $GLOBALS['__cli_logs'], true ), 'human output renders top offenders' );
 	datamachine_code_hygiene_assert( in_array( 'Top repos by size:', $GLOBALS['__cli_logs'], true ), 'human output renders size leaders' );
 	datamachine_code_hygiene_assert( in_array( 'Top repos by worktree count:', $GLOBALS['__cli_logs'], true ), 'human output renders worktree-count leaders' );
 	datamachine_code_hygiene_assert( in_array( 'Cleanup candidates:', $GLOBALS['__cli_logs'], true ), 'human output renders cleanup candidates' );
 	datamachine_code_hygiene_assert( in_array( 'Suggested cleanup review:', $GLOBALS['__cli_logs'], true ), 'human output renders cleanup command' );
+
+	echo "\n[4] Inventory refresh CLI delegates to ability\n";
+	$GLOBALS['__cli_logs'] = array();
+	$command->inventory( array( 'refresh' ), array() );
+	datamachine_code_hygiene_assert( 1 === $inventory_ability->calls, 'inventory refresh CLI calls inventory ability' );
+	datamachine_code_hygiene_assert( in_array( 'success: Inventory refreshed: 3 upserted, 1 marked missing.', $GLOBALS['__cli_logs'], true ), 'inventory refresh CLI prints summary' );
 
 	echo "\nAll workspace hygiene CLI smoke tests passed.\n";
 }

--- a/tests/smoke-worktree-inventory-repository.php
+++ b/tests/smoke-worktree-inventory-repository.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Smoke test for DB-backed worktree inventory repository.
+ *
+ * Run: php tests/smoke-worktree-inventory-repository.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+declare( strict_types=1 );
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! defined( 'ARRAY_A' ) ) {
+	define( 'ARRAY_A', 'ARRAY_A' );
+}
+
+function current_time( string $type, bool $gmt = false ): string { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+	return '2026-05-04 12:00:00';
+}
+
+function wp_json_encode( mixed $value, int $flags = 0, int $depth = 512 ): string|false {
+	return json_encode( $value, $flags, $depth );
+}
+
+function update_option( string $name, mixed $value ): bool {
+	$GLOBALS['datamachine_code_test_options'][ $name ] = $value;
+	return true;
+}
+
+function dbDelta( string $sql ): array {
+	$GLOBALS['datamachine_code_test_schema_sql'] = $sql;
+	return array( 'ok' );
+}
+
+class DatamachineCodeInventoryFakeWpdb {
+	public string $prefix = 'wp_';
+
+	/** @var array<string,array<string,mixed>> */
+	public array $rows = array();
+
+	public function get_charset_collate(): string {
+		return 'DEFAULT CHARSET=utf8mb4';
+	}
+
+	/** @param array<string,mixed> $data */
+	public function replace( string $table, array $data ): int { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		$this->rows[ (string) $data['handle'] ] = $data;
+		return 1;
+	}
+
+	/** @param array<string,mixed> $where */
+	public function delete( string $table, array $where ): int { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		unset( $this->rows[ (string) $where['handle'] ] );
+		return 1;
+	}
+
+	/** @param array<string,mixed> $data @param array<string,mixed> $where */
+	public function update( string $table, array $data, array $where ): int { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		$handle = (string) $where['handle'];
+		if ( ! isset( $this->rows[ $handle ] ) ) {
+			return 0;
+		}
+		$this->rows[ $handle ] = array_merge( $this->rows[ $handle ], $data );
+		return 1;
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	public function get_results( string $sql, string $output ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		$rows = array_values( $this->rows );
+		usort( $rows, fn( array $a, array $b ): int => strcmp( (string) $a['handle'], (string) $b['handle'] ) );
+		return $rows;
+	}
+
+	public function prepare( string $query, mixed ...$args ): string {
+		foreach ( $args as $arg ) {
+			$query = preg_replace( '/%s/', "'" . addslashes( (string) $arg ) . "'", $query, 1 );
+		}
+		return $query;
+	}
+}
+
+require_once dirname( __DIR__ ) . '/inc/Storage/WorktreeInventoryRepository.php';
+
+use DataMachineCode\Storage\WorktreeInventoryRepository;
+
+function datamachine_code_inventory_assert( bool $condition, string $message ): void {
+	if ( $condition ) {
+		echo "  [PASS] {$message}\n";
+		return;
+	}
+	echo "  [FAIL] {$message}\n";
+	exit( 1 );
+}
+
+echo "=== smoke-worktree-inventory-repository ===\n";
+
+$GLOBALS['wpdb'] = new DatamachineCodeInventoryFakeWpdb();
+
+WorktreeInventoryRepository::install_schema();
+datamachine_code_inventory_assert( str_contains( (string) $GLOBALS['datamachine_code_test_schema_sql'], 'datamachine_code_worktrees' ), 'schema creates worktree table' );
+datamachine_code_inventory_assert( '1' === $GLOBALS['datamachine_code_test_options']['datamachine_code_worktrees_schema_version'], 'schema version is recorded' );
+
+$repository = new WorktreeInventoryRepository();
+$repository->upsert(
+	array(
+		'handle'          => 'demo@feature',
+		'repo'            => 'demo',
+		'branch'          => 'feature',
+		'path'            => '/workspace/demo@feature',
+		'lifecycle_state' => 'active',
+		'owner'           => array( 'site' => 'Test Site', 'agent' => 'Franklin' ),
+		'session'         => array( 'primary_id' => 'ses_123' ),
+		'task'            => array( 'task_url' => 'https://github.com/Extra-Chill/data-machine-code/issues/243' ),
+		'metadata'        => array(
+			'created_at'      => '2026-05-04T11:59:00Z',
+			'lifecycle_state' => 'active',
+		),
+	)
+);
+
+$rows = $repository->list();
+datamachine_code_inventory_assert( 1 === count( $rows ), 'upsert writes one row' );
+datamachine_code_inventory_assert( 'demo@feature' === $rows[0]['handle'], 'handle is stable inventory key' );
+datamachine_code_inventory_assert( 'present' === $rows[0]['last_probe_status'], 'upsert marks present probe status' );
+datamachine_code_inventory_assert( 'active' === ( $rows[0]['metadata']['lifecycle_state'] ?? '' ), 'metadata JSON round-trips' );
+
+$repository->upsert(
+	array(
+		'handle'          => 'demo@feature',
+		'repo'            => 'demo',
+		'branch'          => 'feature',
+		'path'            => '/workspace/demo@feature',
+		'lifecycle_state' => 'cleanup_eligible',
+		'pr_url'          => 'https://github.com/acme/demo/pull/7',
+		'metadata'        => array( 'lifecycle_state' => 'cleanup_eligible' ),
+	)
+);
+
+$rows = $repository->list();
+datamachine_code_inventory_assert( 'cleanup_eligible' === $rows[0]['lifecycle_state'], 'second upsert updates lifecycle state' );
+datamachine_code_inventory_assert( 'cleanup_eligible' === $rows[0]['cleanup_signal'], 'cleanup signal is derived from lifecycle state' );
+
+$repository->mark_missing( 'demo@feature' );
+$rows = $repository->list();
+datamachine_code_inventory_assert( 1 === $rows[0]['missing_path'], 'missing path is recorded instead of silently disappearing' );
+datamachine_code_inventory_assert( 'missing_path' === $rows[0]['last_probe_status'], 'missing path probe status is recorded' );
+
+$freshness = $repository->freshness();
+datamachine_code_inventory_assert( 1 === $freshness['total_rows'], 'freshness reports total row count' );
+datamachine_code_inventory_assert( 1 === $freshness['missing_paths'], 'freshness reports missing path count' );
+
+$repository->delete( 'demo@feature' );
+datamachine_code_inventory_assert( array() === $repository->list(), 'delete removes inventory row' );
+
+echo "\nAll worktree inventory repository assertions passed.\n";

--- a/tests/smoke-worktree-lifecycle-metadata.php
+++ b/tests/smoke-worktree-lifecycle-metadata.php
@@ -50,6 +50,10 @@ namespace {
 		define( 'ABSPATH', __DIR__ . '/' );
 	}
 
+	if ( ! defined( 'ARRAY_A' ) ) {
+		define( 'ARRAY_A', 'ARRAY_A' );
+	}
+
 	if ( ! class_exists( 'WP_Error' ) ) {
 		class WP_Error {
 			public string $code;
@@ -99,6 +103,56 @@ namespace {
 		}
 	}
 
+	if ( ! function_exists( 'current_time' ) ) {
+		function current_time( string $type, bool $gmt = false ): string { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+			return gmdate( 'Y-m-d H:i:s' );
+		}
+	}
+
+	if ( ! function_exists( 'wp_json_encode' ) ) {
+		function wp_json_encode( mixed $value, int $flags = 0, int $depth = 512 ): string|false {
+			return json_encode( $value, $flags, $depth );
+		}
+	}
+
+	class DatamachineCodeLifecycleInventoryWpdb {
+		public string $prefix = 'wp_';
+
+		/** @var array<string,array<string,mixed>> */
+		public array $rows = array();
+
+		/** @param array<string,mixed> $data */
+		public function replace( string $table, array $data ): int { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+			$this->rows[ (string) $data['handle'] ] = $data;
+			return 1;
+		}
+
+		/** @param array<string,mixed> $where */
+		public function delete( string $table, array $where ): int { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+			unset( $this->rows[ (string) $where['handle'] ] );
+			return 1;
+		}
+
+		/** @param array<string,mixed> $data @param array<string,mixed> $where */
+		public function update( string $table, array $data, array $where ): int { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+			$handle = (string) $where['handle'];
+			if ( ! isset( $this->rows[ $handle ] ) ) {
+				return 0;
+			}
+			$this->rows[ $handle ] = array_merge( $this->rows[ $handle ], $data );
+			return 1;
+		}
+
+		/** @return array<int,array<string,mixed>> */
+		public function get_results( string $sql, string $output ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+			return array_values( $this->rows );
+		}
+
+		public function prepare( string $query, mixed ...$args ): string {
+			return $query;
+		}
+	}
+
 	if ( ! function_exists( 'apply_filters' ) ) {
 		function apply_filters( string $hook_name, $value, ...$args ) {
 			global $datamachine_code_test_filters;
@@ -139,6 +193,7 @@ namespace {
 	require __DIR__ . '/../inc/Support/GitHubRemote.php';
 	require __DIR__ . '/../inc/Support/GitRunner.php';
 	require __DIR__ . '/../inc/Support/PathSecurity.php';
+	require __DIR__ . '/../inc/Storage/WorktreeInventoryRepository.php';
 	require __DIR__ . '/../inc/Workspace/WorkspaceMutationLock.php';
 	require __DIR__ . '/../inc/Workspace/WorktreeStalenessProbe.php';
 	require __DIR__ . '/../inc/Workspace/WorktreeDiskBudget.php';
@@ -200,6 +255,7 @@ namespace {
 	putenv( 'OPENCODE_PID=12345' );
 
 	$ws = new \DataMachineCode\Workspace\Workspace();
+	$GLOBALS['wpdb'] = new DatamachineCodeLifecycleInventoryWpdb();
 
 	$GLOBALS['datamachine_code_test_filters']['datamachine_worktree_disk_budget_thresholds'] = function ( array $thresholds ): array {
 		$thresholds['refuse_free_bytes'] = PHP_INT_MAX;
@@ -217,6 +273,8 @@ namespace {
 	$assert( true, ! is_wp_error( $result ) && ( $result['success'] ?? false ), 'worktree_add succeeds without context injection' );
 
 	$metadata = \DataMachineCode\Workspace\WorktreeContextInjector::get_metadata( 'demo@feature-metadata' );
+	$assert( true, isset( $GLOBALS['wpdb']->rows['demo@feature-metadata'] ), 'worktree_add writes DB inventory row' );
+	$assert( 'active', $GLOBALS['wpdb']->rows['demo@feature-metadata']['lifecycle_state'] ?? null, 'worktree_add inventory row starts active' );
 	$assert( true, is_array( $metadata ), 'lifecycle metadata recorded at add time' );
 	$assert( 'Origin Site', $metadata['origin_site'] ?? null, 'origin site is recorded' );
 	$assert( 'agent-one', $metadata['origin_agent'] ?? null, 'origin agent is recorded' );
@@ -242,6 +300,8 @@ namespace {
 	$assert( true, isset( $finalized['metadata']['cleanup_eligible_at'] ), 'PR finalizer records cleanup eligibility timestamp' );
 	$assert( 123, $finalized['metadata']['pr_number'] ?? null, 'finalizer extracts PR number' );
 	$assert( 'https://github.com/acme/demo/pull/123', $finalized['metadata']['pr_url'] ?? null, 'finalizer stores normalized PR URL' );
+	$assert( 'cleanup_eligible', $GLOBALS['wpdb']->rows['demo@feature-metadata']['lifecycle_state'] ?? null, 'worktree_finalize updates DB inventory lifecycle state' );
+	$assert( 'cleanup_eligible', $GLOBALS['wpdb']->rows['demo@feature-metadata']['cleanup_signal'] ?? null, 'worktree_finalize records cleanup signal in DB inventory' );
 
 	$filtered = $ws->worktree_list( 'demo', 'cleanup_eligible' );
 	$filtered_items = array_values( array_filter( $filtered['worktrees'] ?? array(), fn( $wt ) => ( $wt['handle'] ?? '' ) === 'demo@feature-metadata' ) );
@@ -260,6 +320,9 @@ namespace {
 
 	$result_old = $ws->worktree_add( 'demo', 'feature/old-record', 'HEAD', false, false, true, false );
 	$assert( true, ! is_wp_error( $result_old ) && ( $result_old['success'] ?? false ), 'second worktree_add succeeds' );
+	$refresh = $ws->worktree_inventory_refresh();
+	$assert( true, ! is_wp_error( $refresh ) && ( $refresh['success'] ?? false ), 'inventory refresh reconciles current worktrees' );
+	$assert( true, in_array( 'demo@feature-old-record', $refresh['upserted'] ?? array(), true ), 'inventory refresh upserts newly observed worktree' );
 	$all_metadata = get_option( \DataMachineCode\Workspace\WorktreeContextInjector::METADATA_OPTION, array() );
 	unset( $all_metadata['demo@feature-old-record'] );
 	update_option( \DataMachineCode\Workspace\WorktreeContextInjector::METADATA_OPTION, $all_metadata, false );
@@ -283,6 +346,10 @@ namespace {
 	$feature_skip = array_values( array_filter( $plan['skipped'] ?? array(), fn( $skip ) => ( $skip['handle'] ?? '' ) === 'demo@feature-metadata' ) );
 	$old_skip = array_values( array_filter( $plan['skipped'] ?? array(), fn( $skip ) => ( $skip['handle'] ?? '' ) === 'demo@feature-old-record' ) );
 	$assert( null, $old_skip[0]['metadata'] ?? null, 'cleanup dry-run tolerates worktrees with missing metadata' );
+
+	$removed_old = $ws->worktree_remove( 'demo', 'feature/old-record', true );
+	$assert( true, ! is_wp_error( $removed_old ) && ( $removed_old['success'] ?? false ), 'worktree_remove succeeds for old record' );
+	$assert( false, isset( $GLOBALS['wpdb']->rows['demo@feature-old-record'] ), 'worktree_remove deletes DB inventory row' );
 
 	if ( $failures > 0 ) {
 		echo "\n{$failures} failure(s) across {$assertions} assertion(s).\n";


### PR DESCRIPTION
## Summary
- Add a DMC-owned `datamachine_code_worktrees` inventory table and repository.
- Refresh/reconcile worktree inventory from filesystem/git state and surface freshness in hygiene output.
- Upsert/delete inventory rows from worktree lifecycle paths like add/finalize/remove/prune.

## Tests
- `php tests/smoke-worktree-inventory-repository.php`
- `php tests/smoke-worktree-lifecycle-metadata.php`
- `php tests/smoke-worktree-finalizer-cli.php`
- `php tests/smoke-worktree-metadata-reconcile.php`
- `php tests/smoke-workspace-hygiene-cli.php`
- `php tests/smoke-workspace-hygiene-report.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafting the DB inventory implementation, tests, and PR description; Chris remains responsible for review and validation.