### PR TITLE
feat: support multiple GitHub credential profiles per agent/repo

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -103,6 +103,81 @@ add_filter( 'datamachine_webhook_verifier_modes', function ( array $modes ): arr
 } );
 
 /**
+ * Register DMC-owned settings keys with the `datamachine/update-settings`
+ * ability so `wp datamachine settings set <key>` flows through the official
+ * ability path instead of requiring direct `wp option patch insert` writes.
+ *
+ * Handles both legacy single-credential keys (back-compat with installs
+ * that haven't migrated to profiles yet) and the new profile structure.
+ *
+ * Migration path:
+ *   - Existing installs continue to use github_pat / github_auth_mode /
+ *     github_app_*. The credential resolver synthesizes those into an
+ *     implicit "default" profile on read.
+ *   - New installs and operator-driven migrations populate
+ *     github_credential_profiles + github_default_profile_id directly.
+ *   - Both shapes coexist; the profile list wins when present.
+ *
+ * @since 0.30.0
+ */
+add_filter( 'datamachine_update_settings', function ( array $filtered, array $input ): array {
+	$settings     = $filtered['settings'] ?? array();
+	$handled_keys = $filtered['handled_keys'] ?? array();
+
+	if ( isset( $input['github_pat'] ) ) {
+		$settings['github_pat'] = sanitize_text_field( (string) $input['github_pat'] );
+		$handled_keys[]         = 'github_pat';
+	}
+
+	if ( isset( $input['github_auth_mode'] ) ) {
+		$mode = strtolower( sanitize_text_field( (string) $input['github_auth_mode'] ) );
+		if ( in_array( $mode, array( 'pat', 'app' ), true ) ) {
+			$settings['github_auth_mode'] = $mode;
+		}
+		$handled_keys[] = 'github_auth_mode';
+	}
+
+	if ( isset( $input['github_app_id'] ) ) {
+		$settings['github_app_id'] = sanitize_text_field( (string) $input['github_app_id'] );
+		$handled_keys[]            = 'github_app_id';
+	}
+
+	if ( isset( $input['github_app_installation_id'] ) ) {
+		$settings['github_app_installation_id'] = sanitize_text_field( (string) $input['github_app_installation_id'] );
+		$handled_keys[]                         = 'github_app_installation_id';
+	}
+
+	if ( isset( $input['github_app_private_key'] ) ) {
+		// Private keys are multiline PEM blobs — sanitize_text_field would strip newlines.
+		// Trim only; the resolver normalizes literal `\n` escapes back to real newlines.
+		$settings['github_app_private_key'] = trim( (string) $input['github_app_private_key'] );
+		$handled_keys[]                     = 'github_app_private_key';
+	}
+
+	if ( isset( $input['github_default_repo'] ) ) {
+		$settings['github_default_repo'] = sanitize_text_field( (string) $input['github_default_repo'] );
+		$handled_keys[]                  = 'github_default_repo';
+	}
+
+	if ( isset( $input['github_credential_profiles'] ) && is_array( $input['github_credential_profiles'] ) ) {
+		$settings['github_credential_profiles'] = \DataMachineCode\Support\GitHubProfileSanitizer::sanitize( $input['github_credential_profiles'] );
+		$handled_keys[]                         = 'github_credential_profiles';
+	}
+
+	if ( isset( $input['github_default_profile_id'] ) ) {
+		$settings['github_default_profile_id'] = sanitize_text_field( (string) $input['github_default_profile_id'] );
+		$handled_keys[]                        = 'github_default_profile_id';
+	}
+
+	return array(
+		'settings'     => $settings,
+		'handled_keys' => $handled_keys,
+	);
+}, 10, 2 );
+
+
+
+/**
  * Register ability categories for data-machine-code.
  *
  * Must be called on `wp_abilities_api_categories_init` — WordPress core

--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -42,6 +42,17 @@ class GitHubAbilities {
 	private static ?\WP_Error $last_auth_error = null;
 
 	/**
+	 * Map of resolved tokens → auth mode ('pat' | 'app').
+	 *
+	 * Lets getHeaders() pick the right Authorization scheme without
+	 * re-resolving the credential. Populated by getPat() / getCredential()
+	 * each time a credential is resolved.
+	 *
+	 * @var array<string,string>
+	 */
+	private static array $token_modes = array();
+
+	/**
 	 * GitHub API base URL.
 	 */
 	const API_BASE = 'https://api.github.com';
@@ -1020,7 +1031,7 @@ class GitHubAbilities {
 			return new \WP_Error( 'missing_repo', 'Repository is required (owner/repo format).', array( 'status' => 400 ) );
 		}
 
-		$pat = self::getPat();
+		$pat = self::getPatForRepo( $repo );
 		if ( empty( $pat ) ) {
 			return self::patError();
 		}
@@ -1068,7 +1079,7 @@ class GitHubAbilities {
 			return new \WP_Error( 'missing_params', 'Repository (owner/repo) and issue_number are required.', array( 'status' => 400 ) );
 		}
 
-		$pat = self::getPat();
+		$pat = self::getPatForRepo( $repo );
 		if ( empty( $pat ) ) {
 			return self::patError();
 		}
@@ -1094,7 +1105,7 @@ class GitHubAbilities {
 			return new \WP_Error( 'missing_params', 'Repository (owner/repo) and issue_number are required.', array( 'status' => 400 ) );
 		}
 
-		$pat = self::getPat();
+		$pat = self::getPatForRepo( $repo );
 		if ( empty( $pat ) ) {
 			return self::patError();
 		}
@@ -1145,7 +1156,7 @@ class GitHubAbilities {
 			return new \WP_Error( 'missing_title', 'Issue title is required.', array( 'status' => 400 ) );
 		}
 
-		$pat = self::getPat();
+		$pat = self::getPatForRepo( $repo );
 		if ( empty( $pat ) ) {
 			return self::patError();
 		}
@@ -1190,7 +1201,7 @@ class GitHubAbilities {
 			return new \WP_Error( 'missing_params', 'Repository, issue_number, and body are required.', array( 'status' => 400 ) );
 		}
 
-		$pat = self::getPat();
+		$pat = self::getPatForRepo( $repo );
 		if ( empty( $pat ) ) {
 			return self::patError();
 		}
@@ -1244,7 +1255,7 @@ class GitHubAbilities {
 			return new \WP_Error( 'missing_head_sha', 'head_sha is required when mode is per_head_sha.', array( 'status' => 400 ) );
 		}
 
-		$pat = self::getPat();
+		$pat = self::getPatForRepo( $repo );
 		if ( empty( $pat ) ) {
 			return self::patError();
 		}
@@ -1416,7 +1427,7 @@ class GitHubAbilities {
 			return new \WP_Error( 'missing_repo', 'Repository is required (owner/repo format).', array( 'status' => 400 ) );
 		}
 
-		$pat = self::getPat();
+		$pat = self::getPatForRepo( $repo );
 		if ( empty( $pat ) ) {
 			return self::patError();
 		}
@@ -1459,7 +1470,7 @@ class GitHubAbilities {
 			return new \WP_Error( 'missing_params', 'Repository (owner/repo) and pull_number are required.', array( 'status' => 400 ) );
 		}
 
-		$pat = self::getPat();
+		$pat = self::getPatForRepo( $repo );
 		if ( empty( $pat ) ) {
 			return self::patError();
 		}
