### PR TITLE
Add workspace patch application

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -439,6 +439,50 @@ class WorkspaceAbilities {
 			);
 
 			wp_register_ability(
+				'datamachine/workspace-apply-patch',
+				array(
+					'label'               => 'Apply Workspace Patch',
+					'description'         => 'Apply a unified diff to a workspace repository through git apply. Mutating ops on the primary checkout require allow_primary_mutation=true. The patch is checked before apply and fails closed on context mismatch.',
+					'category'            => 'datamachine-code-workspace',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'repo'                   => array(
+								'type'        => 'string',
+								'description' => 'Workspace handle: `<repo>` (primary) or `<repo>@<branch-slug>` (worktree).',
+							),
+							'patch'                 => array(
+								'type'        => 'string',
+								'description' => 'Unified diff content to apply.',
+							),
+							'allow_primary_mutation' => array(
+								'type'        => 'boolean',
+								'description' => 'Permit mutation on the primary checkout (default false). Worktrees are always allowed.',
+							),
+						),
+						'required'   => array( 'repo', 'patch' ),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'       => array( 'type' => 'boolean' ),
+							'name'          => array( 'type' => 'string' ),
+							'path'          => array( 'type' => 'string' ),
+							'changed_files' => array(
+								'type'  => 'array',
+								'items' => array( 'type' => 'string' ),
+							),
+							'diff'          => array( 'type' => 'string' ),
+							'status'        => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'applyPatch' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
 				'datamachine/workspace-git-status',
 				array(
 					'label'               => 'Workspace Git Status',
@@ -1836,6 +1880,23 @@ class WorkspaceAbilities {
 			$input['old_string'] ?? '',
 			$input['new_string'] ?? '',
 			! empty( $input['replace_all'] )
+		);
+	}
+
+	/**
+	 * Apply a unified diff to a workspace repo.
+	 *
+	 * @param array $input Input parameters with 'repo', 'patch', optional 'allow_primary_mutation'.
+	 * @return array Result.
+	 */
+	public static function applyPatch( array $input ): array|\WP_Error {
+		$workspace = new Workspace();
+		$writer    = new WorkspaceWriter( $workspace );
+
+		return $writer->apply_patch(
+			$input['repo'] ?? '',
+			$input['patch'] ?? '',
+			! empty( $input['allow_primary_mutation'] )
 		);
 	}
 

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1257,6 +1257,104 @@ class WorkspaceCommand extends BaseCommand {
 	}
 
 	/**
+	 * Apply a unified diff to a workspace repo.
+	 *
+	 * The diff is validated with `git apply --check` before any mutation. On
+	 * success, the command returns changed files plus diff/status evidence for
+	 * the normal workspace git add/commit/push/PR flow.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <operation>
+	 * : Patch operation. Currently only: apply
+	 *
+	 * <repo>
+	 * : Workspace handle: `<repo>` (primary) or `<repo>@<branch-slug>` (worktree).
+	 *
+	 * [--patch=<patch>]
+	 * : Unified diff content. Prefix with @ to read from a local file. If omitted, reads from stdin.
+	 *
+	 * [--allow-primary-mutation]
+	 * : Permit mutation on the primary checkout (default off). Worktrees are always allowed.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Apply a reviewed patch file in a worktree
+	 *     wp datamachine-code workspace patch apply data-machine-code@fix-ci --patch=@/tmp/fix.diff
+	 *
+	 *     # Apply from stdin
+	 *     git diff | wp datamachine-code workspace patch apply data-machine-code@fix-ci
+	 *
+	 * @subcommand patch
+	 */
+	public function patch( array $args, array $assoc_args ): void {
+		$operation = (string) ( $args[0] ?? '' );
+		$repo      = (string) ( $args[1] ?? '' );
+
+		if ( 'apply' !== $operation || '' === $repo ) {
+			WP_CLI::error( 'Usage: wp datamachine-code workspace patch apply <repo> [--patch=<diff>] [--allow-primary-mutation]' );
+			return;
+		}
+
+		$ability = wp_get_ability( 'datamachine/workspace-apply-patch' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'Workspace apply patch ability not available.' );
+			return;
+		}
+
+		$patch = $assoc_args['patch'] ?? null;
+		if ( null !== $patch ) {
+			$patch = $this->resolveAtFile( (string) $patch );
+		}
+
+		if ( null === $patch ) {
+			if ( function_exists( 'posix_isatty' ) && posix_isatty( STDIN ) ) {
+				WP_CLI::error( 'No patch provided. Use --patch=<diff>, --patch=@/tmp/fix.diff, or pipe a unified diff via stdin.' );
+				return;
+			}
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			$patch = file_get_contents( 'php://stdin' );
+			if ( false === $patch ) {
+				WP_CLI::error( 'Failed to read patch from stdin.' );
+				return;
+			}
+		}
+
+		$result = $ability->execute(
+			array(
+				'repo'                   => $repo,
+				'patch'                 => $patch,
+				'allow_primary_mutation' => ! empty( $assoc_args['allow-primary-mutation'] ),
+			)
+		);
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
+
+		if ( 'json' === (string) ( $assoc_args['format'] ?? 'table' ) ) {
+			WP_CLI::log( (string) wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		$changed_files = is_array( $result['changed_files'] ?? null ) ? $result['changed_files'] : array();
+		WP_CLI::success( sprintf( 'Applied patch to %s (%d changed file%s).', $repo, count( $changed_files ), 1 === count( $changed_files ) ? '' : 's' ) );
+		foreach ( $changed_files as $file ) {
+			WP_CLI::log( '  - ' . $file );
+		}
+	}
+
+	/**
 	 * Delete a tracked or untracked path from a workspace repo.
 	 *
 	 * Tracked paths are removed via `git rm` (working tree + index in one

--- a/inc/Workspace/WorkspaceWriter.php
+++ b/inc/Workspace/WorkspaceWriter.php
@@ -16,6 +16,7 @@
 namespace DataMachineCode\Workspace;
 
 use DataMachine\Core\FilesRepository\FilesystemHelper;
+use DataMachineCode\Support\GitRunner;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -192,6 +193,110 @@ class WorkspaceWriter {
 	}
 
 	/**
+	 * Apply a unified diff to a workspace repo using git's context checks.
+	 *
+	 * The patch is checked before it is applied, so stale context or mismatched
+	 * file contents fail closed without mutating the checkout.
+	 *
+	 * @param string $name                   Workspace handle.
+	 * @param string $patch                  Unified diff to apply.
+	 * @param bool   $allow_primary_mutation Permit mutation on a primary checkout.
+	 * @return array{success: bool, name: string, path: string, changed_files: string[], diff: string, status: string, check_output: string, apply_output: string}|\WP_Error
+	 */
+	public function apply_patch( string $name, string $patch, bool $allow_primary_mutation = false ): array|\WP_Error {
+		$repo_path = $this->workspace->get_repo_path( $name );
+		$parsed    = $this->workspace->parse_handle( $name );
+
+		if ( ! is_dir( $repo_path ) ) {
+			return new \WP_Error( 'repo_not_found', sprintf( 'Repository "%s" not found in workspace.', $name ), array( 'status' => 404 ) );
+		}
+
+		if ( empty( $parsed['is_worktree'] ) && ! $allow_primary_mutation ) {
+			return new \WP_Error(
+				'primary_mutation_blocked',
+				sprintf(
+					'Primary checkout "%s" is read-only by default. Pass allow_primary_mutation=true to operate on it, or use a worktree handle (e.g. %s@<branch-slug>).',
+					$parsed['repo'],
+					$parsed['repo']
+				),
+				array( 'status' => 403 )
+			);
+		}
+
+		$patch = str_replace( "\r\n", "\n", $patch );
+		if ( '' === trim( $patch ) ) {
+			return new \WP_Error( 'empty_patch', 'Patch content is required.', array( 'status' => 400 ) );
+		}
+
+		if ( false === strpos( $patch, '--- ' ) || false === strpos( $patch, '+++ ' ) || false === strpos( $patch, '@@' ) ) {
+			return new \WP_Error( 'invalid_patch', 'Patch must be a unified diff with file headers and at least one hunk.', array( 'status' => 400 ) );
+		}
+
+		$temp = function_exists( 'wp_tempnam' ) ? wp_tempnam( 'datamachine-code-patch-' ) : tempnam( sys_get_temp_dir(), 'datamachine-code-patch-' );
+		if ( ! is_string( $temp ) || '' === $temp ) {
+			return new \WP_Error( 'patch_tempfile_failed', 'Failed to create a temporary patch file.', array( 'status' => 500 ) );
+		}
+
+		try {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+			$bytes = file_put_contents( $temp, $patch );
+			if ( false === $bytes ) {
+				return new \WP_Error( 'patch_tempfile_failed', 'Failed to write the temporary patch file.', array( 'status' => 500 ) );
+			}
+
+			$patch_arg = escapeshellarg( $temp );
+			$check     = GitRunner::run( $repo_path, 'apply --check --whitespace=nowarn ' . $patch_arg );
+			if ( is_wp_error( $check ) ) {
+				return new \WP_Error(
+					'patch_check_failed',
+					'Patch did not apply cleanly: ' . $check->get_error_message(),
+					array(
+						'status' => 400,
+						'output' => $check->get_error_data()['output'] ?? '',
+					)
+				);
+			}
+
+			$apply = GitRunner::run( $repo_path, 'apply --whitespace=nowarn ' . $patch_arg );
+			if ( is_wp_error( $apply ) ) {
+				return new \WP_Error(
+					'patch_apply_failed',
+					'Patch check passed but apply failed: ' . $apply->get_error_message(),
+					array(
+						'status' => 500,
+						'output' => $apply->get_error_data()['output'] ?? '',
+					)
+				);
+			}
+
+			$diff    = GitRunner::run( $repo_path, 'diff --no-ext-diff --binary' );
+			$status  = GitRunner::run( $repo_path, 'status --porcelain --untracked-files=all' );
+			$changed = GitRunner::run( $repo_path, 'diff --name-only' );
+			$status_output = is_wp_error( $status ) ? '' : $status['output'];
+			$changed_files = array_unique( array_merge(
+				$this->split_git_lines( is_wp_error( $changed ) ? '' : $changed['output'] ),
+				$this->changed_files_from_status( $status_output )
+			) );
+
+			return array(
+				'success'       => true,
+				'name'          => $name,
+				'path'          => $repo_path,
+				'changed_files' => array_values( $changed_files ),
+				'diff'          => is_wp_error( $diff ) ? '' : $diff['output'],
+				'status'        => $status_output,
+				'check_output'  => $check['output'],
+				'apply_output'  => $apply['output'],
+			);
+		} finally {
+			if ( is_file( $temp ) ) {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+				unlink( $temp );
+			}
+		}
+	}
+
+	/**
 	 * Check if a relative path contains traversal components.
 	 *
 	 * @param string $path Relative path to check.
@@ -205,5 +310,50 @@ class WorkspaceWriter {
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * Split git command output into non-empty lines.
+	 *
+	 * @param string $output Git command output.
+	 * @return string[]
+	 */
+	private function split_git_lines( string $output ): array {
+		$lines = preg_split( '/\r?\n/', trim( $output ) );
+		if ( false === $lines ) {
+			return array();
+		}
+
+		return array_values( array_filter( array_map( 'trim', $lines ), static fn( string $line ): bool => '' !== $line ) );
+	}
+
+	/**
+	 * Extract changed paths from git status porcelain output, including untracked files.
+	 *
+	 * @param string $status Git status --porcelain output.
+	 * @return string[]
+	 */
+	private function changed_files_from_status( string $status ): array {
+		$files = array();
+		$lines = preg_split( '/\r?\n/', rtrim( $status ) );
+		if ( false === $lines ) {
+			return array();
+		}
+
+		foreach ( $lines as $line ) {
+			if ( strlen( $line ) < 4 ) {
+				continue;
+			}
+			$path = trim( substr( $line, 3 ) );
+			if ( str_contains( $path, ' -> ' ) ) {
+				$parts = explode( ' -> ', $path );
+				$path  = trim( (string) end( $parts ) );
+			}
+			if ( '' !== $path ) {
+				$files[] = $path;
+			}
+		}
+
+		return array_values( array_unique( $files ) );
 	}
 }

--- a/tests/smoke-workspace-apply-patch.php
+++ b/tests/smoke-workspace-apply-patch.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Smoke test for workspace unified patch application.
+ *
+ * Run: php tests/smoke-workspace-apply-patch.php
+ */
+
+declare( strict_types=1 );
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			public string $code;
+			public string $message;
+			public array $data;
+
+			public function __construct( $code = '', $message = '', $data = array() ) {
+				$this->code    = (string) $code;
+				$this->message = (string) $message;
+				$this->data    = (array) $data;
+			}
+
+			public function get_error_code(): string {
+				return $this->code;
+			}
+
+			public function get_error_message(): string {
+				return $this->message;
+			}
+
+			public function get_error_data(): array {
+				return $this->data;
+			}
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $thing ): bool {
+			return $thing instanceof \WP_Error;
+		}
+	}
+}
+
+namespace DataMachine\Core\FilesRepository {
+	class FilesystemHelper {
+		public static function get(): self {
+			return new self();
+		}
+
+		public function is_writable( string $path ): bool {
+			return is_writable( $path );
+		}
+	}
+}
+
+namespace {
+	require __DIR__ . '/../inc/Support/GitRunner.php';
+	require __DIR__ . '/../inc/Workspace/Workspace.php';
+	require __DIR__ . '/../inc/Workspace/WorkspaceWriter.php';
+
+	$failures = 0;
+	$total    = 0;
+
+	$assert = function ( $expected, $actual, string $message ) use ( &$failures, &$total ): void {
+		$total++;
+		if ( $expected === $actual ) {
+			echo "  ✓ {$message}\n";
+			return;
+		}
+		$failures++;
+		echo "  ✗ {$message}\n";
+		echo '    expected: ' . var_export( $expected, true ) . "\n";
+		echo '    actual:   ' . var_export( $actual, true ) . "\n";
+	};
+
+	$run = function ( string $command, string $cwd ): void {
+		exec( 'cd ' . escapeshellarg( $cwd ) . ' && ' . $command . ' 2>&1', $output, $exit_code );
+		if ( 0 !== $exit_code ) {
+			throw new RuntimeException( implode( "\n", $output ) );
+		}
+	};
+
+	$tmp = sys_get_temp_dir() . '/dmc-workspace-apply-patch-' . bin2hex( random_bytes( 4 ) );
+	mkdir( $tmp, 0755, true );
+	register_shutdown_function( function () use ( $tmp ) {
+		if ( is_dir( $tmp ) ) {
+			exec( 'rm -rf ' . escapeshellarg( $tmp ) );
+		}
+	} );
+
+	define( 'DATAMACHINE_WORKSPACE_PATH', $tmp );
+
+	$worktree = $tmp . '/demo@ci-fix';
+	mkdir( $worktree, 0755, true );
+	$run( 'git init -q && git config user.email t@example.com && git config user.name Test', $worktree );
+	file_put_contents( $worktree . '/README.md', "one\n" );
+	$run( 'git add README.md && git commit -q -m initial', $worktree );
+
+	$primary = $tmp . '/demo';
+	mkdir( $primary, 0755, true );
+	$run( 'git init -q && git config user.email t@example.com && git config user.name Test', $primary );
+
+	file_put_contents( $worktree . '/README.md', "two\n" );
+	exec( 'cd ' . escapeshellarg( $worktree ) . ' && git diff -- README.md 2>&1', $patch_output, $patch_exit );
+	if ( 0 !== $patch_exit ) {
+		throw new RuntimeException( implode( "\n", $patch_output ) );
+	}
+	$patch = implode( "\n", $patch_output ) . "\n";
+	file_put_contents( $worktree . '/README.md', "one\n" );
+
+	echo "Workspace apply patch\n";
+
+	$writer = new \DataMachineCode\Workspace\WorkspaceWriter( new \DataMachineCode\Workspace\Workspace() );
+	$result = $writer->apply_patch( 'demo@ci-fix', $patch );
+	$assert( false, is_wp_error( $result ), 'patch applies to a worktree handle' );
+	$assert( "two\n", file_get_contents( $worktree . '/README.md' ), 'patch mutates file content' );
+	$assert( array( 'README.md' ), is_wp_error( $result ) ? array() : ( $result['changed_files'] ?? array() ), 'changed file evidence is returned' );
+	$assert( true, is_wp_error( $result ) ? false : str_contains( (string) ( $result['diff'] ?? '' ), '+two' ), 'diff evidence includes applied change' );
+
+	$again = $writer->apply_patch( 'demo@ci-fix', $patch );
+	$assert( true, is_wp_error( $again ), 'stale patch fails closed' );
+	$assert( 'patch_check_failed', is_wp_error( $again ) ? $again->get_error_code() : '', 'stale patch fails during check phase' );
+	$assert( "two\n", file_get_contents( $worktree . '/README.md' ), 'failed check does not mutate file content' );
+
+	$blocked = $writer->apply_patch( 'demo', $patch );
+	$assert( true, is_wp_error( $blocked ), 'primary checkout mutation is blocked by default' );
+	$assert( 'primary_mutation_blocked', is_wp_error( $blocked ) ? $blocked->get_error_code() : '', 'primary block uses expected error code' );
+
+	if ( $failures > 0 ) {
+		echo "\n{$failures} of {$total} assertions failed.\n";
+		exit( 1 );
+	}
+
+	echo "\nAll {$total} workspace apply patch assertions passed.\n";
+}


### PR DESCRIPTION
## Summary
- Adds a CLI-only `datamachine/workspace-apply-patch` ability that validates unified diffs with `git apply --check` before mutating workspace checkouts.
- Adds `wp datamachine-code workspace patch apply <repo>` for patch files or stdin, returning changed files, diff, and status evidence for the existing commit/push/PR workflow.
- Covers worktree patch application, stale-context fail-closed behavior, and primary checkout mutation blocking with a pure-PHP smoke test.

## Testing
- `php -l inc/Workspace/WorkspaceWriter.php && php -l inc/Abilities/WorkspaceAbilities.php && php -l inc/Cli/Commands/WorkspaceCommand.php && php -l tests/smoke-workspace-apply-patch.php`
- `php tests/smoke-workspace-apply-patch.php`
- `php tests/smoke-worktree-handles.php`
- `composer validate --no-check-publish` (passes with existing warning about the `version` field)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the workspace patch primitive, CLI/ability wiring, smoke coverage, and local validation; Chris remains responsible for review and merge.

Fixes #276