### PR TITLE
Create missing branches for GitHub upserts

### DIFF
--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -3190,6 +3190,12 @@ class GitHubAbilities {
 		}
 
 		$branch = sanitize_text_field( $input['branch'] ?? '' );
+		if ( ! empty( $branch ) ) {
+			$branch_result = self::ensureBranchExists( $repo, $branch, $pat );
+			if ( is_wp_error( $branch_result ) ) {
+				return $branch_result;
+			}
+		}
 
 		// Check if the file already exists to get its SHA for update.
 		$get_url    = sprintf( '%s/repos/%s/contents/%s', self::API_BASE, $repo, $file_path );
@@ -3240,6 +3246,61 @@ class GitHubAbilities {
 				$repo
 			),
 		);
+	}
+
+	/**
+	 * Ensure a target branch exists before committing through the Contents API.
+	 *
+	 * @param string $repo   owner/repo identifier.
+	 * @param string $branch Target branch name.
+	 * @param string $pat    GitHub credential token.
+	 * @return true|\WP_Error True when the branch exists or was created.
+	 */
+	private static function ensureBranchExists( string $repo, string $branch, string $pat ): true|\WP_Error {
+		$branch_ref_url = sprintf( '%s/repos/%s/git/ref/heads/%s', self::API_BASE, $repo, rawurlencode( $branch ) );
+		$response       = self::apiGet( $branch_ref_url, array(), $pat );
+
+		if ( ! is_wp_error( $response ) ) {
+			return true;
+		}
+
+		$status = (int) ( $response->get_error_data()['status'] ?? 0 );
+		if ( 404 !== $status ) {
+			return $response;
+		}
+
+		$default_branch = self::resolveDefaultBranch( $repo, $pat );
+		if ( is_wp_error( $default_branch ) ) {
+			return $default_branch;
+		}
+
+		$default_ref_url = sprintf( '%s/repos/%s/git/ref/heads/%s', self::API_BASE, $repo, rawurlencode( $default_branch ) );
+		$default_ref     = self::apiGet( $default_ref_url, array(), $pat );
+		if ( is_wp_error( $default_ref ) ) {
+			return $default_ref;
+		}
+
+		$sha = (string) ( $default_ref['data']['object']['sha'] ?? '' );
+		if ( '' === $sha ) {
+			return new \WP_Error( 'github_default_branch_sha_missing', 'GitHub did not return a SHA for the repository default branch.', array( 'status' => 500 ) );
+		}
+
+		$create_ref_url = sprintf( '%s/repos/%s/git/refs', self::API_BASE, $repo );
+		$created        = self::apiRequest(
+			'POST',
+			$create_ref_url,
+			array(
+				'ref' => 'refs/heads/' . $branch,
+				'sha' => $sha,
+			),
+			$pat
+		);
+
+		if ( is_wp_error( $created ) ) {
+			return $created;
+		}
+
+		return true;
 	}
 
 	/**

--- a/tests/smoke-github-create-abilities.php
+++ b/tests/smoke-github-create-abilities.php
@@ -353,6 +353,62 @@ namespace {
 	$assert( 'createPullRequest 422 carries github_api_error code', $result instanceof WP_Error && 'github_api_error' === $result->get_error_code() );
 	$assert( 'createPullRequest 422 message includes GitHub message', $result instanceof WP_Error && str_contains( $result->get_error_message(), 'already exists' ) );
 
+	// ---- createOrUpdateFile: creates a missing target branch from the default branch.
+	$reset_http();
+	$queue_response( 404, array( 'message' => 'Not Found' ) );
+	$queue_response( 200, array( 'default_branch' => 'main' ) );
+	$queue_response( 200, array( 'object' => array( 'sha' => 'base-sha' ) ) );
+	$queue_response( 201, array( 'ref' => 'refs/heads/store/new-doc' ) );
+	$queue_response( 404, array( 'message' => 'Not Found' ) );
+	$queue_response( 201, array(
+		'commit' => array(
+			'sha'      => 'commit-sha',
+			'html_url' => 'https://github.com/owner/repo/commit/commit-sha',
+			'message'  => 'docs: add generated file',
+		),
+		'content' => array(
+			'path'     => 'docs/generated.md',
+			'html_url' => 'https://github.com/owner/repo/blob/store/new-doc/docs/generated.md',
+		),
+	) );
+	$result = GitHubAbilities::createOrUpdateFile( array(
+		'repo'           => 'owner/repo',
+		'file_path'      => 'docs/generated.md',
+		'content'        => '# Generated',
+		'commit_message' => 'docs: add generated file',
+		'branch'         => 'store/new-doc',
+	) );
+	$assert( 'createOrUpdateFile missing branch returns success=true', is_array( $result ) && true === ( $result['success'] ?? false ) );
+	$assert( 'createOrUpdateFile checks target branch ref first', is_string( $GLOBALS['dmc_http_calls'][0]['url'] ?? null ) && str_ends_with( $GLOBALS['dmc_http_calls'][0]['url'], '/repos/owner/repo/git/ref/heads/store%2Fnew-doc' ) );
+	$assert( 'createOrUpdateFile resolves default branch for missing target branch', is_string( $GLOBALS['dmc_http_calls'][1]['url'] ?? null ) && str_ends_with( $GLOBALS['dmc_http_calls'][1]['url'], '/repos/owner/repo' ) );
+	$assert( 'createOrUpdateFile reads default branch ref', is_string( $GLOBALS['dmc_http_calls'][2]['url'] ?? null ) && str_ends_with( $GLOBALS['dmc_http_calls'][2]['url'], '/repos/owner/repo/git/ref/heads/main' ) );
+	$create_ref_call = $GLOBALS['dmc_http_calls'][3] ?? array();
+	$create_ref_body = is_string( $create_ref_call['args']['body'] ?? null ) ? json_decode( $create_ref_call['args']['body'], true ) : null;
+	$assert( 'createOrUpdateFile creates branch via git refs API', 'POST' === ( $create_ref_call['method'] ?? '' ) && is_string( $create_ref_call['url'] ?? null ) && str_ends_with( $create_ref_call['url'], '/repos/owner/repo/git/refs' ) );
+	$assert( 'createOrUpdateFile creates branch from default branch sha', is_array( $create_ref_body ) && 'refs/heads/store/new-doc' === ( $create_ref_body['ref'] ?? '' ) && 'base-sha' === ( $create_ref_body['sha'] ?? '' ) );
+	$put_call = $GLOBALS['dmc_http_calls'][5] ?? array();
+	$put_body = is_string( $put_call['args']['body'] ?? null ) ? json_decode( $put_call['args']['body'], true ) : null;
+	$assert( 'createOrUpdateFile PUTs generated file to requested branch', 'PUT' === ( $put_call['method'] ?? '' ) && is_array( $put_body ) && 'store/new-doc' === ( $put_body['branch'] ?? '' ) );
+
+	// ---- createOrUpdateFile: existing target branch does not trigger branch creation.
+	$reset_http();
+	$queue_response( 200, array( 'ref' => 'refs/heads/store/existing' ) );
+	$queue_response( 404, array( 'message' => 'Not Found' ) );
+	$queue_response( 201, array(
+		'commit' => array( 'sha' => 'commit-existing' ),
+		'content' => array( 'path' => 'docs/existing.md' ),
+	) );
+	$result = GitHubAbilities::createOrUpdateFile( array(
+		'repo'           => 'owner/repo',
+		'file_path'      => 'docs/existing.md',
+		'content'        => 'Existing branch',
+		'commit_message' => 'docs: update generated file',
+		'branch'         => 'store/existing',
+	) );
+	$assert( 'createOrUpdateFile existing branch returns success=true', is_array( $result ) && true === ( $result['success'] ?? false ) );
+	$assert( 'createOrUpdateFile existing branch only checks ref, contents, and PUTs', 3 === count( $GLOBALS['dmc_http_calls'] ) );
+	$assert( 'createOrUpdateFile existing branch does not create git ref', ! str_ends_with( (string) ( $GLOBALS['dmc_http_calls'][1]['url'] ?? '' ), '/git/refs' ) && ! str_ends_with( (string) ( $GLOBALS['dmc_http_calls'][2]['url'] ?? '' ), '/git/refs' ) );
+
 	if ( ! empty( $failures ) ) {
 		echo "\nFAIL: " . count( $failures ) . " assertion(s)\n";
 		foreach ( $failures as $failure ) {


### PR DESCRIPTION
## Summary
- Create missing non-empty `github_upsert` target branches from the repository default branch before writing contents.
- Preserve existing branch/default-branch writes while keeping the pipeline API-only, with no DMC worktree dependency.
- Add smoke coverage for both missing-branch creation and existing-branch writes.

## Testing
- `php -l inc/Abilities/GitHubAbilities.php`
- `php -l tests/smoke-github-create-abilities.php`
- `php tests/smoke-github-create-abilities.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the implementation and smoke coverage; Chris remains responsible for review and testing.