### PR TITLE
feat: classify merged dirty worktrees with only obsolete-on-default edits

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1883,6 +1883,7 @@ class WorkspaceCommand extends BaseCommand {
 	 * [--only=<section>]
 	 * : Limit cleanup rows to one section or reason code. Supported values:
 	 *   candidates, would-remove, would_remove, removed, no_merge_signal, dirty_worktree,
+	 *   merged_pr_with_only_obsolete_dirty_changes (alias safe-force-cleanup),
 	 *   unpushed_commits, missing_metadata, external_worktree, age_filter, unknown_age.
 	 *
 	 * [--limit=<count>]
@@ -3505,17 +3506,21 @@ class WorkspaceCommand extends BaseCommand {
 	 */
 	private function normalize_worktree_cleanup_only( string $only ): string {
 		$aliases = array(
-			'would-remove'       => 'candidates',
-			'would_remove'       => 'candidates',
-			'dirty'              => 'dirty_worktree',
-			'unpushed'           => 'unpushed_commits',
-			'missing-metadata'   => 'needs_metadata_reconcile',
-			'missing_metadata'   => 'needs_metadata_reconcile',
-			'requires-full-scan' => 'needs_metadata_reconcile',
-			'requires_full_scan' => 'needs_metadata_reconcile',
-			'no-signal'          => 'active_no_signal',
-			'no_signal'          => 'active_no_signal',
-			'external'           => 'external_worktree',
+			'would-remove'          => 'candidates',
+			'would_remove'          => 'candidates',
+			'dirty'                 => 'dirty_worktree',
+			'merged-obsolete-dirty' => 'merged_pr_with_only_obsolete_dirty_changes',
+			'merged_obsolete_dirty' => 'merged_pr_with_only_obsolete_dirty_changes',
+			'safe-force-cleanup'    => 'merged_pr_with_only_obsolete_dirty_changes',
+			'safe_force_cleanup'    => 'merged_pr_with_only_obsolete_dirty_changes',
+			'unpushed'              => 'unpushed_commits',
+			'missing-metadata'      => 'needs_metadata_reconcile',
+			'missing_metadata'      => 'needs_metadata_reconcile',
+			'requires-full-scan'    => 'needs_metadata_reconcile',
+			'requires_full_scan'    => 'needs_metadata_reconcile',
+			'no-signal'             => 'active_no_signal',
+			'no_signal'             => 'active_no_signal',
+			'external'              => 'external_worktree',
 		);
 
 		return $aliases[ $only ] ?? $only;

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -3144,6 +3144,46 @@ class Workspace {
 			}
 
 			if ( $dirty_count > 0 && ! $force ) {
+				// Before falling through to the generic dirty_worktree skip, try to
+				// classify whether this is the "merged PR + obsolete dirty edits"
+				// shape. That bucket is still skipped (force=false stays safe), but
+				// the distinct reason_code lets reviewers spot it as a safe
+				// force-cleanup candidate without manual archaeology.
+				$obsolete_dirty = $this->classify_dirty_obsolete_on_default_branch(
+					$repo,
+					$branch,
+					$wt_path,
+					$skip_github,
+					$github_cache,
+					$fetched,
+					$fetch_timeouts,
+					$metadata,
+					$include_repaired_metadata
+				);
+
+				if ( is_array( $obsolete_dirty ) ) {
+					$skipped[] = array_merge( array(
+						'handle'      => $handle,
+						'repo'        => $repo,
+						'branch'      => $branch,
+						'path'        => $wt_path,
+						'reason_code' => 'merged_pr_with_only_obsolete_dirty_changes',
+						'reason'      => sprintf(
+							'merged branch with %d dirty file(s); all dirty paths already absent on default branch — safe force-cleanup candidate (review then rerun with force=true)',
+							$dirty_count
+						),
+						'dirty'       => $dirty_count,
+						'dirty_obsolete_paths' => $obsolete_dirty['paths'],
+						'merge_signal' => $obsolete_dirty['merge_signal'],
+						'pr_url'      => $obsolete_dirty['pr_url'] ?? null,
+						'default_ref' => $obsolete_dirty['default_ref'] ?? null,
+						'hint'        => 'Dirty edits only touch paths the default branch no longer has. After review, rerun cleanup with force=true to remove this worktree.',
+						'created_at'  => $created_at,
+						'metadata'    => $metadata,
+					), $disk_fields );
+					continue;
+				}
+
 				$skipped[] = array_merge( array(
 					'handle'      => $handle,
 					'repo'        => $repo,
@@ -7057,6 +7097,194 @@ class Workspace {
 			'handle'  => basename( $wt_path ),
 			'message' => sprintf( 'Worktree at "%s" removed.', $wt_path ),
 			'branch'  => $branch,
+		);
+	}
+
+	/**
+	 * Classify a dirty worktree as "merged + only obsolete dirty changes".
+	 *
+	 * Returns the classification payload when:
+	 *   - The branch has a confirmed merge signal (upstream-gone, local-merged,
+	 *     pr-merged, or already cleanup-eligible per metadata).
+	 *   - All dirty paths reported by `git status --porcelain` are tracked
+	 *     paths whose entries are absent on the remote default branch tip
+	 *     (i.e. modifying or deleting files the default branch no longer has).
+	 *
+	 * Returns null in every other case so the caller falls back to the
+	 * generic `dirty_worktree` skip:
+	 *   - No merge signal, or signal cannot be confirmed.
+	 *   - Any dirty path is untracked (could be new content).
+	 *   - Any dirty path still exists on the default branch tip.
+	 *   - Default branch ref cannot be resolved.
+	 *   - Any git probe times out or fails.
+	 *
+	 * The classification keeps cleanup conservative: it never auto-removes
+	 * dirty worktrees, but the distinct reason code lets reviewers spot the
+	 * "safe to force" subset without manual archaeology.
+	 *
+	 * @param string                 $repo                       Repo directory name.
+	 * @param string                 $branch                     Branch name.
+	 * @param string                 $wt_path                    Worktree path.
+	 * @param bool                   $skip_github                Whether to skip GitHub API lookups.
+	 * @param array<string,mixed>    $github_cache               Run-local GitHub cache.
+	 * @param array<string,bool>     $fetched                    Per-repo fetch tracker.
+	 * @param array<string,\WP_Error>$fetch_timeouts             Per-repo fetch timeout tracker.
+	 * @param mixed                  $metadata                   Worktree metadata.
+	 * @param bool                   $include_repaired_metadata  Whether repaired metadata counts as a cleanup signal.
+	 * @return array{paths: array<string,string>, merge_signal: string, pr_url?: ?string, default_ref: string}|null
+	 */
+	private function classify_dirty_obsolete_on_default_branch(
+		string $repo,
+		string $branch,
+		string $wt_path,
+		bool $skip_github,
+		array &$github_cache,
+		array &$fetched,
+		array &$fetch_timeouts,
+		$metadata,
+		bool $include_repaired_metadata
+	): ?array {
+		if ( '' === $repo || '' === $branch || '' === $wt_path || ! is_dir( $wt_path ) ) {
+			return null;
+		}
+
+		$primary_path = $this->get_primary_path( $repo );
+		if ( ! is_dir( $primary_path . '/.git' ) ) {
+			return null;
+		}
+
+		// Refuse to classify if a previous worktree already saw this repo's
+		// fetch time out — the default-ref / merge-signal probes would race
+		// against stale data.
+		if ( isset( $fetch_timeouts[ $repo ] ) ) {
+			return null;
+		}
+
+		// Ensure remote refs are fresh once per repo per cleanup run. Reuses
+		// the caller's `$fetched` tracker so this never double-fetches.
+		if ( empty( $fetched[ $repo ] ) ) {
+			$fetch = $this->run_git( $primary_path, 'fetch --prune --quiet origin', self::CLEANUP_GIT_PROBE_TIMEOUT );
+			if ( $this->is_git_timeout_error( $fetch ) ) {
+				$fetch_timeouts[ $repo ] = $fetch;
+				return null;
+			}
+			$fetched[ $repo ] = true;
+		}
+
+		$default_ref = $this->resolve_remote_default_ref( $primary_path, self::CLEANUP_GIT_PROBE_TIMEOUT );
+		if ( $default_ref instanceof \WP_Error || null === $default_ref || '' === $default_ref ) {
+			return null;
+		}
+
+		// Confirm the default ref actually resolves to a commit. If it doesn't,
+		// every `cat-file -e <ref>:<path>` would fail and we'd mis-classify the
+		// whole worktree as obsolete-on-default.
+		$default_resolve = $this->run_git(
+			$primary_path,
+			sprintf( 'rev-parse --verify --quiet %s', escapeshellarg( $default_ref . '^{commit}' ) ),
+			self::CLEANUP_GIT_PROBE_TIMEOUT
+		);
+		if ( $this->is_git_timeout_error( $default_resolve ) || is_wp_error( $default_resolve ) ) {
+			return null;
+		}
+
+		$signal = null;
+		if ( is_array( $metadata ) && WorktreeContextInjector::has_cleanup_signal( $metadata ) ) {
+			$signal = array(
+				'signal' => 'cleanup_eligible',
+				'reason' => 'worktree finalized or explicitly marked cleanup_eligible',
+			);
+			if ( ! empty( $metadata['pr_url'] ) ) {
+				$signal['pr_url'] = (string) $metadata['pr_url'];
+			}
+		} elseif ( $include_repaired_metadata && is_array( $metadata ) && ! empty( $metadata['metadata_repaired'] ) ) {
+			$signal = array(
+				'signal' => 'repaired_metadata',
+				'reason' => 'operator-approved cleanup of repaired metadata',
+			);
+		} else {
+			$signal = $this->detect_merge_signal( $primary_path, $repo, $branch, $skip_github, $github_cache );
+		}
+
+		if ( ! is_array( $signal ) ) {
+			return null;
+		}
+		$signal_kind    = (string) ( $signal['signal'] ?? '' );
+		$merged_signals = array( 'upstream-gone', 'local-merged', 'pr-merged', 'cleanup_eligible', 'repaired_metadata' );
+		if ( ! in_array( $signal_kind, $merged_signals, true ) ) {
+			return null;
+		}
+
+		// Untracked files are never "obsolete on default" — they could be new
+		// content the operator wants to preserve. Bail at the first hint of
+		// untracked content so this classifier stays conservative.
+		$untracked = $this->run_git(
+			$wt_path,
+			'ls-files --others --exclude-standard',
+			self::CLEANUP_GIT_PROBE_TIMEOUT
+		);
+		if ( $this->is_git_timeout_error( $untracked ) ) {
+			return null;
+		}
+		if ( ! is_wp_error( $untracked ) && '' !== trim( (string) ( $untracked['output'] ?? '' ) ) ) {
+			return null;
+		}
+
+		// Modified/deleted/added tracked paths against the worktree's HEAD.
+		// `diff --name-only HEAD` covers staged and unstaged changes in one
+		// shot and avoids the porcelain status leading-whitespace quirk that
+		// `trim()`-on-output would corrupt.
+		$tracked = $this->run_git(
+			$wt_path,
+			'diff --name-only HEAD',
+			self::CLEANUP_GIT_PROBE_TIMEOUT
+		);
+		if ( $this->is_git_timeout_error( $tracked ) || is_wp_error( $tracked ) ) {
+			return null;
+		}
+
+		$paths = array_values(
+			array_filter(
+				array_map( 'trim', explode( "\n", (string) ( $tracked['output'] ?? '' ) ) ),
+				fn( $line ) => '' !== $line
+			)
+		);
+		if ( array() === $paths ) {
+			return null;
+		}
+
+		$obsolete_paths = array();
+		foreach ( $paths as $path ) {
+			// `cat-file -e <ref>:<path>` exits 0 when the path exists on the
+			// default branch tip. Non-zero (missing/ambiguous) means the path
+			// is absent there — exactly the case we want to classify as
+			// obsolete-on-default.
+			$probe = $this->run_git(
+				$primary_path,
+				sprintf( 'cat-file -e %s', escapeshellarg( $default_ref . ':' . $path ) ),
+				self::CLEANUP_GIT_PROBE_TIMEOUT
+			);
+			if ( $this->is_git_timeout_error( $probe ) ) {
+				return null;
+			}
+			if ( is_wp_error( $probe ) ) {
+				$obsolete_paths[ $path ] = 'absent_on_default';
+				continue;
+			}
+			// Path still exists on the default branch tip — dirty edit may
+			// still be relevant. Refuse to classify into the new bucket.
+			return null;
+		}
+
+		if ( array() === $obsolete_paths ) {
+			return null;
+		}
+
+		return array(
+			'paths'        => $obsolete_paths,
+			'merge_signal' => $signal_kind,
+			'pr_url'       => $signal['pr_url'] ?? null,
+			'default_ref'  => $default_ref,
 		);
 	}
 

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -8,14 +8,14 @@ including safety-rail regressions) lives in `smoke-worktree-cleanup.php`.
 ## 0. Pre-flight — the automated smoke tests
 
 ```bash
-php tests/smoke-worktree-handles.php     # pure-unit, fast
-php tests/smoke-worktree-cleanup.php     # spawns a real git workspace
-php tests/smoke-worktree-bootstrap.php   # fixture + real git, no WP required
+php tests/smoke-worktree-handles.php                          # pure-unit, fast
+php tests/smoke-worktree-cleanup.php                          # spawns a real git workspace
+php tests/smoke-worktree-cleanup-merged-obsolete-dirty.php    # merged + obsolete-on-default classifier
+php tests/smoke-worktree-bootstrap.php                        # fixture + real git, no WP required
 ```
 
-Expected: `32/32 passed`, `18/18 passed`, and `30/30 passed` respectively.
-Skip `smoke-worktree-cleanup.php` and `smoke-worktree-bootstrap.php` if `git`
-is unavailable.
+Expected: `32/32 passed`, `131/131 passed`, `14/14 passed`, and `30/30 passed`
+respectively. Skip the cleanup/bootstrap tests if `git` is unavailable.
 
 Prereqs:
 - WordPress 6.9+ with Data Machine + data-machine-code activated.

--- a/tests/smoke-worktree-cleanup-merged-obsolete-dirty.php
+++ b/tests/smoke-worktree-cleanup-merged-obsolete-dirty.php
@@ -1,0 +1,317 @@
+<?php
+/**
+ * Smoke test for the `merged_pr_with_only_obsolete_dirty_changes` classifier.
+ *
+ * Builds a real workspace where:
+ *   - A branch was merged (simulated by deleting the remote branch + a
+ *     `local-merged` shape where the branch is contained in origin/HEAD).
+ *   - The worktree has dirty edits to a file that the default branch tip no
+ *     longer has.
+ *   - A second branch is merged but has dirty edits to a file the default
+ *     branch still tracks (must NOT classify into the new bucket).
+ *   - A third branch is merged but the dirty entry is untracked (must NOT
+ *     classify into the new bucket).
+ *
+ * Asserts the cleanup dry-run reports the new reason code only for the first
+ * worktree, leaves the other two on the generic `dirty_worktree` bucket, and
+ * never auto-removes any of them.
+ *
+ * Run: php tests/smoke-worktree-cleanup-merged-obsolete-dirty.php
+ *
+ * Skips entirely if `git` is unavailable on $PATH.
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Core\FilesRepository {
+	if ( ! class_exists( __NAMESPACE__ . '\\FilesystemHelper' ) ) {
+		class FilesystemHelper {
+			public static function get() {
+				return null;
+			}
+		}
+	}
+}
+
+namespace DataMachineCode\Abilities {
+	if ( ! class_exists( __NAMESPACE__ . '\\GitHubAbilities' ) ) {
+		class GitHubAbilities {
+			public static function getPat(): string {
+				return '';
+			}
+			public static function apiGet( string $url, array $params, string $pat ) {
+				return array( 'data' => array() );
+			}
+		}
+	}
+}
+
+namespace {
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			public string $code;
+			public string $message;
+			public array $data;
+			public function __construct( $code = '', $message = '', $data = array() ) {
+				$this->code    = (string) $code;
+				$this->message = (string) $message;
+				$this->data    = (array) $data;
+			}
+			public function get_error_message(): string {
+				return $this->message;
+			}
+			public function get_error_code(): string {
+				return $this->code;
+			}
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $thing ): bool {
+			return $thing instanceof \WP_Error;
+		}
+	}
+
+	if ( ! function_exists( 'wp_mkdir_p' ) ) {
+		function wp_mkdir_p( string $path ): bool {
+			return is_dir( $path ) || mkdir( $path, 0755, true );
+		}
+	}
+
+	if ( ! function_exists( 'get_option' ) ) {
+		function get_option( string $name, $default_value = false ) {
+			global $datamachine_code_test_options;
+			return $datamachine_code_test_options[ $name ] ?? $default_value;
+		}
+	}
+
+	if ( ! function_exists( 'update_option' ) ) {
+		function update_option( string $name, $value, $autoload = null ): bool {
+			global $datamachine_code_test_options;
+			$datamachine_code_test_options[ $name ] = $value;
+			return true;
+		}
+	}
+
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( string $hook_name, $value ) {
+			return $value;
+		}
+	}
+
+	if ( ! function_exists( 'size_format' ) ) {
+		function size_format( $bytes ): string {
+			return (string) $bytes;
+		}
+	}
+
+	require __DIR__ . '/../inc/Support/GitHubRemote.php';
+	require __DIR__ . '/../inc/Support/GitRunner.php';
+	require __DIR__ . '/../inc/Support/PathSecurity.php';
+	require __DIR__ . '/../inc/Workspace/WorkspaceMutationLock.php';
+	require __DIR__ . '/../inc/Workspace/WorktreeDiskBudget.php';
+	require __DIR__ . '/../inc/Workspace/WorktreeContextInjector.php';
+	require __DIR__ . '/../inc/Workspace/Workspace.php';
+
+	exec( 'git --version 2>&1', $_gv, $gv_exit );
+	if ( 0 !== $gv_exit ) {
+		echo "SKIP: git not available\n";
+		exit( 0 );
+	}
+
+	$tmp = sys_get_temp_dir() . '/dmc-merged-obsolete-' . bin2hex( random_bytes( 4 ) );
+	mkdir( $tmp, 0755, true );
+	register_shutdown_function( function () use ( $tmp ) {
+		if ( is_dir( $tmp ) ) {
+			exec( 'rm -rf ' . escapeshellarg( $tmp ) );
+		}
+	} );
+
+	define( 'DATAMACHINE_WORKSPACE_PATH', realpath( $tmp ) ? realpath( $tmp ) : $tmp );
+
+	$failures = 0;
+	$total    = 0;
+	$datamachine_code_test_options = array();
+
+	$assert = function ( $expected, $actual, string $message ) use ( &$failures, &$total ): void {
+		++$total;
+		if ( $expected === $actual ) {
+			echo "  ✓ {$message}\n";
+			return;
+		}
+		++$failures;
+		echo "  ✗ {$message}\n";
+		echo "    expected: " . var_export( $expected, true ) . "\n";
+		echo "    actual:   " . var_export( $actual, true ) . "\n";
+	};
+
+	$run = function ( string $cmd, string $cwd = '' ) {
+		$full = '' === $cwd ? $cmd : sprintf( 'cd %s && %s', escapeshellarg( $cwd ), $cmd );
+		exec( $full . ' 2>&1', $out, $rc );
+		return array(
+			'output' => implode( "\n", $out ),
+			'exit'   => $rc,
+		);
+	};
+
+	echo "Setting up workspace at {$tmp}\n";
+
+	// Bare remote stands in for origin.
+	$remote = $tmp . '/remote.git';
+	$run( sprintf( 'git init --bare %s', escapeshellarg( $remote ) ) );
+
+	$primary = $tmp . '/demo';
+	$run( sprintf( 'git clone %s %s', escapeshellarg( $remote ), escapeshellarg( $primary ) ) );
+	$run( 'git config user.email test@example.com', $primary );
+	$run( 'git config user.name test', $primary );
+
+	// Initial main with two tracked files. `obsolete.txt` will be removed
+	// from main later; `survivor.txt` stays on main throughout.
+	file_put_contents( $primary . '/README.md', "demo\n" );
+	file_put_contents( $primary . '/obsolete.txt', "removed-on-default\n" );
+	file_put_contents( $primary . '/survivor.txt', "stays-on-default\n" );
+	$run( 'git add README.md obsolete.txt survivor.txt && git commit -m init', $primary );
+	$run( 'git branch -M main', $primary );
+	$run( 'git push -u origin main', $primary );
+
+	// Branch 1: merged + dirty edit only touches an obsolete-on-default path.
+	$run( 'git checkout -b merged-obsolete-edits', $primary );
+	$run( 'git push -u origin merged-obsolete-edits', $primary );
+	$run( 'git checkout main', $primary );
+
+	// Branch 2: merged + dirty edit touches a file the default branch still has.
+	$run( 'git checkout -b merged-survivor-edits', $primary );
+	$run( 'git push -u origin merged-survivor-edits', $primary );
+	$run( 'git checkout main', $primary );
+
+	// Branch 3: merged + dirty edit is an untracked file.
+	$run( 'git checkout -b merged-untracked-dirty', $primary );
+	$run( 'git push -u origin merged-untracked-dirty', $primary );
+	$run( 'git checkout main', $primary );
+
+	// Now remove `obsolete.txt` from main so the default branch tip no
+	// longer has it. This is the "edits already represented by default" shape
+	// the new classifier is meant to recognize.
+	$run( 'git rm obsolete.txt && git commit -m "remove obsolete file" && git push origin main', $primary );
+
+	// Worktrees on each merged branch.
+	$run( sprintf( 'git worktree add %s merged-obsolete-edits', escapeshellarg( $tmp . '/demo@merged-obsolete-edits' ) ), $primary );
+	$run( sprintf( 'git worktree add %s merged-survivor-edits', escapeshellarg( $tmp . '/demo@merged-survivor-edits' ) ), $primary );
+	$run( sprintf( 'git worktree add %s merged-untracked-dirty', escapeshellarg( $tmp . '/demo@merged-untracked-dirty' ) ), $primary );
+
+	// Branch 1 worktree: modify the file that no longer exists on main.
+	file_put_contents( $tmp . '/demo@merged-obsolete-edits/obsolete.txt', "edited-on-stale-branch\n" );
+
+	// Branch 2 worktree: modify a file main still has.
+	file_put_contents( $tmp . '/demo@merged-survivor-edits/survivor.txt', "edited-on-stale-branch\n" );
+
+	// Branch 3 worktree: only an untracked file dirty.
+	file_put_contents( $tmp . '/demo@merged-untracked-dirty/scratch.log', "scratch\n" );
+
+	// Simulate "remote auto-deleted these branches after merge". With the
+	// remote refs gone, the local upstream tracking ref will be `gone` and
+	// `detect_merge_signal` reports `upstream-gone`. `local-merged` would
+	// also fire since each branch is fully contained in origin/main.
+	$run( sprintf( 'git --git-dir=%s update-ref -d refs/heads/merged-obsolete-edits', escapeshellarg( $remote ) ) );
+	$run( sprintf( 'git --git-dir=%s update-ref -d refs/heads/merged-survivor-edits', escapeshellarg( $remote ) ) );
+	$run( sprintf( 'git --git-dir=%s update-ref -d refs/heads/merged-untracked-dirty', escapeshellarg( $remote ) ) );
+
+	echo "\nDry-run scenario\n";
+	$ws   = new \DataMachineCode\Workspace\Workspace();
+	$plan = $ws->worktree_cleanup_merged(
+		array(
+			'dry_run'     => true,
+			'skip_github' => true,
+		)
+	);
+
+	$assert( true, ! is_wp_error( $plan ) && ( $plan['success'] ?? false ), 'dry-run returns success' );
+
+	$find = function ( string $handle ) use ( $plan ): array {
+		foreach ( (array) ( $plan['skipped'] ?? array() ) as $row ) {
+			if ( ( $row['handle'] ?? '' ) === $handle ) {
+				return $row;
+			}
+		}
+		return array();
+	};
+
+	$obsolete_row  = $find( 'demo@merged-obsolete-edits' );
+	$survivor_row  = $find( 'demo@merged-survivor-edits' );
+	$untracked_row = $find( 'demo@merged-untracked-dirty' );
+
+	$assert(
+		'merged_pr_with_only_obsolete_dirty_changes',
+		$obsolete_row['reason_code'] ?? '',
+		'merged worktree with only obsolete dirty edits classifies into new bucket'
+	);
+	$assert( true, 1 === (int) ( $obsolete_row['dirty'] ?? 0 ), 'classified row preserves dirty file count' );
+	$assert(
+		true,
+		isset( $obsolete_row['dirty_obsolete_paths']['obsolete.txt'] )
+			&& 'absent_on_default' === $obsolete_row['dirty_obsolete_paths']['obsolete.txt'],
+		'classified row enumerates the obsolete-on-default dirty path'
+	);
+	$assert(
+		true,
+		in_array( $obsolete_row['merge_signal'] ?? '', array( 'upstream-gone', 'local-merged', 'pr-merged' ), true ),
+		'classified row records the merge signal that fired'
+	);
+	$assert(
+		true,
+		isset( $obsolete_row['default_ref'] ) && '' !== (string) $obsolete_row['default_ref'],
+		'classified row records the default branch ref used'
+	);
+	$assert(
+		true,
+		isset( $obsolete_row['hint'] ) && str_contains( (string) $obsolete_row['hint'], 'force=true' ),
+		'classified row hints at the force-cleanup follow-up'
+	);
+
+	$assert(
+		'dirty_worktree',
+		$survivor_row['reason_code'] ?? '',
+		'merged worktree with default-tracked dirty edit stays on generic dirty_worktree bucket'
+	);
+
+	$assert(
+		'dirty_worktree',
+		$untracked_row['reason_code'] ?? '',
+		'merged worktree with only untracked dirty entries stays on generic dirty_worktree bucket'
+	);
+
+	$summary = (array) ( $plan['summary'] ?? array() );
+	$by_reason = (array) ( $summary['skipped_by_reason'] ?? array() );
+	$assert(
+		1,
+		(int) ( $by_reason['merged_pr_with_only_obsolete_dirty_changes'] ?? 0 ),
+		'summary aggregates new bucket count'
+	);
+	$assert(
+		2,
+		(int) ( $by_reason['dirty_worktree'] ?? 0 ),
+		'summary still counts genuinely-risky dirty worktrees separately'
+	);
+
+	// Confirm cleanup never auto-removes any of the three dirty worktrees on
+	// a non-force apply path.
+	$candidates = (array) ( $plan['candidates'] ?? array() );
+	foreach ( array( 'demo@merged-obsolete-edits', 'demo@merged-survivor-edits', 'demo@merged-untracked-dirty' ) as $handle ) {
+		$is_candidate = false;
+		foreach ( $candidates as $candidate ) {
+			if ( ( $candidate['handle'] ?? '' ) === $handle ) {
+				$is_candidate = true;
+				break;
+			}
+		}
+		$assert( false, $is_candidate, sprintf( '%s never appears as an auto-removable candidate', $handle ) );
+	}
+
+	echo "\nResult: " . ( $total - $failures ) . "/{$total} passed\n";
+	exit( $failures > 0 ? 1 : 0 );
+}


### PR DESCRIPTION
## Summary

- Adds a new `merged_pr_with_only_obsolete_dirty_changes` cleanup skip reason for worktrees whose dirty edits only touch paths the default branch no longer has.
- Keeps the existing `dirty_worktree` safety gate (no auto-removal without `force=true`), but lets reviewers spot the safe-to-force subset without manual archaeology.
- Reuses the cleanup loop's existing fetch + GitHub caches so the new classifier doesn't double the per-worktree probe budget.

Closes #284.

## What changed

`Workspace::classify_dirty_obsolete_on_default_branch()` is invoked from the dirty-skip branch of `worktree_cleanup_merged()`. A row is classified into the new bucket only when **all** of these hold:

- Merge signal fires: `upstream-gone`, `local-merged`, `pr-merged`, `cleanup_eligible` metadata, or `repaired_metadata`.
- No untracked files (untracked content could be new work).
- Every tracked dirty path (`git diff --name-only HEAD`) is absent on the resolved remote default ref.
- Default ref resolves to a real commit (`rev-parse --verify` guard so a wedged `origin/HEAD` doesn't fake the whole worktree obsolete).

If any check is uncertain — fetch timeout, default ref unresolvable, untracked files, any tracked path still on default — the row falls back to the existing `dirty_worktree` skip. No behavior change for force-cleanup paths.

The skip row carries:

- `reason_code`: `merged_pr_with_only_obsolete_dirty_changes`
- `dirty_obsolete_paths`: map of dirty path → `absent_on_default`
- `merge_signal`: which signal fired
- `pr_url`: when available
- `default_ref`: the ref used for comparison
- `hint`: tells the operator to rerun cleanup with `force=true` after review

## CLI alias

`workspace worktree cleanup --only=merged-obsolete-dirty` (or `safe-force-cleanup`) filters to just the new bucket. Existing `--only` values are unchanged.

## Tests

- `tests/smoke-worktree-cleanup-merged-obsolete-dirty.php` (new): builds a real workspace with three merged worktrees — only-obsolete-dirty, dirty-against-survivor, untracked-only — and asserts only the first lands in the new bucket and none auto-remove. **14/14 passed.**
- `tests/smoke-worktree-cleanup.php`: regression baseline. **131/131 passed.**
- `tests/smoke-worktree-cleanup-cli.php`, `tests/smoke-worktree-cleanup-artifacts.php`, `tests/smoke-worktree-bounded-cleanup-eligible-apply.php`: all pass.
- Full worktree + workspace smoke suite (32 files): all green.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude (claude-sonnet-4-5)
- **Used for:** Drafting the classifier, helper method, smoke test, and CLI alias additions. Chris reviewed every line, ran the smoke suite, and verified the original `dirty_worktree` regression baseline still holds.