### PR TITLE
Add exclude_labels to GitHub fetch handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,20 @@ array(
 
 Workspace git policies are configured via the `datamachine_workspace_git_policies` option for per-repo write/push controls.
 
+### GitHub fetch handler config
+
+The GitHub fetch handler (`data_source: issues` or `pulls`) supports both server-side and post-fetch label/keyword filters. Server-side `labels` is forwarded to GitHub's REST `list issues` / `list pulls` endpoints; the post-fetch filters run after the API call and trim the in-memory result set.
+
+| Field | Tier | Semantics |
+|---|---|---|
+| `labels` | server-side | Comma-separated label names. Forwarded to the GitHub REST endpoint. ANY-match include. |
+| `exclude_labels` | post-fetch | Comma-separated label names. ANY-match drop, case-insensitive. Empty/missing is a no-op. Applies to both `issues` and `pulls`. |
+| `exclude_keywords` | post-fetch | Comma-separated terms matched against title + body. ANY-match drop. |
+| `search` | post-fetch | Required-keyword filter against title + body. |
+| `timeframe_limit` | post-fetch | Bounds items by `created_at`. |
+
+GitHub's REST `list issues` endpoint does not support negative label syntax, so `exclude_labels` is implemented as a post-fetch array intersection — symmetric with `exclude_keywords` in the same handler. Combine `labels` (positive, server-side) with `exclude_labels` (negative, post-fetch) to express "match these AND NOT those" in flow JSON without an AI-step prompt guard. Dropped items are logged at `debug` with the offending label(s).
+
 ### Workspace maintenance pipelines
 
 DMC registers bundled, agent-generic Data Machine pipeline templates for recurring workspace maintenance. They are discoverable through the normal pipeline surface:

--- a/inc/Handlers/GitHub/GitHub.php
+++ b/inc/Handlers/GitHub/GitHub.php
@@ -532,10 +532,19 @@ class GitHub extends FetchHandler {
 
 		$context->log( 'info', sprintf( 'GitHub: Found %d %s.', count( $items ), $data_source ) );
 
-		$search           = $config['search'] ?? '';
-		$exclude_keywords = $config['exclude_keywords'] ?? '';
-		$timeframe_limit  = $config['timeframe_limit'] ?? 'all_time';
-		$eligible_items   = array();
+		$search              = $config['search'] ?? '';
+		$exclude_keywords    = $config['exclude_keywords'] ?? '';
+		$exclude_labels_raw  = $config['exclude_labels'] ?? '';
+		$timeframe_limit     = $config['timeframe_limit'] ?? 'all_time';
+		$eligible_items      = array();
+
+		$exclude_labels = array();
+		if ( ! empty( $exclude_labels_raw ) ) {
+			$exclude_labels = array_values( array_filter( array_map(
+				static fn( $label ) => strtolower( trim( (string) $label ) ),
+				explode( ',', (string) $exclude_labels_raw )
+			), static fn( $label ) => '' !== $label ) );
+		}
 
 		foreach ( $items as $item ) {
 			$guid = sprintf( 'github_%s_%s_%d', $repo, $data_source, $item['number'] );
@@ -548,6 +557,22 @@ class GitHub extends FetchHandler {
 
 			if ( ! empty( $exclude_keywords ) && ! $this->applyExcludeKeywords( $searchable_text, $exclude_keywords ) ) {
 				continue;
+			}
+
+			if ( ! empty( $exclude_labels ) && ! empty( $item['labels'] ) ) {
+				$item_labels_lower = array_map(
+					static fn( $label ) => strtolower( (string) $label ),
+					(array) $item['labels']
+				);
+				$hit = array_values( array_intersect( $item_labels_lower, $exclude_labels ) );
+				if ( ! empty( $hit ) ) {
+					$context->log( 'debug', sprintf(
+						'GitHub: skipping #%d — excluded by label(s): %s',
+						$item['number'] ?? 0,
+						implode( ', ', $hit )
+					) );
+					continue;
+				}
 			}
 
 			if ( 'all_time' !== $timeframe_limit && ! empty( $item['created_at'] ) ) {
@@ -601,8 +626,8 @@ class GitHub extends FetchHandler {
 	 * Fetch a single issue or pull request by number.
 	 *
 	 * Targeted-fetch branch of {@see self::fetchIssuesOrPulls()}. Bypasses
-	 * list filters (search, exclude_keywords, timeframe_limit, timeframe,
-	 * labels) and returns one normalized DataPacket matching the list-path
+	 * list filters (search, exclude_keywords, exclude_labels, timeframe_limit,
+	 * timeframe, labels) and returns one normalized DataPacket matching the list-path
 	 * shape (same `title`, `content`, `metadata`, and `dedup_key` of
 	 * `github_<repo>_<data_source>_<number>`).
 	 *
@@ -641,7 +666,7 @@ class GitHub extends FetchHandler {
 
 		// Warn on ignored list-narrowing config.
 		$ignored_fields = array();
-		foreach ( array( 'search', 'exclude_keywords', 'timeframe_limit', 'timeframe', 'labels' ) as $field ) {
+		foreach ( array( 'search', 'exclude_keywords', 'exclude_labels', 'timeframe_limit', 'timeframe', 'labels' ) as $field ) {
 			if ( ! empty( $config[ $field ] ) && 'all_time' !== $config[ $field ] ) {
 				$ignored_fields[] = $field;
 			}

--- a/inc/Handlers/GitHub/GitHubSettings.php
+++ b/inc/Handlers/GitHub/GitHubSettings.php
@@ -58,7 +58,7 @@ class GitHubSettings extends FetchHandlerSettings {
 			'issue_number'            => array(
 				'type'        => 'number',
 				'label'       => __( 'Issue Number (Targeted Fetch)', 'data-machine-code' ),
-				'description' => __( 'Fetch one specific issue by number (data_source=issues). Mutually exclusive with Pull Request Number. Takes precedence over list filters (search, exclude_keywords, timeframe_limit, labels).', 'data-machine-code' ),
+				'description' => __( 'Fetch one specific issue by number (data_source=issues). Mutually exclusive with Pull Request Number. Takes precedence over list filters (search, exclude_keywords, exclude_labels, timeframe_limit, labels).', 'data-machine-code' ),
 				'required'    => false,
 				'min'         => 1,
 				'default'     => 0,
@@ -66,7 +66,7 @@ class GitHubSettings extends FetchHandlerSettings {
 			'pull_number'             => array(
 				'type'        => 'number',
 				'label'       => __( 'Pull Request Number', 'data-machine-code' ),
-				'description' => __( 'Pull request number. For data_source=pull_review_context this prepares review context; for data_source=pulls this performs a targeted single-PR fetch. Mutually exclusive with Issue Number. Takes precedence over list filters (search, exclude_keywords, timeframe_limit, labels).', 'data-machine-code' ),
+				'description' => __( 'Pull request number. For data_source=pull_review_context this prepares review context; for data_source=pulls this performs a targeted single-PR fetch. Mutually exclusive with Issue Number. Takes precedence over list filters (search, exclude_keywords, exclude_labels, timeframe_limit, labels).', 'data-machine-code' ),
 				'required'    => false,
 				'min'         => 1,
 				'default'     => 0,
@@ -202,6 +202,12 @@ class GitHubSettings extends FetchHandlerSettings {
 				'type'        => 'text',
 				'label'       => __( 'Label Filter', 'data-machine-code' ),
 				'description' => __( 'Comma-separated label names to filter by (issues only).', 'data-machine-code' ),
+				'required'    => false,
+			),
+			'exclude_labels'          => array(
+				'type'        => 'text',
+				'label'       => __( 'Exclude Labels', 'data-machine-code' ),
+				'description' => __( 'Comma-separated label names to exclude (post-fetch, ANY-match, case-insensitive). Applies to both issues and pulls. Empty/missing is a no-op. GitHub\'s list endpoints do not support negative labels server-side, so DMC filters after the fetch — symmetric with exclude_keywords.', 'data-machine-code' ),
 				'required'    => false,
 			),
 			'branch'                  => array(

--- a/tests/smoke-github-fetch-exclude-labels.php
+++ b/tests/smoke-github-fetch-exclude-labels.php
@@ -1,0 +1,286 @@
+<?php
+/**
+ * Smoke tests for GitHub fetch handler `exclude_labels` post-fetch filter.
+ *
+ * Static-text assertions on the handler source plus a behavioral check of the
+ * post-fetch filter loop run inline against an in-process stub of the
+ * fetchIssuesOrPulls() filter tier.
+ *
+ * Run with: php tests/smoke-github-fetch-exclude-labels.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+declare(strict_types=1);
+
+$root     = dirname( __DIR__ );
+$handler  = file_get_contents( $root . '/inc/Handlers/GitHub/GitHub.php' );
+$settings = file_get_contents( $root . '/inc/Handlers/GitHub/GitHubSettings.php' );
+$readme   = file_get_contents( $root . '/README.md' );
+
+$failures = array();
+
+$assert = static function ( bool $condition, string $message ) use ( &$failures ): void {
+	if ( $condition ) {
+		echo "PASS: {$message}\n";
+		return;
+	}
+
+	echo "FAIL: {$message}\n";
+	$failures[] = $message;
+};
+
+// ----------------------------------------------------------------------------
+// Static-source assertions on inc/Handlers/GitHub/GitHub.php.
+// ----------------------------------------------------------------------------
+
+$assert(
+	false !== strpos( $handler, "\$exclude_labels_raw  = \$config['exclude_labels'] ?? '';" )
+	|| false !== strpos( $handler, "\$exclude_labels_raw = \$config['exclude_labels'] ?? '';" ),
+	'handler reads exclude_labels from config alongside the existing post-fetch filters'
+);
+
+$assert(
+	false !== strpos( $handler, "explode( ',', (string) \$exclude_labels_raw )" ),
+	'handler explodes exclude_labels on commas like the rest of the comma-separated config fields'
+);
+
+$assert(
+	false !== strpos( $handler, 'strtolower( trim( (string) $label ) )' ),
+	'handler lowercases and trims each parsed exclude_labels entry'
+);
+
+$assert(
+	false !== strpos( $handler, 'array_intersect( $item_labels_lower, $exclude_labels )' ),
+	'handler uses array_intersect for ANY-match exclusion semantics'
+);
+
+$assert(
+	false !== strpos( $handler, "\$context->log( 'debug'," )
+	&& false !== strpos( $handler, 'excluded by label(s):' ),
+	'handler logs dropped items at debug level with the offending label(s)'
+);
+
+$assert(
+	(int) strpos( $handler, '$exclude_keywords' ) > 0
+	&& (int) strpos( $handler, '$exclude_labels_raw' ) > (int) strpos( $handler, '$exclude_keywords' ),
+	'exclude_labels is parsed alongside exclude_keywords (cohesive post-fetch filter tier)'
+);
+
+$assert(
+	(int) strpos( $handler, 'array_intersect( $item_labels_lower, $exclude_labels )' )
+	< (int) strpos( $handler, "if ( 'all_time' !== \$timeframe_limit" ),
+	'exclude_labels filter runs before timeframe_limit, matching issue #281 implementation sketch'
+);
+
+// Targeted-fetch path warns about ignored exclude_labels too.
+$assert(
+	false !== strpos(
+		$handler,
+		"foreach ( array( 'search', 'exclude_keywords', 'exclude_labels', 'timeframe_limit', 'timeframe', 'labels' ) as \$field )"
+	),
+	'targeted-fetch path lists exclude_labels in its ignored-list-filters warning'
+);
+
+// ----------------------------------------------------------------------------
+// Static-source assertions on inc/Handlers/GitHub/GitHubSettings.php.
+// ----------------------------------------------------------------------------
+
+$assert(
+	false !== strpos( $settings, "'exclude_labels'" ),
+	'settings expose exclude_labels field for bundle import/export round-trip'
+);
+
+$assert(
+	false !== strpos( $settings, "Comma-separated label names to exclude" ),
+	'settings describe exclude_labels with comma-separated semantics'
+);
+
+$assert(
+	false !== strpos( $settings, 'ANY-match' ) && false !== strpos( $settings, 'case-insensitive' ),
+	'settings document ANY-match drop and case-insensitive matching'
+);
+
+$assert(
+	false !== strpos( $settings, 'Applies to both issues and pulls' ),
+	'settings document that exclude_labels applies to both issues and pulls'
+);
+
+// Mutual-exclusion / precedence help text mentions exclude_labels.
+$assert(
+	false !== strpos( $settings, 'exclude_labels, timeframe_limit' ),
+	'targeted-fetch help text lists exclude_labels in its list-filter precedence note'
+);
+
+// ----------------------------------------------------------------------------
+// README assertions.
+// ----------------------------------------------------------------------------
+
+$assert(
+	false !== strpos( $readme, '`exclude_labels`' ),
+	'README documents exclude_labels'
+);
+
+$assert(
+	false !== strpos( $readme, '`labels`' ) && false !== strpos( $readme, '`exclude_keywords`' ),
+	'README documents exclude_labels alongside labels and exclude_keywords'
+);
+
+// ----------------------------------------------------------------------------
+// Behavioral coverage of the post-fetch filter logic.
+// We rebuild the exact array_intersect filter the handler runs and exercise
+// the documented cases. This is the source-of-truth for exclude_labels
+// semantics — keep it byte-for-byte aligned with the handler.
+// ----------------------------------------------------------------------------
+
+/**
+ * Mirror of the parse step inside fetchIssuesOrPulls().
+ */
+$parse_exclude_labels = static function ( $raw ): array {
+	if ( empty( $raw ) ) {
+		return array();
+	}
+	return array_values( array_filter( array_map(
+		static fn( $label ) => strtolower( trim( (string) $label ) ),
+		explode( ',', (string) $raw )
+	), static fn( $label ) => '' !== $label ) );
+};
+
+/**
+ * Mirror of the per-item check inside the foreach loop.
+ *
+ * @return array{kept: bool, hit: array<int,string>}
+ */
+$apply_exclude_labels = static function ( array $item_labels, array $exclude_labels ): array {
+	if ( empty( $exclude_labels ) || empty( $item_labels ) ) {
+		return array( 'kept' => true, 'hit' => array() );
+	}
+
+	$item_labels_lower = array_map(
+		static fn( $label ) => strtolower( (string) $label ),
+		$item_labels
+	);
+	$hit = array_values( array_intersect( $item_labels_lower, $exclude_labels ) );
+	if ( ! empty( $hit ) ) {
+		return array( 'kept' => false, 'hit' => $hit );
+	}
+	return array( 'kept' => true, 'hit' => array() );
+};
+
+// Case 1: empty / missing config is a no-op.
+$assert(
+	$parse_exclude_labels( '' ) === array(),
+	'empty exclude_labels parses to empty array (no-op)'
+);
+$assert(
+	$apply_exclude_labels( array( 'bug', 'status:built' ), array() )['kept'] === true,
+	'empty exclude_labels keeps items with any labels (full backward compatibility)'
+);
+$assert(
+	$apply_exclude_labels( array(), array( 'status:built' ) )['kept'] === true,
+	'item with no labels is never dropped by exclude_labels'
+);
+
+// Case 2: single excluded label — exact match drops.
+$single = $apply_exclude_labels(
+	array( 'status:idea-ready', 'status:built' ),
+	$parse_exclude_labels( 'status:built' )
+);
+$assert(
+	false === $single['kept'] && in_array( 'status:built', $single['hit'], true ),
+	'single excluded label: matching item is dropped and hit reports the offending label'
+);
+
+// Case 3: multiple excluded labels — ANY-match drops.
+$multi_drop = $apply_exclude_labels(
+	array( 'status:idea-ready', 'status:abandoned' ),
+	$parse_exclude_labels( 'status:built,status:abandoned' )
+);
+$assert(
+	false === $multi_drop['kept'] && in_array( 'status:abandoned', $multi_drop['hit'], true ),
+	'multiple excluded labels: ANY-match drops on second label'
+);
+
+$multi_keep = $apply_exclude_labels(
+	array( 'status:idea-ready' ),
+	$parse_exclude_labels( 'status:built,status:abandoned' )
+);
+$assert(
+	true === $multi_keep['kept'],
+	'multiple excluded labels: item with no excluded labels is kept'
+);
+
+// Case 4: case-insensitive match.
+$ci = $apply_exclude_labels(
+	array( 'Status:Built' ),
+	$parse_exclude_labels( 'STATUS:built' )
+);
+$assert(
+	false === $ci['kept'] && in_array( 'status:built', $ci['hit'], true ),
+	'case-insensitive match: mixed-case item label and mixed-case config both fold to lower'
+);
+
+// Whitespace tolerance (consistent with comma-separated config in this handler).
+$assert(
+	$parse_exclude_labels( ' status:built , status:abandoned ' )
+		=== array( 'status:built', 'status:abandoned' ),
+	'parse trims whitespace around each comma-separated entry'
+);
+
+// Empty entries from stray commas drop out.
+$assert(
+	$parse_exclude_labels( 'status:built,,status:abandoned,' )
+		=== array( 'status:built', 'status:abandoned' ),
+	'parse skips empty entries from stray commas'
+);
+
+// Case 5: interaction with positive labels filter.
+//   Positive `labels` filter is server-side (forwarded to GitHub list endpoint).
+//   `exclude_labels` runs post-fetch on the returned set. Behaviorally, items
+//   that came back because they matched the positive filter are still subject
+//   to the negative filter and can be dropped.
+$included_by_server = array(
+	array( 'number' => 1, 'labels' => array( 'status:idea-ready' ) ),                          // kept
+	array( 'number' => 2, 'labels' => array( 'status:idea-ready', 'status:built' ) ),          // dropped
+	array( 'number' => 3, 'labels' => array( 'status:idea-ready', 'status:abandoned' ) ),      // dropped
+	array( 'number' => 4, 'labels' => array( 'status:idea-ready', 'priority:high' ) ),         // kept
+);
+$exclude       = $parse_exclude_labels( 'status:built,status:abandoned' );
+$kept_numbers  = array();
+foreach ( $included_by_server as $item ) {
+	$result = $apply_exclude_labels( $item['labels'], $exclude );
+	if ( $result['kept'] ) {
+		$kept_numbers[] = $item['number'];
+	}
+}
+$assert(
+	$kept_numbers === array( 1, 4 ),
+	'interaction with positive labels filter: server-included items are still negatively filtered post-fetch'
+);
+
+// ----------------------------------------------------------------------------
+// PHP lint check on the touched files.
+// ----------------------------------------------------------------------------
+
+foreach ( array(
+	'inc/Handlers/GitHub/GitHub.php',
+	'inc/Handlers/GitHub/GitHubSettings.php',
+) as $relative ) {
+	$path   = $root . '/' . $relative;
+	$output = array();
+	$status = 0;
+	exec( 'php -l ' . escapeshellarg( $path ) . ' 2>&1', $output, $status );
+	$assert(
+		0 === $status,
+		sprintf( 'php -l clean for %s (output: %s)', $relative, trim( implode( "\n", $output ) ) )
+	);
+}
+
+echo "\n";
+if ( empty( $failures ) ) {
+	echo "OK: GitHub exclude_labels smoke assertions passed.\n";
+	exit( 0 );
+}
+
+echo sprintf( "FAILED: %d assertion(s) failed.\n", count( $failures ) );
+exit( 1 );


### PR DESCRIPTION
## Summary

Closes #281.

Adds a peer `exclude_labels` config field to the GitHub fetch handler, parallel to the existing `exclude_keywords`. GitHub's REST `list issues` / `list pulls` endpoints do not support negative label syntax, so DMC filters in-memory after the fetch — symmetric with how `exclude_keywords` is already filtered post-fetch in the same method.

This unblocks downstream flows that need to express "match these labels AND NOT those" purely through handler config, without an AI-step prompt-level lifecycle guard.

## Behavior

- **Type:** comma-separated string. Trimmed, lowercased on parse.
- **Empty / missing:** no-op. All existing flows behave identically to today.
- **Match rule:** ANY-match drop. An item is excluded if its `labels` array intersects the parsed `exclude_labels` set on at least one entry.
- **Tier:** post-fetch, alongside the existing `search`, `exclude_keywords`, and `timeframe_limit` filters in `fetchIssuesOrPulls()`.
- **Applies to:** both `data_source: issues` and `data_source: pulls`.
- **Comparison:** case-insensitive (consistent with how GitHub treats label matching) and trimmed.
- **Logging:** dropped items are logged at `debug` level with the offending label name(s).

Example flow JSON:

```jsonc
{
    "data_source": "issues",
    "labels": "status:idea-ready",
    "exclude_labels": "status:built,status:abandoned",
    "state": "open",
    "repo": "owner/repo"
}
```

The field is declared in `GitHubSettings` so it round-trips through bundle import/export and the config UI. The targeted-fetch path (`issue_number` / `pull_number`) lists `exclude_labels` in its ignored-list-filter warning.

## Files changed

- `inc/Handlers/GitHub/GitHub.php` — parse `exclude_labels` and apply ANY-match `array_intersect` drop in the per-item loop, immediately after `exclude_keywords`. Add `exclude_labels` to the targeted-fetch ignored-list-filter warning.
- `inc/Handlers/GitHub/GitHubSettings.php` — declare the `exclude_labels` field next to `labels` so it round-trips through bundle export / import. Update `issue_number` / `pull_number` precedence help text to list `exclude_labels`.
- `README.md` — document `exclude_labels` alongside `labels` and `exclude_keywords` in a new GitHub fetch handler config table.
- `tests/smoke-github-fetch-exclude-labels.php` — new static + behavioral smoke covering empty config no-op, single excluded label, multiple excluded labels, case-insensitive match, item with no labels, whitespace / stray-comma tolerance, and the interaction with the existing positive `labels` filter.

## Non-goals

- No switch to the Search API. `listIssues` / `listPulls` remain the transport.
- No wildcard / regex matching. Exact case-insensitive match only.
- No consumer-specific label vocabulary baked into the handler.

## Checks

- `php -l inc/Handlers/GitHub/GitHub.php` → clean.
- `php -l inc/Handlers/GitHub/GitHubSettings.php` → clean.
- `php tests/smoke-github-fetch-exclude-labels.php` → 27/27 passed.
- `php tests/smoke-github-fetch-by-number.php` → 19/19 passed (no regression on the sibling targeted-fetch path).
- `php tests/smoke-github-pr-publish-labels.php` → passed.
- `php tests/smoke-github-create-tools.php` → passed.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the post-fetch filter parse / loop block, the settings field declaration, the README config table, and the targeted smoke test mirroring the `smoke-github-fetch-by-number.php` style. Author reviewed every diff against issue #281's spec and ran the smoke + lint checks above before pushing.