### PR TITLE
Expose GitHub pull request creation tool

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -87,9 +87,6 @@ function datamachine_code_bootstrap() {
 	// Register ability categories on the correct hook (must happen during wp_abilities_api_categories_init).
 	add_action( 'wp_abilities_api_categories_init', 'datamachine_code_register_ability_categories' );
 
-	// Register GitHub issue creation ability via SystemAbilities hook.
-	add_action( 'wp_abilities_api_init', 'datamachine_code_register_system_abilities' );
-
 }
 add_action( 'plugins_loaded', 'datamachine_code_bootstrap', 20 );
 
@@ -218,72 +215,6 @@ function datamachine_code_register_ability_categories() {
 }
 
 /**
- * Register system-level abilities (GitHub issue creation).
- */
-function datamachine_code_register_system_abilities() {
-	if ( ! function_exists( 'wp_register_ability' ) ) {
-		return;
-	}
-
-	wp_register_ability(
-		'datamachine/create-github-issue',
-		array(
-			'label'               => 'Create GitHub Issue',
-			'description'         => 'Create a new GitHub issue in a repository.',
-			'category'            => 'datamachine-code-github',
-			'input_schema'        => array(
-				'type'       => 'object',
-				'required'   => array( 'title' ),
-				'properties' => array(
-					'title'  => array(
-						'type'        => 'string',
-						'description' => 'Issue title.',
-					),
-					'repo'   => array(
-						'type'        => 'string',
-						'description' => 'Repository in owner/repo format.',
-					),
-					'body'   => array(
-						'type'        => 'string',
-						'description' => 'Issue body (supports GitHub Markdown).',
-					),
-					'labels' => array(
-						'type'        => 'array',
-						'description' => 'Labels to apply.',
-					),
-				),
-			),
-			'output_schema'       => array(
-				'type'       => 'object',
-				'properties' => array(
-					'success' => array( 'type' => 'boolean' ),
-					'job_id'  => array( 'type' => 'integer' ),
-					'error'   => array( 'type' => 'string' ),
-				),
-			),
-			'execute_callback'    => function ( array $input ) {
-				if ( ! class_exists( 'DataMachine\Engine\AI\System\TaskScheduler' ) ) {
-					return new \WP_Error( 'scheduler_unavailable', 'TaskScheduler not available.', array( 'status' => 500 ) );
-				}
-
-				$scheduler = new \DataMachine\Engine\AI\System\TaskScheduler();
-				$job_id    = $scheduler->schedule( 'github_create_issue', $input );
-
-				if ( is_wp_error( $job_id ) ) {
-					return $job_id;
-				}
-
-				return $job_id;
-			},
-			'permission_callback' => function () {
-				return \DataMachine\Abilities\PermissionHelper::can_manage();
-			},
-			'meta'                => array( 'show_in_rest' => false ),
-		)
-	);
-}
-
-/**
  * Register WP-CLI commands after core is loaded.
  */
 function datamachine_code_register_cli_commands() {
@@ -314,6 +245,7 @@ function datamachine_code_load_chat_tools() {
 	}
 
 	new \DataMachineCode\Tools\GitHubIssueTool();
+	new \DataMachineCode\Tools\GitHubPullRequestTool();
 	new \DataMachineCode\Tools\GitHubTools();
 	new \DataMachineCode\Tools\WorkspaceTools();
 }

--- a/inc/Tools/GitHubIssueTool.php
+++ b/inc/Tools/GitHubIssueTool.php
@@ -51,10 +51,12 @@ class GitHubIssueTool extends BaseTool {
 		}
 
 		$input = array(
-			'title'  => $parameters['title'] ?? '',
-			'repo'   => $parameters['repo'] ?? '',
-			'body'   => $parameters['body'] ?? '',
-			'labels' => $parameters['labels'] ?? array(),
+			'title'     => $parameters['title'] ?? '',
+			'repo'      => $parameters['repo'] ?? '',
+			'body'      => $parameters['body'] ?? '',
+			'labels'    => $parameters['labels'] ?? array(),
+			'assignees' => $parameters['assignees'] ?? array(),
+			'milestone' => $parameters['milestone'] ?? null,
 		);
 
 		$result = $ability->execute( $input );
@@ -74,6 +76,11 @@ class GitHubIssueTool extends BaseTool {
 				'message'   => sprintf( 'GitHub issue creation scheduled (Job #%d).', $result ),
 				'tool_name' => 'create_github_issue',
 			);
