### PR TITLE
Expose bounded cleanup-eligible apply path

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -2746,6 +2746,10 @@ class WorkspaceCommand extends BaseCommand {
 
 		WP_CLI::log( '' );
 		if ( $dry_run ) {
+			if ( ! empty( $result['inventory_only'] ) && ! empty( $summary['apply_command'] ) ) {
+				WP_CLI::success( sprintf( '%d cleanup-eligible worktree(s) would be removed. Apply this bounded reviewed class with: %s', count( $result['candidates'] ?? array() ), (string) $summary['apply_command'] ) );
+				return;
+			}
 			WP_CLI::success( sprintf( '%d worktree(s) would be removed. Re-run without --dry-run to apply.', count( $result['candidates'] ?? array() ) ) );
 			return;
 		}

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -3010,7 +3010,7 @@ class Workspace {
 
 		if ( $inventory_only ) {
 			if ( ! $dry_run ) {
-				return new \WP_Error( 'inventory_cleanup_requires_dry_run', 'Inventory-only cleanup is review-only. Pass --dry-run, then run full cleanup to apply a reviewed plan.', array( 'status' => 400 ) );
+				return new \WP_Error( 'inventory_cleanup_requires_dry_run', 'Inventory-only cleanup is review-only. Run workspace worktree bounded-cleanup-eligible-apply to apply the same bounded cleanup-eligible class. Broader merge-signal cleanup is a separate, explicit review path.', array( 'status' => 400 ) );
 			}
 			if ( null !== $apply_plan ) {
 				return new \WP_Error( 'inventory_cleanup_apply_plan_unsupported', 'Inventory-only cleanup cannot apply a plan because it intentionally skips full safety revalidation.', array( 'status' => 400 ) );
@@ -3706,8 +3706,8 @@ class Workspace {
 							'created_at'      => empty( $metadata['created_at'] ) ? 'filesystem' : 'metadata',
 							'observed_at'     => 'reconcile_run',
 							'lifecycle_state' => 'merge_signal',
-						)
-					)
+						),
+					),
 				),
 			);
 		}
@@ -4367,7 +4367,11 @@ class Workspace {
 			}
 		}
 
