### PR TITLE
Fix GitHub tool array schemas

### DIFF
--- a/inc/Tools/GitHubIssueTool.php
+++ b/inc/Tools/GitHubIssueTool.php
@@ -143,11 +143,13 @@ class GitHubIssueTool extends BaseTool {
 				),
 				'labels' => array(
 					'type'        => 'array',
+					'items'       => array( 'type' => 'string' ),
 					'required'    => false,
 					'description' => 'Labels to apply to the issue.',
 				),
 				'assignees' => array(
 					'type'        => 'array',
+					'items'       => array( 'type' => 'string' ),
 					'required'    => false,
 					'description' => 'GitHub usernames to assign to the issue.',
 				),

--- a/inc/Tools/GitHubTools.php
+++ b/inc/Tools/GitHubTools.php
@@ -334,6 +334,7 @@ class GitHubTools extends BaseTool {
 				),
 				'labels'       => array(
 					'type'        => 'array',
+					'items'       => array( 'type' => 'string' ),
 					'required'    => false,
 					'description' => 'Labels to set (update action). Replaces existing labels.',
 				),
@@ -818,6 +819,7 @@ class GitHubTools extends BaseTool {
 				),
 				'context_paths'           => array(
 					'type'        => 'array',
+					'items'       => array( 'type' => 'string' ),
 					'required'    => false,
 					'description' => 'Additional repository paths to include from the PR head ref.',
 				),
@@ -1003,6 +1005,7 @@ class GitHubTools extends BaseTool {
 				),
 				'docs_paths'  => array(
 					'type'        => 'array',
+					'items'       => array( 'type' => 'string' ),
 					'required'    => false,
 					'description' => 'Optional documentation path allow-list used when suggesting likely stale docs.',
 				),

--- a/tests/smoke-github-create-tools.php
+++ b/tests/smoke-github-create-tools.php
@@ -87,8 +87,10 @@ namespace {
 
 	require __DIR__ . '/../inc/Tools/GitHubIssueTool.php';
 	require __DIR__ . '/../inc/Tools/GitHubPullRequestTool.php';
+	require __DIR__ . '/../inc/Tools/GitHubTools.php';
 
 	use DataMachineCode\Tools\GitHubIssueTool;
+	use DataMachineCode\Tools\GitHubTools;
 	use DataMachineCode\Tools\GitHubPullRequestTool;
 
 	$failures = array();
@@ -101,11 +103,27 @@ namespace {
 		$failures[] = $label;
 		echo "  fail {$label}\n";
 	};
+	$assert_array_items = function ( array $schema, string $path ) use ( &$assert_array_items, $assert ): void {
+		if ( 'array' === ( $schema['type'] ?? null ) ) {
+			$assert( "{$path} array schema declares items", isset( $schema['items'] ) && is_array( $schema['items'] ) );
+		}
+
+		foreach ( $schema['properties'] ?? array() as $property => $property_schema ) {
+			if ( is_array( $property_schema ) ) {
+				$assert_array_items( $property_schema, "{$path}.properties.{$property}" );
+			}
+		}
+
+		if ( isset( $schema['items'] ) && is_array( $schema['items'] ) ) {
+			$assert_array_items( $schema['items'], "{$path}.items" );
+		}
+	};
 
 	echo "GitHub create tools - smoke\n";
 
 	$issue_tool = new GitHubIssueTool();
 	$pr_tool    = new GitHubPullRequestTool();
+	$github_tools = new GitHubTools();
 
 	$assert( 'create_github_issue tool is registered', isset( $issue_tool->registered['create_github_issue'] ) );
 	$assert( 'create_github_issue is available in chat', in_array( 'chat', $issue_tool->registered['create_github_issue']['contexts'] ?? array(), true ) );
@@ -157,6 +175,25 @@ namespace {
 	$pr_call = $GLOBALS['dmc_tool_ability_calls'][1] ?? array();
 	$assert( 'create_github_pull_request calls PR ability', 'datamachine/create-github-pull-request' === ( $pr_call['name'] ?? '' ) );
 	$assert( 'create_github_pull_request forwards maintainer_can_modify', false === ( $pr_call['input']['maintainer_can_modify'] ?? null ) );
+
+	$tool_definitions = array(
+		'create_github_issue'        => $issue_definition,
+		'create_github_pull_request' => $pr_definition,
+	);
+	foreach ( $github_tools->registered as $tool_name => $registration ) {
+		$callback = $registration['definition_callback'] ?? null;
+		if ( is_callable( $callback ) ) {
+			$tool_definitions[ $tool_name ] = $callback();
+		}
+	}
+
+	foreach ( $tool_definitions as $tool_name => $definition ) {
+		foreach ( $definition['parameters'] ?? array() as $parameter => $parameter_schema ) {
+			if ( is_array( $parameter_schema ) ) {
+				$assert_array_items( $parameter_schema, "{$tool_name}.parameters.{$parameter}" );
+			}
+		}
+	}
 
 	$plugin_source = file_get_contents( __DIR__ . '/../data-machine-code.php' );
 	$assert( 'legacy system ability function is removed', ! str_contains( $plugin_source, 'datamachine_code_register_system_abilities' ) );


### PR DESCRIPTION
## Summary
- Adds `items` schemas to GitHub AI tool array parameters so OpenAI-compatible function schemas pass validation.
- Covers `create_github_issue.labels`, `create_github_issue.assignees`, `manage_github_issue.labels`, `get_github_pull_review_context.context_paths`, and `github_pr_documentation_impact.docs_paths`.
- Extends smoke coverage to instantiate GitHub tool wrappers and assert every array parameter declares `items`.

## Context
The wc-store-blueprints idea flow failed before tool execution on job 585 with:

`Bad Request (400) - Invalid schema for function create_github_issue: In context=(properties, labels), array schema missing items.`

## Validation
- `php tests/smoke-github-create-tools.php`
- `php tests/smoke-github-create-abilities.php`
- `php -l inc/Tools/GitHubIssueTool.php`
- `php -l inc/Tools/GitHubTools.php`
- `php -l tests/smoke-github-create-tools.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the schema fix and smoke coverage; Chris remains responsible for review and merge.