@@ -1525,7 +1536,7 @@ class GitHubAbilities {
 			return new \WP_Error( 'missing_repo', 'Repository is required (owner/repo format).', array( 'status' => 400 ) );
 		}
 
-		$pat = self::getPat();
+		$pat = self::getPatForRepo( $repo );
 		if ( empty( $pat ) ) {
 			return self::patError();
 		}
@@ -1572,7 +1583,7 @@ class GitHubAbilities {
 			return new \WP_Error( 'missing_params', 'Repository (owner/repo) and pull_number are required.', array( 'status' => 400 ) );
 		}
 
-		$pat = self::getPat();
+		$pat = self::getPatForRepo( $repo );
 		if ( empty( $pat ) ) {
 			return self::patError();
 		}
@@ -2424,7 +2435,7 @@ class GitHubAbilities {
 			return new \WP_Error( 'missing_params', 'Repository (owner/repo) and pull_number are required.', array( 'status' => 400 ) );
 		}
 
-		$pat = self::getPat();
+		$pat = self::getPatForRepo( $repo );
 		if ( empty( $pat ) ) {
 			return self::patError();
 		}
@@ -2456,7 +2467,7 @@ class GitHubAbilities {
 			return new \WP_Error( 'missing_params', 'Repository (owner/repo) and pull_number are required.', array( 'status' => 400 ) );
 		}
 
-		$pat = self::getPat();
+		$pat = self::getPatForRepo( $repo );
 		if ( empty( $pat ) ) {
 			return self::patError();
 		}
@@ -2496,7 +2507,7 @@ class GitHubAbilities {
 			return new \WP_Error( 'missing_params', 'Repository (owner/repo) and sha are required.', array( 'status' => 400 ) );
 		}
 
-		$pat = self::getPat();
+		$pat = self::getPatForRepo( $repo );
 		if ( empty( $pat ) ) {
 			return self::patError();
 		}
@@ -2541,7 +2552,7 @@ class GitHubAbilities {
 			return new \WP_Error( 'missing_params', 'Repository (owner/repo) and sha are required.', array( 'status' => 400 ) );
 		}
 
-		$pat = self::getPat();
+		$pat = self::getPatForRepo( $repo );
 		if ( empty( $pat ) ) {
 			return self::patError();
 		}
@@ -2588,7 +2599,7 @@ class GitHubAbilities {
 			return new \WP_Error( 'missing_params', 'Either head_sha or pull_number is required.', array( 'status' => 400 ) );
 		}
 
-		$pat = self::getPat();
+		$pat = self::getPatForRepo( $repo );
 		if ( empty( $pat ) ) {
 			return self::patError();
 		}
@@ -2897,7 +2908,8 @@ class GitHubAbilities {
 			return new \WP_Error( 'missing_owner', 'Owner (user or org) is required.', array( 'status' => 400 ) );
 		}
 
-		$pat = self::getPat();
+		// listRepos lists by owner — no specific repo, so fall back to default profile.
+		$pat = self::getPatForRepo( '' );
 		if ( empty( $pat ) ) {
 			return self::patError();
 		}
@@ -2966,7 +2978,7 @@ class GitHubAbilities {
 			return new \WP_Error( 'missing_commit_message', 'Commit message is required.', array( 'status' => 400 ) );
 		}
 
-		$pat = self::getPat();
+		$pat = self::getPatForRepo( $repo );
 		if ( empty( $pat ) ) {
 			return self::patError();
 		}
@@ -3041,7 +3053,7 @@ class GitHubAbilities {
 			return new \WP_Error( 'missing_repo', 'Repository is required (owner/repo format).', array( 'status' => 400 ) );
 		}
 
-		$pat = self::getPat();
+		$pat = self::getPatForRepo( $repo );
 		if ( empty( $pat ) ) {
 			return self::patError();
 		}
@@ -3101,7 +3113,7 @@ class GitHubAbilities {
 			return new \WP_Error( 'missing_params', 'Repository (owner/repo) and file path are required.', array( 'status' => 400 ) );
 		}
 
-		$pat = self::getPat();
+		$pat = self::getPatForRepo( $repo );
 		if ( empty( $pat ) ) {
 			return self::patError();
 		}
