### PR TITLE
docs: hint --path + --extension combo for unregistered checkouts

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -536,7 +536,7 @@ MD;
 
 `homeboy` is a Rust CLI on this host. Every verb runs the same locally as in CI.
 
-**Quality:** `homeboy audit | lint | test | review | refactor`; use `homeboy review --changed-since --report=pr-comment` for PR-style review loops, and `--baseline` / `--ratchet` when a command supports observation baselines.
+**Quality:** `homeboy audit | lint | test | review | refactor`; use `homeboy review --changed-since --report=pr-comment` for PR-style review loops, and `--baseline` / `--ratchet` when a command supports observation baselines. For unregistered checkouts pass both `--path <repo>` and `--extension <id>` (e.g. `nodejs`) so resolution skips the missing-component error.
 
 **Git:** prefer `homeboy changes | status` and `homeboy git status|commit|push|pull|tag|rebase|cherry-pick|pr|issue` — structured output, component/worktree awareness, safer write verbs. Use `--path <checkout>` when operating outside a registered component or overriding component resolution. One-off reads (`git diff`, `git show`, `git blame`) stay on raw `git`.
 


### PR DESCRIPTION
## Summary

The Homeboy section in DMC's AGENTS.md described `--path` under Git verbs but didn't tell agents that running `homeboy lint --path <repo>` on an **unregistered** checkout also needs `--extension <id>`. Without it Homeboy synthesizes a component id from the path basename and fails with `extension.unsupported`, sending the agent on a detour through `homeboy component set` / `homeboy extension list` hints that don't apply for one-off `--path` probes.

This adds a single trailing sentence to the **Quality:** bullet so future agents reach for the working invocation directly.

## Repro this avoids

\`\`\`bash
homeboy lint --path /Users/chubes/Developer/studio@test-dashboard-update-checks --summary
# -> error: No extension provider configured for component 'studio@test-dashboard-update-checks'

homeboy lint --path /Users/chubes/Developer/studio@test-dashboard-update-checks --extension nodejs --summary
# -> works: runs npm run lint via the nodejs extension
\`\`\`

## Why a doc fix and not a code fix

The functional path already exists — `--extension <id>` is a fully working one-shot override (see Homeboy `ExtensionOverrideArgs`). The gap was purely discoverability in the agent prompt.

## Discovery

Discovered while validating Automattic/studio#3377; the Homeboy issue was tracked at Extra-Chill/homeboy#2361 and closed as not a functional gap.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Locating the registered AGENTS.md section in \`data-machine-code.php\`, drafting the one-line addition, and writing this PR body. Chris reviewed the wording and approved.