### PR TITLE
docs: demote cleanup plan file workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ wp datamachine-code workspace worktree list
 wp datamachine-code workspace worktree remove repo-name fix/foo
 wp datamachine-code workspace worktree prune
 
+# Daily workspace cleanup — task-backed, inspectable by run_id
+wp datamachine-code workspace cleanup run --mode=retention
+wp datamachine-code workspace cleanup status cleanup-run-123
+wp datamachine-code workspace cleanup evidence cleanup-run-123 --format=json
+
 # All read/write/git ops accept either <repo> (primary) or <repo>@<branch-slug> (worktree)
 wp datamachine-code workspace read repo-name@fix-foo src/main.php
 wp datamachine-code workspace ls repo-name@fix-foo src/

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -251,8 +251,10 @@ class WorkspaceCommand extends BaseCommand {
 	 *
 	 * This is the high-level operator surface for cleanup. Destructive runs are
 	 * scheduled through Data Machine's system-task scheduler and return immediately
-	 * with job identifiers. Dry-runs stay synchronous and delegate to the same
-	 * workspace abilities as the lower-level `workspace worktree cleanup*` commands.
+	 * with a run_id. Status, resume, cancel, and evidence commands take that run_id.
+	 * Dry-runs stay synchronous and delegate to the same workspace abilities as the
+	 * lower-level `workspace worktree cleanup*` commands until DB-backed cleanup
+	 * plans land.
 	 *
 	 * ## OPTIONS
 	 *
@@ -324,7 +326,7 @@ class WorkspaceCommand extends BaseCommand {
 	 *     # Apply a reviewed DB-backed run
 	 *     wp datamachine-code workspace cleanup apply cleanup-run-20260504120000-abc123
 	 *
-	 *     # Start task-backed retention cleanup and return immediately
+	 *     # Start task-backed retention cleanup and capture the returned run_id
 	 *     wp datamachine-code workspace cleanup run --mode=retention
 	 *
 	 *     # Review artifact cleanup synchronously (bounded; default limit=100)
@@ -1710,24 +1712,28 @@ class WorkspaceCommand extends BaseCommand {
 	 *   alongside `--task-url` (applies to `add` only). Falls back to the
 	 *   `DATAMACHINE_TASK_REF` environment variable when omitted.
 	 *
-		 * [--force]
-		 * : For `add`, explicitly bypass the disk-budget refusal threshold. For
-		 *   `remove`, force-remove a worktree even if it is dirty. For `cleanup`,
-		 *   force dirty-worktree removal but not the unpushed-commits safety.
-		 *
-     * [--pr=<url-or-number>]
-     * : Attach pull request metadata when finalizing or marking a worktree
-     *   cleanup-eligible.
-     *
-     * [--state=<state>]
-     * : Lifecycle state to record when finalizing a worktree.
-     *
-     * [--dry-run]
-     * : Preview cleanup candidates without removing anything (cleanup only).
-     *
-     * File cleanup plan imports are an emergency escape hatch only. The normal
-     * operator workflow is `workspace cleanup plan` then
-     * `workspace cleanup apply <run-id>`.
+	 * [--force]
+	 * : For `add`, explicitly bypass the disk-budget refusal threshold. For
+	 *   `remove`, force-remove a worktree even if it is dirty. For `cleanup`,
+	 *   force dirty-worktree removal but not the unpushed-commits safety.
+	 *
+	 * [--pr=<url-or-number>]
+	 * : Attach pull request metadata when finalizing or marking a worktree
+	 *   cleanup-eligible.
+	 *
+	 * [--state=<state>]
+	 * : Lifecycle state to record when finalizing a worktree.
+	 *
+	 * [--dry-run]
+	 * : Preview cleanup candidates without removing anything (cleanup only).
+	 *
+	 * [--apply-plan=<file>]
+	 * : Low-level escape hatch for applying a previously reviewed JSON report.
+	 *   Daily cleanup should use `workspace cleanup plan`, then
+	 *   `workspace cleanup apply <run-id>`.
+	 *   The destructive pass still revalidates every planned row and removes only
+	 *   exact current matches. For reconcile-metadata, applies a reviewed
+	 *   non-destructive metadata plan.
 	 *
 	 * [--skip-github]
 	 * : Skip the GitHub API lookup and rely only on the local `upstream-gone`
@@ -1849,12 +1855,22 @@ class WorkspaceCommand extends BaseCommand {
 	 *     # Preview worktrees that would be removed (upstream gone or PR merged)
 	 *     wp datamachine-code workspace worktree cleanup --dry-run
 	 *
-		 *     # Remove all merged worktrees
-		 *     wp datamachine-code workspace worktree cleanup
-		 *
-     *     # Review a DB-backed plan, then apply only those rows after revalidation
-     *     wp datamachine-code workspace cleanup plan --mode=retention
-     *     wp datamachine-code workspace cleanup apply cleanup-run-20260504120000-abc123
+	 *     # Remove all merged worktrees
+	 *     wp datamachine-code workspace worktree cleanup
+	 *
+	 *     # Daily cleanup path: DB-backed plan, then apply only those rows after revalidation
+	 *     wp datamachine-code workspace cleanup plan --mode=retention
+	 *     wp datamachine-code workspace cleanup apply cleanup-run-20260504120000-abc123
+	 *
+	 *     # Task-backed cleanup path, then inspect status/evidence by run_id
+	 *     wp datamachine-code workspace cleanup run --mode=retention
+	 *     wp datamachine-code workspace cleanup status cleanup-run-123
+	 *     wp datamachine-code workspace cleanup evidence cleanup-run-123 --format=json
+	 *
+	 *     # Low-level JSON previews are for diagnostics
+	 *     wp datamachine-code workspace worktree cleanup --dry-run --format=json
+	 *     wp datamachine-code workspace worktree cleanup-artifacts --dry-run --format=json
+	 *     wp datamachine-code workspace worktree emergency-cleanup --format=json
 	 *
 	 *     # Bounded apply restricted to explicit lifecycle cleanup_eligible worktrees
 	 *     # (cheap inventory only — no full git worktree scan, no GitHub lookup)
@@ -1871,8 +1887,7 @@ class WorkspaceCommand extends BaseCommand {
 	 *     wp datamachine-code workspace worktree cleanup --dry-run --inventory-only --skip-github --format=json
 	 *
 	 *     # Adopt/reconcile unmanaged worktree metadata before cleanup
-	 *     wp datamachine-code workspace worktree reconcile-metadata --dry-run --format=json > reconcile-plan.json
-	 *     wp datamachine-code workspace worktree reconcile-metadata --apply-plan=reconcile-plan.json
+	 *     wp datamachine-code workspace worktree reconcile-metadata --dry-run --format=json
 	 *
 	 *     # Ignore dirty working-tree safety (caution)
 	 *     wp datamachine-code workspace worktree cleanup --force
@@ -2922,7 +2937,7 @@ class WorkspaceCommand extends BaseCommand {
 
 		WP_CLI::log( '' );
 		if ( ! empty( $result['dry_run'] ) ) {
-			WP_CLI::success( sprintf( '%d metadata reconciliation proposal(s). Review JSON, then apply with --apply-plan.', count( $proposals ) ) );
+			WP_CLI::success( sprintf( '%d metadata reconciliation proposal(s). Review JSON output before applying; --apply-plan remains a low-level escape hatch until DB-backed cleanup runs land.', count( $proposals ) ) );
 			return;
 		}
 		WP_CLI::success( sprintf( 'Wrote metadata for %d worktree(s); %d skipped.', count( $written ), count( $skipped ) ) );
@@ -3030,7 +3045,7 @@ class WorkspaceCommand extends BaseCommand {
 		}
 
 		if ( $dry_run ) {
-			WP_CLI::success( sprintf( '%d artifact(s) would be removed. Save JSON and re-run with --apply-plan=<file> to apply.', (int) ( $summary['would_remove_artifacts'] ?? 0 ) ) );
+			WP_CLI::success( sprintf( '%d artifact(s) would be removed. Prefer `workspace cleanup run --mode=artifacts`; --apply-plan remains a low-level escape hatch until DB-backed cleanup runs land.', (int) ( $summary['would_remove_artifacts'] ?? 0 ) ) );
 			return;
 		}
 		WP_CLI::success( sprintf( 'Removed %d artifact(s); %d worktree(s) skipped.', (int) ( $summary['removed_artifacts'] ?? 0 ), count( $skipped ) ) );
@@ -3289,7 +3304,7 @@ class WorkspaceCommand extends BaseCommand {
 
 		WP_CLI::log( '' );
 		if ( $dry_run ) {
-			WP_CLI::success( 'Emergency plan generated. Review JSON, then apply with --apply-plan=<file>.' );
+			WP_CLI::success( 'Emergency plan generated. Prefer `workspace cleanup run --mode=emergency`; --apply-plan remains a low-level escape hatch until DB-backed cleanup runs land.' );
 			return;
 		}
 		WP_CLI::success( sprintf( 'Emergency cleanup removed %d artifact group(s) and %d worktree(s); %d skipped.', count( $removed_artifacts ), count( $removed_worktrees ), count( $skipped ) ) );

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -3500,7 +3500,7 @@ class Workspace {
 		}
 
 		if ( ! $dry_run ) {
-			return new \WP_Error( 'metadata_reconcile_requires_review', 'Metadata reconciliation is dry-run-first. Pass --dry-run to write a review plan, then --apply-plan=<file> after review.', array( 'status' => 400 ) );
+			return new \WP_Error( 'metadata_reconcile_requires_review', 'Metadata reconciliation is dry-run-first. Pass --dry-run to review JSON output; --apply-plan=<file> remains a low-level escape hatch until DB-backed cleanup runs land.', array( 'status' => 400 ) );
 		}
 
 		$listing = $this->worktree_list();
@@ -3992,7 +3992,7 @@ class Workspace {
 		}
 
 		if ( ! $dry_run && null === $apply_plan ) {
-			return new \WP_Error( 'artifact_cleanup_plan_required', 'Artifact cleanup requires --dry-run first and --apply-plan=<file> to delete.', array( 'status' => 400 ) );
+			return new \WP_Error( 'artifact_cleanup_plan_required', 'Artifact cleanup applies through reviewed JSON only on this low-level command. Prefer workspace cleanup run --mode=artifacts for daily cleanup; use --dry-run first and --apply-plan=<file> only as an escape hatch.', array( 'status' => 400 ) );
 		}
 
 		$only_handles = null;
@@ -6188,7 +6188,7 @@ class Workspace {
 			'requires_full_scan'          => array(
 				'label'       => 'Repair missing lifecycle metadata in bounded batches',
 				'command'     => 'studio wp datamachine-code workspace worktree reconcile-metadata --dry-run --format=json',
-				'alternative' => 'studio wp datamachine-code workspace worktree reconcile-metadata --apply-plan=<plan-id>',
+				'alternative' => 'Low-level apply still requires a reviewed --apply-plan=<file> until DB-backed cleanup runs land.',
 				'why'         => 'Reconciliation writes lifecycle metadata so future inventory cleanup no longer needs a full scan for those rows.',
 				'destructive' => false,
 			),

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -563,8 +563,15 @@ namespace {
 	datamachine_code_cleanup_assert( str_contains( $doc_comment, "\n\t * [--include-repaired-metadata]" ), 'worktree synopsis declares --include-repaired-metadata at top level' );
 	datamachine_code_cleanup_assert( ! str_contains( $doc_comment, "\n\t\t * [--apply-plan=<file>]" ), 'cleanup flags are not hidden behind nested docblock indentation' );
 	datamachine_code_cleanup_assert( str_contains( $cleanup_doc_comment, 'Control task-backed workspace cleanup runs.' ), 'workspace cleanup command documents task-backed controller surface' );
-	datamachine_code_cleanup_assert( str_contains( $cleanup_doc_comment, '<run|status|resume|cancel|evidence>' ), 'workspace cleanup synopsis exposes run/status/resume/cancel/evidence' );
+	datamachine_code_cleanup_assert( str_contains( $cleanup_doc_comment, '<plan|apply|run|status|resume|cancel|evidence>' ), 'workspace cleanup synopsis exposes DB-backed and task-backed cleanup operations' );
 	datamachine_code_cleanup_assert( str_contains( $cleanup_doc_comment, '[--dry-run]' ), 'task-backed cleanup synopsis keeps synchronous dry-run review' );
+	datamachine_code_cleanup_assert( str_contains( $doc_comment, 'Daily cleanup path: DB-backed plan, then apply only those rows after revalidation' ), 'worktree examples point daily cleanup to DB-backed run_id controller path' );
+	datamachine_code_cleanup_assert( str_contains( $doc_comment, 'workspace cleanup plan --mode=retention' ), 'worktree examples include DB-backed cleanup plan' );
+	datamachine_code_cleanup_assert( str_contains( $doc_comment, 'workspace cleanup run --mode=retention' ), 'worktree examples include task-backed cleanup run' );
+	datamachine_code_cleanup_assert( ! str_contains( $doc_comment, '> cleanup-plan.json' ), 'worktree examples do not normalize cleanup-plan file redirection' );
+	datamachine_code_cleanup_assert( ! str_contains( $doc_comment, '> artifact-plan.json' ), 'worktree examples do not normalize artifact-plan file redirection' );
+	datamachine_code_cleanup_assert( ! str_contains( $doc_comment, '> emergency-plan.json' ), 'worktree examples do not normalize emergency-plan file redirection' );
+	datamachine_code_cleanup_assert( ! str_contains( $doc_comment, '> reconcile-plan.json' ), 'worktree examples do not normalize reconcile-plan file redirection' );
 
 	echo "\n[0b] task-backed workspace cleanup run/status/control output\n";
 	WP_CLI::$logs      = array();
@@ -741,7 +748,7 @@ namespace {
 	$command->worktree( array( 'cleanup' ), array( 'dry-run' => true, 'inventory-only' => true, 'include-repaired-metadata' => true, 'format' => 'json' ) );
 	datamachine_code_cleanup_assert( true === ( $ability->last_input['include_repaired_metadata'] ?? null ), '--include-repaired-metadata forwards to cleanup ability' );
 
-	echo "\n[8b] emergency-cleanup emits fast plan and apply-plan path\n";
+	echo "\n[8b] emergency-cleanup keeps apply-plan as low-level escape hatch\n";
 	WP_CLI::$logs      = array();
 	WP_CLI::$successes = array();
 	$command->worktree( array( 'emergency-cleanup' ), array( 'format' => 'json' ) );
@@ -768,6 +775,13 @@ namespace {
 	datamachine_code_cleanup_assert( array( 'dry_run' => true, 'force' => false ) === $artifact_ability->last_input, 'cleanup-artifacts dry-run flags forwarded to ability' );
 	$artifact_json = json_decode( WP_CLI::$logs[0] ?? '', true );
 	datamachine_code_cleanup_assert( 'target' === ( $artifact_json['candidates'][0]['artifacts'][0]['path'] ?? '' ), 'cleanup-artifacts JSON includes artifact paths' );
+
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->worktree( array( 'cleanup-artifacts' ), array( 'dry-run' => true ) );
+	datamachine_code_cleanup_assert( str_contains( WP_CLI::$successes[0] ?? '', 'workspace cleanup run --mode=artifacts' ), 'cleanup-artifacts dry-run points daily apply path to task-backed cleanup' );
+	datamachine_code_cleanup_assert( str_contains( WP_CLI::$successes[0] ?? '', 'low-level escape hatch' ), 'cleanup-artifacts dry-run demotes apply-plan wording' );
+	datamachine_code_cleanup_assert( ! str_contains( WP_CLI::$successes[0] ?? '', 'Save JSON' ), 'cleanup-artifacts dry-run does not normalize saving plan files' );
 
 	$artifact_plan_file = sys_get_temp_dir() . '/dmc-artifact-cleanup-plan-' . bin2hex( random_bytes( 3 ) ) . '.json';
 	file_put_contents( $artifact_plan_file, wp_json_encode( $artifact_json ) );


### PR DESCRIPTION
## Summary
- Update cleanup docs/help to present DB-backed `workspace cleanup plan/apply <run-id>` as the daily workflow.
- Keep low-level `--apply-plan=<file>` wording as an escape hatch instead of the normal path.
- Add smoke assertions that prevent plan-file redirection examples from returning as the primary workflow.

## Tests
- `php tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-workspace-retention-task.php`
- `php tests/smoke-worktree-cleanup-artifacts.php`
- PHP syntax checks for changed files

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Rebasing the cleanup docs/help transition onto the landed DB cleanup surfaces, resolving conflicts, and drafting this PR description; Chris remains responsible for review and validation.