### PR TITLE
Add GitHub pull request publish handler

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -83,6 +83,7 @@ function datamachine_code_bootstrap() {
 	// Load Handlers (they self-register).
 	new \DataMachineCode\Handlers\GitHub\GitHub();
 	new \DataMachineCode\Handlers\GitHub\GitHubIssuePublish();
+	new \DataMachineCode\Handlers\GitHub\GitHubPullRequestPublish();
 	new \DataMachineCode\Handlers\GitHub\GitHubUpsert();
 
 	// Register ability categories on the correct hook (must happen during wp_abilities_api_categories_init).

--- a/inc/Handlers/GitHub/GitHubPullRequestPublish.php
+++ b/inc/Handlers/GitHub/GitHubPullRequestPublish.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * GitHub Pull Request Publish Handler.
+ *
+ * @package DataMachineCode\Handlers\GitHub
+ */
+
+namespace DataMachineCode\Handlers\GitHub;
+
+use DataMachine\Core\Steps\HandlerRegistrationTrait;
+use DataMachine\Core\Steps\Publish\Handlers\PublishHandler;
+use DataMachineCode\Abilities\GitHubAbilities;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class GitHubPullRequestPublish extends PublishHandler {
+
+	use HandlerRegistrationTrait;
+
+	public function __construct() {
+		parent::__construct( 'github_pull_request' );
+
+		self::registerHandler(
+			'github_pull_request',
+			'publish',
+			self::class,
+			'GitHub Pull Request',
+			'Open GitHub pull requests from AI-generated pipeline packets',
+			false,
+			null,
+			GitHubPullRequestPublishSettings::class,
+			array( self::class, 'registerTools' )
+		);
+	}
+
+	/**
+	 * Register the AI-visible PR publish handler tool.
+	 *
+	 * @param array  $tools          Registered tools.
+	 * @param string $handler_slug   Current handler slug.
+	 * @param array  $handler_config Handler configuration.
+	 * @return array Tools with GitHub PR publish tool added.
+	 */
+	public static function registerTools( array $tools, string $handler_slug, array $handler_config ): array {
+		if ( 'github_pull_request' !== $handler_slug ) {
+			return $tools;
+		}
+
+		$tools['github_pull_request_publish'] = array(
+			'class'       => self::class,
+			'method'      => 'handle_tool_call',
+			'handler'     => 'github_pull_request',
+			'description' => 'Open a GitHub pull request as the publish step for this pipeline item. Call exactly once after all files are committed to the head branch.',
+			'parameters'  => array(
+				'type'       => 'object',
+				'required'   => array( 'title', 'head' ),
+				'properties' => array(
+					'repo'                  => array(
+						'type'        => 'string',
+						'description' => 'Repository in owner/repo format. Overrides handler config when provided.',
+					),
+					'title'                 => array(
+						'type'        => 'string',
+						'description' => 'Pull request title.',
+					),
+					'head'                  => array(
+						'type'        => 'string',
+						'description' => 'Head branch where changes were committed.',
+					),
+					'base'                  => array(
+						'type'        => 'string',
+						'description' => 'Base branch. Defaults to handler config or repository default.',
+					),
+					'body'                  => array(
+						'type'        => 'string',
+						'description' => 'Pull request body in GitHub Markdown.',
+					),
+					'draft'                 => array(
+						'type'        => 'boolean',
+						'description' => 'Whether to open as draft. Defaults to false.',
+					),
+					'maintainer_can_modify' => array(
+						'type'        => 'boolean',
+						'description' => 'Whether maintainers can modify the PR. Defaults to true.',
+					),
+				),
+			),
+		);
+
+		return $tools;
+	}
+
+	/**
+	 * Open the GitHub pull request.
+	 *
+	 * @param array $parameters     Tool parameters.
+	 * @param array $handler_config Handler configuration.
+	 * @return array Publish result.
+	 */
+	protected function executePublish( array $parameters, array $handler_config ): array {
+		$repo = ! empty( $parameters['repo'] )
+			? sanitize_text_field( $parameters['repo'] )
+			: (string) ( $handler_config['repo'] ?? '' );
+
+		if ( '' === $repo ) {
+			$repo = GitHubAbilities::getDefaultRepo();
+		}
+
+		$input = array(
+			'repo'                  => $repo,
+			'title'                 => $parameters['title'] ?? '',
+			'head'                  => $parameters['head'] ?? '',
+			'base'                  => $parameters['base'] ?? ( $handler_config['base'] ?? '' ),
+			'body'                  => $parameters['body'] ?? '',
+			'draft'                 => $this->resolveBool( $parameters['draft'] ?? null, $handler_config['draft'] ?? false ),
+			'maintainer_can_modify' => $this->resolveBool( $parameters['maintainer_can_modify'] ?? null, $handler_config['maintainer_can_modify'] ?? true ),
+		);
+
+		$result = GitHubAbilities::createPullRequest( $input );
+		if ( is_wp_error( $result ) ) {
+			return $this->errorResponse(
+				'GitHub Pull Request: ' . $result->get_error_message(),
+				array(
+					'job_id' => $parameters['job_id'] ?? null,
+					'repo'   => $repo,
+					'head'   => $input['head'],
+				)
+			);
+		}
+
+		return $this->successResponse(
+			array(
+				'repo'        => $repo,
+				'pull_number' => $result['pull_number'] ?? 0,
+				'html_url'    => $result['html_url'] ?? '',
+				'title'       => $input['title'],
+				'head'        => $input['head'],
+				'base'        => $input['base'],
+			)
+		);
+	}
+
+	/**
+	 * Resolve boolean handler values from parameters/config.
+	 *
+	 * @param mixed $parameter Tool parameter override.
+	 * @param mixed $fallback  Handler config fallback.
+	 * @return bool Resolved boolean.
+	 */
+	private function resolveBool( mixed $parameter, mixed $fallback ): bool {
+		$value = null !== $parameter ? $parameter : $fallback;
+		return filter_var( $value, FILTER_VALIDATE_BOOLEAN );
+	}
+}

--- a/inc/Handlers/GitHub/GitHubPullRequestPublishSettings.php
+++ b/inc/Handlers/GitHub/GitHubPullRequestPublishSettings.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * GitHub Pull Request Publish Handler Settings.
+ *
+ * @package DataMachineCode\Handlers\GitHub
+ */
+
+namespace DataMachineCode\Handlers\GitHub;
+
+use DataMachine\Core\Steps\Settings\SettingsHandler;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class GitHubPullRequestPublishSettings extends SettingsHandler {
+
+	/**
+	 * Get settings fields for GitHub PR publishing.
+	 *
+	 * @return array
+	 */
+	public static function get_fields(): array {
+		return array(
+			'repo'                  => array(
+				'type'        => 'text',
+				'label'       => __( 'Repository', 'data-machine-code' ),
+				'description' => __( 'GitHub repository in owner/repo format. Falls back to the default repo in settings.', 'data-machine-code' ),
+				'required'    => false,
+			),
+			'base'                  => array(
+				'type'        => 'text',
+				'label'       => __( 'Base Branch', 'data-machine-code' ),
+				'description' => __( 'Default base branch for pull requests. Leave blank for repository default.', 'data-machine-code' ),
+				'required'    => false,
+			),
+			'draft'                 => array(
+				'type'        => 'checkbox',
+				'label'       => __( 'Open as Draft', 'data-machine-code' ),
+				'description' => __( 'Open pull requests as drafts by default.', 'data-machine-code' ),
+				'required'    => false,
+				'default'     => false,
+			),
+			'maintainer_can_modify' => array(
+				'type'        => 'checkbox',
+				'label'       => __( 'Allow Maintainer Edits', 'data-machine-code' ),
+				'description' => __( 'Allow maintainers to modify the pull request branch.', 'data-machine-code' ),
+				'required'    => false,
+				'default'     => true,
+			),
+		);
+	}
+}

--- a/tests/smoke-github-pr-publish-handler.php
+++ b/tests/smoke-github-pr-publish-handler.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Smoke tests for GitHub pull request publish handler registration and schema.
+ *
+ * Run with: php tests/smoke-github-pr-publish-handler.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+declare(strict_types=1);
+
+$root     = dirname( __DIR__ );
+$handler  = file_get_contents( $root . '/inc/Handlers/GitHub/GitHubPullRequestPublish.php' );
+$settings = file_get_contents( $root . '/inc/Handlers/GitHub/GitHubPullRequestPublishSettings.php' );
+$plugin   = file_get_contents( $root . '/data-machine-code.php' );
+
+$failures = array();
+
+$assert = static function ( bool $condition, string $message ) use ( &$failures ): void {
+	if ( $condition ) {
+		echo "PASS: {$message}\n";
+		return;
+	}
+
+	echo "FAIL: {$message}\n";
+	$failures[] = $message;
+};
+
+$assert( false !== strpos( $handler, "registerHandler(\n\t\t\t'github_pull_request',\n\t\t\t'publish'" ), 'github_pull_request registers as a publish handler' );
+$assert( false !== strpos( $handler, "'handler'     => 'github_pull_request'" ), 'AI tool is marked as the github_pull_request handler tool' );
+$assert( false !== strpos( $handler, "'github_pull_request_publish'" ), 'handler exposes github_pull_request_publish tool' );
+$assert( false !== strpos( $handler, "'required'   => array( 'title', 'head' )" ), 'PR publish requires title and head' );
+$assert( false !== strpos( $handler, 'GitHubAbilities::createPullRequest' ), 'handler delegates PR creation to GitHubAbilities' );
+$assert( false !== strpos( $settings, "'base'" ) && false !== strpos( $settings, "'draft'" ), 'settings expose base and draft defaults' );
+$assert( false !== strpos( $plugin, 'new \\DataMachineCode\\Handlers\\GitHub\\GitHubPullRequestPublish();' ), 'plugin bootstraps GitHub PR publish handler' );
+
+echo "\n";
+if ( empty( $failures ) ) {
+	echo "OK: GitHub PR publish handler smoke assertions passed.\n";
+	exit( 0 );
+}
+
+echo sprintf( "FAILED: %d assertion(s) failed.\n", count( $failures ) );
+exit( 1 );


### PR DESCRIPTION
## Summary
- Add a `github_pull_request` publish handler that opens PRs through `GitHubAbilities::createPullRequest()`.
- Expose `github_pull_request_publish` as the AI-visible publish handler tool.
- Add handler settings for repo, base branch, draft mode, and maintainer edits.

## Testing
- `php -l inc/Handlers/GitHub/GitHubPullRequestPublish.php && php -l inc/Handlers/GitHub/GitHubPullRequestPublishSettings.php && php -l data-machine-code.php`
- `php tests/smoke-github-pr-publish-handler.php && php tests/smoke-github-create-abilities.php && php tests/smoke-github-create-tools.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the PR publish handler and smoke coverage so blueprint flows can use the Data Machine fetch -> AI -> upsert -> publish shape.