### PR TITLE
feat: apply labels on github_pull_request publish (#269)

### DIFF
--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -1378,6 +1378,76 @@ class GitHubAbilities {
 	}
 
 	/**
+	 * Add labels to an issue or pull request.
+	 *
+	 * GitHub treats pull requests as issues for labeling purposes, so this
+	 * single endpoint covers both. Calls
+	 * `POST /repos/{owner}/{repo}/issues/{number}/labels`, which is additive
+	 * (does not remove existing labels).
+	 *
+	 * @param array $input {
+	 *     Required: repo, issue_number (or pull_number), labels (array<string>).
+	 * }
+	 * @return array|\WP_Error { success: bool, applied_labels: string[] } or error.
+	 */
+	public static function addLabels( array $input ): array|\WP_Error {
+		$repo   = self::resolveRepo( sanitize_text_field( $input['repo'] ?? '' ) );
+		$number = (int) ( $input['issue_number'] ?? $input['pull_number'] ?? 0 );
+
+		if ( empty( $repo ) ) {
+			return new \WP_Error( 'missing_repo', 'Repository (owner/repo) is required or configure a default repo.', array( 'status' => 400 ) );
+		}
+		if ( $number <= 0 ) {
+			return new \WP_Error( 'missing_number', 'issue_number or pull_number is required.', array( 'status' => 400 ) );
+		}
+
+		$labels = array();
+		if ( isset( $input['labels'] ) && is_array( $input['labels'] ) ) {
+			$labels = array_values(
+				array_filter(
+					array_map(
+						static fn( $label ): string => sanitize_text_field( (string) $label ),
+						$input['labels']
+					),
+					static fn( string $label ): bool => '' !== $label
+				)
+			);
+		}
+
+		if ( empty( $labels ) ) {
+			return new \WP_Error( 'missing_labels', 'At least one label is required.', array( 'status' => 400 ) );
+		}
+
+		$pat = self::getPatForRepo( $repo );
+		if ( empty( $pat ) ) {
+			return self::patError();
+		}
+
+		$url      = sprintf( '%s/repos/%s/issues/%d/labels', self::API_BASE, $repo, $number );
+		$response = self::apiRequest( 'POST', $url, array( 'labels' => $labels ), $pat );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$applied = array();
+		if ( is_array( $response['data'] ?? null ) ) {
+			foreach ( $response['data'] as $label ) {
+				$name = is_array( $label ) ? ( $label['name'] ?? '' ) : '';
+				if ( '' !== $name ) {
+					$applied[] = (string) $name;
+				}
+			}
+		}
+
+		return array(
+			'success'        => true,
+			'applied_labels' => $applied,
+			'message'        => sprintf( 'Applied %d label(s) to #%d in %s.', count( $applied ), $number, $repo ),
+		);
+	}
+
+	/**
 	 * Resolve the default branch name for a repository.
 	 *
 	 * @param string $repo owner/repo identifier.

--- a/inc/Handlers/GitHub/GitHubPullRequestPublish.php
+++ b/inc/Handlers/GitHub/GitHubPullRequestPublish.php
@@ -103,6 +103,11 @@ class GitHubPullRequestPublish extends PublishHandler {
 						'type'        => 'string',
 						'description' => 'Default commit message for files committed during publish.',
 					),
+					'labels'                => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'string' ),
+						'description' => 'Labels to apply to the pull request after it is opened. Overrides handler config when provided.',
+					),
 					'draft'                 => array(
 						'type'        => 'boolean',
 						'description' => 'Whether to open as draft. Defaults to false.',
@@ -190,15 +195,78 @@ class GitHubPullRequestPublish extends PublishHandler {
 			);
 		}
 
-		return $this->successResponse(
-			array(
+		$pull_number = (int) ( $result['pull_number'] ?? 0 );
+
+		$labels         = $this->resolveListParameter( $parameters['labels'] ?? null, $handler_config['labels'] ?? '' );
+		$applied_labels = array();
+		$label_error    = null;
+
+		if ( ! empty( $labels ) && $pull_number > 0 ) {
+			$label_result = GitHubAbilities::addLabels( array(
 				'repo'        => $repo,
-				'pull_number' => $result['pull_number'] ?? 0,
-				'html_url'    => $result['html_url'] ?? '',
-				'title'       => $input['title'],
-				'head'        => $input['head'],
-				'base'        => $input['base'],
-				'files'       => $committed_files,
+				'pull_number' => $pull_number,
+				'labels'      => $labels,
+			) );
+
+			if ( is_wp_error( $label_result ) ) {
+				$label_error = $label_result->get_error_message();
+				$this->log(
+					'warning',
+					'GitHub Pull Request opened but failed to apply labels: ' . $label_error,
+					array(
+						'job_id'      => $parameters['job_id'] ?? null,
+						'repo'        => $repo,
+						'pull_number' => $pull_number,
+						'labels'      => $labels,
+					)
+				);
+			} else {
+				$applied_labels = $label_result['applied_labels'] ?? array();
+			}
+		}
+
+		$response_data = array(
+			'repo'           => $repo,
+			'pull_number'    => $pull_number,
+			'html_url'       => $result['html_url'] ?? '',
+			'title'          => $input['title'],
+			'head'           => $input['head'],
+			'base'           => $input['base'],
+			'files'          => $committed_files,
+			'labels'         => $labels,
+			'applied_labels' => $applied_labels,
+		);
+
+		if ( null !== $label_error ) {
+			$response_data['label_error'] = $label_error;
+		}
+
+		return $this->successResponse( $response_data );
+	}
+
+	/**
+	 * Resolve a list supplied by tool parameters or comma-separated handler config.
+	 *
+	 * @param mixed  $parameter Tool parameter value.
+	 * @param string $fallback  Comma-separated handler config fallback.
+	 * @return array<int, string> Sanitized list.
+	 */
+	private function resolveListParameter( mixed $parameter, string $fallback ): array {
+		$items = array();
+		if ( is_array( $parameter ) ) {
+			$items = $parameter;
+		} elseif ( is_string( $parameter ) && '' !== $parameter ) {
+			$items = array_map( 'trim', explode( ',', $parameter ) );
+		}
+
+		if ( empty( $items ) && '' !== $fallback ) {
+			$items = array_map( 'trim', explode( ',', $fallback ) );
+		}
+
+		return array_values(
+			array_filter(
+				array_map( 'sanitize_text_field', $items ),
+				static fn( string $item ): bool => '' !== $item
 			)
 		);
 	}

--- a/inc/Handlers/GitHub/GitHubPullRequestPublishSettings.php
+++ b/inc/Handlers/GitHub/GitHubPullRequestPublishSettings.php
@@ -34,6 +34,12 @@ class GitHubPullRequestPublishSettings extends SettingsHandler {
 				'description' => __( 'Default base branch for pull requests. Leave blank for repository default.', 'data-machine-code' ),
 				'required'    => false,
 			),
+			'labels'                => array(
+				'type'        => 'text',
+				'label'       => __( 'Labels', 'data-machine-code' ),
+				'description' => __( 'Comma-separated labels to apply to opened pull requests by default. The AI step can override these.', 'data-machine-code' ),
+				'required'    => false,
+			),
 			'draft'                 => array(
 				'type'        => 'checkbox',
 				'label'       => __( 'Open as Draft', 'data-machine-code' ),

--- a/tests/smoke-github-pr-publish-handler.php
+++ b/tests/smoke-github-pr-publish-handler.php
@@ -34,8 +34,14 @@ $assert( false !== strpos( $handler, 'GitHubAbilities::createPullRequest' ), 'ha
 $assert( false !== strpos( $handler, "'files'" ) && false !== strpos( $handler, "'items'" ), 'PR publish accepts a files array' );
 $assert( false !== strpos( $handler, 'GitHubAbilities::createOrUpdateFile' ), 'handler commits files before opening the PR' );
 $assert( false !== strpos( $handler, '\'branch\'         => $input[\'head\']' ), 'handler commits files to the PR head branch' );
-$assert( false !== strpos( $handler, '\'files\'       => $committed_files' ), 'handler returns committed file metadata' );
+$assert( false !== strpos( $handler, '\'files\'          => $committed_files' ), 'handler returns committed file metadata' );
+$assert( false !== strpos( $handler, "'labels'                => array(" ), 'tool schema exposes labels parameter' );
+$assert( false !== strpos( $handler, 'GitHubAbilities::addLabels' ), 'handler applies labels via GitHubAbilities::addLabels' );
+$assert( false !== strpos( $handler, "'applied_labels' => \$applied_labels" ), 'handler returns applied_labels in result' );
+$assert( false !== strpos( $handler, 'resolveListParameter' ), 'handler resolves labels via shared helper' );
+$assert( false !== strpos( $handler, "'label_error'" ), 'handler reports label_error on partial failure' );
 $assert( false !== strpos( $settings, "'base'" ) && false !== strpos( $settings, "'draft'" ), 'settings expose base and draft defaults' );
+$assert( false !== strpos( $settings, "'labels'" ), 'settings expose labels default' );
 $assert( false !== strpos( $plugin, 'new \\DataMachineCode\\Handlers\\GitHub\\GitHubPullRequestPublish();' ), 'plugin bootstraps GitHub PR publish handler' );
 
 echo "\n";

--- a/tests/smoke-github-pr-publish-labels.php
+++ b/tests/smoke-github-pr-publish-labels.php
@@ -1,0 +1,319 @@
+<?php
+/**
+ * Behavioral smoke tests for GitHub Pull Request publish handler label support.
+ *
+ * Exercises GitHubPullRequestPublish::executePublish() with stubbed
+ * GitHubAbilities to verify label resolution, application, and partial-failure
+ * reporting introduced for issue #269.
+ *
+ * Run: php tests/smoke-github-pr-publish-labels.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Core\Steps {
+	if ( ! trait_exists( __NAMESPACE__ . '\\HandlerRegistrationTrait' ) ) {
+		trait HandlerRegistrationTrait {
+			public static function registerHandler( ...$args ): void {
+				// no-op for tests
+			}
+		}
+	}
+}
+
+namespace DataMachine\Core\Steps\Publish\Handlers {
+	if ( ! class_exists( __NAMESPACE__ . '\\PublishHandler' ) ) {
+		abstract class PublishHandler {
+			protected string $handler_type;
+			public array $log_entries = array();
+
+			public function __construct( string $handler_type ) {
+				$this->handler_type = $handler_type;
+			}
+
+			abstract protected function executePublish( array $parameters, array $handler_config ): array;
+
+			protected function successResponse( array $data ): array {
+				return array(
+					'success'   => true,
+					'data'      => $data,
+					'tool_name' => "{$this->handler_type}_publish",
+				);
+			}
+
+			protected function errorResponse( string $error_message, ?array $context = null, string $severity = 'warning' ): array {
+				$this->log_entries[] = array( 'level' => 'error', 'message' => $error_message, 'context' => $context ?? array() );
+				return array(
+					'success'   => false,
+					'error'     => $error_message,
+					'severity'  => $severity,
+					'tool_name' => "{$this->handler_type}_publish",
+				);
+			}
+
+			protected function log( string $level, string $message, array $context = array() ): void {
+				$this->log_entries[] = array( 'level' => $level, 'message' => $message, 'context' => $context );
+			}
+		}
+	}
+}
+
+namespace DataMachineCode\Abilities {
+	class GitHubAbilities {
+		public static array $createPullRequestCalls = array();
+		public static array $addLabelsCalls         = array();
+		public static array $createOrUpdateFileCalls = array();
+		/** @var callable|null */
+		public static $createPullRequestImpl = null;
+		/** @var callable|null */
+		public static $addLabelsImpl = null;
+		/** @var callable|null */
+		public static $createOrUpdateFileImpl = null;
+
+		public static function reset(): void {
+			self::$createPullRequestCalls   = array();
+			self::$addLabelsCalls           = array();
+			self::$createOrUpdateFileCalls  = array();
+			self::$createPullRequestImpl    = null;
+			self::$addLabelsImpl            = null;
+			self::$createOrUpdateFileImpl   = null;
+		}
+
+		public static function getDefaultRepo(): string {
+			return 'Extra-Chill/data-machine-code';
+		}
+
+		public static function createPullRequest( array $input ): array|\WP_Error {
+			self::$createPullRequestCalls[] = $input;
+			$impl = self::$createPullRequestImpl;
+			if ( is_callable( $impl ) ) {
+				return $impl( $input );
+			}
+			return array(
+				'success'      => true,
+				'pull_request' => array( 'number' => 4242, 'html_url' => 'https://example.test/pull/4242' ),
+				'pull_number'  => 4242,
+				'html_url'     => 'https://example.test/pull/4242',
+			);
+		}
+
+		public static function addLabels( array $input ): array|\WP_Error {
+			self::$addLabelsCalls[] = $input;
+			$impl = self::$addLabelsImpl;
+			if ( is_callable( $impl ) ) {
+				return $impl( $input );
+			}
+			$labels = $input['labels'] ?? array();
+			return array(
+				'success'        => true,
+				'applied_labels' => $labels,
+				'message'        => 'ok',
+			);
+		}
+
+		public static function createOrUpdateFile( array $input ): array|\WP_Error {
+			self::$createOrUpdateFileCalls[] = $input;
+			$impl = self::$createOrUpdateFileImpl;
+			if ( is_callable( $impl ) ) {
+				return $impl( $input );
+			}
+			return array(
+				'content' => array( 'path' => $input['file_path'] ?? '', 'html_url' => 'https://example.test/blob/main/' . ( $input['file_path'] ?? '' ) ),
+				'commit'  => array( 'sha' => 'deadbeef' ),
+			);
+		}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	if ( ! function_exists( 'sanitize_text_field' ) ) {
+		function sanitize_text_field( $value ): string {
+			return is_string( $value ) ? trim( $value ) : (string) $value;
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $thing ): bool {
+			return $thing instanceof \WP_Error;
+		}
+	}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			public function __construct( public string $code = '', public string $message = '', public mixed $data = null ) {}
+			public function get_error_message(): string { return $this->message; }
+			public function get_error_code(): string { return $this->code; }
+		}
+	}
+
+	require_once __DIR__ . '/../inc/Handlers/GitHub/GitHubPullRequestPublish.php';
+
+	use DataMachineCode\Abilities\GitHubAbilities;
+	use DataMachineCode\Handlers\GitHub\GitHubPullRequestPublish;
+
+	/**
+	 * Test subclass exposing executePublish for direct invocation.
+	 */
+	class TestablePullRequestPublish extends GitHubPullRequestPublish {
+		public function callExecutePublish( array $parameters, array $handler_config ): array {
+			return $this->executePublish( $parameters, $handler_config );
+		}
+	}
+
+	$failures = array();
+	$assert   = function ( string $label, bool $cond ) use ( &$failures ): void {
+		if ( $cond ) {
+			echo "  ok {$label}\n";
+			return;
+		}
+		echo "  FAIL {$label}\n";
+		$failures[] = $label;
+	};
+
+	echo "GitHub PR publish handler - label behavior\n";
+
+	// --- Test 1: handler-config labels are applied ---
+	GitHubAbilities::reset();
+	$handler = new TestablePullRequestPublish();
+
+	$result = $handler->callExecutePublish(
+		array(
+			'title' => 'Generated blueprint',
+			'head'  => 'agent/blueprint-1',
+			'body'  => 'body',
+		),
+		array(
+			'repo'   => 'Extra-Chill/data-machine-code',
+			'labels' => 'target:blueprint, automation',
+			'base'   => 'main',
+		)
+	);
+
+	$assert( 'success when handler-config labels apply', true === ( $result['success'] ?? false ) );
+	$assert( 'applied_labels reflects handler-config labels', array( 'target:blueprint', 'automation' ) === ( $result['data']['applied_labels'] ?? array() ) );
+	$assert( 'addLabels called once for handler-config labels', 1 === count( GitHubAbilities::$addLabelsCalls ) );
+	$assert(
+		'addLabels received resolved label array',
+		array( 'target:blueprint', 'automation' ) === ( GitHubAbilities::$addLabelsCalls[0]['labels'] ?? array() )
+	);
+	$assert( 'addLabels uses pull_number from createPullRequest', 4242 === (int) ( GitHubAbilities::$addLabelsCalls[0]['pull_number'] ?? 0 ) );
+	$assert( 'no label_error on success path', ! array_key_exists( 'label_error', $result['data'] ?? array() ) );
+
+	// --- Test 2: tool-parameter labels override handler-config ---
+	GitHubAbilities::reset();
+	$handler = new TestablePullRequestPublish();
+
+	$result = $handler->callExecutePublish(
+		array(
+			'title'  => 'Generated static site',
+			'head'   => 'agent/static-1',
+			'labels' => array( 'target:static-site' ),
+		),
+		array(
+			'repo'   => 'Extra-Chill/data-machine-code',
+			'labels' => 'fallback,unused',
+		)
+	);
+
+	$assert( 'tool-parameter labels override handler-config labels', array( 'target:static-site' ) === ( GitHubAbilities::$addLabelsCalls[0]['labels'] ?? array() ) );
+	$assert( 'response applied_labels uses tool-parameter labels', array( 'target:static-site' ) === ( $result['data']['applied_labels'] ?? array() ) );
+
+	// --- Test 3: no labels = no addLabels call ---
+	GitHubAbilities::reset();
+	$handler = new TestablePullRequestPublish();
+
+	$result = $handler->callExecutePublish(
+		array(
+			'title' => 'No labels PR',
+			'head'  => 'agent/no-labels',
+		),
+		array(
+			'repo' => 'Extra-Chill/data-machine-code',
+		)
+	);
+
+	$assert( 'no labels means addLabels is never called', 0 === count( GitHubAbilities::$addLabelsCalls ) );
+	$assert( 'response applied_labels is empty when no labels', array() === ( $result['data']['applied_labels'] ?? null ) );
+	$assert( 'response labels is empty when no labels', array() === ( $result['data']['labels'] ?? null ) );
+
+	// --- Test 4: label apply failure does NOT roll back PR creation ---
+	GitHubAbilities::reset();
+	GitHubAbilities::$addLabelsImpl = static function ( array $input ): \WP_Error {
+		return new \WP_Error( 'github_api_error', 'GitHub API error (422): Validation failed', array( 'status' => 422 ) );
+	};
+	$handler = new TestablePullRequestPublish();
+
+	$result = $handler->callExecutePublish(
+		array(
+			'title'  => 'Label failure PR',
+			'head'   => 'agent/label-fail',
+			'labels' => array( 'does-not-exist' ),
+		),
+		array(
+			'repo' => 'Extra-Chill/data-machine-code',
+		)
+	);
+
+	$assert( 'PR success is preserved even when labeling fails', true === ( $result['success'] ?? false ) );
+	$assert( 'pull_number returned even when labeling fails', 4242 === (int) ( $result['data']['pull_number'] ?? 0 ) );
+	$assert( 'applied_labels empty when labeling fails', array() === ( $result['data']['applied_labels'] ?? null ) );
+	$assert( 'label_error includes API message', isset( $result['data']['label_error'] ) && str_contains( (string) $result['data']['label_error'], 'Validation failed' ) );
+	$has_label_warning = false;
+	foreach ( $handler->log_entries as $entry ) {
+		if ( 'warning' === $entry['level'] && str_contains( $entry['message'], 'failed to apply labels' ) ) {
+			$has_label_warning = true;
+			break;
+		}
+	}
+	$assert( 'label failure logged as warning', $has_label_warning );
+
+	// --- Test 5: array-shaped tool labels with mixed whitespace get sanitized ---
+	GitHubAbilities::reset();
+	$handler = new TestablePullRequestPublish();
+
+	$result = $handler->callExecutePublish(
+		array(
+			'title'  => 'Sanitization PR',
+			'head'   => 'agent/sanitize',
+			'labels' => array( '  spaced  ', '', 'kept' ),
+		),
+		array( 'repo' => 'Extra-Chill/data-machine-code' )
+	);
+
+	$assert( 'empty label entries are dropped after sanitization', array( 'spaced', 'kept' ) === ( GitHubAbilities::$addLabelsCalls[0]['labels'] ?? array() ) );
+
+	// --- Test 6: comma-separated string label parameter is accepted (issue spec: string[] | string) ---
+	GitHubAbilities::reset();
+	$handler = new TestablePullRequestPublish();
+
+	$result = $handler->callExecutePublish(
+		array(
+			'title'  => 'String labels PR',
+			'head'   => 'agent/string-labels',
+			'labels' => 'one, two , three',
+		),
+		array( 'repo' => 'Extra-Chill/data-machine-code' )
+	);
+
+	$assert(
+		'comma-separated string label parameter is parsed',
+		array( 'one', 'two', 'three' ) === ( GitHubAbilities::$addLabelsCalls[0]['labels'] ?? array() )
+	);
+
+	if ( ! empty( $failures ) ) {
+		echo "\nFAIL: " . count( $failures ) . " assertion(s)\n";
+		foreach ( $failures as $failure ) {
+			echo "  - {$failure}\n";
+		}
+		exit( 1 );
+	}
+
+	echo "\nOK\n";
+	exit( 0 );
+}