+		}
+
+		if ( is_array( $result ) && ! empty( $result['success'] ) ) {
+			$result['tool_name'] = 'create_github_issue';
+			return $result;
 		}
 
 		if ( is_array( $result ) && ! empty( $result['error'] ) ) {
@@ -138,6 +145,16 @@ class GitHubIssueTool extends BaseTool {
 					'type'        => 'array',
 					'required'    => false,
 					'description' => 'Labels to apply to the issue.',
+				),
+				'assignees' => array(
+					'type'        => 'array',
+					'required'    => false,
+					'description' => 'GitHub usernames to assign to the issue.',
+				),
+				'milestone' => array(
+					'type'        => 'integer',
+					'required'    => false,
+					'description' => 'Milestone number to attach to the issue.',
 				),
 			),
 		);

--- a/inc/Tools/GitHubPullRequestTool.php
+++ b/inc/Tools/GitHubPullRequestTool.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * GitHub Pull Request Tool — AI agent wrapper for create-github-pull-request.
+ *
+ * Provides the AI-callable tool interface for opening GitHub pull requests.
+ *
+ * @package DataMachineCode\Tools
+ * @since 0.30.1
+ */
+
+namespace DataMachineCode\Tools;
+
+use DataMachine\Engine\AI\Tools\BaseTool;
+
+defined( 'ABSPATH' ) || exit;
+
+class GitHubPullRequestTool extends BaseTool {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->registerTool( 'create_github_pull_request', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline' ), array( 'ability' => 'datamachine/create-github-pull-request' ) );
+	}
+
+	/**
+	 * Execute GitHub pull request creation by delegating to the ability.
+	 *
+	 * @param array $parameters Contains ability-shaped pull request parameters.
+	 * @param array $tool_def   Tool definition (unused).
+	 * @return array Tool response.
+	 */
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		$ability = wp_get_ability( 'datamachine/create-github-pull-request' );
+
+		if ( ! $ability ) {
+			return $this->buildErrorResponse(
+				'GitHub pull request creation ability not registered. Ensure WordPress 6.9+ is active.',
+				'create_github_pull_request'
+			);
+		}
+
+		$input = array(
+			'repo'                  => $parameters['repo'] ?? '',
+			'title'                 => $parameters['title'] ?? '',
+			'head'                  => $parameters['head'] ?? '',
+			'base'                  => $parameters['base'] ?? '',
+			'body'                  => $parameters['body'] ?? '',
+			'draft'                 => $parameters['draft'] ?? false,
+			'maintainer_can_modify' => $parameters['maintainer_can_modify'] ?? true,
+		);
+
+		$result = $ability->execute( $input );
+
+		if ( is_wp_error( $result ) ) {
+			return $this->buildErrorResponse(
+				$result->get_error_message(),
+				'create_github_pull_request'
+			);
+		}
+
+		if ( is_array( $result ) && ! empty( $result['success'] ) ) {
+			$result['tool_name'] = 'create_github_pull_request';
+			return $result;
+		}
+
+		if ( is_array( $result ) && ! empty( $result['error'] ) ) {
+			return $this->buildErrorResponse(
+				$result['error'],
+				'create_github_pull_request'
+			);
+		}
+
+		return $this->buildErrorResponse(
+			'Failed to create GitHub pull request.',
+			'create_github_pull_request'
+		);
+	}
+
+	/**
+	 * Get tool definition for AI agents.
+	 *
+	 * @return array Tool definition array.
+	 */
+	public function getToolDefinition(): array {
+		$description = 'Create a GitHub pull request in a repository. Requires a GitHub PAT or App credential configured in settings.';
+
+		$repos = \DataMachineCode\Abilities\GitHubAbilities::getRegisteredRepos();
+		if ( ! empty( $repos ) ) {
+			$repo_list    = array_map(
+				function ( $r ) {
+					return $r['owner'] . '/' . $r['repo'] . ' (' . $r['label'] . ')';
+				},
+				$repos
+			);
+			$description .= ' Available repos: ' . implode( ', ', $repo_list ) . '.';
+		}
+
+		return array(
+			'class'       => __CLASS__,
+			'method'      => 'handle_tool_call',
+			'description' => $description,
+			'parameters'  => array(
+				'repo'                  => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Repository in owner/repo format.',
+				),
+				'title'                 => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Pull request title.',
+				),
+				'head'                  => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Branch where changes are implemented. Use owner:branch for cross-fork PRs.',
+				),
+				'base'                  => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Branch to merge into. Defaults to the repository default branch.',
+				),
+				'body'                  => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Pull request description. Supports GitHub Markdown.',
+				),
+				'draft'                 => array(
+					'type'        => 'boolean',
+					'required'    => false,
+					'description' => 'Whether to open the pull request as a draft. Default: false.',
+				),
+				'maintainer_can_modify' => array(
+					'type'        => 'boolean',
+					'required'    => false,
+					'description' => 'Whether maintainers can modify the pull request. Default: true.',
+				),
+			),
+		);
+	}
+}

