### PR TITLE
fix(github): complete issue array schemas

### DIFF
--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -247,10 +247,12 @@ class GitHubAbilities {
 							),
 							'labels'    => array(
 								'type'        => 'array',
+								'items'       => array( 'type' => 'string' ),
 								'description' => 'Labels to attach to the issue.',
 							),
 							'assignees' => array(
 								'type'        => 'array',
+								'items'       => array( 'type' => 'string' ),
 								'description' => 'GitHub usernames to assign to the issue.',
 							),
 							'milestone' => array(


### PR DESCRIPTION
## Summary
- Add missing `items` definitions for the `labels` and `assignees` arrays on `datamachine/create-github-issue`.
- Keeps the ability schema valid for OpenAI tool/function calling when surfaced through Data Machine agents.

## Testing
- `php -l inc/Abilities/GitHubAbilities.php`
- Verified via wc-site-generator iterator smoke: previous failure advanced from missing `properties` to this specific array-schema validation error.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Traced the OpenAI schema validation failure and drafted the minimal schema fix; Chris remains responsible for review and merge.