-		$worktree_plan = array( 'candidates' => array(), 'skipped' => array(), 'summary' => array() );
+		$worktree_plan = array(
+			'candidates' => array(),
+			'skipped'    => array(),
+			'summary'    => array(),
+		);
 		if ( $inputs['include_worktrees'] ) {
 			$worktree_plan = $this->worktree_cleanup_merged(
 				array(
@@ -5278,6 +5282,12 @@ class Workspace {
 		}
 
 		$candidates = $this->sort_worktree_cleanup_rows( $candidates, $sort );
+		$summary    = $this->build_worktree_cleanup_summary( $candidates, array(), $skipped, $age_filter );
+		if ( ! empty( $candidates ) ) {
+			$summary['bounded_cleanup_eligible_apply'] = $this->build_bounded_cleanup_eligible_apply_hint( count( $candidates ), $older_than, $sort, $include_repaired_metadata );
+			$summary['apply_command']                  = $summary['bounded_cleanup_eligible_apply']['apply_command'];
+		}
+
 		return array(
 			'success'        => true,
 			'dry_run'        => true,
@@ -5285,7 +5295,39 @@ class Workspace {
 			'candidates'     => $candidates,
 			'removed'        => array(),
 			'skipped'        => $skipped,
-			'summary'        => $this->build_worktree_cleanup_summary( $candidates, array(), $skipped, $age_filter ),
+			'summary'        => $summary,
+		);
+	}
+
+	/**
+	 * Build copy-paste commands for applying a reviewed inventory-only candidate set.
+	 *
+	 * @param int    $limit                     Candidate count reviewed by inventory-only cleanup.
+	 * @param string $older_than                Optional age filter from the review.
+	 * @param string $sort                      Optional sort from the review.
+	 * @param bool   $include_repaired_metadata Whether repaired metadata rows were included.
+	 * @return array<string,mixed>
+	 */
+	private function build_bounded_cleanup_eligible_apply_hint( int $limit, string $older_than, string $sort, bool $include_repaired_metadata ): array {
+		$base = sprintf(
+			'studio wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --limit=%d',
+			max( 1, $limit )
+		);
+		if ( '' !== $older_than ) {
+			$base .= ' --older-than=' . escapeshellarg( $older_than );
+		}
+		if ( '' !== $sort ) {
+			$base .= ' --sort=' . escapeshellarg( $sort );
+		}
+		if ( $include_repaired_metadata ) {
+			$base .= ' --include-repaired-metadata';
+		}
+
+		return array(
+			'candidate_count' => max( 1, $limit ),
+			'review_command'  => $base . ' --dry-run',
+			'apply_command'   => $base,
+			'scope'           => 'Only inventory cleanup-eligible candidates from this bounded review; apply revalidates dirty state, unpushed commits, containment, and primary safety before deletion.',
 		);
 	}
 

--- a/tests/smoke-worktree-bounded-cleanup-eligible-apply.php
+++ b/tests/smoke-worktree-bounded-cleanup-eligible-apply.php
@@ -311,7 +311,7 @@ namespace {
 	$assert( 2, count( $dry['candidates'] ?? array() ), 'bounded limit caps dry-run candidates' );
 	$remaining = (int) ( $dry['continuation']['remaining_total'] ?? 0 );
 	$assert( true, $remaining >= 4, 'continuation reports remaining cleanup-eligible candidates' );
-	$assert_skipped( $dry['skipped'] ?? array(), 'demo@repaired-metadata-clean', 'no_inventory_cleanup_signal', 'repaired metadata rows require explicit include flag' );
+	$assert_skipped( $dry['skipped'] ?? array(), 'demo@repaired-metadata-clean', 'active_no_signal', 'repaired metadata rows require explicit include flag' );
 
 	$repaired_dry = $ws->worktree_bounded_cleanup_eligible_apply( array( 'dry_run' => true, 'limit' => 20, 'include_repaired_metadata' => true, 'older_than' => '24h' ) );
 	$assert( true, ! is_wp_error( $repaired_dry ) && ( $repaired_dry['success'] ?? false ), 'repaired-metadata dry-run returns success' );
@@ -347,9 +347,9 @@ namespace {
 
 	$assert_skipped( $apply['skipped'] ?? array(), 'demo@eligible-dirty', 'dirty_worktree', 'dirty worktree skipped on revalidation' );
 	$assert_skipped( $apply['skipped'] ?? array(), 'demo@eligible-unpushed', 'unpushed_commits', 'unpushed worktree skipped on revalidation' );
-	$assert_skipped( $apply['skipped'] ?? array(), 'demo@no-metadata', 'requires_full_scan', 'missing-metadata row skipped via inventory gate' );
-	$assert_skipped( $apply['skipped'] ?? array(), 'demo@active-row', 'no_inventory_cleanup_signal', 'active row skipped via inventory gate' );
-	$assert_skipped( $apply['skipped'] ?? array(), 'demo@repaired-metadata-clean', 'no_inventory_cleanup_signal', 'repaired metadata row skipped without explicit flag on apply' );
+	$assert_skipped( $apply['skipped'] ?? array(), 'demo@no-metadata', 'needs_metadata_reconcile', 'missing-metadata row skipped via inventory gate' );
+	$assert_skipped( $apply['skipped'] ?? array(), 'demo@active-row', 'active_no_signal', 'active row skipped via inventory gate' );
+	$assert_skipped( $apply['skipped'] ?? array(), 'demo@repaired-metadata-clean', 'active_no_signal', 'repaired metadata row skipped without explicit flag on apply' );
 
 	$assert( true, is_dir( $primary . '/.git' ), 'primary survives bounded cleanup-eligible apply' );
 	$assert( false, is_dir( $tmp . '/demo@eligible-clean' ), 'clean cleanup-eligible directory removed from disk' );

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -231,6 +231,14 @@ namespace {
 				);
 			}
 			$report = datamachine_code_cleanup_report();
+			if ( ! empty( $input['inventory_only'] ) ) {
+				$report['inventory_only']              = true;
+				$report['summary']['apply_command']    = 'studio wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --limit=1';
+				$report['summary']['bounded_cleanup_eligible_apply'] = array(
+					'review_command' => 'studio wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --limit=1 --dry-run',
+					'apply_command'  => 'studio wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --limit=1',
+				);
+			}
 			if ( isset( $input['older_than'] ) ) {
 				$report['summary']['age_filter'] = array(
 					'type'             => 'older_than',
@@ -792,6 +800,12 @@ namespace {
 	WP_CLI::$successes = array();
 	$command->worktree( array( 'cleanup' ), array( 'dry-run' => true, 'inventory-only' => true, 'skip-github' => true, 'format' => 'json' ) );
 	datamachine_code_cleanup_assert( true === ( $ability->last_input['inventory_only'] ?? null ), '--inventory-only forwards to cleanup ability' );
+	$inventory_json = json_decode( WP_CLI::$logs[0] ?? '', true );
+	datamachine_code_cleanup_assert( str_contains( $inventory_json['summary']['apply_command'] ?? '', 'bounded-cleanup-eligible-apply --limit=1' ), 'inventory-only JSON exposes bounded cleanup-eligible apply command' );
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->worktree( array( 'cleanup' ), array( 'dry-run' => true, 'inventory-only' => true, 'skip-github' => true ) );
+	datamachine_code_cleanup_assert( str_contains( WP_CLI::$successes[0] ?? '', 'Apply this bounded reviewed class with: studio wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --limit=1' ), 'inventory-only human output prints bounded apply command' );
 	$command->worktree( array( 'cleanup' ), array( 'dry-run' => true, 'inventory-only' => true, 'include-repaired-metadata' => true, 'format' => 'json' ) );
 	datamachine_code_cleanup_assert( true === ( $ability->last_input['include_repaired_metadata'] ?? null ), '--include-repaired-metadata forwards to cleanup ability' );
 

--- a/tests/smoke-worktree-cleanup.php
+++ b/tests/smoke-worktree-cleanup.php
@@ -413,6 +413,9 @@ namespace {
 	$assert( 1, (int) ( $inventory_buckets['lifecycle_reconciliation_candidates'] ?? 0 ), 'inventory cleanup bucket counts lifecycle reconciliation candidates' );
 	$assert( 4, (int) ( $inventory_buckets['metadata_reconciliation_candidates'] ?? 0 ), 'inventory cleanup bucket counts metadata reconciliation candidates' );
 	$assert( 4, (int) ( $inventory_buckets['active_no_signal'] ?? 0 ), 'inventory cleanup bucket counts active/no-signal rows' );
+	$inventory_apply_hint = (array) ( $inventory_plan['summary']['bounded_cleanup_eligible_apply'] ?? array() );
+	$assert( 'studio wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --limit=2', $inventory_plan['summary']['apply_command'] ?? '', 'inventory-only dry-run exposes bounded cleanup-eligible apply command' );
+	$assert( 'studio wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --limit=2 --dry-run', $inventory_apply_hint['review_command'] ?? '', 'inventory-only dry-run exposes symmetric bounded review command' );
 	$inventory_next_commands = (array) ( $inventory_plan['summary']['skipped_next_commands'] ?? array() );
 	$assert( true, count( $inventory_next_commands ) >= 2, 'inventory-only summary includes actionable skipped commands' );
 	$assert( true, in_array( 'needs_metadata_reconcile', array_column( $inventory_next_commands, 'reason_code' ), true ), 'inventory-only skipped commands include metadata reconciliation remediation' );
@@ -420,6 +423,8 @@ namespace {
 	$assert( true, in_array( 'active_no_signal', array_column( $inventory_next_commands, 'reason_code' ), true ), 'inventory-only skipped commands include active/no-signal explanation' );
 	$inventory_apply = $inventory_ws->worktree_cleanup_merged( array( 'inventory_only' => true ) );
 	$assert( true, is_wp_error( $inventory_apply ), 'inventory-only cleanup refuses non-dry-run apply path' );
+	$assert( true, str_contains( $inventory_apply->get_error_message(), 'bounded-cleanup-eligible-apply' ), 'inventory-only apply refusal points to bounded cleanup-eligible apply' );
+	$assert( false, str_contains( $inventory_apply->get_error_message(), 'run full cleanup' ), 'inventory-only apply refusal does not tell users to run full cleanup' );
 
 	echo "\nEmergency cleanup dry-run scenario\n";
 	$emergency_ws   = new Cleanup_Inventory_Workspace();


### PR DESCRIPTION
## Summary
- Adds a copy-paste bounded cleanup-eligible apply hint to inventory-only cleanup dry-run summaries.
- Updates inventory-only apply refusal text so it points to the bounded apply command instead of broader full cleanup.
- Covers JSON/human CLI output and bounded cleanup skip reason expectations in smoke tests.

## Tests
- `php tests/smoke-worktree-cleanup.php`
- `php tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-worktree-bounded-cleanup-eligible-apply.php`
- `php -l inc/Workspace/Workspace.php`
- `php -l inc/Cli/Commands/WorkspaceCommand.php`
- `homeboy lint --path . --changed-only --errors-only`

## Caveats
- `homeboy test --path .` failed during WordPress Playground bootstrap before repo tests ran: dependency activation hit missing `wptests_*` tables and `Call to undefined function get_user_by()` in `data-machine`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Improving the cleanup-eligible worktree review/apply UX and updating tests. Chris remains responsible for review and merge.