--- a/tests/smoke-github-create-tools.php
+++ b/tests/smoke-github-create-tools.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Pure-PHP smoke test for GitHub create chat/pipeline tools.
+ *
+ * Run: php tests/smoke-github-create-tools.php
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Engine\AI\Tools {
+	class BaseTool {
+		public array $registered = array();
+
+		protected function registerTool( string $name, array $definition_callback, array $contexts, array $options = array() ): void {
+			$this->registered[ $name ] = array(
+				'definition_callback' => $definition_callback,
+				'contexts'            => $contexts,
+				'options'             => $options,
+			);
+		}
+
+		protected function buildErrorResponse( string $message, string $tool_name ): array {
+			return array(
+				'success'   => false,
+				'error'     => $message,
+				'tool_name' => $tool_name,
+			);
+		}
+	}
+}
+
+namespace DataMachineCode\Abilities {
+	class GitHubAbilities {
+		public static function getRegisteredRepos(): array {
+			return array(
+				array(
+					'owner' => 'Extra-Chill',
+					'repo'  => 'data-machine-code',
+					'label' => 'Data Machine Code',
+				),
+			);
+		}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	$GLOBALS['dmc_tool_ability_calls'] = array();
+
+	class DMC_Test_Ability {
+		public function __construct( private string $name ) {}
+
+		public function execute( array $input ): array {
+			$GLOBALS['dmc_tool_ability_calls'][] = array(
+				'name'  => $this->name,
+				'input' => $input,
+			);
+
+			if ( 'datamachine/create-github-pull-request' === $this->name ) {
+				return array(
+					'success'      => true,
+					'pull_request' => array( 'number' => 261 ),
+				);
+			}
+
+			return array(
+				'success'      => true,
+				'issue_number' => 262,
+			);
+		}
+	}
+
+	function wp_get_ability( string $name ): ?DMC_Test_Ability {
+		if ( in_array( $name, array( 'datamachine/create-github-issue', 'datamachine/create-github-pull-request' ), true ) ) {
+			return new DMC_Test_Ability( $name );
+		}
+
+		return null;
+	}
+
+	function is_wp_error( $thing ): bool {
+		return false;
+	}
+
+	require __DIR__ . '/../inc/Tools/GitHubIssueTool.php';
+	require __DIR__ . '/../inc/Tools/GitHubPullRequestTool.php';
+
+	use DataMachineCode\Tools\GitHubIssueTool;
+	use DataMachineCode\Tools\GitHubPullRequestTool;
+
+	$failures = array();
+	$assert   = function ( string $label, bool $cond ) use ( &$failures ): void {
+		if ( $cond ) {
+			echo "  ok {$label}\n";
+			return;
+		}
+
+		$failures[] = $label;
+		echo "  fail {$label}\n";
+	};
+
+	echo "GitHub create tools - smoke\n";
+
+	$issue_tool = new GitHubIssueTool();
+	$pr_tool    = new GitHubPullRequestTool();
+
+	$assert( 'create_github_issue tool is registered', isset( $issue_tool->registered['create_github_issue'] ) );
+	$assert( 'create_github_issue is available in chat', in_array( 'chat', $issue_tool->registered['create_github_issue']['contexts'] ?? array(), true ) );
+	$assert( 'create_github_issue is available in pipeline', in_array( 'pipeline', $issue_tool->registered['create_github_issue']['contexts'] ?? array(), true ) );
+	$assert( 'create_github_issue links to create issue ability', 'datamachine/create-github-issue' === ( $issue_tool->registered['create_github_issue']['options']['ability'] ?? '' ) );
+
+	$assert( 'create_github_pull_request tool is registered', isset( $pr_tool->registered['create_github_pull_request'] ) );
+	$assert( 'create_github_pull_request is available in chat', in_array( 'chat', $pr_tool->registered['create_github_pull_request']['contexts'] ?? array(), true ) );
+	$assert( 'create_github_pull_request is available in pipeline', in_array( 'pipeline', $pr_tool->registered['create_github_pull_request']['contexts'] ?? array(), true ) );
+	$assert( 'create_github_pull_request links to create PR ability', 'datamachine/create-github-pull-request' === ( $pr_tool->registered['create_github_pull_request']['options']['ability'] ?? '' ) );
+
+	$issue_definition = $issue_tool->getToolDefinition();
+	$issue_params     = $issue_definition['parameters'] ?? array();
+	$assert( 'create_github_issue exposes assignees from ability schema', array_key_exists( 'assignees', $issue_params ) );
+	$assert( 'create_github_issue exposes milestone from ability schema', array_key_exists( 'milestone', $issue_params ) );
+
+	$pr_definition = $pr_tool->getToolDefinition();
+	$pr_params     = $pr_definition['parameters'] ?? array();
+	$assert( 'create_github_pull_request requires repo', true === ( $pr_params['repo']['required'] ?? false ) );
+	$assert( 'create_github_pull_request requires title', true === ( $pr_params['title']['required'] ?? false ) );
+	$assert( 'create_github_pull_request requires head', true === ( $pr_params['head']['required'] ?? false ) );
+	foreach ( array( 'repo', 'title', 'head', 'base', 'body', 'draft', 'maintainer_can_modify' ) as $param ) {
+		$assert( "create_github_pull_request exposes {$param}", array_key_exists( $param, $pr_params ) );
+	}
+
+	$issue_result = $issue_tool->handle_tool_call( array(
+		'repo'      => 'Extra-Chill/data-machine-code',
+		'title'     => 'Issue title',
+		'body'      => 'Issue body',
+		'labels'    => array( 'bug' ),
+		'assignees' => array( 'chubes4' ),
+		'milestone' => 7,
+	) );
+	$assert( 'create_github_issue returns direct ability success', true === ( $issue_result['success'] ?? false ) );
+	$assert( 'create_github_issue response names tool', 'create_github_issue' === ( $issue_result['tool_name'] ?? '' ) );
+
+	$pr_result = $pr_tool->handle_tool_call( array(
+		'repo'                  => 'Extra-Chill/data-machine-code',
+		'title'                 => 'PR title',
+		'head'                  => 'fix/github-pr-tool',
+		'base'                  => 'main',
+		'body'                  => 'PR body',
+		'draft'                 => true,
+		'maintainer_can_modify' => false,
+	) );
+	$assert( 'create_github_pull_request returns direct ability success', true === ( $pr_result['success'] ?? false ) );
+	$assert( 'create_github_pull_request response names tool', 'create_github_pull_request' === ( $pr_result['tool_name'] ?? '' ) );
+
+	$pr_call = $GLOBALS['dmc_tool_ability_calls'][1] ?? array();
+	$assert( 'create_github_pull_request calls PR ability', 'datamachine/create-github-pull-request' === ( $pr_call['name'] ?? '' ) );
+	$assert( 'create_github_pull_request forwards maintainer_can_modify', false === ( $pr_call['input']['maintainer_can_modify'] ?? null ) );
+
+	$plugin_source = file_get_contents( __DIR__ . '/../data-machine-code.php' );
+	$assert( 'legacy system ability function is removed', ! str_contains( $plugin_source, 'datamachine_code_register_system_abilities' ) );
+	$assert( 'legacy create-github-issue registration is removed from plugin bootstrap', ! str_contains( $plugin_source, "wp_register_ability(\n\t\t'datamachine/create-github-issue'" ) );
+	$assert( 'plugin instantiates PR create tool', str_contains( $plugin_source, 'new \\DataMachineCode\\Tools\\GitHubPullRequestTool();' ) );
+
+	if ( ! empty( $failures ) ) {
+		echo "\nFAIL: " . count( $failures ) . " assertion(s)\n";
+		foreach ( $failures as $failure ) {
+			echo "  - {$failure}\n";
+		}
+		exit( 1 );
+	}
+
+	echo "\nOK\n";
+	exit( 0 );
+}


### PR DESCRIPTION
## Summary
- Adds an AI-callable `create_github_pull_request` tool for chat and pipeline contexts, linked to `datamachine/create-github-pull-request`.
- Removes the legacy duplicate `datamachine/create-github-issue` ability registration from plugin bootstrap.
- Adds smoke coverage for create tool registration, ability linkage, PR parameters, direct ability results, and the removed duplicate registration path.

## Validation
- `php tests/smoke-github-create-abilities.php`
- `php tests/smoke-github-create-tools.php`
- `php -l data-machine-code.php`
- `php -l inc/Tools/GitHubIssueTool.php`
- `php -l inc/Tools/GitHubPullRequestTool.php`
- `php -l tests/smoke-github-create-tools.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the code and smoke test changes; Chris remains responsible for review and merge.