### PR TITLE
Add targeted GitHub fetch by issue_number / pull_number

### DIFF
--- a/inc/Handlers/GitHub/GitHub.php
+++ b/inc/Handlers/GitHub/GitHub.php
@@ -492,8 +492,15 @@ class GitHub extends FetchHandler {
 	 * @return array DataPacket-compatible array or empty on no data.
 	 */
 	private function fetchIssuesOrPulls( array $config, ExecutionContext $context, string $repo, string $data_source ): array {
-		$state  = $config['state'] ?? 'open';
-		$labels = $config['labels'] ?? '';
+		$state         = $config['state'] ?? 'open';
+		$labels        = $config['labels'] ?? '';
+		$issue_number  = (int) ( $config['issue_number'] ?? 0 );
+		$pull_number   = (int) ( $config['pull_number'] ?? 0 );
+
+		// Targeted single-item fetch by issue_number / pull_number.
+		if ( $issue_number > 0 || $pull_number > 0 ) {
+			return $this->fetchSingleIssueOrPull( $config, $context, $repo, $data_source, $issue_number, $pull_number );
+		}
 
 		$input = array(
 			'repo'     => $repo,
@@ -588,6 +595,135 @@ class GitHub extends FetchHandler {
 
 		$context->log( 'info', sprintf( 'GitHub: Found %d eligible items.', count( $eligible_items ) ) );
 		return array( 'items' => $eligible_items );
+	}
+
+	/**
+	 * Fetch a single issue or pull request by number.
+	 *
+	 * Targeted-fetch branch of {@see self::fetchIssuesOrPulls()}. Bypasses
+	 * list filters (search, exclude_keywords, timeframe_limit, timeframe,
+	 * labels) and returns one normalized DataPacket matching the list-path
+	 * shape (same `title`, `content`, `metadata`, and `dedup_key` of
+	 * `github_<repo>_<data_source>_<number>`).
+	 *
+	 * @param array            $config       Handler configuration.
+	 * @param ExecutionContext $context      Execution context.
+	 * @param string           $repo         Repository in owner/repo format.
+	 * @param string           $data_source  'issues' or 'pulls'.
+	 * @param int              $issue_number Targeted issue number (0 if unused).
+	 * @param int              $pull_number  Targeted pull number (0 if unused).
+	 * @return array DataPacket-compatible array or empty on validation/state error.
+	 */
+	private function fetchSingleIssueOrPull(
+		array $config,
+		ExecutionContext $context,
+		string $repo,
+		string $data_source,
+		int $issue_number,
+		int $pull_number
+	): array {
+		// Mutual exclusion.
+		if ( $issue_number > 0 && $pull_number > 0 ) {
+			$context->log( 'error', 'GitHub: issue_number and pull_number are mutually exclusive — set one, not both.' );
+			return array();
+		}
+
+		// data_source alignment.
+		if ( $issue_number > 0 && 'issues' !== $data_source ) {
+			$context->log( 'error', sprintf( 'GitHub: issue_number requires data_source=issues (got %s).', $data_source ) );
+			return array();
+		}
+
+		if ( $pull_number > 0 && 'pulls' !== $data_source ) {
+			$context->log( 'error', sprintf( 'GitHub: pull_number requires data_source=pulls (got %s).', $data_source ) );
+			return array();
+		}
+
+		// Warn on ignored list-narrowing config.
+		$ignored_fields = array();
+		foreach ( array( 'search', 'exclude_keywords', 'timeframe_limit', 'timeframe', 'labels' ) as $field ) {
+			if ( ! empty( $config[ $field ] ) && 'all_time' !== $config[ $field ] ) {
+				$ignored_fields[] = $field;
+			}
+		}
+		if ( ! empty( $ignored_fields ) ) {
+			$context->log( 'info', 'GitHub: targeted fetch ignores list filters: ' . implode( ', ', $ignored_fields ) );
+		}
+
+		$number          = $issue_number > 0 ? $issue_number : $pull_number;
+		$expected_state  = $config['state'] ?? 'open';
+
+		if ( 'pulls' === $data_source ) {
+			$result = GitHubAbilities::getPull( array(
+				'repo'        => $repo,
+				'pull_number' => $number,
+			) );
+		} else {
+			$result = GitHubAbilities::getIssue( array(
+				'repo'         => $repo,
+				'issue_number' => $number,
+			) );
+		}
+
+		if ( is_wp_error( $result ) ) {
+			$context->log( 'error', 'GitHub: API error — ' . $result->get_error_message() );
+			return array();
+		}
+
+		$item = 'pulls' === $data_source ? ( $result['pull'] ?? array() ) : ( $result['issue'] ?? array() );
+
+		if ( empty( $item ) ) {
+			$context->log( 'info', sprintf( 'GitHub: No %s found for #%d.', $data_source, $number ) );
+			return array();
+		}
+
+		// State filter (mirrors list-path implicit filtering via API state param).
+		$item_state = (string) ( $item['state'] ?? '' );
+		if ( 'all' !== $expected_state && $item_state !== $expected_state ) {
+			$context->log( 'info', sprintf(
+				'GitHub: Targeted %s #%d state=%s does not match configured state=%s — dropping.',
+				$data_source,
+				$number,
+				$item_state,
+				$expected_state
+			) );
+			return array();
+		}
+
+		$context->log( 'info', sprintf( 'GitHub: Targeted fetch for %s #%d from %s', $data_source, $number, $repo ) );
+
+		$guid       = sprintf( 'github_%s_%s_%d', $repo, $data_source, $item['number'] );
+		$labels_str = ! empty( $item['labels'] ) ? implode( ', ', $item['labels'] ) : '';
+
+		if ( 'pulls' === $data_source ) {
+			$title   = sprintf( 'PR #%d: %s', $item['number'], $item['title'] );
+			$content = $this->buildPrContent( $item );
+		} else {
+			$title   = sprintf( 'Issue #%d: %s', $item['number'], $item['title'] );
+			$content = $this->buildIssueContent( $item );
+		}
+
+		$packet = array(
+			'title'    => $title,
+			'content'  => $content,
+			'metadata' => array(
+				'source_type'       => 'github',
+				'original_id'       => $guid,
+				'dedup_key'         => $guid,
+				'original_title'    => $item['title'] ?? '',
+				'original_date_gmt' => $item['created_at'] ?? '',
+				'github_repo'       => $repo,
+				'github_type'       => $data_source,
+				'github_number'     => $item['number'],
+				'github_state'      => $item['state'] ?? '',
+				'github_labels'     => $labels_str,
+				'github_user'       => $item['user'] ?? '',
+				'github_url'        => $item['html_url'] ?? '',
+				'source_url'        => $item['html_url'] ?? '',
+			),
+		);
+
+		return array( 'items' => array( $packet ) );
 	}
 
 	/**

--- a/inc/Handlers/GitHub/GitHubSettings.php
+++ b/inc/Handlers/GitHub/GitHubSettings.php
@@ -55,11 +55,21 @@ class GitHubSettings extends FetchHandlerSettings {
 				'description' => __( 'Commit SHA, branch, or tag ref for check runs and commit statuses. Falls back to Expected Head SHA.', 'data-machine-code' ),
 				'required'    => false,
 			),
+			'issue_number'            => array(
+				'type'        => 'number',
+				'label'       => __( 'Issue Number (Targeted Fetch)', 'data-machine-code' ),
+				'description' => __( 'Fetch one specific issue by number (data_source=issues). Mutually exclusive with Pull Request Number. Takes precedence over list filters (search, exclude_keywords, timeframe_limit, labels).', 'data-machine-code' ),
+				'required'    => false,
+				'min'         => 1,
+				'default'     => 0,
+			),
 			'pull_number'             => array(
 				'type'        => 'number',
 				'label'       => __( 'Pull Request Number', 'data-machine-code' ),
-				'description' => __( 'Pull request number to prepare for review context.', 'data-machine-code' ),
+				'description' => __( 'Pull request number. For data_source=pull_review_context this prepares review context; for data_source=pulls this performs a targeted single-PR fetch. Mutually exclusive with Issue Number. Takes precedence over list filters (search, exclude_keywords, timeframe_limit, labels).', 'data-machine-code' ),
 				'required'    => false,
+				'min'         => 1,
+				'default'     => 0,
 			),
 			'head_sha'                => array(
 				'type'        => 'text',

--- a/tests/smoke-github-fetch-by-number.php
+++ b/tests/smoke-github-fetch-by-number.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Smoke tests for GitHub fetch handler targeted fetch by issue_number / pull_number.
+ *
+ * Run with: php tests/smoke-github-fetch-by-number.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+declare(strict_types=1);
+
+$root     = dirname( __DIR__ );
+$handler  = file_get_contents( $root . '/inc/Handlers/GitHub/GitHub.php' );
+$settings = file_get_contents( $root . '/inc/Handlers/GitHub/GitHubSettings.php' );
+
+$failures = array();
+
+$assert = static function ( bool $condition, string $message ) use ( &$failures ): void {
+	if ( $condition ) {
+		echo "PASS: {$message}\n";
+		return;
+	}
+
+	echo "FAIL: {$message}\n";
+	$failures[] = $message;
+};
+
+// Handler config reads.
+$assert( false !== strpos( $handler, "\$issue_number  = (int) ( \$config['issue_number'] ?? 0 )" ), 'handler reads issue_number from config' );
+$assert( false !== strpos( $handler, "\$pull_number   = (int) ( \$config['pull_number'] ?? 0 )" ), 'handler reads pull_number from config' );
+
+// Targeted-fetch dispatch.
+$assert( false !== strpos( $handler, 'fetchSingleIssueOrPull' ), 'handler dispatches to fetchSingleIssueOrPull when a number is set' );
+$assert( false !== strpos( $handler, 'if ( $issue_number > 0 || $pull_number > 0 )' ), 'handler branches on either number being set' );
+
+// Abilities calls (use the actual method names that exist in GitHubAbilities).
+$assert( false !== strpos( $handler, 'GitHubAbilities::getIssue' ), 'handler calls GitHubAbilities::getIssue for targeted issue fetch' );
+$assert( false !== strpos( $handler, 'GitHubAbilities::getPull' ), 'handler calls GitHubAbilities::getPull for targeted pull fetch' );
+
+// Mutual exclusion error path.
+$assert( false !== strpos( $handler, 'mutually exclusive' ), 'handler enforces issue_number/pull_number mutual exclusion with an error log' );
+
+// data_source alignment checks.
+$assert( false !== strpos( $handler, "issue_number > 0 && 'issues' !== \$data_source" ), 'handler validates issue_number requires data_source=issues' );
+$assert( false !== strpos( $handler, "pull_number > 0 && 'pulls' !== \$data_source" ), 'handler validates pull_number requires data_source=pulls' );
+
+// List-filter ignore log.
+$assert( false !== strpos( $handler, 'targeted fetch ignores list filters' ), 'handler logs ignored list filters in targeted mode' );
+
+// State drop log.
+$assert( false !== strpos( $handler, 'does not match configured state' ), 'handler drops items whose state does not match configured state' );
+
+// DataPacket shape parity (same dedup_key format as list path).
+$assert( false !== strpos( $handler, "sprintf( 'github_%s_%s_%d', \$repo, \$data_source, \$item['number'] )" ), 'targeted packet uses the same dedup_key shape as the list path' );
+$assert( false !== strpos( $handler, "'source_type'       => 'github'" ), 'targeted packet metadata uses source_type=github' );
+$assert( false !== strpos( $handler, 'buildIssueContent' ) && false !== strpos( $handler, 'buildPrContent' ), 'targeted path reuses buildIssueContent / buildPrContent for parity' );
+
+// Settings schema fields.
+$assert( false !== strpos( $settings, "'issue_number'" ), 'settings expose issue_number field' );
+$assert( false !== strpos( $settings, "'pull_number'" ), 'settings expose pull_number field' );
+$assert( false !== strpos( $settings, 'Mutually exclusive with Pull Request Number' ), 'issue_number help text mentions mutual exclusion' );
+$assert( false !== strpos( $settings, 'Mutually exclusive with Issue Number' ), 'pull_number help text mentions mutual exclusion' );
+$assert( false !== strpos( $settings, 'Takes precedence over list filters' ), 'settings help text documents precedence over list filters' );
+
+echo "\n";
+if ( empty( $failures ) ) {
+	echo "OK: GitHub fetch-by-number smoke assertions passed.\n";
+	exit( 0 );
+}
+
+echo sprintf( "FAILED: %d assertion(s) failed.\n", count( $failures ) );
+exit( 1 );


### PR DESCRIPTION
## Summary

- Add optional `issue_number` and `pull_number` config fields to the GitHub fetch handler. When set, the handler bypasses `GitHubAbilities::listIssues` / `listPulls` and calls `getIssue` / `getPull` for one targeted item, normalized into the existing list-path DataPacket shape (same `title`, `content`, `metadata.github_*`, `dedup_key = github_<repo>_<data_source>_<number>`).
- Enforce validation: numbers are mutually exclusive, `data_source` must align (`issues` ↔ `issue_number`, `pulls` ↔ `pull_number`), state mismatches drop the item with an info log, and list-narrowing config (`search`, `exclude_keywords`, `timeframe_limit`, `timeframe`, `labels`) is ignored in targeted mode (logged for transparency).
- List-path behavior is untouched. When neither number is set, the handler behaves exactly as before.

Refs #279

## Why

Single-item agent runs from CI `workflow_dispatch`, webhook responders, retry-by-number flows, and Intelligence flows need to hydrate one specific issue or PR as the source of truth. Today the only options are prompt injection, brittle title-based search, or bypassing the fetch step from a probe — all paper-overs that break the bundle's flow contract. This lands the upstream-first fix so every consumer can opt into targeted fetch with `handler_config.github.issue_number = N` (or `pull_number`) and skip the workaround.

## Downstream consumer

Unblocks chubes4/wc-site-generator#99 (Phase 1 wc-static-site-agent CI workflow). Once this merges, that probe just sets `handler_config.github.issue_number = $issue_number` from `workflow_dispatch` and runs the imported flow unchanged — no shim, no prompt injection, no bypass.

## Files changed

- `inc/Handlers/GitHub/GitHub.php` — new `fetchSingleIssueOrPull` branch in `fetchIssuesOrPulls`, reusing `buildIssueContent` / `buildPrContent` for shape parity.
- `inc/Handlers/GitHub/GitHubSettings.php` — add `issue_number` field; refresh `pull_number` description to document targeted-fetch precedence and mutual exclusion.
- `tests/smoke-github-fetch-by-number.php` — file-content-grep smoke test (no network) covering config reads, abilities calls, mutual-exclusion error path, `data_source` alignment, ignored-filter log, dedup_key shape parity, and settings schema fields.

## Checks

- `php -l` clean on all three files.
- `php tests/smoke-github-fetch-by-number.php` exits 0 (19/19 PASS).
- No network calls in tests; no live WordPress required.

## Notes / deviations

- The abilities method for pulls is `GitHubAbilities::getPull()` (not `getPullRequest()`); the handler uses the actual method name. Issue spec mentioned both — used what exists.
- `pull_number` field already existed for `pull_review_context`. Reused it: when `data_source=pulls` it triggers targeted fetch; when `data_source=pull_review_context` the existing review-context path still consumes it. Description updated to disambiguate.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting handler changes, settings field, smoke test, and PR description per the upstream-first scope from issue #279.