### PR TITLE
Generalize GitHub Actions artifact retrieval

### DIFF
--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -662,10 +662,64 @@ class GitHubAbilities {
 			);
 
 			wp_register_ability(
+				'datamachine/get-github-actions-artifact',
+				array(
+					'label'               => 'Get GitHub Actions Artifact',
+					'description'         => 'Download a GitHub Actions artifact for a pull request or commit SHA and optionally parse JSON files from the ZIP',
+					'category'            => 'datamachine-code-github',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'repo', 'artifact_name' ),
+						'properties' => array(
+							'repo'               => array(
+								'type'        => 'string',
+								'description' => 'Repository in owner/repo format.',
+							),
+							'head_sha'           => array(
+								'type'        => 'string',
+								'description' => 'Pull request head SHA or commit SHA to match artifacts against.',
+							),
+							'pull_number'        => array(
+								'type'        => 'integer',
+								'description' => 'Pull request number. Used to resolve head_sha when head_sha is omitted.',
+							),
+							'artifact_name'      => array(
+								'type'        => 'string',
+								'description' => 'GitHub Actions artifact name.',
+							),
+							'max_artifact_bytes' => array(
+								'type'        => 'integer',
+								'description' => 'Maximum artifact ZIP bytes to download. Default: 2000000.',
+							),
+							'include_json'       => array(
+								'type'        => 'boolean',
+								'description' => 'Parse and include JSON files from the artifact ZIP. Default: true.',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'     => array( 'type' => 'boolean' ),
+							'repo'        => array( 'type' => 'string' ),
+							'head_sha'    => array( 'type' => 'string' ),
+							'pull_number' => array( 'type' => 'integer' ),
+							'artifact'    => array( 'type' => 'object' ),
+							'json_files'  => array( 'type' => 'object' ),
+							'error'       => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'getActionsArtifact' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
 				'datamachine/get-github-homeboy-ci-results',
 				array(
-					'label'               => 'Get GitHub Homeboy CI Results',
-					'description'         => 'Download and summarize the homeboy-ci-results artifact for a pull request or commit SHA',
+					'label'               => 'Get GitHub Homeboy CI Results (Deprecated)',
+					'description'         => 'Deprecated compatibility wrapper around datamachine/get-github-actions-artifact for existing Homeboy CI result consumers',
 					'category'            => 'datamachine-code-github',
 					'input_schema'        => array(
 						'type'       => 'object',
@@ -2852,7 +2906,7 @@ class GitHubAbilities {
 	}
 
 	/**
-	 * Download and summarize a Homeboy CI artifact for a pull request or head SHA.
+	 * Download and parse a generic GitHub Actions artifact for a pull request or head SHA.
 	 *
 	 * @param array         $input Required: repo plus head_sha or pull_number.
 	 * @param callable|null $api_get Test seam for JSON GitHub GET calls.
@@ -2860,15 +2914,19 @@ class GitHubAbilities {
 	 * @param callable|null $extract Test seam for ZIP extraction.
 	 * @return array|\WP_Error
 	 */
-	public static function getHomeboyCiResults( array $input, ?callable $api_get = null, ?callable $download = null, ?callable $extract = null ): array|\WP_Error {
+	public static function getActionsArtifact( array $input, ?callable $api_get = null, ?callable $download = null, ?callable $extract = null ): array|\WP_Error {
 		$repo          = sanitize_text_field( $input['repo'] ?? '' );
 		$head_sha      = sanitize_text_field( $input['head_sha'] ?? $input['sha'] ?? '' );
 		$pull_number   = (int) ( $input['pull_number'] ?? $input['pr_number'] ?? 0 );
-		$artifact_name = sanitize_text_field( $input['artifact_name'] ?? 'homeboy-ci-results' );
-		$include_raw   = ! empty( $input['include_raw'] );
+		$artifact_name = sanitize_text_field( $input['artifact_name'] ?? '' );
+		$include_json  = ! array_key_exists( 'include_json', $input ) || ! empty( $input['include_json'] );
 
 		if ( empty( $repo ) ) {
 			return new \WP_Error( 'missing_params', 'Repository (owner/repo) is required.', array( 'status' => 400 ) );
+		}
+
+		if ( '' === $artifact_name ) {
+			return new \WP_Error( 'missing_params', 'Artifact name is required.', array( 'status' => 400 ) );
 		}
 
 		if ( '' === $head_sha && $pull_number <= 0 ) {
@@ -2889,7 +2947,7 @@ class GitHubAbilities {
 
 			$head_sha = sanitize_text_field( $pull_response['data']['head']['sha'] ?? '' );
 			if ( '' === $head_sha ) {
-				return new \WP_Error( 'github_homeboy_ci_missing_head_sha', 'Pull request head SHA could not be resolved.', array( 'status' => 404 ) );
+				return new \WP_Error( 'github_actions_artifact_missing_head_sha', 'Pull request head SHA could not be resolved.', array( 'status' => 404 ) );
 			}
 		}
 
@@ -2905,9 +2963,81 @@ class GitHubAbilities {
 			return $artifacts_response;
 		}
 
-		$artifact_result = self::selectHomeboyArtifact( $artifacts_response['data']['artifacts'] ?? array(), $artifact_name, $head_sha );
+		$artifact_result = self::selectActionsArtifact( $artifacts_response['data']['artifacts'] ?? array(), $artifact_name, $head_sha );
 		if ( is_wp_error( $artifact_result ) ) {
-			$pending = self::detectPendingHomeboyChecks( $repo, $head_sha, $api_get );
+			return $artifact_result;
+		}
+
+		$artifact = $artifact_result;
+		$json     = array();
+
+		if ( $include_json ) {
+			$download = $download ?? static fn( string $url, int $max_bytes ) => self::apiRawGet( $url, $pat, $max_bytes );
+			$zip      = $download( (string) ( $artifact['archive_download_url'] ?? '' ), max( 1, (int) ( $input['max_artifact_bytes'] ?? 2000000 ) ) );
+			if ( is_wp_error( $zip ) ) {
+				return $zip;
+			}
+
+			$extract = $extract ?? array( self::class, 'extractZipJsonFiles' );
+			$json    = $extract( $zip );
+			if ( is_wp_error( $json ) ) {
+				return $json;
+			}
+		}
+
+		return array(
+			'success'     => true,
+			'repo'        => $repo,
+			'head_sha'    => $head_sha,
+			'pull_number' => $pull_number,
+			'artifact'    => self::normalizeActionsArtifact( $artifact ),
+			'json_files'  => $json,
+		);
+	}
+
+	/**
+	 * Download and summarize a Homeboy CI artifact for a pull request or head SHA.
+	 *
+	 * Deprecated compatibility wrapper around getActionsArtifact(). New callers
+	 * should use datamachine/get-github-actions-artifact for generic artifact data.
+	 *
+	 * @param array         $input Required: repo plus head_sha or pull_number.
+	 * @param callable|null $api_get Test seam for JSON GitHub GET calls.
+	 * @param callable|null $download Test seam for artifact ZIP download.
+	 * @param callable|null $extract Test seam for ZIP extraction.
+	 * @return array|\WP_Error
+	 */
+	public static function getHomeboyCiResults( array $input, ?callable $api_get = null, ?callable $download = null, ?callable $extract = null ): array|\WP_Error {
+		$repo          = sanitize_text_field( $input['repo'] ?? '' );
+		$head_sha      = sanitize_text_field( $input['head_sha'] ?? $input['sha'] ?? '' );
+		$pull_number   = (int) ( $input['pull_number'] ?? $input['pr_number'] ?? 0 );
+		$artifact_name = sanitize_text_field( $input['artifact_name'] ?? 'homeboy-ci-results' );
+		$include_raw   = ! empty( $input['include_raw'] );
+
+		$artifact_result = self::getActionsArtifact(
+			array_merge(
+				$input,
+				array(
+					'artifact_name' => '' !== $artifact_name ? $artifact_name : 'homeboy-ci-results',
+					'include_json'  => true,
+				)
+			),
+			$api_get,
+			$download,
+			$extract
+		);
+
+		if ( is_wp_error( $artifact_result ) ) {
+			$error_code          = $artifact_result->get_error_code();
+			$api_get_for_pending = $api_get;
+			if ( 'github_actions_artifact_not_found' === $error_code && null === $api_get_for_pending ) {
+				$pat = empty( $repo ) ? '' : self::getPatForRepo( $repo );
+				if ( ! empty( $pat ) ) {
+					$api_get_for_pending = static fn( string $url, array $query ) => self::apiGet( $url, $query, $pat );
+				}
+			}
+
+			$pending = 'github_actions_artifact_not_found' === $error_code && null !== $api_get_for_pending ? self::detectPendingHomeboyChecks( $repo, $head_sha, $api_get_for_pending ) : array();
 			if ( ! empty( $pending ) ) {
 				return new \WP_Error(
 					'github_homeboy_ci_pending',
@@ -2919,25 +3049,22 @@ class GitHubAbilities {
 				);
 			}
 
+			if ( 'github_actions_artifact_expired' === $error_code ) {
+				return new \WP_Error( 'github_homeboy_ci_artifact_expired', 'Homeboy CI artifact exists for this head SHA but has expired.', $artifact_result->get_error_data() );
+			}
+
+			if ( 'github_actions_artifact_not_found' === $error_code ) {
+				return new \WP_Error( 'github_homeboy_ci_artifact_not_found', 'No homeboy-ci-results artifact found for this head SHA.', $artifact_result->get_error_data() );
+			}
+
 			return $artifact_result;
 		}
 
-		$artifact = $artifact_result;
-		$download = $download ?? static fn( string $url, int $max_bytes ) => self::apiRawGet( $url, $pat, $max_bytes );
-		$zip      = $download( (string) ( $artifact['archive_download_url'] ?? '' ), max( 1, (int) ( $input['max_artifact_bytes'] ?? 2000000 ) ) );
-		if ( is_wp_error( $zip ) ) {
-			return $zip;
-		}
-
-		$extract = $extract ?? array( self::class, 'extractZipJsonFiles' );
-		$files   = $extract( $zip );
-		if ( is_wp_error( $files ) ) {
-			return $files;
-		}
-
-		$results = self::summarizeHomeboyCiArtifact( $files, array(
+		$artifact = is_array( $artifact_result['artifact'] ?? null ) ? $artifact_result['artifact'] : array();
+		$files    = is_array( $artifact_result['json_files'] ?? null ) ? $artifact_result['json_files'] : array();
+		$results  = self::summarizeHomeboyCiArtifact( $files, array(
 			'repo'          => $repo,
-			'head_sha'      => $head_sha,
+			'head_sha'      => (string) ( $artifact_result['head_sha'] ?? $head_sha ),
 			'pull_number'   => $pull_number,
 			'artifact'      => $artifact,
 			'artifact_name' => $artifact_name,
@@ -2955,9 +3082,9 @@ class GitHubAbilities {
 	}
 
 	/**
-	 * Pick the newest matching Homeboy artifact for a head SHA.
+	 * Pick the newest matching GitHub Actions artifact for a head SHA.
 	 */
-	public static function selectHomeboyArtifact( array $artifacts, string $artifact_name, string $head_sha ): array|\WP_Error {
+	public static function selectActionsArtifact( array $artifacts, string $artifact_name, string $head_sha ): array|\WP_Error {
 		$expired_match = null;
 		$matches       = array();
 
@@ -2981,10 +3108,10 @@ class GitHubAbilities {
 
 		if ( empty( $matches ) ) {
 			if ( null !== $expired_match ) {
-				return new \WP_Error( 'github_homeboy_ci_artifact_expired', 'Homeboy CI artifact exists for this head SHA but has expired.', array( 'status' => 410 ) );
+				return new \WP_Error( 'github_actions_artifact_expired', 'GitHub Actions artifact exists for this head SHA but has expired.', array( 'status' => 410 ) );
 			}
 
-			return new \WP_Error( 'github_homeboy_ci_artifact_not_found', 'No homeboy-ci-results artifact found for this head SHA.', array( 'status' => 404 ) );
+			return new \WP_Error( 'github_actions_artifact_not_found', 'No matching GitHub Actions artifact found for this head SHA.', array( 'status' => 404 ) );
 		}
 
 		usort( $matches, static fn( $a, $b ) => strcmp( (string) ( $b['updated_at'] ?? $b['created_at'] ?? '' ), (string) ( $a['updated_at'] ?? $a['created_at'] ?? '' ) ) );
@@ -2992,23 +3119,67 @@ class GitHubAbilities {
 	}
 
 	/**
-	 * Parse Homeboy JSON files from a GitHub artifact ZIP.
+	 * Deprecated Homeboy-specific artifact selector compatibility shim.
+	 */
+	public static function selectHomeboyArtifact( array $artifacts, string $artifact_name, string $head_sha ): array|\WP_Error {
+		$result = self::selectActionsArtifact( $artifacts, $artifact_name, $head_sha );
+		if ( ! is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		if ( 'github_actions_artifact_expired' === $result->get_error_code() ) {
+			return new \WP_Error( 'github_homeboy_ci_artifact_expired', 'Homeboy CI artifact exists for this head SHA but has expired.', $result->get_error_data() );
+		}
+
+		if ( 'github_actions_artifact_not_found' === $result->get_error_code() ) {
+			return new \WP_Error( 'github_homeboy_ci_artifact_not_found', 'No homeboy-ci-results artifact found for this head SHA.', $result->get_error_data() );
+		}
+
+		return $result;
+	}
+
+	private static function normalizeActionsArtifact( array $artifact ): array {
+		$workflow_run = is_array( $artifact['workflow_run'] ?? null ) ? $artifact['workflow_run'] : array();
+
+		return array(
+			'id'                   => (int) ( $artifact['id'] ?? 0 ),
+			'node_id'              => (string) ( $artifact['node_id'] ?? '' ),
+			'name'                 => (string) ( $artifact['name'] ?? '' ),
+			'size_in_bytes'        => (int) ( $artifact['size_in_bytes'] ?? 0 ),
+			'url'                  => (string) ( $artifact['url'] ?? '' ),
+			'archive_download_url' => (string) ( $artifact['archive_download_url'] ?? '' ),
+			'expired'              => ! empty( $artifact['expired'] ),
+			'created_at'           => (string) ( $artifact['created_at'] ?? '' ),
+			'updated_at'           => (string) ( $artifact['updated_at'] ?? '' ),
+			'expires_at'           => (string) ( $artifact['expires_at'] ?? '' ),
+			'workflow_run'         => array(
+				'id'          => (int) ( $workflow_run['id'] ?? 0 ),
+				'head_sha'    => (string) ( $workflow_run['head_sha'] ?? $artifact['head_sha'] ?? '' ),
+				'head_branch' => (string) ( $workflow_run['head_branch'] ?? '' ),
+				'event'       => (string) ( $workflow_run['event'] ?? '' ),
+				'html_url'    => (string) ( $workflow_run['html_url'] ?? '' ),
+			),
+		);
+	}
+
+	/**
+	 * Parse JSON files from a GitHub Actions artifact ZIP.
 	 */
 	public static function extractZipJsonFiles( string $zip_bytes ): array|\WP_Error {
 		if ( ! class_exists( '\ZipArchive' ) ) {
-			return new \WP_Error( 'github_homeboy_ci_zip_unavailable', 'ZipArchive is not available, so GitHub artifact ZIPs cannot be parsed.', array( 'status' => 500 ) );
+			return new \WP_Error( 'github_actions_artifact_zip_unavailable', 'ZipArchive is not available, so GitHub artifact ZIPs cannot be parsed.', array( 'status' => 500 ) );
 		}
 
-		$tmp = tempnam( sys_get_temp_dir(), 'dmc-homeboy-ci-' );
+		$tmp = tempnam( sys_get_temp_dir(), 'dmc-gh-artifact-' );
 		if ( false === $tmp ) {
-			return new \WP_Error( 'github_homeboy_ci_temp_failed', 'Could not allocate a temporary file for artifact parsing.', array( 'status' => 500 ) );
+			return new \WP_Error( 'github_actions_artifact_temp_failed', 'Could not allocate a temporary file for artifact parsing.', array( 'status' => 500 ) );
 		}
 
 		file_put_contents( $tmp, $zip_bytes ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Required for ZipArchive.
 		$zip = new \ZipArchive();
 		if ( true !== $zip->open( $tmp ) ) {
 			self::deleteTempFile( $tmp );
-			return new \WP_Error( 'github_homeboy_ci_zip_invalid', 'Homeboy CI artifact is not a valid ZIP archive.', array( 'status' => 422 ) );
+			return new \WP_Error( 'github_actions_artifact_zip_invalid', 'GitHub Actions artifact is not a valid ZIP archive.', array( 'status' => 422 ) );
 		}
 
 		$files = array();
@@ -3027,7 +3198,7 @@ class GitHubAbilities {
 			if ( ! is_array( $data ) ) {
 				$zip->close();
 				self::deleteTempFile( $tmp );
-				return new \WP_Error( 'github_homeboy_ci_malformed_json', sprintf( 'Homeboy CI artifact file %s is not valid JSON.', $name ), array( 'status' => 422 ) );
+				return new \WP_Error( 'github_actions_artifact_malformed_json', sprintf( 'GitHub Actions artifact file %s is not valid JSON.', $name ), array( 'status' => 422 ) );
 			}
 
 			$files[ basename( $name ) ] = $data;
@@ -3521,7 +3692,7 @@ class GitHubAbilities {
 
 	public static function apiRawGet( string $url, string $pat, int $max_bytes = 2000000 ): string|\WP_Error {
 		if ( '' === $url ) {
-			return new \WP_Error( 'github_homeboy_ci_download_missing', 'GitHub artifact download URL is missing.', array( 'status' => 404 ) );
+			return new \WP_Error( 'github_actions_artifact_download_missing', 'GitHub artifact download URL is missing.', array( 'status' => 404 ) );
 		}
 
 		$response = wp_remote_get( $url, array(
@@ -3540,7 +3711,7 @@ class GitHubAbilities {
 		}
 
 		if ( strlen( $body ) > $max_bytes ) {
-			return new \WP_Error( 'github_homeboy_ci_artifact_too_large', sprintf( 'Homeboy CI artifact exceeded the configured %d byte limit.', $max_bytes ), array( 'status' => 413 ) );
+			return new \WP_Error( 'github_actions_artifact_too_large', sprintf( 'GitHub Actions artifact exceeded the configured %d byte limit.', $max_bytes ), array( 'status' => 413 ) );
 		}
 
 		return $body;

--- a/inc/Tools/GitHubTools.php
+++ b/inc/Tools/GitHubTools.php
@@ -49,6 +49,10 @@ class GitHubTools extends BaseTool {
 			'access_level' => 'editor',
 			'ability'      => 'datamachine/get-github-commit-statuses',
 		) );
+		$this->registerTool( 'get_github_actions_artifact', array( $this, 'getActionsArtifactDefinition' ), $contexts, array(
+			'access_level' => 'editor',
+			'ability'      => 'datamachine/get-github-actions-artifact',
+		) );
 		$this->registerTool( 'get_github_homeboy_ci_results', array( $this, 'getHomeboyCiResultsDefinition' ), $contexts, array(
 			'access_level' => 'editor',
 			'ability'      => 'datamachine/get-github-homeboy-ci-results',
@@ -114,6 +118,7 @@ class GitHubTools extends BaseTool {
 			'get_github_pull_files',
 			'get_github_check_runs',
 			'get_github_commit_statuses',
+			'get_github_actions_artifact',
 			'get_github_homeboy_ci_results',
 			'get_github_pull_review_context',
 			'github_repo_review_profile',
@@ -677,6 +682,16 @@ class GitHubTools extends BaseTool {
 	}
 
 	/**
+	 * Handle get_github_actions_artifact tool call.
+	 *
+	 * @param array $parameters Tool parameters.
+	 * @return array
+	 */
+	public function handleActionsArtifact( array $parameters ): array {
+		return $this->executeGitHubAbility( 'datamachine/get-github-actions-artifact', 'get_github_actions_artifact', $parameters );
+	}
+
+	/**
 	 * Handle get_github_homeboy_ci_results tool call.
 	 *
 	 * @param array $parameters Tool parameters.
@@ -706,6 +721,51 @@ class GitHubTools extends BaseTool {
 					'type'        => 'string',
 					'required'    => true,
 					'description' => 'Commit SHA, branch, or tag ref.',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Get tool definition for get_github_actions_artifact.
+	 *
+	 * @return array
+	 */
+	public function getActionsArtifactDefinition(): array {
+		return array(
+			'class'       => __CLASS__,
+			'method'      => 'handleActionsArtifact',
+			'description' => 'Download a GitHub Actions artifact by artifact name for a pull request or commit SHA and return generic artifact metadata plus parsed JSON files. Does not interpret producer-specific payload semantics.',
+			'parameters'  => array(
+				'repo'               => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Repository in owner/repo format.',
+				),
+				'head_sha'           => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Commit SHA to match the artifact against.',
+				),
+				'pull_number'        => array(
+					'type'        => 'integer',
+					'required'    => false,
+					'description' => 'Pull request number. Used to resolve head_sha when head_sha is omitted.',
+				),
+				'artifact_name'      => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'GitHub Actions artifact name.',
+				),
+				'max_artifact_bytes' => array(
+					'type'        => 'integer',
+					'required'    => false,
+					'description' => 'Maximum artifact ZIP bytes to download. Default: 2000000.',
+				),
+				'include_json'       => array(
+					'type'        => 'boolean',
+					'required'    => false,
+					'description' => 'Parse and include JSON files from the artifact ZIP. Default: true.',
 				),
 			),
 		);

--- a/tests/smoke-github-homeboy-ci-results.php
+++ b/tests/smoke-github-homeboy-ci-results.php
@@ -177,7 +177,24 @@ namespace {
 		return str_contains( $url, '/artifacts/44/zip' ) && $max_bytes > strlen( $zip_bytes ) ? $zip_bytes : new \WP_Error( 'bad_download', 'Unexpected download.' );
 	};
 
-	$result = \DataMachineCode\Abilities\GitHubAbilities::getHomeboyCiResults(
+	$generic = \DataMachineCode\Abilities\GitHubAbilities::getActionsArtifact(
+		array(
+			'repo'               => 'Extra-Chill/data-machine-code',
+			'pull_number'        => 106,
+			'artifact_name'      => 'homeboy-ci-results',
+			'max_artifact_bytes' => 2000000,
+		),
+		$api_get,
+		$download
+	);
+	$assert( ! is_wp_error( $generic ), 'generic artifact ability resolves PR head SHA, downloads artifact, and parses ZIP' );
+	$assert( 'abc123head' === ( $generic['head_sha'] ?? '' ), 'generic artifact ability returns resolved head SHA' );
+	$assert( 44 === (int) ( $generic['artifact']['id'] ?? 0 ), 'generic artifact ability returns normalized artifact metadata' );
+	$assert( isset( $generic['json_files']['review.json'], $generic['json_files']['manifest.json'] ), 'generic artifact ability returns parsed JSON files' );
+	$assert( ! isset( $generic['results'], $generic['state'], $generic['summary'], $generic['stages'] ), 'generic artifact ability does not interpret Homeboy result semantics' );
+
+	$api_calls = array();
+	$result    = \DataMachineCode\Abilities\GitHubAbilities::getHomeboyCiResults(
 		array(
 			'repo'               => 'Extra-Chill/data-machine-code',
 			'pull_number'        => 106,
@@ -216,6 +233,12 @@ namespace {
 		'abc123head'
 	);
 	$assert( is_wp_error( $expired ) && 'github_homeboy_ci_artifact_expired' === $expired->get_error_code(), 'expired artifact gets explicit error code' );
+	$generic_expired = \DataMachineCode\Abilities\GitHubAbilities::selectActionsArtifact(
+		array( array_merge( $artifact, array( 'expired' => true ) ) ),
+		'homeboy-ci-results',
+		'abc123head'
+	);
+	$assert( is_wp_error( $generic_expired ) && 'github_actions_artifact_expired' === $generic_expired->get_error_code(), 'generic expired artifact gets generic error code' );
 
 	$pending_api = function ( string $url, array $query ) use ( $artifact ): array|\WP_Error {
 		if ( str_contains( $url, '/actions/artifacts' ) ) {
@@ -235,6 +258,7 @@ namespace {
 	$tool_source     = file_get_contents( __DIR__ . '/../inc/Tools/GitHubTools.php' );
 	$scaffold_source = file_get_contents( __DIR__ . '/../inc/GitHub/PrReviewFlowScaffold.php' );
 
+	$assert( str_contains( $ability_source, "'datamachine/get-github-actions-artifact'" ), 'generic GitHub Actions artifact ability is registered' );
 	$assert( str_contains( $ability_source, "'datamachine/get-github-homeboy-ci-results'" ), 'Homeboy CI ability is registered' );
 	$assert( str_contains( $handler_source, "'homeboy_ci_results' === $" . 'data_source' ), 'GitHub fetch handler routes homeboy_ci_results data source' );
 	$assert( str_contains( $settings_source, "'homeboy_ci_results'" ), 'handler settings expose homeboy_ci_results data source' );

--- a/tests/smoke-github-readonly-tools.php
+++ b/tests/smoke-github-readonly-tools.php
@@ -117,6 +117,11 @@ namespace {
 						'statuses' => array(),
 						'count'    => 0,
 					),
+					'datamachine/get-github-actions-artifact' => array(
+						'success'    => true,
+						'artifact'   => array( 'name' => $parameters['artifact_name'] ?? '' ),
+						'json_files' => array( 'manifest.json' => array( 'schema' => 'example.v1' ) ),
+					),
 					'datamachine/get-github-homeboy-ci-results' => array(
 						'success' => true,
 						'results' => array( 'state' => 'success', 'mode' => 'review' ),
@@ -208,6 +213,14 @@ namespace {
 			'callback' => array( GitHubAbilities::class, 'getCommitStatuses' ),
 			'required' => array( 'repo', 'sha' ),
 			'params'   => array( 'repo' => 'Extra-Chill/data-machine-code', 'sha' => 'abc123' ),
+		),
+		'get_github_actions_artifact'     => array(
+			'ability'  => 'datamachine/get-github-actions-artifact',
+			'method'   => 'handleActionsArtifact',
+			'callback' => array( GitHubAbilities::class, 'getActionsArtifact' ),
+			'required' => array( 'repo', 'artifact_name' ),
+			'optional' => array( 'head_sha', 'pull_number', 'max_artifact_bytes', 'include_json' ),
+			'params'   => array( 'repo' => 'Extra-Chill/data-machine-code', 'head_sha' => 'abc123', 'artifact_name' => 'homeboy-ci-results' ),
 		),
 		'get_github_homeboy_ci_results'  => array(
 			'ability'  => 'datamachine/get-github-homeboy-ci-results',


### PR DESCRIPTION
## Summary
- Add a generic `datamachine/get-github-actions-artifact` ability that retrieves GitHub Actions artifacts by repo, pull number/head SHA, and artifact name.
- Return generic artifact metadata plus parsed JSON files without interpreting Homeboy-specific result semantics.
- Keep the Homeboy CI results ability as a deprecated compatibility wrapper and expose a generic read-only tool.

## Tests
- `php tests/smoke-github-homeboy-ci-results.php`
- `php tests/smoke-github-readonly-tools.php`
- `homeboy lint --changed-only --path /Users/chubes/Developer/data-machine-code@fix-generic-github-actions-artifacts --summary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation and smoke test updates; Chris requested the issue fix and immediate PR merge.