### PR TITLE
Auto-finalize merged worktree metadata

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -2216,6 +2216,7 @@ class WorkspaceAbilities {
 		$workspace = new Workspace();
 		$opts      = array(
 			'dry_run' => ! empty( $input['dry_run'] ),
+			'apply'   => ! empty( $input['apply'] ),
 		);
 		if ( isset( $input['apply_plan'] ) && is_array( $input['apply_plan'] ) ) {
 			$opts['apply_plan'] = $input['apply_plan'];

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1888,6 +1888,7 @@ class WorkspaceCommand extends BaseCommand {
 	 *
 	 *     # Adopt/reconcile unmanaged worktree metadata before cleanup
 	 *     wp datamachine-code workspace worktree reconcile-metadata --dry-run --format=json
+	 *     wp datamachine-code workspace worktree reconcile-metadata --apply --format=json
 	 *
 	 *     # Ignore dirty working-tree safety (caution)
 	 *     wp datamachine-code workspace worktree cleanup --force
@@ -2075,6 +2076,7 @@ class WorkspaceCommand extends BaseCommand {
 				break;
 			case 'reconcile-metadata':
 				$input['dry_run'] = ! empty( $assoc_args['dry-run'] );
+				$input['apply']   = ! empty( $assoc_args['apply'] );
 				if ( ! empty( $assoc_args['apply-plan'] ) ) {
 					$input['apply_plan'] = $this->read_worktree_json_plan( (string) $assoc_args['apply-plan'], 'metadata reconciliation' );
 				}

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -3493,14 +3493,15 @@ class Workspace {
 	 */
 	public function worktree_reconcile_metadata( array $opts = array() ): array|\WP_Error {
 		$dry_run    = ! empty( $opts['dry_run'] );
+		$apply      = ! empty( $opts['apply'] );
 		$apply_plan = isset( $opts['apply_plan'] ) && is_array( $opts['apply_plan'] ) ? $opts['apply_plan'] : null;
 
 		if ( null !== $apply_plan ) {
 			return $this->apply_worktree_metadata_reconciliation_plan( $apply_plan );
 		}
 
-		if ( ! $dry_run ) {
-			return new \WP_Error( 'metadata_reconcile_requires_review', 'Metadata reconciliation is dry-run-first. Pass --dry-run to review JSON output; --apply-plan=<file> remains a low-level escape hatch until DB-backed cleanup runs land.', array( 'status' => 400 ) );
+		if ( ! $dry_run && ! $apply ) {
+			return new \WP_Error( 'metadata_reconcile_requires_review', 'Metadata reconciliation is dry-run-first. Pass --dry-run to review JSON output, or pass apply=true for DMC-owned lifecycle reconciliation.', array( 'status' => 400 ) );
 		}
 
 		$listing = $this->worktree_list();
@@ -3508,15 +3509,17 @@ class Workspace {
 			return $listing;
 		}
 
-		$proposals = array();
-		$skipped   = array();
+		$proposals    = array();
+		$skipped      = array();
+		$github_cache = array();
+		$fetched      = array();
 
 		foreach ( (array) ( $listing['worktrees'] ?? array() ) as $wt ) {
 			if ( ! empty( $wt['is_primary'] ) ) {
 				continue;
 			}
 
-			$proposal = $this->build_worktree_metadata_reconciliation_row( $wt );
+			$proposal = $this->build_worktree_metadata_reconciliation_row( $wt, $github_cache, $fetched );
 			if ( isset( $proposal['proposal'] ) ) {
 				$proposals[] = $proposal['proposal'];
 			} elseif ( isset( $proposal['skip'] ) ) {
@@ -3526,9 +3529,9 @@ class Workspace {
 
 		$classified_skips = $this->classify_worktree_metadata_reconciliation_skips( $skipped );
 
-		return array(
+		$plan = array(
 			'success'        => true,
-			'dry_run'        => true,
+			'dry_run'        => $dry_run,
 			'applied'        => false,
 			'generated_at'   => gmdate( 'c' ),
 			'workspace_path' => $this->workspace_path,
@@ -3539,6 +3542,12 @@ class Workspace {
 			'external_worktrees' => $classified_skips['external_worktrees'],
 			'summary'        => $this->build_worktree_metadata_reconciliation_summary( count( (array) ( $listing['worktrees'] ?? array() ) ), $proposals, array(), $skipped ),
 		);
+
+		if ( $apply ) {
+			return $this->apply_worktree_metadata_reconciliation_plan( $plan );
+		}
+
+		return $plan;
 	}
 
 	/**
@@ -3547,7 +3556,7 @@ class Workspace {
 	 * @param array<string,mixed> $wt Worktree list row.
 	 * @return array{proposal?:array<string,mixed>,skip?:array<string,mixed>}
 	 */
-	private function build_worktree_metadata_reconciliation_row( array $wt ): array {
+	private function build_worktree_metadata_reconciliation_row( array $wt, array &$github_cache = array(), array &$fetched = array() ): array {
 		$handle   = (string) ( $wt['handle'] ?? '' );
 		$repo     = (string) ( $wt['repo'] ?? '' );
 		$branch   = (string) ( $wt['branch'] ?? '' );
@@ -3601,6 +3610,103 @@ class Workspace {
 					array(
 						'reason_code' => 'noncanonical_handle',
 						'reason'      => 'worktree is not represented by a canonical <repo>@<slug> workspace handle',
+					)
+				),
+			);
+		}
+
+		$dirty   = (int) ( $wt['dirty'] ?? 0 );
+		$unpushed = $this->count_unpushed_commits( $path );
+		if ( is_wp_error( $unpushed ) ) {
+			return array(
+				'skip' => array_merge(
+					$base_row,
+					array(
+						'reason_code' => 'probe_timeout',
+						'reason'      => 'cleanup safety probe failed - leaving lifecycle unchanged: ' . $unpushed->get_error_message(),
+					)
+				),
+			);
+		}
+
+		$finalizer_signal = $this->detect_worktree_lifecycle_finalizer_signal( $wt, $metadata, $github_cache, $fetched );
+		if ( null !== $finalizer_signal && 'probe-timeout' === ( $finalizer_signal['signal'] ?? '' ) ) {
+			return array(
+				'skip' => array_merge(
+					$base_row,
+					array(
+						'reason_code' => 'probe_timeout',
+						'reason'      => 'merge-signal probe timed out - leaving lifecycle unchanged: ' . $finalizer_signal['reason'],
+					)
+				),
+			);
+		}
+
+		if ( null !== $finalizer_signal && ! WorktreeContextInjector::has_cleanup_signal( $metadata ) ) {
+			if ( $dirty > 0 || $unpushed > 0 ) {
+				return array(
+					'skip' => array_merge(
+						$base_row,
+						array(
+							'reason_code' => 'unsafe_cleanup_eligible_state',
+							'reason'      => 'merged lifecycle signal found, but dirty or unpushed worktree is not auto-finalized',
+							'dirty'       => $dirty,
+							'unpushed'    => $unpushed,
+							'signal'      => $finalizer_signal['signal'],
+						)
+					),
+				);
+			}
+
+			$finalizer_metadata = WorktreeContextInjector::build_finalizer_metadata(
+				WorktreeContextInjector::STATE_MERGED,
+				isset( $finalizer_signal['pr_url'] ) ? (string) $finalizer_signal['pr_url'] : null
+			);
+			$proposed           = array_merge(
+				$metadata,
+				array(
+					'handle'       => $handle,
+					'repo'         => $repo,
+					'branch'       => $branch,
+					'path'         => $path,
+					'observed_at'  => gmdate( 'c' ),
+					'last_seen_at' => gmdate( 'c' ),
+				),
+				$finalizer_metadata,
+				array(
+					'auto_finalized_by'     => 'worktree_reconcile_metadata',
+					'auto_finalized_signal' => $finalizer_signal['signal'],
+					'auto_finalized_reason' => $finalizer_signal['reason'],
+				)
+			);
+
+			if ( empty( $proposed['created_at'] ) ) {
+				$created_at = file_exists( $path ) ? filemtime( $path ) : false;
+				if ( false !== $created_at ) {
+					$proposed['created_at'] = gmdate( 'c', (int) $created_at );
+				}
+			}
+
+			return array(
+				'proposal' => array_merge(
+					$base_row,
+					array(
+						'reason_code'       => 'auto_finalize_merged',
+						'reason'            => 'merged PR or branch state proves lifecycle can be finalized as cleanup_eligible',
+						'dirty'             => $dirty,
+						'unpushed'          => $unpushed,
+						'signal'            => $finalizer_signal['signal'],
+						'pr_url'            => $finalizer_signal['pr_url'] ?? null,
+						'proposed_metadata' => $proposed,
+						'source_map'        => array(
+							'handle'          => 'filesystem',
+							'repo'            => 'filesystem',
+							'branch'          => 'git',
+							'path'            => 'git',
+							'created_at'      => empty( $metadata['created_at'] ) ? 'filesystem' : 'metadata',
+							'observed_at'     => 'reconcile_run',
+							'lifecycle_state' => 'merge_signal',
+						)
 					)
 				),
 			);
@@ -3691,8 +3797,8 @@ class Workspace {
 				array(
 					'reason_code'       => 'metadata_backfill',
 					'reason'            => 'unmanaged worktree metadata can be reconciled without changing cleanup eligibility',
-					'dirty'             => (int) ( $wt['dirty'] ?? 0 ),
-					'unpushed'          => $this->count_unpushed_commits( $path ),
+					'dirty'             => $dirty,
+					'unpushed'          => $unpushed,
 					'missing_fields'    => $metadata_missing,
 					'invalid_fields'    => $invalid_fields,
 					'proposed_metadata' => $proposed,
@@ -3700,6 +3806,120 @@ class Workspace {
 				)
 			),
 		);
+	}
+
+	/**
+	 * Detect an unambiguous merge signal for lifecycle reconciliation.
+	 *
+	 * @param array<string,mixed> $wt           Current worktree listing row.
+	 * @param array<string,mixed> $metadata     Persisted lifecycle metadata.
+	 * @param array               $github_cache Run-local GitHub lookup cache.
+	 * @param array               $fetched      Run-local fetched repo cache.
+	 * @return array{signal:string,reason:string,pr_url?:string}|null
+	 */
+	private function detect_worktree_lifecycle_finalizer_signal( array $wt, array $metadata, array &$github_cache, array &$fetched ): ?array {
+		$repo         = (string) ( $wt['repo'] ?? '' );
+		$branch       = (string) ( $wt['branch'] ?? '' );
+		$primary_path = '' !== $repo ? $this->get_primary_path( $repo ) : '';
+		if ( '' === $repo || '' === $branch || ! is_dir( $primary_path . '/.git' ) ) {
+			return null;
+		}
+
+		if ( empty( $fetched[ $repo ] ) ) {
+			$fetch = $this->run_git( $primary_path, 'fetch --prune --quiet origin', self::CLEANUP_GIT_PROBE_TIMEOUT );
+			if ( $this->is_git_timeout_error( $fetch ) ) {
+				return array(
+					'signal' => 'probe-timeout',
+					'reason' => $fetch->get_error_message(),
+				);
+			}
+			$fetched[ $repo ] = true;
+		}
+
+		$pr_signal = $this->detect_stored_pr_merged_signal( $metadata, $github_cache );
+		if ( null !== $pr_signal ) {
+			return $pr_signal;
+		}
+
+		$signal = $this->detect_merge_signal( $primary_path, $repo, $branch, true, $github_cache );
+		if ( null === $signal ) {
+			return null;
+		}
+
+		if ( in_array( (string) ( $signal['signal'] ?? '' ), array( 'upstream-gone', 'local-merged' ), true ) ) {
+			return $signal;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Check stored PR metadata for a merged PR signal.
+	 *
+	 * @param array<string,mixed> $metadata     Persisted lifecycle metadata.
+	 * @param array               $github_cache Run-local GitHub lookup cache.
+	 * @return array{signal:string,reason:string,pr_url?:string}|null
+	 */
+	private function detect_stored_pr_merged_signal( array $metadata, array &$github_cache ): ?array {
+		$pr_repo   = isset( $metadata['pr_repo'] ) ? (string) $metadata['pr_repo'] : '';
+		$pr_number = isset( $metadata['pr_number'] ) ? (int) $metadata['pr_number'] : 0;
+		$pr_url    = isset( $metadata['pr_url'] ) ? (string) $metadata['pr_url'] : '';
+
+		if ( ( '' === $pr_repo || $pr_number <= 0 ) && '' !== $pr_url && preg_match( '~^https?://github\.com/([^/]+)/([^/]+)/pull/(\d+)(?:[/?#].*)?$~', $pr_url, $matches ) ) {
+			$pr_repo   = $matches[1] . '/' . $matches[2];
+			$pr_number = (int) $matches[3];
+		}
+
+		if ( '' === $pr_repo || $pr_number <= 0 ) {
+			return null;
+		}
+
+		$cache_key = $pr_repo . '#' . $pr_number;
+		if ( array_key_exists( $cache_key, $github_cache ) ) {
+			$pr = $github_cache[ $cache_key ];
+		} else {
+			$pr = $this->fetch_github_pull_request( $pr_repo, $pr_number );
+			$github_cache[ $cache_key ] = $pr;
+		}
+
+		if ( ! is_array( $pr ) || empty( $pr['merged_at'] ) ) {
+			return null;
+		}
+
+		return array(
+			'signal' => 'pr-merged',
+			'reason' => sprintf( 'stored PR #%d merged (%s)', $pr_number, (string) ( $pr['state'] ?? 'closed' ) ),
+			'pr_url' => (string) ( $pr['html_url'] ?? $pr_url ),
+		);
+	}
+
+	/**
+	 * Fetch one pull request from GitHub when API credentials are available.
+	 *
+	 * @return array<string,mixed>|null
+	 */
+	private function fetch_github_pull_request( string $slug, int $number ): ?array {
+		if ( ! class_exists( '\DataMachineCode\Abilities\GitHubAbilities' ) ) {
+			return null;
+		}
+
+		$pat = \DataMachineCode\Abilities\GitHubAbilities::getPat();
+		if ( empty( $pat ) ) {
+			return null;
+		}
+
+		$response = \DataMachineCode\Abilities\GitHubAbilities::apiGet(
+			GitHubRemote::apiUrl( $slug, 'pulls/' . $number ),
+			array(),
+			$pat,
+			self::CLEANUP_GITHUB_TIMEOUT
+		);
+		if ( is_wp_error( $response ) ) {
+			return null;
+		}
+
+		$data = $response['data'] ?? null;
+		return is_array( $data ) ? $data : null;
 	}
 
 	/**

--- a/tests/smoke-worktree-metadata-reconcile.php
+++ b/tests/smoke-worktree-metadata-reconcile.php
@@ -21,9 +21,19 @@ namespace DataMachineCode\Abilities {
 	if ( ! class_exists( __NAMESPACE__ . '\GitHubAbilities' ) ) {
 		class GitHubAbilities {
 			public static function getPat(): string {
-				return '';
+				return 'test-token';
 			}
 			public static function apiGet( string $url, array $params, string $pat ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+				if ( str_ends_with( $url, '/pulls/101' ) ) {
+					return array(
+						'data' => array(
+							'number'    => 101,
+							'state'     => 'closed',
+							'merged_at' => '2026-04-03T00:00:00Z',
+							'html_url'  => 'https://github.com/acme/demo/pull/101',
+						),
+					);
+				}
 				return array( 'data' => array() );
 			}
 		}
@@ -181,6 +191,10 @@ namespace {
 	$make_branch( 'unmanaged-dirty' );
 	$make_branch( 'unmanaged-invalid' );
 	$make_branch( 'already-current' );
+	$make_branch( 'pr-merged' );
+	$make_branch( 'upstream-gone' );
+	$make_branch( 'dirty-merged' );
+	$make_branch( 'unpushed-merged' );
 	$make_branch( 'external-branch' );
 
 	$run( sprintf( 'git worktree add %s unmanaged-missing', escapeshellarg( $tmp . '/demo@unmanaged-missing' ) ), $primary );
@@ -188,9 +202,18 @@ namespace {
 	$run( sprintf( 'git worktree add %s unmanaged-dirty', escapeshellarg( $tmp . '/demo@unmanaged-dirty' ) ), $primary );
 	$run( sprintf( 'git worktree add %s unmanaged-invalid', escapeshellarg( $tmp . '/demo@unmanaged-invalid' ) ), $primary );
 	$run( sprintf( 'git worktree add %s already-current', escapeshellarg( $tmp . '/demo@already-current' ) ), $primary );
+	$run( sprintf( 'git worktree add %s pr-merged', escapeshellarg( $tmp . '/demo@pr-merged' ) ), $primary );
+	$run( sprintf( 'git worktree add %s upstream-gone', escapeshellarg( $tmp . '/demo@upstream-gone' ) ), $primary );
+	$run( sprintf( 'git worktree add %s dirty-merged', escapeshellarg( $tmp . '/demo@dirty-merged' ) ), $primary );
+	$run( sprintf( 'git worktree add %s unpushed-merged', escapeshellarg( $tmp . '/demo@unpushed-merged' ) ), $primary );
 	mkdir( $tmp . '-external', 0755, true );
 	$run( sprintf( 'git worktree add %s external-branch', escapeshellarg( $tmp . '-external/demo-external' ) ), $primary );
 	file_put_contents( $tmp . '/demo@unmanaged-dirty/scratch.txt', 'dirty' );
+	file_put_contents( $tmp . '/demo@dirty-merged/scratch.txt', 'dirty' );
+	file_put_contents( $tmp . '/demo@unpushed-merged/local.txt', 'local' );
+	$run( 'git add local.txt && git commit -m local-unpushed', $tmp . '/demo@unpushed-merged' );
+	$run( sprintf( 'git --git-dir=%s update-ref -d refs/heads/upstream-gone', escapeshellarg( $remote ) ) );
+	$run( sprintf( 'git --git-dir=%s update-ref -d refs/heads/dirty-merged', escapeshellarg( $remote ) ) );
 
 	\DataMachineCode\Workspace\WorktreeContextInjector::store_metadata(
 		'demo@unmanaged-partial',
@@ -225,6 +248,36 @@ namespace {
 			'lifecycle_state' => \DataMachineCode\Workspace\WorktreeContextInjector::STATE_ACTIVE,
 		)
 	);
+	\DataMachineCode\Workspace\WorktreeContextInjector::store_lifecycle_metadata(
+		'demo@pr-merged',
+		array(
+			'handle'          => 'demo@pr-merged',
+			'repo'            => 'demo',
+			'branch'          => 'pr-merged',
+			'path'            => $tmp . '/demo@pr-merged',
+			'created_at'      => '2026-04-01T00:00:00+00:00',
+			'observed_at'     => '2026-04-01T00:00:00+00:00',
+			'lifecycle_state' => \DataMachineCode\Workspace\WorktreeContextInjector::STATE_ACTIVE,
+			'pr_url'          => 'https://github.com/acme/demo/pull/101',
+			'pr_number'       => 101,
+			'pr_repo'         => 'acme/demo',
+		)
+	);
+	\DataMachineCode\Workspace\WorktreeContextInjector::store_lifecycle_metadata(
+		'demo@unpushed-merged',
+		array(
+			'handle'          => 'demo@unpushed-merged',
+			'repo'            => 'demo',
+			'branch'          => 'unpushed-merged',
+			'path'            => $tmp . '/demo@unpushed-merged',
+			'created_at'      => '2026-04-01T00:00:00+00:00',
+			'observed_at'     => '2026-04-01T00:00:00+00:00',
+			'lifecycle_state' => \DataMachineCode\Workspace\WorktreeContextInjector::STATE_ACTIVE,
+			'pr_url'          => 'https://github.com/acme/demo/pull/101',
+			'pr_number'       => 101,
+			'pr_repo'         => 'acme/demo',
+		)
+	);
 
 	$ws = new \DataMachineCode\Workspace\Workspace();
 
@@ -232,9 +285,10 @@ namespace {
 	$plan = $ws->worktree_reconcile_metadata( array( 'dry_run' => true ) );
 	$assert( true, ! is_wp_error( $plan ) && ( $plan['success'] ?? false ), 'dry-run succeeds' );
 	$assert( true, $plan['dry_run'] ?? false, 'dry-run flag is true' );
-	$assert( 4, (int) ( $plan['summary']['proposed'] ?? 0 ), 'dry-run proposes only unmanaged rows' );
+	$assert( 6, (int) ( $plan['summary']['proposed'] ?? 0 ), 'dry-run proposes unmanaged rows and safe merged lifecycle finalizers' );
 	$assert( 0, (int) ( $plan['summary']['written'] ?? 0 ), 'dry-run writes nothing' );
 	$assert( 1, (int) ( $plan['summary']['skipped_by_reason']['external_worktree'] ?? 0 ), 'dry-run distinguishes external worktrees' );
+	$assert( 2, (int) ( $plan['summary']['skipped_by_reason']['unsafe_cleanup_eligible_state'] ?? 0 ), 'dry-run keeps dirty and unpushed merged worktrees out of auto-finalize proposals' );
 	$assert( 1, count( $plan['external_worktrees'] ?? array() ), 'dry-run exposes external worktree bucket' );
 
 	$by_handle = array();
@@ -251,28 +305,48 @@ namespace {
 	$assert( \DataMachineCode\Workspace\WorktreeContextInjector::STATE_ACTIVE, $by_handle['demo@unmanaged-invalid']['proposed_metadata']['lifecycle_state'] ?? '', 'invalid lifecycle state becomes conservative active proposal' );
 	$assert( 1, (int) ( $by_handle['demo@unmanaged-dirty']['dirty'] ?? 0 ), 'dirty row is visible but not cleanup-eligible' );
 	$assert( \DataMachineCode\Workspace\WorktreeContextInjector::STATE_ACTIVE, $by_handle['demo@unmanaged-dirty']['proposed_metadata']['lifecycle_state'] ?? '', 'dirty row proposal stays active' );
+	$assert( 'auto_finalize_merged', $by_handle['demo@pr-merged']['reason_code'] ?? '', 'merged stored PR is proposed for auto-finalization' );
+	$assert( 'pr-merged', $by_handle['demo@pr-merged']['signal'] ?? '', 'stored PR proposal records pr-merged signal' );
+	$assert( 'cleanup_eligible', $by_handle['demo@pr-merged']['proposed_metadata']['lifecycle_state'] ?? '', 'stored PR proposal becomes cleanup_eligible metadata' );
+	$assert( 'merged', $by_handle['demo@pr-merged']['proposed_metadata']['finalized_state'] ?? '', 'stored PR proposal preserves merged finalized state' );
+	$assert( 'auto_finalize_merged', $by_handle['demo@upstream-gone']['reason_code'] ?? '', 'upstream-gone branch is proposed for auto-finalization' );
+	$assert( 'upstream-gone', $by_handle['demo@upstream-gone']['signal'] ?? '', 'upstream-gone proposal records local merge signal' );
+	$unsafe_by_handle = array();
+	foreach ( $plan['skipped'] as $row ) {
+		$unsafe_by_handle[ $row['handle'] ?? '' ] = $row;
+	}
+	$assert( 'unsafe_cleanup_eligible_state', $unsafe_by_handle['demo@dirty-merged']['reason_code'] ?? '', 'dirty merged worktree is not auto-finalized' );
+	$assert( 'unsafe_cleanup_eligible_state', $unsafe_by_handle['demo@unpushed-merged']['reason_code'] ?? '', 'unpushed merged worktree is not auto-finalized' );
 	$stale_plan  = $plan;
 	$unsafe_plan = $plan;
 
 	$inventory_before = $ws->worktree_cleanup_merged( array( 'dry_run' => true, 'inventory_only' => true, 'skip_github' => true ) );
-	$assert( 2, (int) ( $inventory_before['summary']['skipped_by_reason']['requires_full_scan'] ?? 0 ), 'inventory cleanup sees missing metadata before apply' );
+	$assert( 4, (int) ( $inventory_before['summary']['skipped_by_reason']['requires_full_scan'] ?? 0 ), 'inventory cleanup sees missing metadata before apply' );
 
 	echo "\nApply reviewed plan\n";
 	$apply = $ws->worktree_reconcile_metadata( array( 'apply_plan' => $plan ) );
 	$assert( true, ! is_wp_error( $apply ) && ( $apply['success'] ?? false ), 'apply succeeds' );
-	$assert( 4, (int) ( $apply['summary']['written'] ?? 0 ), 'apply writes exact current matches' );
-	$assert( 4, (int) ( $apply['summary']['written'] ?? 0 ), 'apply reports written metadata rows' );
+	$assert( 6, (int) ( $apply['summary']['written'] ?? 0 ), 'apply writes exact current matches' );
+	$assert( 6, (int) ( $apply['summary']['written'] ?? 0 ), 'apply reports written metadata rows' );
 	$assert( 0, (int) ( $apply['summary']['skipped'] ?? 0 ), 'apply skips nothing for current plan' );
-	$assert( 4, count( $apply['written'] ?? array() ), 'apply exposes written rows distinctly' );
+	$assert( 6, count( $apply['written'] ?? array() ), 'apply exposes written rows distinctly' );
 	$stored = \DataMachineCode\Workspace\WorktreeContextInjector::get_metadata( 'demo@unmanaged-missing' );
 	$assert( 'demo@unmanaged-missing', $stored['handle'] ?? '', 'stored metadata includes handle' );
 	$assert( true, ! empty( $stored['observed_at'] ), 'stored metadata includes observed_at' );
 	$assert( 'Origin Test', $stored['origin_site'] ?? '', 'stored metadata includes origin site when available' );
 	$assert( 'operator_plan', $stored['reconciled_sources']['lifecycle_state'] ?? '', 'stored metadata keeps source map' );
+	$stored_pr = \DataMachineCode\Workspace\WorktreeContextInjector::get_metadata( 'demo@pr-merged' );
+	$assert( 'cleanup_eligible', $stored_pr['lifecycle_state'] ?? '', 'apply stores cleanup_eligible for merged PR worktree' );
+	$assert( 'merged', $stored_pr['finalized_state'] ?? '', 'apply stores merged finalizer state for merged PR worktree' );
+	$stored_gone = \DataMachineCode\Workspace\WorktreeContextInjector::get_metadata( 'demo@upstream-gone' );
+	$assert( 'cleanup_eligible', $stored_gone['lifecycle_state'] ?? '', 'apply stores cleanup_eligible for upstream-gone worktree' );
+
+	$auto_apply = $ws->worktree_reconcile_metadata( array( 'apply' => true ) );
+	$assert( true, ! is_wp_error( $auto_apply ) && ( $auto_apply['success'] ?? false ), 'DMC-owned reconciliation apply path runs without a manual plan' );
 
 	$inventory_after = $ws->worktree_cleanup_merged( array( 'dry_run' => true, 'inventory_only' => true, 'skip_github' => true ) );
-	$assert( 0, (int) ( $inventory_after['summary']['skipped_by_reason']['requires_full_scan'] ?? 0 ), 'inventory cleanup requires fewer full scans after apply' );
-	$assert( 5, (int) ( $inventory_after['summary']['skipped_by_reason']['no_inventory_cleanup_signal'] ?? 0 ), 'inventory cleanup treats reconciled active metadata like current active metadata' );
+	$assert( 1, (int) ( $inventory_after['summary']['skipped_by_reason']['requires_full_scan'] ?? 0 ), 'inventory cleanup requires fewer full scans after apply' );
+	$assert( 6, (int) ( $inventory_after['summary']['skipped_by_reason']['no_inventory_cleanup_signal'] ?? 0 ), 'inventory cleanup treats reconciled active metadata like current active metadata' );
 	$assert( false, isset( $inventory_after['summary']['repair_status'] ), 'inventory cleanup no longer exposes migration status' );
 
 	echo "\nSafety gates\n";


### PR DESCRIPTION
## Summary
- Auto-finalizes managed worktree metadata as `cleanup_eligible` when reconciliation proves a stored PR is merged or a branch is locally merged/upstream-gone.
- Keeps dirty and unpushed worktrees out of auto-finalization so deletion still depends on existing revalidation safety rails.
- Adds smoke coverage for PR-merged, upstream-gone, no-signal/active, dirty, and unpushed reconciliation behavior.

## Testing
- `php tests/smoke-worktree-metadata-reconcile.php`
- `php tests/smoke-worktree-lifecycle-metadata.php`
- `php tests/smoke-worktree-cleanup.php`
- `php tests/smoke-worktree-finalizer-cli.php`
- `php tests/smoke-worktree-cleanup-cli.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementing the lifecycle reconciliation change, adding smoke coverage, and running focused verification. Chris provided the issue, constraints, and reviewed direction.

Fixes #253