### PR TITLE
feat: add datamachine/create-github-issue and create-github-pull-request abilities

### DIFF
--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -213,6 +213,110 @@ class GitHubAbilities {
 			);
 
 			wp_register_ability(
+				'datamachine/create-github-issue',
+				array(
+					'label'               => 'Create GitHub Issue',
+					'description'         => 'Create a new GitHub issue with optional labels, assignees, and milestone',
+					'category'            => 'datamachine-code-github',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'repo', 'title' ),
+						'properties' => array(
+							'repo'      => array(
+								'type'        => 'string',
+								'description' => 'Repository in owner/repo format.',
+							),
+							'title'     => array(
+								'type'        => 'string',
+								'description' => 'Issue title (required).',
+							),
+							'body'      => array(
+								'type'        => 'string',
+								'description' => 'Issue body (supports GitHub Markdown).',
+							),
+							'labels'    => array(
+								'type'        => 'array',
+								'description' => 'Labels to attach to the issue.',
+							),
+							'assignees' => array(
+								'type'        => 'array',
+								'description' => 'GitHub usernames to assign to the issue.',
+							),
+							'milestone' => array(
+								'type'        => array( 'integer', 'null' ),
+								'description' => 'Milestone number to attach to the issue.',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'issue'   => array( 'type' => 'object' ),
+							'error'   => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'createIssue' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/create-github-pull-request',
+				array(
+					'label'               => 'Create GitHub Pull Request',
+					'description'         => 'Open a new GitHub pull request from a head branch into a base branch',
+					'category'            => 'datamachine-code-github',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'repo', 'title', 'head' ),
+						'properties' => array(
+							'repo'                  => array(
+								'type'        => 'string',
+								'description' => 'Repository in owner/repo format.',
+							),
+							'title'                 => array(
+								'type'        => 'string',
+								'description' => 'Pull request title (required).',
+							),
+							'head'                  => array(
+								'type'        => 'string',
+								'description' => 'Branch where changes are implemented (required). Use owner:branch for cross-fork PRs.',
+							),
+							'base'                  => array(
+								'type'        => 'string',
+								'description' => 'Branch to merge into. Defaults to the repository default branch.',
+							),
+							'body'                  => array(
+								'type'        => 'string',
+								'description' => 'Pull request description (supports GitHub Markdown).',
+							),
+							'draft'                 => array(
+								'type'        => 'boolean',
+								'description' => 'Whether to open the pull request as a draft. Default: false.',
+							),
+							'maintainer_can_modify' => array(
+								'type'        => 'boolean',
+								'description' => 'Whether maintainers can modify the pull request. Default: true.',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'      => array( 'type' => 'boolean' ),
+							'pull_request' => array( 'type' => 'object' ),
+							'error'        => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'createPullRequest' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
 				'datamachine/comment-github-issue',
 				array(
 					'label'               => 'Comment on GitHub Issue',
@@ -1161,6 +1265,12 @@ class GitHubAbilities {
 		if ( ! empty( $input['assignees'] ) && is_array( $input['assignees'] ) ) {
 			$body['assignees'] = array_map( 'sanitize_text_field', $input['assignees'] );
 		}
+		if ( isset( $input['milestone'] ) && null !== $input['milestone'] && '' !== $input['milestone'] ) {
+			$milestone = (int) $input['milestone'];
+			if ( $milestone > 0 ) {
+				$body['milestone'] = $milestone;
+			}
+		}
 
 		$url      = sprintf( '%s/repos/%s/issues', self::API_BASE, $repo );
 		$response = self::apiRequest( 'POST', $url, $body, $pat );
@@ -1179,6 +1289,102 @@ class GitHubAbilities {
 			'html_url'     => $issue['html_url'] ?? '',
 			'message'      => sprintf( 'Issue #%d created in %s.', $issue['number'] ?? 0, $repo ),
 		);
+	}
+
+	/**
+	 * Create a new pull request.
+	 *
+	 * Calls `POST /repos/{owner}/{repo}/pulls`.
+	 *
+	 * @param array $input {
+	 *     Required: repo, title, head. Optional: base, body, draft, maintainer_can_modify.
+	 * }
+	 * @return array|\WP_Error { success: bool, pull_request: normalized, error: string|null } or error.
+	 */
+	public static function createPullRequest( array $input ): array|\WP_Error {
+		$repo = self::resolveRepo( sanitize_text_field( $input['repo'] ?? '' ) );
+		if ( empty( $repo ) ) {
+			return new \WP_Error( 'missing_repo', 'Repository (owner/repo) is required or configure a default repo.', array( 'status' => 400 ) );
+		}
+
+		$title = sanitize_text_field( $input['title'] ?? '' );
+		if ( empty( $title ) ) {
+			return new \WP_Error( 'missing_title', 'Pull request title is required.', array( 'status' => 400 ) );
+		}
+
+		$head = sanitize_text_field( $input['head'] ?? '' );
+		if ( empty( $head ) ) {
+			return new \WP_Error( 'missing_head', 'Pull request head branch is required.', array( 'status' => 400 ) );
+		}
+
+		$pat = self::getPat();
+		if ( empty( $pat ) ) {
+			return self::patError();
+		}
+
+		$body = array(
+			'title' => $title,
+			'head'  => $head,
+		);
+
+		$base = sanitize_text_field( $input['base'] ?? '' );
+		if ( '' === $base ) {
+			$base = self::resolveDefaultBranch( $repo, $pat );
+			if ( is_wp_error( $base ) ) {
+				return $base;
+			}
+		}
+		$body['base'] = $base;
+
+		if ( isset( $input['body'] ) && '' !== $input['body'] ) {
+			$body['body'] = (string) $input['body'];
+		}
+		if ( array_key_exists( 'draft', $input ) ) {
+			$body['draft'] = (bool) $input['draft'];
+		}
+		if ( array_key_exists( 'maintainer_can_modify', $input ) ) {
+			$body['maintainer_can_modify'] = (bool) $input['maintainer_can_modify'];
+		} else {
+			$body['maintainer_can_modify'] = true;
+		}
+
+		$url      = sprintf( '%s/repos/%s/pulls', self::API_BASE, $repo );
+		$response = self::apiRequest( 'POST', $url, $body, $pat );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$pull = self::normalizePull( $response['data'] );
+
+		return array(
+			'success'      => true,
+			'pull_request' => $pull,
+			'pull_number'  => $pull['number'] ?? 0,
+			'html_url'     => $pull['html_url'] ?? '',
+			'message'      => sprintf( 'Pull request #%d opened in %s.', $pull['number'] ?? 0, $repo ),
+		);
+	}
+
+	/**
+	 * Resolve the default branch name for a repository.
+	 *
+	 * @param string $repo owner/repo identifier.
+	 * @param string $pat  GitHub credential token.
+	 * @return string|\WP_Error Default branch name or error.
+	 */
+	private static function resolveDefaultBranch( string $repo, string $pat ): string|\WP_Error {
+		$response = self::apiGet( sprintf( '%s/repos/%s', self::API_BASE, $repo ), array(), $pat );
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$default_branch = (string) ( $response['data']['default_branch'] ?? '' );
+		if ( '' === $default_branch ) {
+			return new \WP_Error( 'default_branch_missing', 'GitHub did not return a default branch for the repository.', array( 'status' => 500 ) );
+		}
+
+		return $default_branch;
 	}
 
 	public static function commentOnIssue( array $input ): array|\WP_Error {

--- a/tests/smoke-github-create-abilities.php
+++ b/tests/smoke-github-create-abilities.php
@@ -1,0 +1,366 @@
+<?php
+/**
+ * Pure-PHP smoke test for the GitHub create abilities.
+ *
+ * Run: php tests/smoke-github-create-abilities.php
+ *
+ * Verifies that `datamachine/create-github-issue` and
+ * `datamachine/create-github-pull-request` are registered with the right
+ * shape, validate required fields, surface GitHub errors via the `error`
+ * field, and fall through to `PermissionHelper::can_manage()`.
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Abilities {
+	class PermissionHelper {
+		public static int $can_manage_calls = 0;
+		public static bool $can_manage_result = true;
+
+		public static function can_manage(): bool {
+			++self::$can_manage_calls;
+			return self::$can_manage_result;
+		}
+	}
+}
+
+namespace DataMachine\Core {
+	class PluginSettings {
+		public static function get( string $key, string $default_value = '' ): string {
+			return $default_value;
+		}
+	}
+}
+
+namespace DataMachineCode\Support {
+	class GitHubCredentialResolver {
+		public static string $mode = 'pat';
+		public static $resolution = null;
+
+		public static function resolve() {
+			if ( null === self::$resolution ) {
+				return array( 'token' => 'test-token', 'mode' => self::$mode );
+			}
+			return self::$resolution;
+		}
+
+		public static function isConfigured(): bool {
+			return true;
+		}
+
+		public static function status(): array {
+			return array( 'configured' => true );
+		}
+
+		public static function mode(): string {
+			return self::$mode;
+		}
+	}
+}
+
+namespace DataMachineCode\GitHub {
+	class PrReviewEscalationPolicy {}
+	class PrHomeboyReviewRunner {}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	class WP_Ability {}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			public array $error_data;
+			public function __construct( private string $code = '', private string $message = '', array $data = array() ) {
+				$this->error_data = $data;
+			}
+			public function get_error_message(): string { return $this->message; }
+			public function get_error_code(): string { return $this->code; }
+			public function get_error_data() { return $this->error_data; }
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $thing ): bool { return $thing instanceof WP_Error; }
+	}
+
+	if ( ! function_exists( 'sanitize_text_field' ) ) {
+		function sanitize_text_field( $value ): string {
+			return is_string( $value ) ? trim( $value ) : '';
+		}
+	}
+
+	if ( ! function_exists( 'wp_json_encode' ) ) {
+		function wp_json_encode( $data ): string { return json_encode( $data ); }
+	}
+
+	if ( ! function_exists( 'add_query_arg' ) ) {
+		function add_query_arg( array $args, string $url ): string {
+			$separator = str_contains( $url, '?' ) ? '&' : '?';
+			return $url . $separator . http_build_query( $args );
+		}
+	}
+
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( string $hook, $value ) { return $value; }
+	}
+
+	$GLOBALS['dmc_registered_abilities'] = array();
+	$GLOBALS['dmc_http_calls']            = array();
+	$GLOBALS['dmc_http_responses']        = array();
+
+	function wp_register_ability( string $name, array $definition ): void {
+		$GLOBALS['dmc_registered_abilities'][ $name ] = $definition;
+	}
+
+	function doing_action( string $hook ): bool { return 'wp_abilities_api_init' === $hook; }
+	function did_action( string $hook ): int { return 0; }
+	function add_action( string $hook, callable $callback ): void {}
+
+	function wp_remote_get( string $url, array $args = array() ) {
+		$GLOBALS['dmc_http_calls'][] = array( 'method' => 'GET', 'url' => $url, 'args' => $args );
+		return array_shift( $GLOBALS['dmc_http_responses'] );
+	}
+
+	function wp_remote_request( string $url, array $args = array() ) {
+		$GLOBALS['dmc_http_calls'][] = array( 'method' => $args['method'] ?? 'POST', 'url' => $url, 'args' => $args );
+		return array_shift( $GLOBALS['dmc_http_responses'] );
+	}
+
+	function wp_remote_retrieve_response_code( $response ): int {
+		return (int) ( $response['response']['code'] ?? 0 );
+	}
+
+	function wp_remote_retrieve_body( $response ): string {
+		return (string) ( $response['body'] ?? '' );
+	}
+
+	require __DIR__ . '/../inc/Abilities/GitHubAbilities.php';
+
+	use DataMachineCode\Abilities\GitHubAbilities;
+	use DataMachine\Abilities\PermissionHelper;
+
+	$failures = array();
+	$assert   = function ( string $label, bool $cond ) use ( &$failures ): void {
+		if ( $cond ) {
+			echo "  ok {$label}\n";
+			return;
+		}
+		$failures[] = $label;
+		echo "  fail {$label}\n";
+	};
+
+	$queue_response = static function ( int $status, array $payload ): void {
+		$GLOBALS['dmc_http_responses'][] = array(
+			'response' => array( 'code' => $status ),
+			'body'     => json_encode( $payload ),
+		);
+	};
+
+	$reset_http = static function (): void {
+		$GLOBALS['dmc_http_calls']     = array();
+		$GLOBALS['dmc_http_responses'] = array();
+	};
+
+	echo "GitHub create abilities - smoke\n";
+
+	new GitHubAbilities();
+
+	$issue_ability = $GLOBALS['dmc_registered_abilities']['datamachine/create-github-issue'] ?? null;
+	$pr_ability    = $GLOBALS['dmc_registered_abilities']['datamachine/create-github-pull-request'] ?? null;
+
+	$assert( 'create-github-issue ability is registered', null !== $issue_ability );
+	$assert( 'create-github-issue uses createIssue execute_callback', array( GitHubAbilities::class, 'createIssue' ) === ( $issue_ability['execute_callback'] ?? null ) );
+	$assert( 'create-github-issue requires repo and title', array( 'repo', 'title' ) === ( $issue_ability['input_schema']['required'] ?? array() ) );
+	$assert( 'create-github-issue exposes labels', array_key_exists( 'labels', $issue_ability['input_schema']['properties'] ?? array() ) );
+	$assert( 'create-github-issue exposes assignees', array_key_exists( 'assignees', $issue_ability['input_schema']['properties'] ?? array() ) );
+	$assert( 'create-github-issue exposes milestone', array_key_exists( 'milestone', $issue_ability['input_schema']['properties'] ?? array() ) );
+	$assert( 'create-github-issue is hidden from REST', false === ( $issue_ability['meta']['show_in_rest'] ?? null ) );
+	$assert( 'create-github-issue category matches family', 'datamachine-code-github' === ( $issue_ability['category'] ?? '' ) );
+
+	$assert( 'create-github-pull-request ability is registered', null !== $pr_ability );
+	$assert( 'create-github-pull-request uses createPullRequest execute_callback', array( GitHubAbilities::class, 'createPullRequest' ) === ( $pr_ability['execute_callback'] ?? null ) );
+	$assert( 'create-github-pull-request requires repo, title, head', array( 'repo', 'title', 'head' ) === ( $pr_ability['input_schema']['required'] ?? array() ) );
+	$assert( 'create-github-pull-request exposes base', array_key_exists( 'base', $pr_ability['input_schema']['properties'] ?? array() ) );
+	$assert( 'create-github-pull-request exposes draft', array_key_exists( 'draft', $pr_ability['input_schema']['properties'] ?? array() ) );
+	$assert( 'create-github-pull-request exposes maintainer_can_modify', array_key_exists( 'maintainer_can_modify', $pr_ability['input_schema']['properties'] ?? array() ) );
+	$assert( 'create-github-pull-request is hidden from REST', false === ( $pr_ability['meta']['show_in_rest'] ?? null ) );
+
+	// Permission gating uses PermissionHelper::can_manage().
+	$issue_permission = $issue_ability['permission_callback'] ?? null;
+	$pr_permission    = $pr_ability['permission_callback'] ?? null;
+	$assert( 'create-github-issue permission_callback is callable', is_callable( $issue_permission ) );
+	$assert( 'create-github-pull-request permission_callback is callable', is_callable( $pr_permission ) );
+
+	PermissionHelper::$can_manage_calls = 0;
+	PermissionHelper::$can_manage_result = true;
+	$assert( 'create-github-issue allows can_manage users', true === $issue_permission() );
+	$assert( 'create-github-issue called PermissionHelper::can_manage', 1 === PermissionHelper::$can_manage_calls );
+
+	PermissionHelper::$can_manage_result = false;
+	$assert( 'create-github-pull-request denies non-can_manage users', false === $pr_permission() );
+	PermissionHelper::$can_manage_result = true;
+
+	// ---- createIssue: required-field validation
+	$reset_http();
+	$result = GitHubAbilities::createIssue( array() );
+	$assert( 'createIssue rejects missing repo', $result instanceof WP_Error && 'missing_repo' === $result->get_error_code() );
+
+	$result = GitHubAbilities::createIssue( array( 'repo' => 'owner/repo' ) );
+	$assert( 'createIssue rejects missing title', $result instanceof WP_Error && 'missing_title' === $result->get_error_code() );
+
+	// ---- createIssue: success path includes all optional inputs
+	$reset_http();
+	$queue_response( 201, array(
+		'number'   => 42,
+		'title'    => 'Hello',
+		'state'    => 'open',
+		'html_url' => 'https://github.com/owner/repo/issues/42',
+		'labels'   => array( array( 'name' => 'bug' ) ),
+	) );
+	$result = GitHubAbilities::createIssue( array(
+		'repo'      => 'owner/repo',
+		'title'     => 'Hello',
+		'body'      => 'Body text',
+		'labels'    => array( 'bug' ),
+		'assignees' => array( 'octocat' ),
+		'milestone' => 7,
+	) );
+	$assert( 'createIssue success path returns success=true', is_array( $result ) && true === ( $result['success'] ?? false ) );
+	$assert( 'createIssue success path returns normalized issue', is_array( $result ) && 42 === ( $result['issue']['number'] ?? 0 ) );
+	$assert( 'createIssue success exposes issue_number', is_array( $result ) && 42 === ( $result['issue_number'] ?? 0 ) );
+	$call = $GLOBALS['dmc_http_calls'][0] ?? array();
+	$body = is_string( $call['args']['body'] ?? null ) ? json_decode( $call['args']['body'], true ) : null;
+	$assert( 'createIssue posts to /repos/owner/repo/issues', is_string( $call['url'] ?? null ) && str_ends_with( $call['url'], '/repos/owner/repo/issues' ) );
+	$assert( 'createIssue forwards labels', is_array( $body ) && array( 'bug' ) === ( $body['labels'] ?? array() ) );
+	$assert( 'createIssue forwards assignees', is_array( $body ) && array( 'octocat' ) === ( $body['assignees'] ?? array() ) );
+	$assert( 'createIssue forwards milestone as int', is_array( $body ) && 7 === ( $body['milestone'] ?? null ) );
+
+	// ---- createIssue: ignores null milestone
+	$reset_http();
+	$queue_response( 201, array( 'number' => 43, 'title' => 'No milestone' ) );
+	GitHubAbilities::createIssue( array(
+		'repo'      => 'owner/repo',
+		'title'     => 'No milestone',
+		'milestone' => null,
+	) );
+	$call = $GLOBALS['dmc_http_calls'][0] ?? array();
+	$body = is_string( $call['args']['body'] ?? null ) ? json_decode( $call['args']['body'], true ) : null;
+	$assert( 'createIssue omits milestone when null', is_array( $body ) && ! array_key_exists( 'milestone', $body ) );
+
+	// ---- createIssue: GitHub error surfaces via WP_Error
+	$reset_http();
+	$queue_response( 422, array( 'message' => 'Validation Failed' ) );
+	$result = GitHubAbilities::createIssue( array(
+		'repo'  => 'owner/repo',
+		'title' => 'Bad payload',
+	) );
+	$assert( 'createIssue surfaces 422 as WP_Error', $result instanceof WP_Error );
+	$assert( 'createIssue 422 carries github_api_error code', $result instanceof WP_Error && 'github_api_error' === $result->get_error_code() );
+	$assert( 'createIssue 422 message includes GitHub message', $result instanceof WP_Error && str_contains( $result->get_error_message(), 'Validation Failed' ) );
+
+	// ---- createPullRequest: required-field validation
+	$reset_http();
+	$result = GitHubAbilities::createPullRequest( array() );
+	$assert( 'createPullRequest rejects missing repo', $result instanceof WP_Error && 'missing_repo' === $result->get_error_code() );
+
+	$result = GitHubAbilities::createPullRequest( array( 'repo' => 'owner/repo' ) );
+	$assert( 'createPullRequest rejects missing title', $result instanceof WP_Error && 'missing_title' === $result->get_error_code() );
+
+	$result = GitHubAbilities::createPullRequest( array( 'repo' => 'owner/repo', 'title' => 'PR' ) );
+	$assert( 'createPullRequest rejects missing head', $result instanceof WP_Error && 'missing_head' === $result->get_error_code() );
+
+	// ---- createPullRequest: success path with explicit base, draft default false
+	$reset_http();
+	$queue_response( 201, array(
+		'number'   => 88,
+		'title'    => 'Open PR',
+		'state'    => 'open',
+		'html_url' => 'https://github.com/owner/repo/pull/88',
+		'head'     => array( 'ref' => 'feature/x', 'sha' => 'aaa' ),
+		'base'     => array( 'ref' => 'main', 'sha' => 'bbb' ),
+		'draft'    => false,
+	) );
+	$result = GitHubAbilities::createPullRequest( array(
+		'repo'  => 'owner/repo',
+		'title' => 'Open PR',
+		'head'  => 'feature/x',
+		'base'  => 'main',
+		'body'  => 'Body',
+	) );
+	$assert( 'createPullRequest success returns success=true', is_array( $result ) && true === ( $result['success'] ?? false ) );
+	$assert( 'createPullRequest exposes pull_request key', is_array( $result ) && isset( $result['pull_request']['number'] ) && 88 === $result['pull_request']['number'] );
+	$assert( 'createPullRequest normalized head ref', is_array( $result ) && 'feature/x' === ( $result['pull_request']['head'] ?? '' ) );
+
+	$call = $GLOBALS['dmc_http_calls'][0] ?? array();
+	$body = is_string( $call['args']['body'] ?? null ) ? json_decode( $call['args']['body'], true ) : null;
+	$assert( 'createPullRequest posts to /repos/owner/repo/pulls', is_string( $call['url'] ?? null ) && str_ends_with( $call['url'], '/repos/owner/repo/pulls' ) );
+	$assert( 'createPullRequest forwards head and base', is_array( $body ) && 'feature/x' === ( $body['head'] ?? '' ) && 'main' === ( $body['base'] ?? '' ) );
+	$assert( 'createPullRequest defaults maintainer_can_modify=true', is_array( $body ) && true === ( $body['maintainer_can_modify'] ?? null ) );
+	$assert( 'createPullRequest does not set draft when omitted', is_array( $body ) && ! array_key_exists( 'draft', $body ) );
+
+	// ---- createPullRequest: explicit draft and maintainer_can_modify=false
+	$reset_http();
+	$queue_response( 201, array(
+		'number' => 89,
+		'head'   => array( 'ref' => 'feat/y' ),
+		'base'   => array( 'ref' => 'main' ),
+	) );
+	GitHubAbilities::createPullRequest( array(
+		'repo'                  => 'owner/repo',
+		'title'                 => 'Draft PR',
+		'head'                  => 'feat/y',
+		'base'                  => 'main',
+		'draft'                 => true,
+		'maintainer_can_modify' => false,
+	) );
+	$call = $GLOBALS['dmc_http_calls'][0] ?? array();
+	$body = is_string( $call['args']['body'] ?? null ) ? json_decode( $call['args']['body'], true ) : null;
+	$assert( 'createPullRequest forwards draft=true', is_array( $body ) && true === ( $body['draft'] ?? null ) );
+	$assert( 'createPullRequest forwards maintainer_can_modify=false', is_array( $body ) && false === ( $body['maintainer_can_modify'] ?? null ) );
+
+	// ---- createPullRequest: missing base falls back to default branch via GET /repos
+	$reset_http();
+	$queue_response( 200, array( 'default_branch' => 'trunk' ) );
+	$queue_response( 201, array(
+		'number' => 90,
+		'head'   => array( 'ref' => 'feat/z' ),
+		'base'   => array( 'ref' => 'trunk' ),
+	) );
+	$result = GitHubAbilities::createPullRequest( array(
+		'repo'  => 'owner/repo',
+		'title' => 'Default branch PR',
+		'head'  => 'feat/z',
+	) );
+	$assert( 'createPullRequest fallback resolves default branch', is_array( $result ) && true === ( $result['success'] ?? false ) );
+	$assert( 'createPullRequest fallback issued GET /repos/owner/repo first', is_string( $GLOBALS['dmc_http_calls'][0]['url'] ?? null ) && str_contains( $GLOBALS['dmc_http_calls'][0]['url'], '/repos/owner/repo' ) && 'GET' === ( $GLOBALS['dmc_http_calls'][0]['method'] ?? '' ) );
+	$pr_call = $GLOBALS['dmc_http_calls'][1] ?? array();
+	$pr_body = is_string( $pr_call['args']['body'] ?? null ) ? json_decode( $pr_call['args']['body'], true ) : null;
+	$assert( 'createPullRequest sends fallback default base', is_array( $pr_body ) && 'trunk' === ( $pr_body['base'] ?? '' ) );
+
+	// ---- createPullRequest: GitHub validation error surfaces as WP_Error
+	$reset_http();
+	$queue_response( 422, array( 'message' => 'A pull request already exists for owner:feat/x.' ) );
+	$result = GitHubAbilities::createPullRequest( array(
+		'repo'  => 'owner/repo',
+		'title' => 'Dup PR',
+		'head'  => 'feat/x',
+		'base'  => 'main',
+	) );
+	$assert( 'createPullRequest surfaces 422 as WP_Error', $result instanceof WP_Error );
+	$assert( 'createPullRequest 422 carries github_api_error code', $result instanceof WP_Error && 'github_api_error' === $result->get_error_code() );
+	$assert( 'createPullRequest 422 message includes GitHub message', $result instanceof WP_Error && str_contains( $result->get_error_message(), 'already exists' ) );
+
+	if ( ! empty( $failures ) ) {
+		echo "\nFAIL: " . count( $failures ) . " assertion(s)\n";
+		foreach ( $failures as $failure ) {
+			echo "  - {$failure}\n";
+		}
+		exit( 1 );
+	}
+
+	echo "\nOK\n";
+	exit( 0 );
+}


### PR DESCRIPTION
## Summary
- Add `datamachine/create-github-issue` ability (wraps the existing `createIssue()` callback, now with `milestone` support).
- Add `datamachine/create-github-pull-request` ability with a new `createPullRequest()` callback.
- Closes #260.

## Implementation notes
- Both abilities follow the surrounding family conventions in `inc/Abilities/GitHubAbilities.php`: declarative `wp_register_ability` block, `category = datamachine-code-github`, dedicated static `execute_callback`, `permission_callback => PermissionHelper::can_manage()`, REST disabled (`show_in_rest => false`).
- `createIssue` was extended with strict, optional `milestone` handling — only positive integers are forwarded; null/empty/zero values are omitted from the POST body so existing callers (`GitHubIssueTask`) are unaffected.
- `createPullRequest` POSTs to `/repos/{owner}/{repo}/pulls`. Required: `repo`, `title`, `head`. Optional: `base`, `body`, `draft` (default `false` — only sent when explicitly set), `maintainer_can_modify` (default `true`). When `base` is omitted, the ability resolves the repository default branch via `GET /repos/{owner}/{repo}` and uses `default_branch` as the fallback.
- Both abilities surface GitHub validation/auth/server errors through the existing `parseResponse()` `WP_Error` path (`github_api_error`, `github_not_found`, `github_server_error`) so callers see the failure via the standard error field rather than as exceptions.
- Per coordination on #259, this PR does **not** touch `GitHubCredentialResolver`, settings registration, or per-call credential overrides — it calls `GitHubCredentialResolver::resolve()` zero-arg via the existing `getPat()` helper exactly like every other ability in this file.

## Tests
- New `tests/smoke-github-create-abilities.php` (51 assertions) covers both abilities end-to-end without bootstrapping WordPress:
  - Registration shape (id, callback, schema required fields, optional fields, REST opt-out, category).
  - Permission gate routes through `PermissionHelper::can_manage()` (positive and negative).
  - Required-field validation (`missing_repo`, `missing_title`, `missing_head`).
  - Success-path payload mapping for `createIssue` (labels, assignees, milestone forwarded as int) and `createPullRequest` (head/base, draft default behavior, `maintainer_can_modify` default true).
  - Default-branch fallback issues a preliminary `GET /repos/owner/repo` and forwards `default_branch` into the PR `base` field.
  - GitHub `422` responses surface as `WP_Error` with `github_api_error` and the upstream message preserved.
- Run: `php tests/smoke-github-create-abilities.php` — output ends with `OK` and no failed assertions.
- Existing GitHub smoke tests still pass (`smoke-github-app-auth.php`, `smoke-github-readonly-tools.php`, `smoke-github-pr-comment-tool.php`, `smoke-github-pr-review-comment-upsert.php`, etc.).
- `homeboy review --changed-since=main` reports lint passing with 0 findings on changed scope and audit clean against changed files. The test stage failure in that run is the pre-existing Playground bootstrap SQLite issue (missing `wptests_users` table during `data-machine` activation) — unrelated to this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafting and implementing the two new GitHub create abilities, extending `createIssue` to support `milestone`, and writing the smoke test. Chris reviewed scope and will review the diff.