### PR TITLE
fix: declare GitHub issue array schema items

### DIFF
--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -201,10 +201,12 @@ class GitHubAbilities {
 							),
 							'labels'       => array(
 								'type'        => 'array',
+								'items'       => array( 'type' => 'string' ),
 								'description' => 'Labels to set on the issue (replaces existing).',
 							),
 							'assignees'    => array(
 								'type'        => 'array',
+								'items'       => array( 'type' => 'string' ),
 								'description' => 'Assignees to set on the issue (replaces existing).',
 							),
 						),
@@ -247,10 +249,12 @@ class GitHubAbilities {
 							),
 							'labels'    => array(
 								'type'        => 'array',
+								'items'       => array( 'type' => 'string' ),
 								'description' => 'Labels to attach to the issue.',
 							),
 							'assignees' => array(
 								'type'        => 'array',
+								'items'       => array( 'type' => 'string' ),
 								'description' => 'GitHub usernames to assign to the issue.',
 							),
 							'milestone' => array(

--- a/tests/smoke-github-create-abilities.php
+++ b/tests/smoke-github-create-abilities.php
@@ -175,7 +175,9 @@ namespace {
 	$assert( 'create-github-issue uses createIssue execute_callback', array( GitHubAbilities::class, 'createIssue' ) === ( $issue_ability['execute_callback'] ?? null ) );
 	$assert( 'create-github-issue requires repo and title', array( 'repo', 'title' ) === ( $issue_ability['input_schema']['required'] ?? array() ) );
 	$assert( 'create-github-issue exposes labels', array_key_exists( 'labels', $issue_ability['input_schema']['properties'] ?? array() ) );
+	$assert( 'create-github-issue labels schema declares string items', array( 'type' => 'string' ) === ( $issue_ability['input_schema']['properties']['labels']['items'] ?? null ) );
 	$assert( 'create-github-issue exposes assignees', array_key_exists( 'assignees', $issue_ability['input_schema']['properties'] ?? array() ) );
+	$assert( 'create-github-issue assignees schema declares string items', array( 'type' => 'string' ) === ( $issue_ability['input_schema']['properties']['assignees']['items'] ?? null ) );
 	$assert( 'create-github-issue exposes milestone', array_key_exists( 'milestone', $issue_ability['input_schema']['properties'] ?? array() ) );
 	$assert( 'create-github-issue is hidden from REST', false === ( $issue_ability['meta']['show_in_rest'] ?? null ) );
 	$assert( 'create-github-issue category matches family', 'datamachine-code-github' === ( $issue_ability['category'] ?? '' ) );


### PR DESCRIPTION
## Summary
- Add `items: { type: string }` to GitHub issue label/assignee array input schemas so OpenAI tool validation accepts them.
- Cover the create issue ability schema in the existing smoke test.

## Verification
- `php tests/smoke-github-create-abilities.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the OpenAI tool-schema rejection in the iterator smoke path and drafted the focused schema/test fix; Chris remains responsible for review and merge.