### PR TITLE
feat: surface live workspace inventory in AGENTS.md (#287)

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -493,6 +493,19 @@ MD;
 		'description' => 'Memory, automation, workspace, and system operations.',
 	) );
 
+	// Workspace Inventory — live snapshot of cloned repos + active worktrees.
+	// Sits between datamachine (10) and abilities (20) so the agent reads
+	// "what's in my workspace right now" immediately after the WP-CLI surface
+	// description. The section is regenerated whenever
+	// `datamachine_code_workspace_changed` fires (debounced by
+	// ComposableFileInvalidation's 60-second transient).
+	\DataMachine\Engine\AI\SectionRegistry::register( 'AGENTS.md', 'workspace-inventory', 15, function () use ( $wp ) {
+		return datamachine_code_render_workspace_inventory_section( $wp );
+	}, array(
+		'label'       => 'Workspace Inventory',
+		'description' => 'Live snapshot of cloned repos + active worktrees in the workspace.',
+	) );
+
 	// Abilities — WordPress Abilities API discovery.
 	\DataMachine\Engine\AI\SectionRegistry::register( 'AGENTS.md', 'abilities', 20, function () use ( $wp ) {
 		return <<<MD
@@ -639,4 +652,156 @@ function datamachine_code_resolve_workspace_path_for_agents_md(): string {
 	}
 
 	return 'unavailable; run datamachine-code workspace path to diagnose';
+}
+
+/**
+ * Hook the workspace-lifecycle action into the composable AGENTS.md
+ * regenerator so the inventory section refreshes whenever a clone, adopt,
+ * remove, or worktree add/remove lands. Regeneration is debounced by
+ * ComposableFileInvalidation's 60-second transient.
+ *
+ * @since 0.31.0
+ */
+add_filter( 'datamachine_composable_invalidation_hooks', function ( array $hooks ): array {
+	$hooks[] = 'datamachine_code_workspace_changed';
+	return $hooks;
+} );
+
+/**
+ * Render the workspace-inventory section for AGENTS.md.
+ *
+ * Pulls live state from `Workspace::list_repos()` — the same source the
+ * `wp datamachine-code workspace list` CLI uses — so the agent sees an
+ * accurate snapshot of cloned repos and active worktrees without probing.
+ *
+ * Render shape (compact, default):
+ *
+ *   - **<repo>** (`<branch>`) — N worktrees · <remote>
+ *
+ * Render shape (full, opt-in via filter):
+ *
+ *   - **<repo>** (`<branch>`) — <remote>
+ *     - `<branch-slug>` (`<branch>`)
+ *
+ * Returns an empty string when the Workspace class is missing or no git
+ * repos are cloned, which causes the composer to skip the section entirely
+ * (no stub heading).
+ *
+ * @since 0.31.0
+ *
+ * @param string $wp WP-CLI command prefix for the current environment.
+ * @return string Markdown for the section, or '' to skip.
+ */
+function datamachine_code_render_workspace_inventory_section( string $wp ): string {
+	if ( ! class_exists( '\DataMachineCode\Workspace\Workspace' ) ) {
+		return '';
+	}
+
+	$workspace = new \DataMachineCode\Workspace\Workspace();
+	$listing   = $workspace->list_repos();
+
+	if ( is_wp_error( $listing ) || empty( $listing['repos'] ) ) {
+		return '';
+	}
+
+	// Group entries by primary repo. Skip non-git directories (`.locks`,
+	// `_bench-evidence`, etc) — `list_repos()` exposes the `git` flag for
+	// exactly this distinction.
+	$by_repo = array();
+	foreach ( $listing['repos'] as $entry ) {
+		if ( empty( $entry['git'] ) ) {
+			continue;
+		}
+
+		$repo = $entry['repo'] ?? $entry['name'] ?? '';
+		if ( '' === $repo ) {
+			continue;
+		}
+
+		if ( ! isset( $by_repo[ $repo ] ) ) {
+			$by_repo[ $repo ] = array(
+				'primary'   => null,
+				'worktrees' => array(),
+			);
+		}
+
+		if ( ! empty( $entry['is_worktree'] ) ) {
+			$by_repo[ $repo ]['worktrees'][] = $entry;
+		} else {
+			$by_repo[ $repo ]['primary'] = $entry;
+		}
+	}
+
+	if ( empty( $by_repo ) ) {
+		return '';
+	}
+
+	ksort( $by_repo, SORT_NATURAL | SORT_FLAG_CASE );
+
+	$workspace_path = $listing['path'] ?? $workspace->get_path();
+
+	/**
+	 * Filter the workspace-inventory render mode.
+	 *
+	 * - `compact` (default): one bullet per repo with branch + worktree count + remote.
+	 * - `full`: also list each worktree's slug + branch beneath its primary.
+	 *
+	 * @since 0.31.0
+	 *
+	 * @param string $mode One of `compact`|`full`.
+	 */
+	$mode = apply_filters( 'datamachine_code_workspace_inventory_mode', 'compact' );
+	if ( ! in_array( $mode, array( 'compact', 'full' ), true ) ) {
+		$mode = 'compact';
+	}
+
+	$lines = array();
+	foreach ( $by_repo as $repo => $bucket ) {
+		$primary    = $bucket['primary'];
+		$worktrees  = $bucket['worktrees'];
+		$wt_count   = count( $worktrees );
+		$branch     = $primary['branch'] ?? null;
+		$remote     = $primary['remote'] ?? null;
+		$branch_str = ( null !== $branch && '' !== $branch ) ? sprintf( ' (`%s`)', $branch ) : '';
+
+		if ( 'compact' === $mode ) {
+			$suffix_parts = array();
+			$suffix_parts[] = sprintf( '%d %s', $wt_count, 1 === $wt_count ? 'worktree' : 'worktrees' );
+			if ( null !== $remote && '' !== $remote ) {
+				$suffix_parts[] = $remote;
+			}
+			$lines[] = sprintf( '- **%s**%s — %s', $repo, $branch_str, implode( ' · ', $suffix_parts ) );
+			continue;
+		}
+
+		// full mode.
+		$header = sprintf( '- **%s**%s', $repo, $branch_str );
+		if ( null !== $remote && '' !== $remote ) {
+			$header .= ' — ' . $remote;
+		}
+		$lines[] = $header;
+
+		usort( $worktrees, function ( $a, $b ) {
+			return strnatcasecmp( (string) ( $a['name'] ?? '' ), (string) ( $b['name'] ?? '' ) );
+		} );
+		foreach ( $worktrees as $wt ) {
+			$slug      = $wt['branch_slug'] ?? '';
+			$wt_branch = $wt['branch'] ?? null;
+			$wt_label  = '' !== $slug ? sprintf( '`%s`', $slug ) : sprintf( '`%s`', $wt['name'] ?? '?' );
+			if ( null !== $wt_branch && '' !== $wt_branch && $wt_branch !== $slug ) {
+				$wt_label .= sprintf( ' (`%s`)', $wt_branch );
+			}
+			$lines[] = '  - ' . $wt_label;
+		}
+	}
+
+	$body = implode( "\n", $lines );
+
+	return <<<MD
+## Workspace Inventory
+
+Live snapshot of cloned repos in `{$workspace_path}`. Run `{$wp} datamachine-code workspace list` to drill into worktrees.
+
+{$body}
+MD;
 }

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -501,6 +501,8 @@ class Workspace {
 			return new \WP_Error( 'clone_failed', sprintf( 'Git clone failed (exit %d): %s', $exit_code, implode( "\n", $output ) ), array( 'status' => 500 ) );
 		}
 
+		$this->emit_workspace_changed( 'clone', $name, $name, $repo_path );
+
 		return array(
 			'success' => true,
 			'name'    => $name,
@@ -577,6 +579,8 @@ class Workspace {
 			return new \WP_Error( 'adopt_requires_workspace_path', sprintf( 'Adoption is non-destructive: %s must already be located at %s. Move or symlink operations are intentionally not performed by v1.', $real_path, $expected_path ), array( 'status' => 400 ) );
 		}
 
+		$this->emit_workspace_changed( 'adopt', $name, $name, $real_path );
+
 		return array(
 			'success'         => true,
 			'name'            => $name,
@@ -640,6 +644,13 @@ class Workspace {
 			}
 			$this->worktree_inventory()->delete( $parsed['dir_name'] );
 		}
+
+		$this->emit_workspace_changed(
+			$parsed['is_worktree'] ? 'worktree_remove' : 'remove',
+			$parsed['repo'],
+			$parsed['dir_name'],
+			$repo_path
+		);
 
 		return array(
 			'success' => true,
@@ -1348,6 +1359,8 @@ class Workspace {
 		}
 
 		$this->worktree_inventory()->upsert( $this->build_worktree_inventory_row_from_handle( $wt_handle ) );
+
+		$this->emit_workspace_changed( 'worktree_add', $repo, $wt_handle, $wt_path );
 
 		return $response;
 	}
@@ -2900,6 +2913,8 @@ class Workspace {
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
+
+		$this->emit_workspace_changed( 'worktree_remove', $repo, $wt_handle, $wt_path );
 
 		return array(
 			'success' => true,
@@ -8039,5 +8054,52 @@ class Workspace {
 		if ( ! file_exists( $index ) ) {
 			$fs->put_contents( $index, "<?php\n// Silence is golden.\n" );
 		}
+	}
+
+	/**
+	 * Fire the shared workspace-lifecycle action after a successful mutation.
+	 *
+	 * Listeners use this signal to refresh derived state (e.g. invalidating
+	 * the composable AGENTS.md so its workspace-inventory section reflects the
+	 * change). Only emitted on success, AFTER the on-disk change is durable.
+	 * The payload mirrors the workspace `name`/`repo` taxonomy used elsewhere
+	 * in this class:
+	 *
+	 *   - `op`:   one of `clone`, `adopt`, `remove`, `worktree_add`, `worktree_remove`.
+	 *   - `repo`: bare repository name (no `@<slug>` suffix).
+	 *   - `name`: workspace entry name on disk (`<repo>` for primaries,
+	 *             `<repo>@<slug>` for worktrees).
+	 *   - `path`: absolute path of the workspace entry that changed.
+	 *
+	 * @since 0.31.0
+	 *
+	 * @param string $op   Mutation kind.
+	 * @param string $repo Bare repo name.
+	 * @param string $name Workspace entry name (`<repo>` or `<repo>@<slug>`).
+	 * @param string $path Absolute path of the entry that changed.
+	 * @return void
+	 */
+	private function emit_workspace_changed( string $op, string $repo, string $name, string $path ): void {
+		/**
+		 * Fires after a successful Workspace mutation lands on disk.
+		 *
+		 * @since 0.31.0
+		 *
+		 * @param array{op: string, repo: string, name: string, path: string} $payload {
+		 *     @type string $op   One of clone|adopt|remove|worktree_add|worktree_remove.
+		 *     @type string $repo Bare repository name (no @-suffix).
+		 *     @type string $name Workspace entry name (<repo> or <repo>@<slug>).
+		 *     @type string $path Absolute path of the workspace entry.
+		 * }
+		 */
+		do_action(
+			'datamachine_code_workspace_changed',
+			array(
+				'op'   => $op,
+				'repo' => $repo,
+				'name' => $name,
+				'path' => $path,
+			)
+		);
 	}
 }


### PR DESCRIPTION
## Summary

Adds a **Workspace Inventory** section to the composed `AGENTS.md` so coding agents see which repos are cloned and how many worktrees each has without probing `wp datamachine-code workspace list` every session.

Also introduces `datamachine_code_workspace_changed` as the shared lifecycle signal for workspace mutations — `clone_repo`, `adopt_repo`, `remove_repo`, `worktree_add`, and `worktree_remove` fire this action after the on-disk change is durable. Same shape as the proposal in #287.

Closes #287

## Changes

### `inc/Workspace/Workspace.php`
- New private `emit_workspace_changed( $op, $repo, $name, $path )` helper that fires `do_action( 'datamachine_code_workspace_changed', ... )`. Payload mirrors the workspace `name`/`repo` taxonomy used elsewhere in the class.
- Hooked into `clone_repo` (op=`clone`), `adopt_repo` (op=`adopt`), `remove_repo` (op=`remove` for primaries / op=`worktree_remove` for stale worktree dirs removed via this path), `worktree_add` (op=`worktree_add`, fired after the inventory upsert), and `worktree_remove` (op=`worktree_remove`).
- Each emit happens **only on success**, **after** the on-disk change is durable.

### `data-machine-code.php`
- New `SectionRegistry::register( 'AGENTS.md', 'workspace-inventory', 15, ... )` — sits between `datamachine` (10) and `abilities` (20).
- New `datamachine_composable_invalidation_hooks` filter callback registering `datamachine_code_workspace_changed` so the section refreshes automatically. Debounce is the existing 60s transient in `ComposableFileInvalidation`.
- New `datamachine_code_render_workspace_inventory_section()` renderer:
  - Pulls live state from `Workspace::list_repos()` — same source as `wp datamachine-code workspace list`.
  - Groups entries by primary repo, sorts alphabetically (`SORT_NATURAL | SORT_FLAG_CASE`).
  - Skips non-git directories via the existing `git` flag (covers `.locks`, `_bench-evidence`, etc).
  - Returns `''` when the Workspace class is missing or no git repos exist — composer skips empty sections so no stub heading appears.
  - Compact mode (default): `- **<repo>** (`<branch>`) — N worktrees · <remote>`.
  - Full mode (opt-in via `datamachine_code_workspace_inventory_mode` filter): adds nested bullets for each worktree's slug + branch.

## Render shape

```md
## Workspace Inventory

Live snapshot of cloned repos in `/Users/chubes/Developer`. Run `studio wp datamachine-code workspace list` to drill into worktrees.

- **agents-api** (`main`) — 12 worktrees · https://github.com/Automattic/agents-api.git
- **data-machine** (`main`) — 76 worktrees · https://github.com/Extra-Chill/data-machine.git
- **data-machine-code** (`main`) — 36 worktrees · https://github.com/Extra-Chill/data-machine-code.git
...
```

## Validation

Tested against the live `intelligence-chubes4` Studio install via plugin symlink swap (worktree symlinked over `wp-content/plugins/data-machine-code`, then restored).

1. `php -l` clean on both touched files.
2. `studio wp datamachine memory compose AGENTS.md` → 7 sections (was 6); `## Workspace Inventory` rendered between `## Data Machine` and `## Abilities`.
3. `studio wp datamachine-code workspace worktree add data-machine-code test-inventory-trigger --base-branch=main` → AGENTS.md auto-regenerated, `data-machine-code` line went `36 worktrees` → `37 worktrees`.
4. `studio wp datamachine-code workspace worktree remove data-machine-code test-inventory-trigger --force` → AGENTS.md auto-regenerated, count back to `36 worktrees`.
5. Restored original plugin directory; final `compose AGENTS.md` returned to 6 sections.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafted the lifecycle action plumbing, the `workspace-inventory` section renderer, the invalidation filter wiring, and this PR description from the design in #287. Chris reviewed each step and ran the live-site validation against the Studio install.