### PR TITLE
Enable safe workspace retention cleanup

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -282,7 +282,7 @@ add_filter( 'datamachine_recurring_schedules', function ( array $schedules ): ar
 		'task_type'       => 'workspace_retention_cleanup',
 		'interval'        => 'daily',
 		'enabled_setting' => \DataMachineCode\Tasks\WorkspaceRetentionCleanupTask::SETTING_KEY,
-		'default_enabled' => false,
+		'default_enabled' => true,
 		'label'           => 'Daily — applies workspace retention cleanup',
 		'task_params'     => array(
 			'source'              => 'recurring_schedule',

--- a/inc/Tasks/WorkspaceRetentionCleanupTask.php
+++ b/inc/Tasks/WorkspaceRetentionCleanupTask.php
@@ -38,9 +38,9 @@ class WorkspaceRetentionCleanupTask extends SystemTask {
 	public static function getTaskMeta(): array {
 		return array(
 			'label'           => 'Workspace Retention Cleanup',
-			'description'     => 'Age-gated cleanup for stale DMC worktrees plus aggressive cleanup of reconstructable artifacts. Runs daily when enabled.',
+			'description'     => 'Age-gated cleanup for stale DMC worktrees plus bounded cleanup of reconstructable artifacts. Runs daily by default on local agent installs.',
 			'setting_key'     => self::SETTING_KEY,
-			'default_enabled' => false,
+			'default_enabled' => true,
 			'supports_run'    => true,
 		);
 	}
@@ -54,7 +54,7 @@ class WorkspaceRetentionCleanupTask extends SystemTask {
 	 */
 	public function executeTask( int $jobId, array $params ): void {
 		$source  = (string) ( $params['source'] ?? '' );
-		$enabled = (bool) PluginSettings::get( self::SETTING_KEY, false )
+		$enabled = (bool) PluginSettings::get( self::SETTING_KEY, true )
 			|| 'workspace_cleanup_cli' === $source;
 		if ( ! $enabled ) {
 			$this->completeJob(

--- a/inc/Tasks/WorktreeCleanupTask.php
+++ b/inc/Tasks/WorktreeCleanupTask.php
@@ -9,9 +9,12 @@
  *   wp datamachine system run worktree_cleanup
  *   wp datamachine system health --types=worktree_cleanup
  *
- * The task is disabled by default — cleanup is destructive (removes a
- * worktree directory and deletes the local branch) and agents should opt
- * in explicitly. Once enabled, it respects the usual safety rails:
+ * The standalone task is disabled by default — cleanup is destructive
+ * (removes a worktree directory and deletes the local branch) and operators
+ * should opt in explicitly. DMC-owned recurring cleanup runs through the
+ * safer WorkspaceRetentionCleanupTask path, which builds reviewed plans and
+ * schedules bounded child jobs. Once this task is enabled, it respects the
+ * usual safety rails:
  *
  *   - Protected branches (main, master, trunk, develop, HEAD) are never touched.
  *   - Worktrees outside the workspace path are skipped.
@@ -22,9 +25,9 @@
  *   - Only branches with a clear merge signal (upstream branch deleted on
  *     origin, or GitHub PR closed+merged) are candidates.
  *
- * Auto-scheduling via Action Scheduler is intentionally out of scope for
- * this task class — it just handles the execution contract. See the
- * follow-up issue for opt-in daily/weekly scheduling.
+ * Auto-scheduling is declared in data-machine-code.php via
+ * `datamachine_recurring_schedules`; this task class only handles the
+ * execution contract.
  *
  * @package DataMachineCode\Tasks
  * @since   0.7.0
@@ -87,7 +90,7 @@ class WorktreeCleanupTask extends SystemTask {
 			'label'           => 'Worktree Cleanup',
 			'description'     => 'Remove worktrees whose branches have been merged and deleted upstream. Destructive: removes worktree directories and deletes local branches. Runs daily when enabled.',
 			'setting_key'     => self::SETTING_KEY,
-			// Opt-in only — cleanup is destructive, agents should flip this
+			// Opt-in only — this direct task is destructive, operators should flip this
 			// on explicitly (via React UI, REST, or `wp datamachine settings
 			// set worktree_cleanup_enabled true`).
 			'default_enabled' => false,

--- a/tests/smoke-recurring-cleanup-defaults.php
+++ b/tests/smoke-recurring-cleanup-defaults.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Smoke test for DMC recurring cleanup schedule defaults.
+ *
+ *   php tests/smoke-recurring-cleanup-defaults.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace {
+	if ( ! defined( 'WPINC' ) ) {
+		define( 'WPINC', __DIR__ );
+	}
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ );
+	}
+
+	function datamachine_code_recurring_defaults_assert( bool $condition, string $message ): void {
+		if ( $condition ) {
+			echo "  [PASS] {$message}\n";
+			return;
+		}
+		echo "  [FAIL] {$message}\n";
+		exit( 1 );
+	}
+
+	echo "=== smoke-recurring-cleanup-defaults ===\n";
+
+	$plugin = (string) file_get_contents( dirname( __DIR__ ) . '/data-machine-code.php' );
+	$retention_start = strpos( $plugin, "\$schedules['workspace_retention_cleanup']" );
+	$retention_end   = strpos( $plugin, "\$schedules['workspace_disk_emergency_cleanup']", (int) $retention_start );
+	$direct_start    = strpos( $plugin, "\$schedules['worktree_cleanup']" );
+	$direct_end      = strpos( $plugin, "\$schedules['workspace_retention_cleanup']", (int) $direct_start );
+	$retention       = false === $retention_start || false === $retention_end ? '' : substr( $plugin, $retention_start, $retention_end - $retention_start );
+	$direct          = false === $direct_start || false === $direct_end ? '' : substr( $plugin, $direct_start, $direct_end - $direct_start );
+
+	datamachine_code_recurring_defaults_assert( str_contains( $retention, "'default_enabled' => true" ), 'retention cleanup schedule defaults on' );
+	datamachine_code_recurring_defaults_assert( str_contains( $retention, 'WorkspaceRetentionCleanupTask::SETTING_KEY' ), 'retention schedule uses retention setting key' );
+	datamachine_code_recurring_defaults_assert( str_contains( $retention, "'worktree_older_than' => '14d'" ), 'retention cleanup remains age-gated' );
+	datamachine_code_recurring_defaults_assert( str_contains( $retention, "'skip_github'         => true" ), 'retention cleanup stays local-signal only by default' );
+	datamachine_code_recurring_defaults_assert( str_contains( $retention, "'artifact_cleanup'    => true" ), 'retention cleanup includes bounded artifact cleanup' );
+	datamachine_code_recurring_defaults_assert( str_contains( $direct, "'default_enabled' => false" ), 'direct worktree cleanup remains opt-in' );
+
+	echo "\nAll recurring cleanup default smoke tests passed.\n";
+}

--- a/tests/smoke-workspace-retention-task.php
+++ b/tests/smoke-workspace-retention-task.php
@@ -27,10 +27,10 @@ namespace {
 
 namespace DataMachine\Core {
 	class PluginSettings {
-		public static bool $enabled = false;
+		public static array $settings = array();
 
-		public static function get( string $key, $default = null ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
-			return self::$enabled;
+		public static function get( string $key, $default = null ) {
+			return array_key_exists( $key, self::$settings ) ? self::$settings[ $key ] : $default;
 		}
 	}
 }
@@ -134,23 +134,34 @@ namespace {
 
 	echo "=== smoke-workspace-retention-task ===\n";
 
-	echo "\n[1] Disabled task completes as skipped\n";
+	echo "\n[1] Default-enabled task runs without an explicit setting\n";
 	$settings_class = '\\DataMachine\\Core\\PluginSettings';
-	$enabled_prop   = 'enabled';
-	$settings_class::$$enabled_prop = false;
+	$settings_prop  = 'settings';
+	$settings_class::$$settings_prop = array();
 	$task = new \DataMachineCode\Tasks\WorkspaceRetentionCleanupTask();
-	$task->executeTask( 201, array() );
+	$task->executeTask( 201, array( 'dry_run' => true ) );
 	$completed_prop = 'completed';
 	$failed_prop    = 'failed';
 	$completed      = $task->{$completed_prop};
 	$failed         = $task->{$failed_prop};
 	datamachine_code_retention_task_assert( 'workspace_retention_cleanup' === $task->getTaskType(), 'task type is stable' );
-	datamachine_code_retention_task_assert( true === ( $completed[0][1]['skipped'] ?? false ), 'disabled task reports skipped completion' );
-	datamachine_code_retention_task_assert( array() === $failed, 'disabled task does not fail the job' );
+	datamachine_code_retention_task_assert( true === (bool) ( $completed[0][1]['dry_run'] ?? false ), 'task runs with default PluginSettings fallback' );
+	datamachine_code_retention_task_assert( array() === $failed, 'default-enabled task does not fail the job' );
+	$meta = \DataMachineCode\Tasks\WorkspaceRetentionCleanupTask::getTaskMeta();
+	datamachine_code_retention_task_assert( true === (bool) ( $meta['default_enabled'] ?? false ), 'task metadata defaults retention cleanup on' );
+
+	echo "\n[1b] Explicit disabled setting completes as skipped\n";
+	$settings_class::$$settings_prop = array( \DataMachineCode\Tasks\WorkspaceRetentionCleanupTask::SETTING_KEY => false );
+	$task = new \DataMachineCode\Tasks\WorkspaceRetentionCleanupTask();
+	$task->executeTask( 211, array() );
+	$completed = $task->{$completed_prop};
+	$failed    = $task->{$failed_prop};
+	datamachine_code_retention_task_assert( true === ( $completed[0][1]['skipped'] ?? false ), 'explicit disabled setting reports skipped completion' );
+	datamachine_code_retention_task_assert( array() === $failed, 'explicit disabled setting does not fail the job' );
 
 	echo "\n[2] Enabled task stores report and logs concise summary\n";
 	$GLOBALS['__retention_task_logs'] = array();
-	$settings_class::$$enabled_prop = true;
+	$settings_class::$$settings_prop = array( \DataMachineCode\Tasks\WorkspaceRetentionCleanupTask::SETTING_KEY => true );
 	$task = new \DataMachineCode\Tasks\WorkspaceRetentionCleanupTask();
 	$task->executeTask( 202, array( 'dry_run' => true ) );
 	$completed = $task->{$completed_prop};
@@ -162,7 +173,7 @@ namespace {
 
 	echo "\n[3] Explicit CLI run bypasses global disabled setting\n";
 	$GLOBALS['__retention_task_logs'] = array();
-	$settings_class::$$enabled_prop = false;
+	$settings_class::$$settings_prop = array( \DataMachineCode\Tasks\WorkspaceRetentionCleanupTask::SETTING_KEY => false );
 	$task = new \DataMachineCode\Tasks\WorkspaceRetentionCleanupTask();
 	$task->executeTask( 203, array( 'source' => 'workspace_cleanup_cli', 'dry_run' => true ) );
 	$completed = $task->{$completed_prop};


### PR DESCRIPTION
## Summary
- Enable the daily `workspace_retention_cleanup` schedule by default so DMC-owned safe cleanup runs automatically on local agent installs.
- Keep the direct `worktree_cleanup` task opt-in while routing default automation through the age-gated, local-signal, job-backed retention path.
- Update smoke coverage for schedule defaults and PluginSettings fallback behavior.

## Testing
- `php tests/smoke-recurring-cleanup-defaults.php`
- `php tests/smoke-workspace-retention-task.php`
- `php tests/smoke-workspace-retention-cleanup.php`
- `php tests/smoke-workspace-disk-emergency-task.php`
- `php tests/smoke-worktree-cleanup-cli.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the scheduling/defaults fix, smoke test updates, and PR description; Chris remains responsible for review and merge.