@@ -3218,7 +3230,11 @@ class GitHubAbilities {
 	}
 
 	private static function getHeaders( string $pat ): array {
-		$authorization = 'app' === GitHubCredentialResolver::mode() ? 'Bearer ' . $pat : 'token ' . $pat;
+		// Prefer per-token mode tracked at resolution time so multi-profile
+		// callers get the right Authorization scheme regardless of which
+		// profile is the global default.
+		$mode          = self::$token_modes[ $pat ] ?? GitHubCredentialResolver::mode();
+		$authorization = 'app' === $mode ? 'Bearer ' . $pat : 'token ' . $pat;
 
 		return array(
 			'Authorization' => $authorization,
@@ -3613,15 +3629,42 @@ class GitHubAbilities {
 	// Utilities
 	// -------------------------------------------------------------------------
 
-	public static function getPat(): string {
-		$credential = GitHubCredentialResolver::resolve();
+	/**
+	 * Resolve a GitHub credential token.
+	 *
+	 * @param array<string,mixed>|null $selector Optional `profile_id` or `repo` selector. See GitHubCredentialResolver::resolve().
+	 * @return string Token string, or empty string when resolution fails (caller should call patError()).
+	 */
+	public static function getPat( ?array $selector = null ): string {
+		$credential = GitHubCredentialResolver::resolve( null, null, $selector );
 		if ( is_wp_error( $credential ) ) {
 			self::$last_auth_error = $credential;
 			return '';
 		}
 
-		self::$last_auth_error = null;
-		return (string) $credential['token'];
+		self::$last_auth_error       = null;
+		$token                       = (string) $credential['token'];
+		self::$token_modes[ $token ] = (string) ( $credential['mode'] ?? 'pat' );
+		return $token;
+	}
+
+	/**
+	 * Resolve a full credential array for callers that need both the token and its mode.
+	 *
+	 * @param array<string,mixed>|null $selector
+	 * @return array{mode:string,token:string,authorization:string,profile_id:string}|\WP_Error
+	 */
+	public static function getCredential( ?array $selector = null ): array|\WP_Error {
+		$credential = GitHubCredentialResolver::resolve( null, null, $selector );
+		if ( is_wp_error( $credential ) ) {
+			self::$last_auth_error = $credential;
+			return $credential;
+		}
+
+		$token                       = (string) $credential['token'];
+		self::$last_auth_error       = null;
+		self::$token_modes[ $token ] = (string) ( $credential['mode'] ?? 'pat' );
+		return $credential;
 	}
 
 	public static function isConfigured(): bool {
@@ -3686,6 +3729,17 @@ class GitHubAbilities {
 		}
 
 		return '';
+	}
+
+	/**
+	 * Resolve a PAT/installation token, scoped to the current repo when known.
+	 *
+	 * Internal sugar for ability methods that already have the repo in scope.
+	 * Pass the empty string to fall back to the default profile.
+	 */
+	private static function getPatForRepo( string $repo ): string {
+		$selector = '' !== trim( $repo ) ? array( 'repo' => $repo ) : null;
+		return self::getPat( $selector );
 	}
 
 	private static function patError(): \WP_Error {

--- a/inc/Cli/Commands/GitHubCommand.php
+++ b/inc/Cli/Commands/GitHubCommand.php
@@ -510,6 +510,29 @@ class GitHubCommand extends BaseCommand {
 
 		$this->format_items( $items, array( 'setting', 'value' ), $assoc_args );
 
+		// Show configured credential profiles.
+		$profiles = $auth_status['profiles'] ?? array();
+		if ( ! empty( $profiles ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( 'Configured credential profiles:' );
+			$profile_items = array();
+			foreach ( $profiles as $profile ) {
+				$profile_items[] = array(
+					'id'            => $profile['id'] ?? '',
+					'label'         => $profile['label'] ?? '',
+					'mode'          => $profile['mode'] ?? '',
+					'configured'    => ! empty( $profile['configured'] ) ? 'yes' : 'no',
+					'default_repo'  => $profile['default_repo'] ?? '',
+					'allowed_repos' => implode( ', ', $profile['allowed_repos'] ?? array() ),
+				);
+			}
+			$this->format_items( $profile_items, array( 'id', 'label', 'mode', 'configured', 'default_repo', 'allowed_repos' ), $assoc_args );
+			$default_id = $auth_status['default_profile_id'] ?? '';
+			if ( '' !== $default_id ) {
+				WP_CLI::log( sprintf( 'Default profile: %s', $default_id ) );
+			}
+		}
+
 		// Show registered repos from the filter.
 		$repos = GitHubAbilities::getRegisteredRepos();
 		if ( ! empty( $repos ) ) {
@@ -685,7 +708,7 @@ class GitHubCommand extends BaseCommand {
 	 */
 	private function requireConfig(): void {
 		if ( ! GitHubAbilities::isConfigured() ) {
-			WP_CLI::error( 'GitHub authentication is not configured. Set github_pat for PAT mode or GitHub App credentials for app mode.' );
+			WP_CLI::error( 'GitHub authentication is not configured. Configure a credential profile (github_credential_profiles) or set legacy github_pat / GitHub App credentials.' );
 		}
 	}
 

--- a/inc/GitSync/GitSyncFetcher.php
+++ b/inc/GitSync/GitSyncFetcher.php
@@ -56,7 +56,9 @@ final class GitSyncFetcher {
 			return new \WP_Error( 'unparseable_remote', sprintf( 'Cannot parse GitHub owner/repo from %s.', $binding->remote_url ), array( 'status' => 400 ) );
 		}
 
-		$pat = (string) GitHubAbilities::getPat();
+		// Pass the repo through so credential profiles with `allowed_repos`
+		// can win over the global default profile.
+		$pat = (string) GitHubAbilities::getPat( array( 'repo' => $slug ) );
 		if ( '' === $pat ) {
 			return new \WP_Error( 'missing_github_auth', 'GitHub authentication is not configured.', array( 'status' => 500 ) );
 		}

--- a/inc/GitSync/GitSyncProposer.php
+++ b/inc/GitSync/GitSyncProposer.php
@@ -306,7 +306,9 @@ final class GitSyncProposer {
 			return new \WP_Error( 'unparseable_remote', sprintf( 'Cannot parse GitHub owner/repo from %s.', $binding->remote_url ), array( 'status' => 400 ) );
 		}
 
-		$pat = (string) GitHubAbilities::getPat();
+		// Pass the repo through so credential profiles with `allowed_repos`
+		// can win over the global default profile.
+		$pat = (string) GitHubAbilities::getPat( array( 'repo' => $slug ) );
 		if ( '' === $pat ) {
 			return new \WP_Error( 'missing_github_auth', 'GitHub authentication is not configured — cannot write.', array( 'status' => 500 ) );
 		}

--- a/inc/Support/GitHubCredentialResolver.php
+++ b/inc/Support/GitHubCredentialResolver.php
@@ -3,7 +3,29 @@
  * GitHub credential resolver.
  *
  * Supports the classic PAT path and GitHub App installation tokens behind the
- * same API-token contract used by GitHubAbilities.
+ * same API-token contract used by GitHubAbilities. Credentials are organized
+ * as **profiles**: a list of named credential entries (`id`, `label`, `mode`,
+ * `pat` or App fields, optional `default_repo`, optional `allowed_repos`)
+ * stored in `github_credential_profiles`, with `github_default_profile_id`
+ * pointing at the fallback profile.
+ *
+ * Selectors:
+ *   - Pass `profile_id` to resolve a specific named profile. Unknown ids
+ *     fail closed — never silently fall back to the default.
+ *   - Pass `repo` (owner/repo) to resolve the profile whose
+ *     `allowed_repos` contains the repo, or whose `default_repo` matches.
+ *     Unmatched repos fall through to the default profile.
+ *   - Zero-arg `resolve()` returns the default profile.
+ *
+ * Backward compatibility:
+ *   - Existing installs that stored a single global credential under
+ *     `github_pat`, `github_auth_mode`, and `github_app_*` keep working —
+ *     when `github_credential_profiles` is empty or missing, the legacy
+ *     shape is synthesized into an implicit `default` profile on read.
+ *   - New writes should populate `github_credential_profiles` directly via
+ *     the `datamachine/update-settings` ability. The legacy keys remain
+ *     readable (and writable) so existing tooling and per-key reads keep
+ *     functioning until operators migrate.
  *
  * @package DataMachineCode\Support
  */
@@ -19,33 +41,52 @@ final class GitHubCredentialResolver {
 	private const APP_TOKEN_CACHE_PREFIX = 'datamachine_code_github_app_token_';
 	private const APP_TOKEN_EXPIRY_SKEW  = 60;
 
+	public const DEFAULT_PROFILE_ID = 'default';
+
 	/**
 	 * Resolve the active GitHub credential.
 	 *
-	 * @param callable|null $http_request Test seam: fn(string $url, array $args): array|\WP_Error.
-	 * @param int|null      $now          Test seam for cache expiry checks.
-	 * @return array{mode:string,token:string,authorization:string,cached?:bool,expires_at?:string}|\WP_Error
+	 * @param callable|null            $http_request Test seam: fn(string $url, array $args): array|\WP_Error.
+	 * @param int|null                 $now          Test seam for cache expiry checks.
+	 * @param array<string,mixed>|null $selector     Optional selector: `profile_id` or `repo`.
+	 * @return array{mode:string,token:string,authorization:string,profile_id:string,cached?:bool,expires_at?:string}|\WP_Error
 	 */
-	public static function resolve( ?callable $http_request = null, ?int $now = null ): array|\WP_Error {
-		$mode = self::mode();
+	public static function resolve( ?callable $http_request = null, ?int $now = null, ?array $selector = null ): array|\WP_Error {
+		$profile = self::selectProfile( $selector );
+		if ( is_wp_error( $profile ) ) {
+			return $profile;
+		}
+
+		$profile_id = (string) $profile['id'];
+		$mode       = strtolower( (string) ( $profile['mode'] ?? 'pat' ) );
+
 		if ( 'pat' === $mode ) {
-			$pat = self::setting( 'github_pat' );
+			$pat = trim( (string) ( $profile['pat'] ?? '' ) );
 			if ( '' === $pat ) {
-				return new \WP_Error( 'github_pat_not_configured', 'GitHub Personal Access Token not configured. Set github_pat in Data Machine settings.', array( 'status' => 403 ) );
+				return new \WP_Error(
+					'github_pat_not_configured',
+					sprintf( 'GitHub Personal Access Token not configured for profile "%s".', $profile_id ),
+					array( 'status' => 403 )
+				);
 			}
 
 			return array(
 				'mode'          => 'pat',
 				'token'         => $pat,
 				'authorization' => 'token ' . $pat,
+				'profile_id'    => $profile_id,
 			);
 		}
 
 		if ( 'app' !== $mode ) {
-			return new \WP_Error( 'github_auth_mode_invalid', 'Invalid github_auth_mode. Expected "pat" or "app".', array( 'status' => 400 ) );
+			return new \WP_Error(
+				'github_auth_mode_invalid',
+				sprintf( 'Invalid mode "%s" for profile "%s". Expected "pat" or "app".', $mode, $profile_id ),
+				array( 'status' => 400 )
+			);
 		}
 
-		return self::resolveApp( $http_request, $now );
+		return self::resolveApp( $profile, $http_request, $now );
 	}
 
 	/**
@@ -54,35 +95,43 @@ final class GitHubCredentialResolver {
 	 * @return array<string, mixed>
 	 */
 	public static function status(): array {
-		$mode = self::mode();
+		$profiles = self::profiles();
+		$default  = self::resolveDefaultProfile( $profiles );
+		$mode     = strtolower( (string) ( $default['mode'] ?? 'pat' ) );
+
+		$profile_summaries = array();
+		foreach ( $profiles as $profile ) {
+			$profile_summaries[] = self::summarizeProfile( $profile );
+		}
 
 		return array(
+			// Top-level fields preserve the historical surface for back-compat with existing CLI/status callers.
 			'mode'                        => $mode,
-			'pat_configured'              => '' !== self::setting( 'github_pat' ),
-			'app_id_configured'           => '' !== self::setting( 'github_app_id' ),
-			'app_installation_configured' => '' !== self::setting( 'github_app_installation_id' ),
-			'app_private_key_configured'  => '' !== self::setting( 'github_app_private_key' ),
+			'pat_configured'              => '' !== trim( (string) ( $default['pat'] ?? '' ) ),
+			'app_id_configured'           => '' !== trim( (string) ( $default['app_id'] ?? '' ) ),
+			'app_installation_configured' => '' !== trim( (string) ( $default['app_installation_id'] ?? '' ) ),
+			'app_private_key_configured'  => '' !== trim( (string) ( $default['app_private_key'] ?? '' ) ),
 			'configured'                  => self::isConfigured(),
 			'checks_permission'           => 'read',
 			'commit_statuses_permission'  => 'read',
 			'actions_permission'          => 'read recommended when fetching workflow artifacts',
+			// New profile-aware fields.
+			'default_profile_id'          => (string) $default['id'],
+			'profiles'                    => $profile_summaries,
 		);
 	}
 
 	public static function isConfigured(): bool {
-		$mode = self::mode();
-		if ( 'pat' === $mode ) {
-			return '' !== self::setting( 'github_pat' );
-		}
-
-		return 'app' === $mode
-			&& '' !== self::setting( 'github_app_id' )
-			&& '' !== self::setting( 'github_app_installation_id' )
-			&& '' !== self::setting( 'github_app_private_key' );
+		$profile = self::resolveDefaultProfile( self::profiles() );
+		return self::profileIsConfigured( $profile );
 	}
 
+	/**
+	 * Active mode for the default profile (back-compat helper).
+	 */
 	public static function mode(): string {
-		$mode = strtolower( self::setting( 'github_auth_mode', 'pat' ) );
+		$profile = self::resolveDefaultProfile( self::profiles() );
+		$mode    = strtolower( (string) ( $profile['mode'] ?? 'pat' ) );
 		return '' === $mode ? 'pat' : $mode;
 	}
 
@@ -127,25 +176,78 @@ final class GitHubCredentialResolver {
 	}
 
 	/**
-	 * @return array{mode:string,token:string,authorization:string,cached?:bool,expires_at?:string}|\WP_Error
+	 * Return the configured profile list, synthesizing a legacy "default"
+	 * profile from the legacy `github_pat` / `github_app_*` keys when the
+	 * new structure is empty.
+	 *
+	 * @return array<int,array<string,mixed>>
 	 */
-	private static function resolveApp( ?callable $http_request, ?int $now ): array|\WP_Error {
+	public static function profiles(): array {
+		$raw = PluginSettings::get( 'github_credential_profiles', array() );
+		if ( is_array( $raw ) && ! empty( $raw ) ) {
+			$normalized = array();
+			foreach ( $raw as $entry ) {
+				if ( ! is_array( $entry ) ) {
+					continue;
+				}
+				$profile = self::normalizeProfile( $entry );
+				if ( null !== $profile ) {
+					$normalized[] = $profile;
+				}
+			}
+			if ( ! empty( $normalized ) ) {
+				return $normalized;
+			}
+		}
+
+		return self::synthesizeLegacyProfiles();
+	}
+
+	/**
+	 * Resolve the default profile id from settings, falling back to the
+	 * first profile when the configured id is unknown or missing.
+	 *
+	 * @param array<int,array<string,mixed>> $profiles
+	 * @return array<string,mixed>
+	 */
+	public static function resolveDefaultProfile( array $profiles ): array {
+		if ( empty( $profiles ) ) {
+			return self::emptyDefaultProfile();
+		}
+
+		$configured = trim( (string) PluginSettings::get( 'github_default_profile_id', '' ) );
+		if ( '' !== $configured ) {
+			foreach ( $profiles as $profile ) {
+				if ( (string) ( $profile['id'] ?? '' ) === $configured ) {
+					return $profile;
+				}
+			}
+		}
+
+		return $profiles[0];
+	}
+
+	/**
+	 * @return array{mode:string,token:string,authorization:string,profile_id:string,cached?:bool,expires_at?:string}|\WP_Error
+	 */
+	private static function resolveApp( array $profile, ?callable $http_request, ?int $now ): array|\WP_Error {
 		$now             = $now ?? time();
-		$app_id          = self::setting( 'github_app_id' );
-		$installation_id = self::setting( 'github_app_installation_id' );
-		$private_key     = self::setting( 'github_app_private_key' );
+		$profile_id      = (string) $profile['id'];
+		$app_id          = trim( (string) ( $profile['app_id'] ?? '' ) );
+		$installation_id = trim( (string) ( $profile['app_installation_id'] ?? '' ) );
+		$private_key     = (string) ( $profile['app_private_key'] ?? '' );
 
 		if ( '' === $app_id ) {
-			return new \WP_Error( 'github_app_id_missing', 'GitHub App auth selected but github_app_id is not configured.', array( 'status' => 400 ) );
+			return new \WP_Error( 'github_app_id_missing', sprintf( 'GitHub App auth selected but app_id is not configured for profile "%s".', $profile_id ), array( 'status' => 400 ) );
 		}
 		if ( '' === $installation_id ) {
-			return new \WP_Error( 'github_app_installation_id_missing', 'GitHub App auth selected but github_app_installation_id is not configured.', array( 'status' => 400 ) );
+			return new \WP_Error( 'github_app_installation_id_missing', sprintf( 'GitHub App auth selected but app_installation_id is not configured for profile "%s".', $profile_id ), array( 'status' => 400 ) );
 		}
-		if ( '' === $private_key ) {
-			return new \WP_Error( 'github_app_private_key_missing', 'GitHub App auth selected but github_app_private_key is not configured.', array( 'status' => 400 ) );
+		if ( '' === trim( $private_key ) ) {
+			return new \WP_Error( 'github_app_private_key_missing', sprintf( 'GitHub App auth selected but app_private_key is not configured for profile "%s".', $profile_id ), array( 'status' => 400 ) );
 		}
 
-		$cache_key = self::cacheKey( $app_id, $installation_id );
+		$cache_key = self::cacheKey( $profile_id, $app_id, $installation_id );
 		$cached    = get_transient( $cache_key );
 		if ( is_array( $cached ) ) {
 			$token      = (string) ( $cached['token'] ?? '' );
@@ -156,6 +258,7 @@ final class GitHubCredentialResolver {
 					'mode'          => 'app',
 					'token'         => $token,
 					'authorization' => 'Bearer ' . $token,
+					'profile_id'    => $profile_id,
 					'cached'        => true,
 					'expires_at'    => $expires_at,
 				);
@@ -214,17 +317,181 @@ final class GitHubCredentialResolver {
 			'mode'          => 'app',
 			'token'         => $token,
 			'authorization' => 'Bearer ' . $token,
+			'profile_id'    => $profile_id,
 			'cached'        => false,
 			'expires_at'    => $expires_at,
 		);
 	}
 
-	private static function setting( string $key, string $default_value = '' ): string {
-		return trim( (string) PluginSettings::get( $key, $default_value ) );
+	/**
+	 * Pick a profile based on the optional selector.
+	 *
+	 * - Explicit `profile_id` fails closed when the id is unknown.
+	 * - `repo` selects the profile whose `allowed_repos` contains the
+	 *   repo, falling back to the profile whose `default_repo` matches,
+	 *   then to the default profile.
+	 * - No selector → default profile.
+	 *
+	 * @param array<string,mixed>|null $selector
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private static function selectProfile( ?array $selector ): array|\WP_Error {
+		$profiles = self::profiles();
+
+		if ( is_array( $selector ) ) {
+			$profile_id = isset( $selector['profile_id'] ) ? trim( (string) $selector['profile_id'] ) : '';
+			if ( '' !== $profile_id ) {
+				foreach ( $profiles as $profile ) {
+					if ( (string) ( $profile['id'] ?? '' ) === $profile_id ) {
+						return $profile;
+					}
+				}
+				return new \WP_Error(
+					'github_profile_not_found',
+					sprintf( 'GitHub credential profile "%s" is not configured.', $profile_id ),
+					array( 'status' => 404 )
+				);
+			}
+
+			$repo = isset( $selector['repo'] ) ? strtolower( trim( (string) $selector['repo'] ) ) : '';
+			if ( '' !== $repo ) {
+				// Prefer profiles that explicitly list the repo in allowed_repos.
+				foreach ( $profiles as $profile ) {
+					$allowed = isset( $profile['allowed_repos'] ) && is_array( $profile['allowed_repos'] )
+						? array_map( 'strtolower', array_map( 'strval', $profile['allowed_repos'] ) )
+						: array();
+					if ( in_array( $repo, $allowed, true ) ) {
+						return $profile;
+					}
+				}
+				// Fall back to a profile whose default_repo matches.
+				foreach ( $profiles as $profile ) {
+					$default_repo = strtolower( trim( (string) ( $profile['default_repo'] ?? '' ) ) );
+					if ( '' !== $default_repo && $default_repo === $repo ) {
+						return $profile;
+					}
+				}
+				// No repo match → fall through to default profile.
+			}
+		}
+
+		return self::resolveDefaultProfile( $profiles );
 	}
 
-	private static function cacheKey( string $app_id, string $installation_id ): string {
-		return self::APP_TOKEN_CACHE_PREFIX . md5( $app_id . ':' . $installation_id );
+	/**
+	 * Synthesize the legacy single-credential shape into a one-profile list.
+	 *
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function synthesizeLegacyProfiles(): array {
+		$raw_mode            = strtolower( trim( (string) PluginSettings::get( 'github_auth_mode', '' ) ) );
+		$mode                = '' === $raw_mode ? 'pat' : $raw_mode;
+		$pat                 = trim( (string) PluginSettings::get( 'github_pat', '' ) );
+		$app_id              = trim( (string) PluginSettings::get( 'github_app_id', '' ) );
+		$app_installation_id = trim( (string) PluginSettings::get( 'github_app_installation_id', '' ) );
+		$app_private_key     = (string) PluginSettings::get( 'github_app_private_key', '' );
+		$default_repo        = trim( (string) PluginSettings::get( 'github_default_repo', '' ) );
+
+		// Always synthesize a default profile that carries the legacy mode
+		// even when no credentials are populated yet. This keeps error paths
+		// like "app mode but app_id missing" intact for installs that set
+		// github_auth_mode without populating the credentials.
+		return array(
+			array(
+				'id'                  => self::DEFAULT_PROFILE_ID,
+				'label'               => 'Default',
+				'mode'                => $mode,
+				'pat'                 => $pat,
+				'app_id'              => $app_id,
+				'app_installation_id' => $app_installation_id,
+				'app_private_key'     => $app_private_key,
+				'default_repo'        => $default_repo,
+				'allowed_repos'       => array(),
+			),
+		);
+	}
+
+	/**
+	 * Normalize a raw profile entry from settings — accepts loose arrays
+	 * and produces a consistent shape, dropping entries without an id.
+	 *
+	 * @return array<string,mixed>|null
+	 */
+	private static function normalizeProfile( array $entry ): ?array {
+		$id = trim( (string) ( $entry['id'] ?? '' ) );
+		if ( '' === $id ) {
+			return null;
+		}
+
+		$allowed = array();
+		if ( isset( $entry['allowed_repos'] ) && is_array( $entry['allowed_repos'] ) ) {
+			foreach ( $entry['allowed_repos'] as $repo ) {
+				$repo = trim( (string) $repo );
+				if ( '' !== $repo ) {
+					$allowed[] = $repo;
+				}
+			}
+		}
+
+		return array(
+			'id'                  => $id,
+			'label'               => (string) ( $entry['label'] ?? $id ),
+			'mode'                => strtolower( (string) ( $entry['mode'] ?? 'pat' ) ),
+			'pat'                 => (string) ( $entry['pat'] ?? '' ),
+			'app_id'              => (string) ( $entry['app_id'] ?? '' ),
+			'app_installation_id' => (string) ( $entry['app_installation_id'] ?? '' ),
+			'app_private_key'     => (string) ( $entry['app_private_key'] ?? '' ),
+			'default_repo'        => (string) ( $entry['default_repo'] ?? '' ),
+			'allowed_repos'       => $allowed,
+		);
+	}
+
+	private static function emptyDefaultProfile(): array {
+		return array(
+			'id'                  => self::DEFAULT_PROFILE_ID,
+			'label'               => 'Default',
+			'mode'                => 'pat',
+			'pat'                 => '',
+			'app_id'              => '',
+			'app_installation_id' => '',
+			'app_private_key'     => '',
+			'default_repo'        => '',
+			'allowed_repos'       => array(),
+		);
+	}
+
+	private static function profileIsConfigured( array $profile ): bool {
+		$mode = strtolower( (string) ( $profile['mode'] ?? 'pat' ) );
+		if ( 'pat' === $mode ) {
+			return '' !== trim( (string) ( $profile['pat'] ?? '' ) );
+		}
+
+		return 'app' === $mode
+			&& '' !== trim( (string) ( $profile['app_id'] ?? '' ) )
+			&& '' !== trim( (string) ( $profile['app_installation_id'] ?? '' ) )
+			&& '' !== trim( (string) ( $profile['app_private_key'] ?? '' ) );
+	}
+
+	private static function summarizeProfile( array $profile ): array {
+		$mode = strtolower( (string) ( $profile['mode'] ?? 'pat' ) );
+		return array(
+			'id'                          => (string) $profile['id'],
+			'label'                       => (string) ( $profile['label'] ?? $profile['id'] ),
+			'mode'                        => $mode,
+			'pat_configured'              => '' !== trim( (string) ( $profile['pat'] ?? '' ) ),
+			'app_id_configured'           => '' !== trim( (string) ( $profile['app_id'] ?? '' ) ),
+			'app_installation_configured' => '' !== trim( (string) ( $profile['app_installation_id'] ?? '' ) ),
+			'app_private_key_configured'  => '' !== trim( (string) ( $profile['app_private_key'] ?? '' ) ),
+			'default_repo'                => (string) ( $profile['default_repo'] ?? '' ),
+			'allowed_repos'               => isset( $profile['allowed_repos'] ) && is_array( $profile['allowed_repos'] )
+				? array_values( array_map( 'strval', $profile['allowed_repos'] ) )
+				: array(),
+			'configured'                  => self::profileIsConfigured( $profile ),
+		);
+	}
+
+	private static function cacheKey( string $profile_id, string $app_id, string $installation_id ): string {
+		return self::APP_TOKEN_CACHE_PREFIX . md5( $profile_id . ':' . $app_id . ':' . $installation_id );
 	}
 
 	private static function normalizePrivateKey( string $private_key ): string {

--- a/inc/Support/GitHubProfileSanitizer.php
+++ b/inc/Support/GitHubProfileSanitizer.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * GitHub credential profile sanitizer.
+ *
+ * Single source of truth for the shape coercion applied when DMC writes the
+ * credential profiles array through the `datamachine/update-settings` ability.
+ *
+ * Lives in its own file so the smoke tests can exercise the same contract
+ * without booting the full plugin bootstrap.
+ *
+ * @package DataMachineCode\Support
+ */
+
+namespace DataMachineCode\Support;
+
+defined( 'ABSPATH' ) || exit;
+
+final class GitHubProfileSanitizer {
+
+	/**
+	 * Sanitize a raw credential profiles array.
+	 *
+	 * - Drops entries without a non-empty `id` (after sanitize_key).
+	 * - Normalizes `mode` to `pat` or `app`, defaulting to `pat`.
+	 * - Trims `allowed_repos` and drops empties.
+	 * - Preserves PEM newlines on `app_private_key` (sanitize_text_field
+	 *   would strip them).
+	 *
+	 * @param array<int|string,mixed> $profiles
+	 * @return array<int,array<string,mixed>>
+	 */
+	public static function sanitize( array $profiles ): array {
+		$sanitized = array();
+		foreach ( $profiles as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+			$id = sanitize_key( (string) ( $entry['id'] ?? '' ) );
+			if ( '' === $id ) {
+				continue;
+			}
+
+			$allowed = array();
+			if ( isset( $entry['allowed_repos'] ) && is_array( $entry['allowed_repos'] ) ) {
+				foreach ( $entry['allowed_repos'] as $repo ) {
+					$repo = sanitize_text_field( (string) $repo );
+					if ( '' !== $repo ) {
+						$allowed[] = $repo;
+					}
+				}
+			}
+
+			$mode = strtolower( sanitize_text_field( (string) ( $entry['mode'] ?? 'pat' ) ) );
+			if ( ! in_array( $mode, array( 'pat', 'app' ), true ) ) {
+				$mode = 'pat';
+			}
+
+			$sanitized[] = array(
+				'id'                  => $id,
+				'label'               => sanitize_text_field( (string) ( $entry['label'] ?? $id ) ),
+				'mode'                => $mode,
+				'pat'                 => sanitize_text_field( (string) ( $entry['pat'] ?? '' ) ),
+				'app_id'              => sanitize_text_field( (string) ( $entry['app_id'] ?? '' ) ),
+				'app_installation_id' => sanitize_text_field( (string) ( $entry['app_installation_id'] ?? '' ) ),
+				'app_private_key'     => trim( (string) ( $entry['app_private_key'] ?? '' ) ),
+				'default_repo'        => sanitize_text_field( (string) ( $entry['default_repo'] ?? '' ) ),
+				'allowed_repos'       => $allowed,
+			);
+		}
+		return $sanitized;
+	}
+}

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -3903,7 +3903,9 @@ class Workspace {
 			return null;
 		}
 
-		$pat = \DataMachineCode\Abilities\GitHubAbilities::getPat();
+		// Pass the repo through so credential profiles with `allowed_repos`
+		// can win over the global default profile when fetching merge state.
+		$pat = \DataMachineCode\Abilities\GitHubAbilities::getPat( array( 'repo' => $slug ) );
 		if ( empty( $pat ) ) {
 			return null;
 		}
@@ -7222,7 +7224,9 @@ class Workspace {
 			return null;
 		}
 
-		$pat = \DataMachineCode\Abilities\GitHubAbilities::getPat();
+		// Pass the repo through so credential profiles with `allowed_repos`
+		// can win over the global default profile when scanning closed PRs.
+		$pat = \DataMachineCode\Abilities\GitHubAbilities::getPat( array( 'repo' => $slug ) );
 		if ( empty( $pat ) ) {
 			$github_cache[ $slug ] = null;
 			return null;

--- a/tests/smoke-github-app-auth.php
+++ b/tests/smoke-github-app-auth.php
@@ -9,8 +9,8 @@ declare( strict_types=1 );
 
 namespace DataMachine\Core {
 	class PluginSettings {
-		public static function get( string $key, string $default = '' ): string {
-			return $GLOBALS['dmc_settings'][ $key ] ?? $default;
+		public static function get( string $key, mixed $default_value = null ): mixed {
+			return $GLOBALS['dmc_settings'][ $key ] ?? $default_value;
 		}
 	}
 }

--- a/tests/smoke-github-credential-profiles.php
+++ b/tests/smoke-github-credential-profiles.php
@@ -1,0 +1,291 @@
+<?php
+/**
+ * Pure-PHP smoke test for GitHub credential profiles.
+ *
+ * Covers:
+ *   - Zero-arg resolve() falls back to the default profile.
+ *   - Explicit profile_id resolves the matching profile.
+ *   - Unknown profile_id fails closed (no silent fallback).
+ *   - repo selector picks the profile whose allowed_repos contains the repo.
+ *   - repo selector falls back to default when no profile matches.
+ *   - Legacy github_pat shape still works (synthesized into "default" profile).
+ *   - DM update-settings filter round-trips profile arrays end-to-end.
+ *
+ * Run: php tests/smoke-github-credential-profiles.php
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Core {
+	class PluginSettings {
+		public static function get( string $key, mixed $default_value = null ): mixed {
+			return $GLOBALS['dmc_settings'][ $key ] ?? $default_value;
+		}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	class WP_Error {
+		private string $code;
+		private string $message;
+		private array $data;
+
+		public function __construct( string $code, string $message, array $data = array() ) {
+			$this->code    = $code;
+			$this->message = $message;
+			$this->data    = $data;
+		}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+
+		public function get_error_data(): array {
+			return $this->data;
+		}
+	}
+
+	function is_wp_error( $value ): bool {
+		return $value instanceof WP_Error;
+	}
+
+	function wp_json_encode( $value, $flags = 0, $depth = 512 ) {
+		return json_encode( $value, $flags, $depth );
+	}
+
+	function get_transient( string $key ) {
+		return $GLOBALS['dmc_transients'][ $key ] ?? false;
+	}
+
+	function set_transient( string $key, $value, int $expiration ): bool {
+		$GLOBALS['dmc_transients'][ $key ] = $value;
+		return true;
+	}
+
+	function wp_remote_retrieve_response_code( $response ): int {
+		return (int) ( $response['response']['code'] ?? 0 );
+	}
+
+	function wp_remote_retrieve_body( $response ): string {
+		return (string) ( $response['body'] ?? '' );
+	}
+
+	function sanitize_text_field( $value ) {
+		// Mimic WP: collapse whitespace, strip tags. Good enough for smoke.
+		return is_string( $value ) ? trim( strip_tags( $value ) ) : '';
+	}
+
+	function sanitize_key( $key ) {
+		// Mirrors WP's sanitize_key: lowercase first, then strip to [a-z0-9_-].
+		if ( ! is_string( $key ) ) {
+			return '';
+		}
+		return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( $key ) );
+	}
+
+	require __DIR__ . '/../inc/Support/GitHubCredentialResolver.php';
+	require __DIR__ . '/../inc/Support/GitHubProfileSanitizer.php';
+
+	use DataMachineCode\Support\GitHubCredentialResolver;
+	use DataMachineCode\Support\GitHubProfileSanitizer;
+
+	$failures = array();
+	$assert   = function ( string $label, bool $cond ) use ( &$failures ): void {
+		if ( $cond ) {
+			echo "  ok {$label}\n";
+			return;
+		}
+		$failures[] = $label;
+		echo "  fail {$label}\n";
+	};
+
+	$reset = function ( array $settings = array() ): void {
+		$GLOBALS['dmc_settings']   = $settings;
+		$GLOBALS['dmc_transients'] = array();
+	};
+
+	echo "GitHub credential profiles — smoke\n";
+
+	// 1. Zero-arg resolve falls back to default (legacy github_pat shape).
+	$reset( array( 'github_pat' => 'legacy-token' ) );
+	$cred = GitHubCredentialResolver::resolve();
+	$assert( 'zero-arg resolve uses legacy github_pat as default profile', ! is_wp_error( $cred ) && 'legacy-token' === $cred['token'] && 'default' === $cred['profile_id'] );
+
+	// 2. Multiple profiles → explicit profile_id picks the right one.
+	$reset( array(
+		'github_credential_profiles' => array(
+			array(
+				'id'    => 'extrachill',
+				'label' => 'Extra Chill',
+				'mode'  => 'pat',
+				'pat'   => 'extrachill-token',
+			),
+			array(
+				'id'    => 'automattic',
+				'label' => 'Automattic',
+				'mode'  => 'pat',
+				'pat'   => 'automattic-token',
+			),
+		),
+		'github_default_profile_id'  => 'extrachill',
+	) );
+
+	$default_cred = GitHubCredentialResolver::resolve();
+	$assert( 'default_profile_id wins when no selector is passed', ! is_wp_error( $default_cred ) && 'extrachill-token' === $default_cred['token'] && 'extrachill' === $default_cred['profile_id'] );
+
+	$auto_cred = GitHubCredentialResolver::resolve( null, null, array( 'profile_id' => 'automattic' ) );
+	$assert( 'explicit profile_id selects matching profile', ! is_wp_error( $auto_cred ) && 'automattic-token' === $auto_cred['token'] );
+
+	// 3. Unknown profile_id fails closed.
+	$missing = GitHubCredentialResolver::resolve( null, null, array( 'profile_id' => 'does-not-exist' ) );
+	$assert( 'unknown profile_id fails closed', is_wp_error( $missing ) && 'github_profile_not_found' === $missing->get_error_code() );
+	$assert( 'unknown profile_id error mentions requested id', is_wp_error( $missing ) && str_contains( $missing->get_error_message(), 'does-not-exist' ) );
+
+	// 4. repo selector picks profile whose allowed_repos contains the repo.
+	$reset( array(
+		'github_credential_profiles' => array(
+			array(
+				'id'            => 'personal',
+				'mode'          => 'pat',
+				'pat'           => 'personal-token',
+				'allowed_repos' => array( 'chubes4/site' ),
+			),
+			array(
+				'id'            => 'work',
+				'mode'          => 'pat',
+				'pat'           => 'work-token',
+				'allowed_repos' => array( 'Automattic/wpcom', 'Automattic/intelligence' ),
+			),
+		),
+		'github_default_profile_id'  => 'personal',
+	) );
+
+	$work = GitHubCredentialResolver::resolve( null, null, array( 'repo' => 'Automattic/intelligence' ) );
+	$assert( 'repo selector picks profile via allowed_repos', ! is_wp_error( $work ) && 'work-token' === $work['token'] );
+
+	$work_case = GitHubCredentialResolver::resolve( null, null, array( 'repo' => 'automattic/wpcom' ) );
+	$assert( 'repo selector is case-insensitive', ! is_wp_error( $work_case ) && 'work-token' === $work_case['token'] );
+
+	$personal = GitHubCredentialResolver::resolve( null, null, array( 'repo' => 'chubes4/site' ) );
+	$assert( 'repo selector picks personal profile', ! is_wp_error( $personal ) && 'personal-token' === $personal['token'] );
+
+	// 5. Repo with no profile match falls through to default (does NOT error).
+	$fallthrough = GitHubCredentialResolver::resolve( null, null, array( 'repo' => 'someone-else/repo' ) );
+	$assert( 'unmatched repo falls back to default profile', ! is_wp_error( $fallthrough ) && 'personal-token' === $fallthrough['token'] );
+
+	// 6. default_repo on a profile is used when allowed_repos has no match.
+	$reset( array(
+		'github_credential_profiles' => array(
+			array(
+				'id'           => 'project-a',
+				'mode'         => 'pat',
+				'pat'          => 'project-a-token',
+				'default_repo' => 'team/project-a',
+			),
+			array(
+				'id'           => 'project-b',
+				'mode'         => 'pat',
+				'pat'          => 'project-b-token',
+				'default_repo' => 'team/project-b',
+			),
+		),
+		'github_default_profile_id'  => 'project-a',
+	) );
+	$by_default_repo = GitHubCredentialResolver::resolve( null, null, array( 'repo' => 'team/project-b' ) );
+	$assert( 'repo selector falls back to default_repo match', ! is_wp_error( $by_default_repo ) && 'project-b-token' === $by_default_repo['token'] );
+
+	// 7. Profile with empty PAT fails closed (does not silently use default).
+	$reset( array(
+		'github_credential_profiles' => array(
+			array(
+				'id'   => 'empty',
+				'mode' => 'pat',
+				'pat'  => '',
+			),
+			array(
+				'id'   => 'real',
+				'mode' => 'pat',
+				'pat'  => 'real-token',
+			),
+		),
+		'github_default_profile_id'  => 'real',
+	) );
+	$empty_explicit = GitHubCredentialResolver::resolve( null, null, array( 'profile_id' => 'empty' ) );
+	$assert( 'explicit empty profile fails closed (no fallback to default)', is_wp_error( $empty_explicit ) && 'github_pat_not_configured' === $empty_explicit->get_error_code() );
+
+	// 8. Status surface exposes profile summaries without leaking secrets.
+	$reset( array(
+		'github_credential_profiles' => array(
+			array(
+				'id'            => 'p1',
+				'label'         => 'First',
+				'mode'          => 'pat',
+				'pat'           => 'p1-secret',
+				'allowed_repos' => array( 'a/b' ),
+			),
+			array(
+				'id'    => 'p2',
+				'label' => 'Second',
+				'mode'  => 'pat',
+				'pat'   => '',
+			),
+		),
+		'github_default_profile_id'  => 'p1',
+	) );
+	$status = GitHubCredentialResolver::status();
+	$assert( 'status reports configured profiles', count( $status['profiles'] ) === 2 );
+	$assert( 'status default_profile_id matches setting', 'p1' === $status['default_profile_id'] );
+	$assert( 'status profile entry hides PAT body', ! str_contains( wp_json_encode( $status ), 'p1-secret' ) );
+	$assert( 'status profile reports configured booleans', $status['profiles'][0]['pat_configured'] && ! $status['profiles'][1]['pat_configured'] );
+
+	// 9. Migration shape: legacy single-cred install still resolves.
+	$reset( array(
+		'github_pat'         => 'legacy-only',
+		'github_default_repo' => 'team/legacy',
+	) );
+	$legacy = GitHubCredentialResolver::resolve();
+	$assert( 'legacy install still resolves via synthesized default profile', ! is_wp_error( $legacy ) && 'legacy-only' === $legacy['token'] );
+	$legacy_status = GitHubCredentialResolver::status();
+	$assert( 'legacy status surface still reports pat_configured at top-level', true === $legacy_status['pat_configured'] );
+
+	// 10. DM update-settings filter wiring — round-trip through GitHubProfileSanitizer.
+	$raw_input = array(
+		array(
+			'id'            => 'Marketing',
+			'label'         => '<b>Marketing</b>',
+			'mode'          => 'PAT',
+			'pat'           => 'marketing-secret',
+			'default_repo'  => 'team/marketing',
+			'allowed_repos' => array( 'team/marketing', '   team/sub  ' ),
+		),
+		array(
+			// Missing id → must be dropped.
+			'mode' => 'pat',
+			'pat'  => 'orphan',
+		),
+	);
+	$sanitized = GitHubProfileSanitizer::sanitize( $raw_input );
+	$assert( 'sanitizer drops profiles without id', count( $sanitized ) === 1 );
+	$assert( 'sanitizer normalizes mode to lowercase', 'pat' === $sanitized[0]['mode'] );
+	$assert( 'sanitizer normalizes id via sanitize_key', 'marketing' === $sanitized[0]['id'] );
+	$assert( 'sanitizer preserves PAT', 'marketing-secret' === $sanitized[0]['pat'] );
+	$assert( 'sanitizer trims allowed_repos entries', $sanitized[0]['allowed_repos'] === array( 'team/marketing', 'team/sub' ) );
+
+	if ( $failures ) {
+		echo "\nFailures:\n";
+		foreach ( $failures as $failure ) {
+			echo " - {$failure}\n";
+		}
+		exit( 1 );
+	}
+
+	echo "All assertions passed.\n";
+}

--- a/tests/smoke-github-pr-review-comment-upsert.php
+++ b/tests/smoke-github-pr-review-comment-upsert.php
@@ -9,8 +9,8 @@ declare( strict_types=1 );
 
 namespace DataMachine\Core {
     class PluginSettings {
-        public static function get( string $key, string $default = '' ): string {
-            return 'github_pat' === $key ? 'test-token' : $default;
+        public static function get( string $key, mixed $default_value = null ): mixed {
+            return 'github_pat' === $key ? 'test-token' : $default_value;
         }
     }
 }

--- a/tests/smoke-github-readonly-tools.php
+++ b/tests/smoke-github-readonly-tools.php
@@ -31,7 +31,7 @@ namespace DataMachine\Engine\AI\Tools {
 
 namespace DataMachine\Core {
 	class PluginSettings {
-		public static function get( string $key, string $default_value = '' ): string {
+		public static function get( string $key, mixed $default_value = null ): mixed {
 			return 'github_pat' === $key ? 'test-token' : $default_value;
 		}
 	}


### PR DESCRIPTION
## Summary
- Replace the single global GitHub credential with a list of credential profiles (`github_credential_profiles` + `github_default_profile_id`) — each profile carries its own mode (`pat`|`app`), credentials, optional `default_repo`, and optional `allowed_repos` whitelist.
- `GitHubCredentialResolver::resolve()` accepts a selector (`profile_id` or `repo`); the GitSync, Workspace cleanup, and `GitHubAbilities` call sites pass the target repo through so per-repo profiles win over the global default.
- DMC now registers its GitHub settings keys with the DM `datamachine/update-settings` ability whitelist via the `datamachine_update_settings` filter, so `wp datamachine settings set github_pat …` (and equivalents for App mode + the new profile array) work end-to-end through the official ability path.
- Closes #259

## Implementation notes
- **Profile shape:** `id`, `label`, `mode` (`pat`|`app`), `pat` or App fields, optional `default_repo`, optional `allowed_repos[]` — stored under `github_credential_profiles`. `github_default_profile_id` controls fallback.
- **Selector semantics:** explicit `profile_id` fails closed when the id is unknown (`github_profile_not_found`). `repo` selectors prefer profiles that explicitly list the repo in `allowed_repos`, then profiles whose `default_repo` matches; unmatched repos fall through to the default profile rather than erroring.
- **Migration path:** existing installs keep working unchanged. When `github_credential_profiles` is empty, the resolver synthesizes an implicit `default` profile from the legacy `github_pat` / `github_auth_mode` / `github_app_*` keys on read. New writes should populate `github_credential_profiles` directly via the update-settings ability; both shapes coexist and the profile list wins when present.
- **Header scheme:** `GitHubAbilities::getHeaders()` now consults a per-token mode map populated when the credential is resolved, so multi-profile callers get the right `Authorization` scheme regardless of which profile is the global default.
- **Sanitization:** profile shape coercion lives in a new `GitHubProfileSanitizer` class so the bootstrap filter and the smoke tests exercise the same contract — no duplicated stub.
- **Naming:** every new identifier uses the `datamachine_` / `DataMachineCode\` prefix per site rule (no `dm_` shorthand).

## Tests
- Existing `tests/smoke-github-app-auth.php` still passes; the in-test `PluginSettings` stub was loosened to `mixed` to match the real signature now that the resolver passes `array()` defaults.
- New `tests/smoke-github-credential-profiles.php` (22 assertions) covers:
  - zero-arg `resolve()` returns the default profile
  - explicit `profile_id` resolves the matching profile
  - unknown `profile_id` fails closed (no silent fallback)
  - `repo` selector picks the profile whose `allowed_repos` contains the repo (case-insensitive)
  - `repo` selector falls back to `default_repo` matches and then to the default profile
  - explicit selector for an empty profile fails closed
  - status surface exposes profile summaries without leaking secrets
  - legacy single-credential install still resolves through the synthesized default
  - `GitHubProfileSanitizer::sanitize()` round-trip drops orphan entries, normalizes mode/id, trims `allowed_repos`
- Run: `php tests/smoke-github-credential-profiles.php` (and `php tests/smoke-github-app-auth.php` for the back-compat path). Spot-checked the rest of the GitHub-touching smoke suite — only stubs that hardcoded a `string`-typed `PluginSettings::get` needed loosening to `mixed`; no functional regressions.
- `homeboy lint --path .` delta vs `main`: net 0 new findings.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafting and implementing the credential-profiles refactor and settings whitelist registration. Chris reviewed scope and will review the diff.