### PR DESCRIPTION
## Summary
- Add optional label support to the `github_pull_request_publish` handler so generated-output flows (e.g. `wc-store-blueprints` static-site / blueprint agents) can route opened PRs by label (`target:blueprint`, `target:static-site`) without polluting the upstream idea issue.
- Mirrors the pattern already used by `github_issue_publish`: handler-config default + tool-parameter override resolved through a `resolveListParameter` helper.
- Labels are applied after the PR is created via a new `GitHubAbilities::addLabels()` helper that hits `POST /repos/{owner}/{repo}/issues/{number}/labels`.

Closes #269.

## Behavior

### Settings UI
`GitHubPullRequestPublishSettings` exposes a new `labels` text field (comma-separated default labels). The AI tool can override at call time.

### Tool schema
`github_pull_request_publish` gains a `labels` parameter. Per the issue spec it accepts `string[] | string` (comma-separated). Tool params win over handler config; if neither is supplied, the label step is a no-op.

### Result shape
Successful publish now returns:

```json
{
  "success": true,
  "data": {
    "repo": "...",
    "pull_number": 4242,
    "html_url": "...",
    "title": "...",
    "head": "...",
    "base": "...",
    "files": [...],
    "labels": ["target:blueprint", "automation"],
    "applied_labels": ["target:blueprint", "automation"]
  }
}
```

