### PR TITLE
Skip schema upgrade during WP install bootstrap

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -42,6 +42,10 @@ register_activation_hook( __FILE__, 'datamachine_code_install_schema' );
  * Keep schema current for already-active installs after deploy/update.
  */
 function datamachine_code_maybe_upgrade_schema(): void {
+	if ( function_exists( 'wp_installing' ) && wp_installing() ) {
+		return;
+	}
+
 	$worktrees_installed = function_exists( 'get_option' ) ? (string) get_option( 'datamachine_code_worktrees_schema_version', '' ) : '';
 	$cleanup_installed   = function_exists( 'get_option' ) ? (string) get_option( 'datamachine_code_cleanup_schema_version', '' ) : '';
 	$cleanup_version     = '20260504-cleanup-runs';

--- a/tests/smoke-schema-upgrade-installing.php
+++ b/tests/smoke-schema-upgrade-installing.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Smoke test for schema upgrade bootstrap during WordPress install.
+ *
+ * Run: php tests/smoke-schema-upgrade-installing.php
+ */
+
+declare( strict_types=1 );
+
+define( 'WPINC', 'wp-includes' );
+define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+
+$GLOBALS['datamachine_code_test_wp_installing']  = true;
+$GLOBALS['datamachine_code_test_option_reads']   = 0;
+$GLOBALS['datamachine_code_test_option_writes']  = 0;
+$GLOBALS['datamachine_code_test_registered_hook'] = false;
+
+function wp_installing(): bool {
+	return (bool) $GLOBALS['datamachine_code_test_wp_installing'];
+}
+
+function get_option( string $name, mixed $default = false ): mixed {
+	unset( $name );
+	++$GLOBALS['datamachine_code_test_option_reads'];
+	return $default;
+}
+
+function update_option( string $name, mixed $value, mixed $autoload = null ): bool {
+	unset( $name, $value, $autoload );
+	++$GLOBALS['datamachine_code_test_option_writes'];
+	return true;
+}
+
+function register_activation_hook( string $file, callable|string $callback ): void {
+	unset( $file, $callback );
+}
+
+function add_action( string $hook_name, callable|string $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	unset( $accepted_args );
+	if ( 'plugins_loaded' === $hook_name && 'datamachine_code_maybe_upgrade_schema' === $callback && 5 === $priority ) {
+		$GLOBALS['datamachine_code_test_registered_hook'] = true;
+	}
+}
+
+function add_filter( string $hook_name, callable|string $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	unset( $hook_name, $callback, $priority, $accepted_args );
+}
+
+function plugin_dir_path( string $file ): string {
+	return dirname( $file ) . '/';
+}
+
+function plugin_dir_url( string $file ): string {
+	unset( $file );
+	return 'https://example.test/wp-content/plugins/data-machine-code/';
+}
+
+function datamachine_code_schema_upgrade_installing_assert( bool $condition, string $message ): void {
+	if ( $condition ) {
+		echo "  [PASS] {$message}\n";
+		return;
+	}
+
+	echo "  [FAIL] {$message}\n";
+	exit( 1 );
+}
+
+echo "=== smoke-schema-upgrade-installing ===\n";
+
+require dirname( __DIR__ ) . '/data-machine-code.php';
+
+datamachine_code_maybe_upgrade_schema();
+
+datamachine_code_schema_upgrade_installing_assert(
+	$GLOBALS['datamachine_code_test_registered_hook'],
+	'schema upgrade hook stays registered'
+);
+datamachine_code_schema_upgrade_installing_assert(
+	0 === $GLOBALS['datamachine_code_test_option_reads'],
+	'install bootstrap skips schema option reads'
+);
+datamachine_code_schema_upgrade_installing_assert(
+	0 === $GLOBALS['datamachine_code_test_option_writes'],
+	'install bootstrap skips schema option writes'
+);
+
+echo "\nSchema upgrade installing smoke passed.\n";


### PR DESCRIPTION
## Summary
- Skip the `plugins_loaded` schema upgrade check while WordPress reports `wp_installing()` so wp-phpunit pre-install bootstrap does not read or write missing options tables.
- Keep activation schema installation and normal already-active upgrade behavior unchanged.
- Add a smoke test that fails if the install bootstrap path touches DMC schema option reads or writes.

Fixes #273

## Verification
- `php tests/smoke-schema-upgrade-installing.php`
- `php tests/smoke-worktree-inventory-repository.php`
- `php tests/smoke-cleanup-run-storage.php`
- `homeboy test`
- `DMC_PATH=/Users/chubes/Developer/data-machine-code@fix-preinstall-schema-upgrade-guard bash tests/playground-ci/scripts/run-stage-3.sh` from `/Users/chubes/Developer/wc-store-blueprints@feat-playground-ci-proof-stage3`
- `DMC_PATH=/Users/chubes/Developer/data-machine-code@fix-preinstall-schema-upgrade-guard bash tests/playground-ci/scripts/run-stage-1.sh` from `/Users/chubes/Developer/wc-store-blueprints@feat-playground-ci-proof-stage3`

## Notes
- `homeboy lint` still reports the repository's existing lint backlog in unrelated files; this PR does not touch those areas.
- Stage 1 and Stage 3 no longer emit the DMC `wptests_options` database-error blocks. They still emit the pre-existing non-fatal Action Scheduler early-init notice.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the code/test changes and ran verification; Chris reviews the final diff.