### PR TITLE
Add GitHub issue publish handler

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -82,6 +82,7 @@ function datamachine_code_bootstrap() {
 
 	// Load Handlers (they self-register).
 	new \DataMachineCode\Handlers\GitHub\GitHub();
+	new \DataMachineCode\Handlers\GitHub\GitHubIssuePublish();
 	new \DataMachineCode\Handlers\GitHub\GitHubUpsert();
 
 	// Register ability categories on the correct hook (must happen during wp_abilities_api_categories_init).

--- a/inc/Handlers/GitHub/GitHubIssuePublish.php
+++ b/inc/Handlers/GitHub/GitHubIssuePublish.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * GitHub Issue Publish Handler.
+ *
+ * @package DataMachineCode\Handlers\GitHub
+ */
+
+namespace DataMachineCode\Handlers\GitHub;
+
+use DataMachine\Core\Steps\HandlerRegistrationTrait;
+use DataMachine\Core\Steps\Publish\Handlers\PublishHandler;
+use DataMachineCode\Abilities\GitHubAbilities;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class GitHubIssuePublish extends PublishHandler {
+
+	use HandlerRegistrationTrait;
+
+	public function __construct() {
+		parent::__construct( 'github_issue' );
+
+		self::registerHandler(
+			'github_issue',
+			'publish',
+			self::class,
+			'GitHub Issue',
+			'Create GitHub issues from AI-generated pipeline packets',
+			false,
+			null,
+			GitHubIssuePublishSettings::class,
+			array( self::class, 'registerTools' )
+		);
+	}
+
+	/**
+	 * Register the AI-visible publish handler tool.
+	 *
+	 * @param array  $tools          Registered tools.
+	 * @param string $handler_slug   Current handler slug.
+	 * @param array  $handler_config Handler configuration.
+	 * @return array Tools with GitHub issue publish tool added.
+	 */
+	public static function registerTools( array $tools, string $handler_slug, array $handler_config ): array {
+		if ( 'github_issue' !== $handler_slug ) {
+			return $tools;
+		}
+
+		$tools['github_issue_publish'] = array(
+			'class'       => self::class,
+			'method'      => 'handle_tool_call',
+			'handler'     => 'github_issue',
+			'description' => 'Create a GitHub issue as the publish step for this pipeline item. Call exactly once with the final issue title and body.',
+			'parameters'  => array(
+				'type'       => 'object',
+				'required'   => array( 'title', 'body' ),
+				'properties' => array(
+					'title'     => array(
+						'type'        => 'string',
+						'description' => 'GitHub issue title.',
+					),
+					'body'      => array(
+						'type'        => 'string',
+						'description' => 'GitHub issue body in Markdown.',
+					),
+					'repo'      => array(
+						'type'        => 'string',
+						'description' => 'Repository in owner/repo format. Overrides handler config when provided.',
+					),
+					'labels'    => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'string' ),
+						'description' => 'Labels to apply to the issue. Overrides handler config when provided.',
+					),
+					'assignees' => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'string' ),
+						'description' => 'GitHub usernames to assign.',
+					),
+					'milestone' => array(
+						'type'        => 'integer',
+						'description' => 'Milestone number to assign.',
+					),
+				),
+			),
+		);
+
+		return $tools;
+	}
+
+	/**
+	 * Create the GitHub issue.
+	 *
+	 * @param array $parameters     Tool parameters.
+	 * @param array $handler_config Handler configuration.
+	 * @return array Publish result.
+	 */
+	protected function executePublish( array $parameters, array $handler_config ): array {
+		$repo = ! empty( $parameters['repo'] )
+			? sanitize_text_field( $parameters['repo'] )
+			: (string) ( $handler_config['repo'] ?? '' );
+
+		if ( '' === $repo ) {
+			$repo = GitHubAbilities::getDefaultRepo();
+		}
+
+		$labels = $this->resolveListParameter( $parameters['labels'] ?? null, $handler_config['labels'] ?? '' );
+
+		$input = array(
+			'repo'      => $repo,
+			'title'     => $parameters['title'] ?? '',
+			'body'      => $parameters['body'] ?? '',
+			'labels'    => $labels,
+			'assignees' => $this->resolveListParameter( $parameters['assignees'] ?? null, $handler_config['assignees'] ?? '' ),
+		);
+
+		if ( isset( $parameters['milestone'] ) && '' !== $parameters['milestone'] ) {
+			$input['milestone'] = (int) $parameters['milestone'];
+		} elseif ( isset( $handler_config['milestone'] ) && '' !== $handler_config['milestone'] ) {
+			$input['milestone'] = (int) $handler_config['milestone'];
+		}
+
+		$result = GitHubAbilities::createIssue( $input );
+		if ( is_wp_error( $result ) ) {
+			return $this->errorResponse(
+				'GitHub Issue: ' . $result->get_error_message(),
+				array(
+					'job_id' => $parameters['job_id'] ?? null,
+					'repo'   => $repo,
+				)
+			);
+		}
+
+		return $this->successResponse(
+			array(
+				'repo'         => $repo,
+				'issue_url'    => $result['issue_url'] ?? '',
+				'issue_number' => $result['issue_number'] ?? 0,
+				'html_url'     => $result['html_url'] ?? '',
+				'title'        => $input['title'],
+				'labels'       => $labels,
+			)
+		);
+	}
+
+	/**
+	 * Resolve a list supplied by tool parameters or comma-separated handler config.
+	 *
+	 * @param mixed  $parameter Tool parameter value.
+	 * @param string $fallback  Comma-separated handler config fallback.
+	 * @return array<int, string> Sanitized list.
+	 */
+	private function resolveListParameter( mixed $parameter, string $fallback ): array {
+		$items = is_array( $parameter ) ? $parameter : array();
+		if ( empty( $items ) && '' !== $fallback ) {
+			$items = array_map( 'trim', explode( ',', $fallback ) );
+		}
+
+		return array_values(
+			array_filter(
+				array_map( 'sanitize_text_field', $items ),
+				static fn( string $item ): bool => '' !== $item
+			)
+		);
+	}
+}