`labels` is the resolved input list; `applied_labels` is the list confirmed by GitHub's response.

### Partial-failure contract
If the PR opens but the labels endpoint fails (e.g. 422 unknown label), the publish still returns `success: true` so the flow does not roll back. The failure surfaces as:

- `data.label_error`: human-readable API error message.
- A `warning`-level log entry with `repo`, `pull_number`, `labels` context.

This matches the issue's requirement: "If label application fails, do not fail the whole publish."

## Tests

Existing `smoke-github-pr-publish-handler.php` extended with schema + wiring assertions for the new `labels` parameter, settings field, helper usage, and `applied_labels`/`label_error` reporting.

New `smoke-github-pr-publish-labels.php` exercises `executePublish()` directly with stubbed `GitHubAbilities` and covers:

1. Handler-config labels are resolved and applied; `applied_labels` reflects them.
2. Tool-parameter labels override handler-config labels.
3. No labels = `addLabels` is never called.
4. A 422 from `addLabels` surfaces as `data.label_error` while the PR result remains `success: true` with `pull_number` intact, and a warning is logged.
5. Whitespace and empty entries are stripped during sanitization.
6. Comma-separated string input is parsed (per issue spec).

Run locally:

```
php tests/smoke-github-pr-publish-handler.php
php tests/smoke-github-pr-publish-labels.php
php tests/smoke-github-issue-publish-handler.php   # regression
```

All green.

## Note on PHPUnit
The implementation prompt mentioned PHPUnit, but this repo's test convention is pure-PHP smoke tests under `tests/` (no PHPUnit dependency in `composer.json`). I followed local convention rather than introducing a new test framework. The new `smoke-github-pr-publish-labels.php` is behavioral (not just string-matching) — it loads the real handler against stubbed namespaces and asserts on actual return shapes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Code authoring (`addLabels` helper, handler wiring, settings field), behavioral smoke test, and PR copy. Chris reviewed and ran the smoke suite locally before merge.
