### PR TITLE
fix: surface cleanup lifecycle buckets

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -2630,6 +2630,12 @@ class WorkspaceCommand extends BaseCommand {
 				'count'  => (int) $count,
 			);
 		}
+		foreach ( (array) ( $summary['cleanup_buckets'] ?? array() ) as $bucket => $count ) {
+			$summary_rows[] = array(
+				'metric' => 'bucket:' . $bucket,
+				'count'  => (int) $count,
+			);
+		}
 		if ( isset( $summary['age_filter'] ) && is_array( $summary['age_filter'] ) ) {
 			$summary_rows[] = array(
 				'metric' => 'age_filter:excluded',
@@ -3395,12 +3401,17 @@ class WorkspaceCommand extends BaseCommand {
 	 */
 	private function normalize_worktree_cleanup_only( string $only ): string {
 		$aliases = array(
-			'would-remove'     => 'candidates',
-			'would_remove'     => 'candidates',
-			'dirty'            => 'dirty_worktree',
-			'unpushed'         => 'unpushed_commits',
-			'missing-metadata' => 'missing_metadata',
-			'external'         => 'external_worktree',
+			'would-remove'       => 'candidates',
+			'would_remove'       => 'candidates',
+			'dirty'              => 'dirty_worktree',
+			'unpushed'           => 'unpushed_commits',
+			'missing-metadata'   => 'needs_metadata_reconcile',
+			'missing_metadata'   => 'needs_metadata_reconcile',
+			'requires-full-scan' => 'needs_metadata_reconcile',
+			'requires_full_scan' => 'needs_metadata_reconcile',
+			'no-signal'          => 'active_no_signal',
+			'no_signal'          => 'active_no_signal',
+			'external'           => 'external_worktree',
 		);
 
 		return $aliases[ $only ] ?? $only;

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -4307,9 +4307,20 @@ class Workspace {
 				continue;
 			}
 			$reason = (string) ( $row['reason_code'] ?? '' );
-			if ( ! in_array( $reason, array( 'requires_full_scan', 'no_inventory_cleanup_signal' ), true ) ) {
+			if ( ! in_array( $reason, array( 'needs_metadata_reconcile', 'requires_full_scan', 'lifecycle_reconciliation_candidate', 'active_no_signal', 'no_inventory_cleanup_signal' ), true ) ) {
 				continue;
 			}
+
+			$resolver_type = match ( $reason ) {
+				'needs_metadata_reconcile', 'requires_full_scan' => 'metadata_reconciliation',
+				'lifecycle_reconciliation_candidate' => 'lifecycle_reconciliation',
+				default => 'merge_signal',
+			};
+			$next_action = match ( $resolver_type ) {
+				'metadata_reconciliation'  => 'workspace worktree reconcile-metadata --dry-run --format=json',
+				'lifecycle_reconciliation' => 'workspace worktree cleanup --dry-run --format=json',
+				default                    => 'workspace worktree cleanup --dry-run --skip-github --format=json',
+			};
 
 			$resolver = array(
 				'handle'       => (string) ( $row['handle'] ?? '' ),
@@ -4318,7 +4329,8 @@ class Workspace {
 				'path'         => (string) ( $row['path'] ?? '' ),
 				'created_at'   => $row['created_at'] ?? null,
 				'metadata'     => $row['metadata'] ?? null,
-				'resolver'     => 'merge_signal',
+				'resolver'     => $resolver_type,
+				'next_action'  => $next_action,
 				'reason_code'  => $reason,
 				'reason'       => 'resolve merge or lifecycle cleanup signal before any worktree removal chunk is emitted',
 				'row_type'     => 'resolver',
@@ -4923,9 +4935,9 @@ class Workspace {
 
 			if ( ! is_array( $metadata ) ) {
 				$skipped[] = array_merge( $base_row, array(
-					'reason_code' => 'requires_full_scan',
-					'reason'      => 'inventory row has no lifecycle metadata; cleanup safety requires a full scan',
-					'hint'        => 'Run workspace worktree cleanup --dry-run without --inventory-only when you are ready for full git safety probes.',
+					'reason_code' => 'needs_metadata_reconcile',
+					'reason'      => 'inventory row has no lifecycle metadata; metadata reconciliation is required before cleanup planning can classify it',
+					'hint'        => 'Run workspace worktree reconcile-metadata --dry-run --format=json to generate reviewed metadata reconciliation rows.',
 				) );
 				continue;
 			}
@@ -4983,11 +4995,7 @@ class Workspace {
 					$candidates[] = $candidate;
 					continue;
 				}
-				$skipped[] = array_merge( $base_row, array(
-					'reason_code'   => 'no_inventory_cleanup_signal',
-					'reason'        => 'no explicit inventory cleanup signal — leaving in place',
-					'hint'          => 'Mark the worktree cleanup-eligible after review, or run full cleanup to detect merge signals.',
-				) );
+				$skipped[] = $this->build_inventory_cleanup_no_signal_skip( $base_row, $wt, $metadata );
 				continue;
 			}
 
@@ -5057,6 +5065,45 @@ class Workspace {
 			'skipped'        => $skipped,
 			'summary'        => $this->build_worktree_cleanup_summary( $candidates, array(), $skipped, $age_filter ),
 		);
+	}
+
+	/**
+	 * Build an inventory-only skip row when lifecycle metadata has no cleanup signal.
+	 *
+	 * @param array<string,mixed> $base_row Base worktree row.
+	 * @param array<string,mixed> $wt       Inventory row.
+	 * @param array<string,mixed> $metadata Lifecycle metadata.
+	 * @return array<string,mixed>
+	 */
+	private function build_inventory_cleanup_no_signal_skip( array $base_row, array $wt, array $metadata ): array {
+		$liveness        = (string) ( $wt['liveness'] ?? WorktreeContextInjector::LIVENESS_UNKNOWN );
+		$liveness_reason = (string) ( $wt['liveness_reason'] ?? '' );
+		$state           = isset( $metadata['lifecycle_state'] ) ? WorktreeContextInjector::normalize_state( (string) $metadata['lifecycle_state'] ) : null;
+		$has_pr_context  = ! empty( $metadata['pr_url'] ) || ! empty( $metadata['pr_number'] ) || ! empty( $metadata['pr_ref'] );
+		$has_task_context = is_array( $metadata['origin_task'] ?? null ) && ! empty( $metadata['origin_task']['task_url'] );
+
+		if ( WorktreeContextInjector::LIVENESS_LIVE !== $liveness && ( $has_pr_context || $has_task_context ) ) {
+			return array_merge( $base_row, array(
+				'reason_code'     => 'lifecycle_reconciliation_candidate',
+				'reason'          => 'stale or PR/task-backed lifecycle metadata has no cleanup signal; reconcile lifecycle state before cleanup eligibility is decided',
+				'hint'            => 'Run workspace worktree cleanup --dry-run --format=json for merge/PR signal detection, then persist lifecycle state through DMC-owned finalization.',
+				'lifecycle_state' => $state,
+				'liveness'        => $liveness,
+				'liveness_reason' => $liveness_reason,
+				'pr_url'          => $metadata['pr_url'] ?? null,
+				'pr_number'       => $metadata['pr_number'] ?? null,
+				'origin_task'     => $metadata['origin_task'] ?? null,
+			) );
+		}
+
+		return array_merge( $base_row, array(
+			'reason_code'     => 'active_no_signal',
+			'reason'          => 'active lifecycle metadata has no cleanup signal; leaving in place',
+			'hint'            => 'No cleanup action is safe from inventory alone. Keep active, or run full cleanup when you need merge-signal detection.',
+			'lifecycle_state' => $state,
+			'liveness'        => $liveness,
+			'liveness_reason' => $liveness_reason,
+		) );
 	}
 
 	/**
@@ -6153,6 +6200,7 @@ class Workspace {
 			'skipped'               => count( $skipped ),
 			'skipped_by_reason'     => $skipped_by_reason,
 			'skipped_next_commands' => $this->worktree_cleanup_skipped_next_commands( $skipped_by_reason ),
+			'cleanup_buckets'       => $this->worktree_cleanup_buckets( $candidates_by_signal, $skipped_by_reason ),
 			'candidates_by_signal'  => $candidates_by_signal,
 			'total_size_bytes'      => $total_size_bytes,
 			'artifact_size_bytes'   => $total_artifact_bytes,
@@ -6171,6 +6219,26 @@ class Workspace {
 	}
 
 	/**
+	 * Build stable high-level cleanup buckets for plan/report consumers.
+	 *
+	 * @param array<string,int> $candidates_by_signal Candidate signal counts.
+	 * @param array<string,int> $skipped_by_reason    Skipped reason counts.
+	 * @return array<string,int>
+	 */
+	private function worktree_cleanup_buckets( array $candidates_by_signal, array $skipped_by_reason ): array {
+		$buckets = array(
+			'explicit_cleanup_candidates'         => (int) ( $candidates_by_signal['cleanup_eligible'] ?? 0 ),
+			'lifecycle_reconciliation_candidates' => (int) ( $skipped_by_reason['lifecycle_reconciliation_candidate'] ?? 0 ),
+			'metadata_reconciliation_candidates'  => (int) ( $skipped_by_reason['needs_metadata_reconcile'] ?? 0 ) + (int) ( $skipped_by_reason['requires_full_scan'] ?? 0 ) + (int) ( $skipped_by_reason['missing_metadata'] ?? 0 ),
+			'dirty_unpushed'                      => (int) ( $skipped_by_reason['dirty_worktree'] ?? 0 ) + (int) ( $skipped_by_reason['unpushed_commits'] ?? 0 ),
+			'active_no_signal'                    => (int) ( $skipped_by_reason['active_no_signal'] ?? 0 ) + (int) ( $skipped_by_reason['no_inventory_cleanup_signal'] ?? 0 ),
+		);
+
+		ksort( $buckets );
+		return $buckets;
+	}
+
+	/**
 	 * Build copy-pasteable next commands for skipped cleanup buckets.
 	 *
 	 * @param array<string,int> $skipped_by_reason Skipped reason counts.
@@ -6178,6 +6246,27 @@ class Workspace {
 	 */
 	private function worktree_cleanup_skipped_next_commands( array $skipped_by_reason ): array {
 		$templates = array(
+			'lifecycle_reconciliation_candidate' => array(
+				'label'       => 'Run DMC-owned lifecycle reconciliation before cleanup eligibility',
+				'command'     => 'studio wp datamachine-code workspace worktree cleanup --dry-run --format=json',
+				'alternative' => 'studio wp datamachine-code workspace cleanup plan --mode=retention --format=json',
+				'why'         => 'Runs full merge/PR signal detection so DMC can persist lifecycle state instead of relying on manual agent finalization.',
+				'destructive' => false,
+			),
+			'needs_metadata_reconcile' => array(
+				'label'       => 'Repair missing lifecycle metadata in bounded batches',
+				'command'     => 'studio wp datamachine-code workspace worktree reconcile-metadata --dry-run --format=json',
+				'alternative' => 'Low-level apply still requires a reviewed --apply-plan=<file> until DB-backed cleanup runs land.',
+				'why'         => 'Reconciliation writes lifecycle metadata so future inventory cleanup can classify these rows without a full scan.',
+				'destructive' => false,
+			),
+			'active_no_signal' => array(
+				'label'       => 'Keep active rows or run full merge-signal review',
+				'command'     => 'studio wp datamachine-code workspace worktree cleanup --dry-run --skip-github --format=json',
+				'alternative' => 'No automatic cleanup action is safe from active inventory metadata alone.',
+				'why'         => 'Active rows without stale liveness or PR/task context are not cleanup candidates from inventory alone.',
+				'destructive' => false,
+			),
 			'repaired_metadata'           => array(
 				'label'       => 'Review repaired metadata with bounded safety probes',
 				'command'     => 'studio wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --dry-run --include-repaired-metadata --limit=25 --older-than=7d',

--- a/tests/smoke-workspace-hygiene-report.php
+++ b/tests/smoke-workspace-hygiene-report.php
@@ -173,8 +173,9 @@ namespace {
 		datamachine_code_hygiene_report_assert( str_contains( $with_cleanup['suggested_cleanup_command'] ?? '', '--inventory-only' ), 'suggested cleanup command uses inventory-only review' );
 		datamachine_code_hygiene_report_assert( true === ( $with_cleanup['cleanup']['inventory_only'] ?? false ), 'cleanup report declares inventory_only mode' );
 		datamachine_code_hygiene_report_assert( 1 === (int) ( $with_cleanup['cleanup']['summary']['would_remove'] ?? 0 ), 'inventory cleanup counts explicit cleanup signal' );
-		datamachine_code_hygiene_report_assert( 1 === (int) ( $with_cleanup['cleanup']['summary']['skipped_by_reason']['no_inventory_cleanup_signal'] ?? 0 ), 'inventory cleanup skips active metadata with stable reason' );
-		datamachine_code_hygiene_report_assert( 1 === (int) ( $with_cleanup['cleanup']['summary']['skipped_by_reason']['requires_full_scan'] ?? 0 ), 'inventory cleanup skips missing metadata with full-scan reason' );
+		datamachine_code_hygiene_report_assert( 1 === (int) ( $with_cleanup['cleanup']['summary']['skipped_by_reason']['lifecycle_reconciliation_candidate'] ?? 0 ), 'inventory cleanup surfaces stale PR-backed metadata as lifecycle reconciliation candidate' );
+		datamachine_code_hygiene_report_assert( 1 === (int) ( $with_cleanup['cleanup']['summary']['skipped_by_reason']['needs_metadata_reconcile'] ?? 0 ), 'inventory cleanup skips missing metadata with metadata reconciliation reason' );
+		datamachine_code_hygiene_report_assert( 1 === (int) ( $with_cleanup['cleanup']['summary']['cleanup_buckets']['metadata_reconciliation_candidates'] ?? 0 ), 'inventory cleanup buckets count metadata reconciliation candidates' );
 
 		echo "\n[2] Full report remains explicitly available\n";
 		$full = $workspace->workspace_hygiene_report(

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -91,10 +91,10 @@ namespace {
 			'repo'           => '',
 			'branch'         => '',
 			'path'           => '',
-			'reason_code'         => 'missing_metadata',
-			'reason'              => 'missing repo/branch/path',
+			'reason_code'         => 'needs_metadata_reconcile',
+			'reason'              => 'inventory row has no lifecycle metadata; metadata reconciliation is required before cleanup planning can classify it',
 			'missing_fields'      => array( 'repo', 'branch', 'path' ),
-			'hint'                => 'Run workspace worktree prune if this is a stale registry entry; inspect manually if the path still exists.',
+			'hint'                => 'Run workspace worktree reconcile-metadata --dry-run --format=json to generate reviewed metadata reconciliation rows.',
 			'size_bytes'          => 0,
 			'artifact_size_bytes' => 0,
 		);
@@ -112,16 +112,24 @@ namespace {
 			'repo'        => 'repo',
 			'branch'      => 'needs-full-scan',
 			'path'        => '/workspace/repo@needs-full-scan',
-			'reason_code' => 'requires_full_scan',
-			'reason'      => 'inventory row has no lifecycle metadata; cleanup safety requires a full scan',
+			'reason_code' => 'needs_metadata_reconcile',
+			'reason'      => 'inventory row has no lifecycle metadata; metadata reconciliation is required before cleanup planning can classify it',
 		);
 		$skipped[] = array(
 			'handle'      => 'repo@needs-review',
 			'repo'        => 'repo',
 			'branch'      => 'needs-review',
 			'path'        => '/workspace/repo@needs-review',
-			'reason_code' => 'no_inventory_cleanup_signal',
-			'reason'      => 'no explicit inventory cleanup signal - leaving in place',
+			'reason_code' => 'active_no_signal',
+			'reason'      => 'active lifecycle metadata has no cleanup signal; leaving in place',
+		);
+		$skipped[] = array(
+			'handle'      => 'repo@needs-lifecycle-reconcile',
+			'repo'        => 'repo',
+			'branch'      => 'needs-lifecycle-reconcile',
+			'path'        => '/workspace/repo@needs-lifecycle-reconcile',
+			'reason_code' => 'lifecycle_reconciliation_candidate',
+			'reason'      => 'stale or PR/task-backed lifecycle metadata has no cleanup signal; reconcile lifecycle state before cleanup eligibility is decided',
 		);
 
 		return array(
@@ -148,34 +156,48 @@ namespace {
 				'removed'              => 0,
 				'skipped'              => count( $skipped ),
 				'skipped_by_reason'    => array(
-					'dirty_worktree'               => 1,
-					'missing_metadata'             => 1,
-					'repaired_metadata'    => 1,
-					'no_inventory_cleanup_signal'  => 1,
-					'no_merge_signal'              => 10,
-					'requires_full_scan'           => 1,
+					'active_no_signal'                    => 1,
+					'dirty_worktree'                       => 1,
+					'lifecycle_reconciliation_candidate'  => 1,
+					'needs_metadata_reconcile'             => 2,
+					'no_merge_signal'                      => 10,
+					'repaired_metadata'                    => 1,
+				),
+				'cleanup_buckets'       => array(
+					'active_no_signal'                    => 1,
+					'dirty_unpushed'                      => 1,
+					'explicit_cleanup_candidates'         => 0,
+					'lifecycle_reconciliation_candidates' => 1,
+					'metadata_reconciliation_candidates'  => 2,
 				),
 				'skipped_next_commands' => array(
+					array(
+						'reason_code' => 'lifecycle_reconciliation_candidate',
+						'count'       => 1,
+						'command'     => 'studio wp datamachine-code workspace worktree cleanup --dry-run --format=json',
+						'alternative' => 'studio wp datamachine-code workspace cleanup plan --mode=retention --format=json',
+						'destructive' => false,
+					),
+					array(
+						'reason_code' => 'needs_metadata_reconcile',
+						'count'       => 2,
+						'command'     => 'studio wp datamachine-code workspace worktree reconcile-metadata --dry-run --format=json',
+						'alternative' => 'Low-level apply still requires a reviewed --apply-plan=<file> until DB-backed cleanup runs land.',
+						'destructive' => false,
+					),
+					array(
+						'reason_code' => 'active_no_signal',
+						'count'       => 1,
+						'command'     => 'studio wp datamachine-code workspace worktree cleanup --dry-run --skip-github --format=json',
+						'alternative' => 'No automatic cleanup action is safe from active inventory metadata alone.',
+						'destructive' => false,
+					),
 					array(
 						'reason_code' => 'repaired_metadata',
 						'count'       => 1,
 						'command'     => 'studio wp datamachine-code workspace cleanup run --mode=retention --older-than=7d',
 						'alternative' => 'studio wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --dry-run --limit=25 --older-than=7d',
 						'destructive' => true,
-					),
-					array(
-						'reason_code' => 'requires_full_scan',
-						'count'       => 1,
-						'command'     => 'studio wp datamachine-code workspace worktree reconcile-metadata-batch --dry-run --limit=25 --format=json',
-						'alternative' => 'studio wp datamachine-code workspace worktree reconcile-metadata-batch --limit=25',
-						'destructive' => false,
-					),
-					array(
-						'reason_code' => 'no_inventory_cleanup_signal',
-						'count'       => 1,
-						'command'     => 'studio wp datamachine-code workspace worktree finalize <handle> --pr=<pr-url>',
-						'alternative' => 'studio wp datamachine-code workspace worktree mark-cleanup-eligible <handle>',
-						'destructive' => false,
 					),
 				),
 				'candidates_by_signal' => array(
@@ -673,13 +695,16 @@ namespace {
 	$decoded = json_decode( WP_CLI::$logs[0], true );
 	datamachine_code_cleanup_assert( JSON_ERROR_NONE === json_last_error(), 'JSON output parses cleanly' );
 	datamachine_code_cleanup_assert( 'dirty_worktree' === ( $decoded['skipped'][0]['reason_code'] ?? '' ), 'JSON rows include stable reason code' );
-	datamachine_code_cleanup_assert( array( 'repo', 'branch', 'path' ) === ( $decoded['skipped'][11]['missing_fields'] ?? array() ), 'JSON missing_metadata includes missing fields' );
-	datamachine_code_cleanup_assert( str_contains( $decoded['skipped'][11]['hint'] ?? '', 'workspace worktree prune' ), 'JSON missing_metadata includes remediation hint' );
+	datamachine_code_cleanup_assert( array( 'repo', 'branch', 'path' ) === ( $decoded['skipped'][11]['missing_fields'] ?? array() ), 'JSON metadata reconciliation row includes missing fields' );
+	datamachine_code_cleanup_assert( 'needs_metadata_reconcile' === ( $decoded['skipped'][11]['reason_code'] ?? '' ), 'JSON missing metadata row uses metadata reconciliation reason' );
+	datamachine_code_cleanup_assert( str_contains( $decoded['skipped'][11]['hint'] ?? '', 'reconcile-metadata --dry-run' ), 'JSON metadata reconciliation row includes remediation hint' );
 	datamachine_code_cleanup_assert( 10 === (int) ( $decoded['summary']['skipped_by_reason']['no_merge_signal'] ?? 0 ), 'JSON summary includes reason counts' );
-	datamachine_code_cleanup_assert( 3 === count( $decoded['summary']['skipped_next_commands'] ?? array() ), 'JSON summary includes actionable skipped next commands' );
-	datamachine_code_cleanup_assert( str_contains( $decoded['summary']['skipped_next_commands'][0]['command'] ?? '', 'workspace cleanup run --mode=retention --older-than=7d' ), 'JSON repaired metadata command is task-backed retention cleanup' );
-	datamachine_code_cleanup_assert( str_contains( $decoded['summary']['skipped_next_commands'][1]['command'] ?? '', 'reconcile-metadata-batch --dry-run --limit=25' ), 'JSON full-scan command is bounded metadata reconciliation' );
-	datamachine_code_cleanup_assert( str_contains( $decoded['summary']['skipped_next_commands'][2]['command'] ?? '', 'finalize <handle> --pr=<pr-url>' ), 'JSON no-signal command records explicit review metadata' );
+	datamachine_code_cleanup_assert( 1 === (int) ( $decoded['summary']['cleanup_buckets']['lifecycle_reconciliation_candidates'] ?? 0 ), 'JSON summary includes lifecycle reconciliation bucket count' );
+	datamachine_code_cleanup_assert( 2 === (int) ( $decoded['summary']['cleanup_buckets']['metadata_reconciliation_candidates'] ?? 0 ), 'JSON summary includes metadata reconciliation bucket count' );
+	datamachine_code_cleanup_assert( 4 === count( $decoded['summary']['skipped_next_commands'] ?? array() ), 'JSON summary includes actionable skipped next commands' );
+	datamachine_code_cleanup_assert( str_contains( $decoded['summary']['skipped_next_commands'][0]['command'] ?? '', 'worktree cleanup --dry-run --format=json' ), 'JSON lifecycle command runs DMC-owned cleanup signal detection' );
+	datamachine_code_cleanup_assert( str_contains( $decoded['summary']['skipped_next_commands'][1]['command'] ?? '', 'reconcile-metadata --dry-run --format=json' ), 'JSON metadata command is metadata reconciliation' );
+	datamachine_code_cleanup_assert( str_contains( $decoded['summary']['skipped_next_commands'][2]['alternative'] ?? '', 'No automatic cleanup action is safe' ), 'JSON active/no-signal command explains no automatic cleanup action' );
 
 	echo "\n[1b] --apply-plan decodes JSON and forbids force\n";
 	$plan_file = sys_get_temp_dir() . '/dmc-cleanup-plan-' . bin2hex( random_bytes( 3 ) ) . '.json';
@@ -708,8 +733,8 @@ namespace {
 	datamachine_code_cleanup_assert( in_array( 'table:10:handle,reason_code,age_days,size,artifacts,reason', WP_CLI::$logs, true ), 'default skipped table omits path and hint fields but keeps disk fields' );
 	datamachine_code_cleanup_assert( in_array( 'Top repos by worktree size:', WP_CLI::$logs, true ), 'human output includes top repo size summary' );
 	datamachine_code_cleanup_assert( in_array( 'Next commands for skipped buckets:', WP_CLI::$logs, true ), 'human output includes actionable skipped command section' );
-	datamachine_code_cleanup_assert( in_array( 'table:3:reason_code,count,destructive,command,alternative', WP_CLI::$logs, true ), 'human output renders compact skipped command table' );
-	datamachine_code_cleanup_assert( in_array( 'Showing 10 of 15 skipped rows. Re-run with --verbose for all rows or --only=<reason_code> to filter.', WP_CLI::$logs, true ), 'human output truncates skipped rows with hint' );
+	datamachine_code_cleanup_assert( in_array( 'table:4:reason_code,count,destructive,command,alternative', WP_CLI::$logs, true ), 'human output renders compact skipped command table' );
+	datamachine_code_cleanup_assert( in_array( 'Showing 10 of 16 skipped rows. Re-run with --verbose for all rows or --only=<reason_code> to filter.', WP_CLI::$logs, true ), 'human output truncates skipped rows with hint' );
 	datamachine_code_cleanup_assert( 1 === count( WP_CLI::$successes ), 'human output keeps success suffix' );
 
 	echo "\n[3] verbose output keeps detailed human fields\n";
@@ -717,7 +742,7 @@ namespace {
 	WP_CLI::$successes = array();
 	$command->worktree( array( 'cleanup' ), array( 'dry-run' => true, 'skip-github' => true, 'verbose' => true ) );
 	datamachine_code_cleanup_assert( in_array( 'table:1:handle,branch,age_days,size,artifacts,signal,reason', WP_CLI::$logs, true ), 'verbose candidate table keeps full reason field' );
-	datamachine_code_cleanup_assert( in_array( 'table:15:handle,reason_code,reason,age_days,size,artifacts,repo,branch,path,primary_path,missing,hint', WP_CLI::$logs, true ), 'verbose skipped table keeps diagnostic fields' );
+	datamachine_code_cleanup_assert( in_array( 'table:16:handle,reason_code,reason,age_days,size,artifacts,repo,branch,path,primary_path,missing,hint', WP_CLI::$logs, true ), 'verbose skipped table keeps diagnostic fields' );
 
 	echo "\n[4] --only filters rows while keeping full summary\n";
 	WP_CLI::$logs      = array();
@@ -725,9 +750,9 @@ namespace {
 	$command->worktree( array( 'cleanup' ), array( 'dry-run' => true, 'only' => 'missing-metadata', 'format' => 'json' ) );
 	$filtered = json_decode( WP_CLI::$logs[0], true );
 	datamachine_code_cleanup_assert( array() === ( $filtered['candidates'] ?? null ), '--only reason hides candidates' );
-	datamachine_code_cleanup_assert( 1 === count( $filtered['skipped'] ?? array() ), '--only reason keeps matching skipped rows only' );
-	datamachine_code_cleanup_assert( 'missing_metadata' === ( $filtered['skipped'][0]['reason_code'] ?? '' ), '--only alias resolves to reason code' );
-	datamachine_code_cleanup_assert( 15 === (int) ( $filtered['summary']['skipped'] ?? 0 ), '--only leaves summary counts unfiltered' );
+	datamachine_code_cleanup_assert( 2 === count( $filtered['skipped'] ?? array() ), '--only reason keeps matching skipped rows only' );
+	datamachine_code_cleanup_assert( 'needs_metadata_reconcile' === ( $filtered['skipped'][0]['reason_code'] ?? '' ), '--only alias resolves to metadata reconciliation reason code' );
+	datamachine_code_cleanup_assert( 16 === (int) ( $filtered['summary']['skipped'] ?? 0 ), '--only leaves summary counts unfiltered' );
 
 	echo "\n[5] --only aliases resolve candidate section\n";
 	foreach ( array( 'candidates', 'would-remove', 'would_remove' ) as $alias ) {
@@ -747,7 +772,7 @@ namespace {
 	$command->worktree( array( 'cleanup' ), array( 'dry-run' => true, 'skip-github' => true, 'older-than' => '7d' ) );
 	datamachine_code_cleanup_assert( '7d' === ( $ability->last_input['older_than'] ?? null ), 'older-than forwards to cleanup ability as older_than' );
 	datamachine_code_cleanup_assert( is_callable( $ability->last_input['progress_callback'] ?? null ), 'human cleanup passes progress callback to ability' );
-	datamachine_code_cleanup_assert( in_array( 'table:13:metric,count', WP_CLI::$logs, true ), 'age filter and disk summary rows are rendered' );
+	datamachine_code_cleanup_assert( in_array( 'table:18:metric,count', WP_CLI::$logs, true ), 'age filter, cleanup buckets, and disk summary rows are rendered' );
 
 	WP_CLI::$logs      = array();
 	WP_CLI::$successes = array();

--- a/tests/smoke-worktree-cleanup.php
+++ b/tests/smoke-worktree-cleanup.php
@@ -276,6 +276,7 @@ namespace {
 	mkdir( $tmp . '/demo@inventory-cleanup-eligible', 0755, true );
 	mkdir( $tmp . '/demo@inventory-finalized-pr', 0755, true );
 	mkdir( $tmp . '/demo@inventory-active', 0755, true );
+	mkdir( $tmp . '/demo@inventory-stale-lifecycle', 0755, true );
 	mkdir( $tmp . '/demo@inventory-missing-metadata', 0755, true );
 	\DataMachineCode\Workspace\WorktreeContextInjector::store_lifecycle_metadata(
 		'demo@inventory-cleanup-eligible',
@@ -300,7 +301,18 @@ namespace {
 		'demo@inventory-active',
 		array(
 			'created_at'      => '2026-04-01T00:00:00+00:00',
+			'last_seen_at'    => gmdate( 'c' ),
 			'lifecycle_state' => \DataMachineCode\Workspace\WorktreeContextInjector::STATE_ACTIVE,
+		)
+	);
+	\DataMachineCode\Workspace\WorktreeContextInjector::store_lifecycle_metadata(
+		'demo@inventory-stale-lifecycle',
+		array(
+			'created_at'      => '2026-04-01T00:00:00+00:00',
+			'last_seen_at'    => '2026-04-01T00:00:00+00:00',
+			'lifecycle_state' => \DataMachineCode\Workspace\WorktreeContextInjector::STATE_ACTIVE,
+			'pr_url'          => 'https://github.com/acme/demo/pull/44',
+			'pr_number'       => 44,
 		)
 	);
 
@@ -391,13 +403,21 @@ namespace {
 	$assert_contains( $inventory_plan['candidates'] ?? array(), 'demo@inventory-finalized-pr', 'inventory-only flags persisted PR-finalized worktree' );
 	$assert( 2, count( $inventory_plan['candidates'] ?? array() ), 'inventory-only only returns cheap cleanup signals as candidates' );
 	$inventory_active = array_values( array_filter( $inventory_plan['skipped'] ?? array(), fn( $s ) => ( $s['handle'] ?? '' ) === 'demo@inventory-active' ) )[0] ?? array();
-	$assert( 'no_inventory_cleanup_signal', $inventory_active['reason_code'] ?? '', 'inventory-only active metadata uses stable ambiguous reason' );
+	$assert( 'active_no_signal', $inventory_active['reason_code'] ?? '', 'inventory-only active metadata uses stable active/no-signal reason' );
+	$inventory_stale = array_values( array_filter( $inventory_plan['skipped'] ?? array(), fn( $s ) => ( $s['handle'] ?? '' ) === 'demo@inventory-stale-lifecycle' ) )[0] ?? array();
+	$assert( 'lifecycle_reconciliation_candidate', $inventory_stale['reason_code'] ?? '', 'inventory-only stale PR-backed metadata surfaces lifecycle reconciliation candidate' );
 	$inventory_missing = array_values( array_filter( $inventory_plan['skipped'] ?? array(), fn( $s ) => ( $s['handle'] ?? '' ) === 'demo@inventory-missing-metadata' ) )[0] ?? array();
-	$assert( 'requires_full_scan', $inventory_missing['reason_code'] ?? '', 'inventory-only missing metadata requires full scan' );
+	$assert( 'needs_metadata_reconcile', $inventory_missing['reason_code'] ?? '', 'inventory-only missing metadata requires metadata reconciliation' );
+	$inventory_buckets = (array) ( $inventory_plan['summary']['cleanup_buckets'] ?? array() );
+	$assert( 2, (int) ( $inventory_buckets['explicit_cleanup_candidates'] ?? 0 ), 'inventory cleanup bucket counts explicit cleanup candidates' );
+	$assert( 1, (int) ( $inventory_buckets['lifecycle_reconciliation_candidates'] ?? 0 ), 'inventory cleanup bucket counts lifecycle reconciliation candidates' );
+	$assert( 4, (int) ( $inventory_buckets['metadata_reconciliation_candidates'] ?? 0 ), 'inventory cleanup bucket counts metadata reconciliation candidates' );
+	$assert( 4, (int) ( $inventory_buckets['active_no_signal'] ?? 0 ), 'inventory cleanup bucket counts active/no-signal rows' );
 	$inventory_next_commands = (array) ( $inventory_plan['summary']['skipped_next_commands'] ?? array() );
 	$assert( true, count( $inventory_next_commands ) >= 2, 'inventory-only summary includes actionable skipped commands' );
-	$assert( true, in_array( 'requires_full_scan', array_column( $inventory_next_commands, 'reason_code' ), true ), 'inventory-only skipped commands include full-scan remediation' );
-	$assert( true, in_array( 'no_inventory_cleanup_signal', array_column( $inventory_next_commands, 'reason_code' ), true ), 'inventory-only skipped commands include explicit review remediation' );
+	$assert( true, in_array( 'needs_metadata_reconcile', array_column( $inventory_next_commands, 'reason_code' ), true ), 'inventory-only skipped commands include metadata reconciliation remediation' );
+	$assert( true, in_array( 'lifecycle_reconciliation_candidate', array_column( $inventory_next_commands, 'reason_code' ), true ), 'inventory-only skipped commands include lifecycle reconciliation remediation' );
+	$assert( true, in_array( 'active_no_signal', array_column( $inventory_next_commands, 'reason_code' ), true ), 'inventory-only skipped commands include active/no-signal explanation' );
 	$inventory_apply = $inventory_ws->worktree_cleanup_merged( array( 'inventory_only' => true ) );
 	$assert( true, is_wp_error( $inventory_apply ), 'inventory-only cleanup refuses non-dry-run apply path' );
 

--- a/tests/smoke-worktree-metadata-reconcile.php
+++ b/tests/smoke-worktree-metadata-reconcile.php
@@ -255,7 +255,7 @@ namespace {
 	$unsafe_plan = $plan;
 
 	$inventory_before = $ws->worktree_cleanup_merged( array( 'dry_run' => true, 'inventory_only' => true, 'skip_github' => true ) );
-	$assert( 2, (int) ( $inventory_before['summary']['skipped_by_reason']['requires_full_scan'] ?? 0 ), 'inventory cleanup sees missing metadata before apply' );
+	$assert( 2, (int) ( $inventory_before['summary']['skipped_by_reason']['needs_metadata_reconcile'] ?? 0 ), 'inventory cleanup sees missing metadata before apply' );
 
 	echo "\nApply reviewed plan\n";
 	$apply = $ws->worktree_reconcile_metadata( array( 'apply_plan' => $plan ) );
@@ -271,8 +271,8 @@ namespace {
 	$assert( 'operator_plan', $stored['reconciled_sources']['lifecycle_state'] ?? '', 'stored metadata keeps source map' );
 
 	$inventory_after = $ws->worktree_cleanup_merged( array( 'dry_run' => true, 'inventory_only' => true, 'skip_github' => true ) );
-	$assert( 0, (int) ( $inventory_after['summary']['skipped_by_reason']['requires_full_scan'] ?? 0 ), 'inventory cleanup requires fewer full scans after apply' );
-	$assert( 5, (int) ( $inventory_after['summary']['skipped_by_reason']['no_inventory_cleanup_signal'] ?? 0 ), 'inventory cleanup treats reconciled active metadata like current active metadata' );
+	$assert( 0, (int) ( $inventory_after['summary']['skipped_by_reason']['needs_metadata_reconcile'] ?? 0 ), 'inventory cleanup requires fewer metadata reconciliation passes after apply' );
+	$assert( 5, (int) ( $inventory_after['summary']['skipped_by_reason']['active_no_signal'] ?? 0 ), 'inventory cleanup treats reconciled active metadata like current active metadata' );
 	$assert( false, isset( $inventory_after['summary']['repair_status'] ), 'inventory cleanup no longer exposes migration status' );
 
 	echo "\nSafety gates\n";


### PR DESCRIPTION
## Summary
- Split inventory-only cleanup skips into actionable lifecycle reconciliation, metadata reconciliation, and active/no-signal buckets.
- Add stable `cleanup_buckets` summary counts and next-action hints for cleanup plan/report consumers.
- Keep cleanup planning non-destructive while preserving legacy aliases for existing filters.

Fixes #254

## Tests
- `php tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-worktree-cleanup.php`
- `php tests/smoke-workspace-hygiene-report.php`
- `php tests/smoke-worktree-metadata-reconcile.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementing the cleanup planning bucket/reporting changes, updating smoke coverage, and running verification. Chris remains responsible for review and merge.