--- a/inc/Handlers/GitHub/GitHubIssuePublishSettings.php
+++ b/inc/Handlers/GitHub/GitHubIssuePublishSettings.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * GitHub Issue Publish Handler Settings.
+ *
+ * @package DataMachineCode\Handlers\GitHub
+ */
+
+namespace DataMachineCode\Handlers\GitHub;
+
+use DataMachine\Core\Steps\Settings\SettingsHandler;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class GitHubIssuePublishSettings extends SettingsHandler {
+
+	/**
+	 * Get settings fields for GitHub issue publishing.
+	 *
+	 * @return array
+	 */
+	public static function get_fields(): array {
+		return array(
+			'repo'      => array(
+				'type'        => 'text',
+				'label'       => __( 'Repository', 'data-machine-code' ),
+				'description' => __( 'GitHub repository in owner/repo format. Falls back to the default repo in settings.', 'data-machine-code' ),
+				'required'    => false,
+			),
+			'labels'    => array(
+				'type'        => 'text',
+				'label'       => __( 'Labels', 'data-machine-code' ),
+				'description' => __( 'Comma-separated labels to apply by default. The AI step can override these.', 'data-machine-code' ),
+				'required'    => false,
+			),
+			'assignees' => array(
+				'type'        => 'text',
+				'label'       => __( 'Assignees', 'data-machine-code' ),
+				'description' => __( 'Comma-separated GitHub usernames to assign by default.', 'data-machine-code' ),
+				'required'    => false,
+			),
+			'milestone' => array(
+				'type'        => 'number',
+				'label'       => __( 'Milestone', 'data-machine-code' ),
+				'description' => __( 'Optional GitHub milestone number.', 'data-machine-code' ),
+				'required'    => false,
+			),
+		);
+	}
+}

--- a/tests/smoke-github-issue-publish-handler.php
+++ b/tests/smoke-github-issue-publish-handler.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Smoke tests for GitHub issue publish handler registration and schema.
+ *
+ * Run with: php tests/smoke-github-issue-publish-handler.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+declare(strict_types=1);
+
+$root     = dirname( __DIR__ );
+$handler  = file_get_contents( $root . '/inc/Handlers/GitHub/GitHubIssuePublish.php' );
+$settings = file_get_contents( $root . '/inc/Handlers/GitHub/GitHubIssuePublishSettings.php' );
+$plugin   = file_get_contents( $root . '/data-machine-code.php' );
+
+$failures = array();
+
+$assert = static function ( bool $condition, string $message ) use ( &$failures ): void {
+	if ( $condition ) {
+		echo "PASS: {$message}\n";
+		return;
+	}
+
+	echo "FAIL: {$message}\n";
+	$failures[] = $message;
+};
+
+$assert( false !== strpos( $handler, "registerHandler(\n\t\t\t'github_issue',\n\t\t\t'publish'" ), 'github_issue registers as a publish handler' );
+$assert( false !== strpos( $handler, "'handler'     => 'github_issue'" ), 'AI tool is marked as the github_issue handler tool' );
+$assert( false !== strpos( $handler, "'github_issue_publish'" ), 'handler exposes github_issue_publish tool' );
+$assert( false !== strpos( $handler, "'items'       => array( 'type' => 'string' )" ), 'array parameters include item schemas' );
+$assert( false !== strpos( $handler, 'GitHubAbilities::createIssue' ), 'handler delegates issue creation to GitHubAbilities' );
+$assert( false !== strpos( $settings, "'labels'" ) && false !== strpos( $settings, "'assignees'" ), 'settings expose labels and assignees defaults' );
+$assert( false !== strpos( $plugin, 'new \\DataMachineCode\\Handlers\\GitHub\\GitHubIssuePublish();' ), 'plugin bootstraps GitHub issue publish handler' );
+
+echo "\n";
+if ( empty( $failures ) ) {
+	echo "OK: GitHub issue publish handler smoke assertions passed.\n";
+	exit( 0 );
+}
+
+echo sprintf( "FAILED: %d assertion(s) failed.\n", count( $failures ) );
+exit( 1 );


### PR DESCRIPTION
## Summary
- Add a `github_issue` publish handler that creates GitHub issues through `GitHubAbilities::createIssue()`.
- Expose a `github_issue_publish` handler tool for AI -> publish pipelines.
- Add handler settings for repo, labels, assignees, and milestone defaults.

## Testing
- `php -l inc/Handlers/GitHub/GitHubIssuePublish.php && php -l inc/Handlers/GitHub/GitHubIssuePublishSettings.php && php -l data-machine-code.php`
- `php tests/smoke-github-issue-publish-handler.php && php tests/smoke-github-create-abilities.php && php tests/smoke-github-create-tools.php`

## Notes
- `./vendor/bin/phpcs ...` could not run locally because this worktree does not install PHPCS.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the publish handler and focused smoke coverage so GitHub issue creation can use the Data Machine AI -> publish shape.