### PR TITLE
Stream workspace clone progress

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -270,6 +270,10 @@ class WorkspaceAbilities {
 								'type'        => 'string',
 								'description' => 'Directory name override (derived from URL if omitted).',
 							),
+							'full' => array(
+								'type'        => 'boolean',
+								'description' => 'Disable the default blobless partial clone for remote repositories.',
+							),
 						),
 						'required'   => array( 'url' ),
 					),
@@ -1818,7 +1822,8 @@ class WorkspaceAbilities {
 		$workspace = new Workspace();
 		return $workspace->clone_repo(
 			$input['url'] ?? '',
-			$input['name'] ?? null
+			$input['name'] ?? null,
+			array( 'full' => (bool) ( $input['full'] ?? false ) )
 		);
 	}
 
@@ -2396,7 +2401,6 @@ class WorkspaceAbilities {
 		if ( isset( $input['chunk_size'] ) ) {
 			$opts['chunk_size'] = (int) $input['chunk_size'];
 		}
-
 
 		$service = new CleanupRunService();
 		$plan    = $service->plan( $opts );

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -5,9 +5,9 @@
  * Provides CLI access to the agent workspace — a managed directory
  * for cloning repos and working with files outside the web root.
  *
- * All commands delegate to WordPress Abilities API primitives registered
- * in WorkspaceAbilities. The CLI layer handles argument parsing, confirmation
- * prompts, and output formatting only.
+ * Commands delegate to the same services as WordPress Abilities API primitives.
+ * The CLI layer handles argument parsing, confirmation prompts, and output
+ * formatting only.
  *
  * @package DataMachineCode\Cli\Commands
  * @since 0.1.0
@@ -162,6 +162,9 @@ class WorkspaceCommand extends BaseCommand {
 	 * [--name=<name>]
 	 * : Directory name in workspace (derived from URL if omitted).
 	 *
+	 * [--full]
+	 * : Disable the default blobless partial clone (`--filter=blob:none`). Useful for servers that do not support partial clone or when all blobs are needed immediately.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Clone a repo
@@ -178,18 +181,18 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 
-		$ability = wp_get_ability( 'datamachine/workspace-clone' );
-		if ( ! $ability ) {
-			WP_CLI::error( 'Workspace clone ability not available.' );
-			return;
-		}
-
-		$input = array( 'url' => $args[0] );
-		if ( ! empty( $assoc_args['name'] ) ) {
-			$input['name'] = $assoc_args['name'];
-		}
-
-		$result = $ability->execute( $input );
+		$workspace = new Workspace();
+		$result    = $workspace->clone_repo(
+			$args[0],
+			$assoc_args['name'] ?? null,
+			array(
+				'full'              => isset( $assoc_args['full'] ),
+				'progress_callback' => static function ( array $event ): void {
+					$elapsed = number_format( (float) ( $event['elapsed'] ?? 0 ), 1 );
+					WP_CLI::log( sprintf( '[clone %ss] %s', $elapsed, (string) ( $event['message'] ?? '' ) ) );
+				},
+			)
+		);
 
 		if ( is_wp_error( $result ) ) {
 			WP_CLI::error( $result->get_error_message() );

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -447,11 +447,12 @@ class Workspace {
 	/**
 	 * Clone a git repository into the workspace.
 	 *
-	 * @param string      $url  Git clone URL.
-	 * @param string|null $name Directory name override (derived from URL if null).
+	 * @param string      $url     Git clone URL.
+	 * @param string|null $name    Directory name override (derived from URL if null).
+	 * @param array       $options Optional clone options.
 	 * @return array{success: bool, name?: string, path?: string, message?: string}|\WP_Error
 	 */
-	public function clone_repo( string $url, ?string $name = null ): array|\WP_Error {
+	public function clone_repo( string $url, ?string $name = null, array $options = array() ): array|\WP_Error {
 		$visible = $this->require_workspace_visible();
 		if ( null !== $visible ) {
 			return $visible;
@@ -480,7 +481,7 @@ class Workspace {
 
 		// Check if already exists.
 		if ( is_dir( $repo_path ) ) {
-			return new \WP_Error( 'repo_exists', sprintf( 'Directory already exists: %s. Use "remove" first to re-clone.', $name ), array( 'status' => 400 ) );
+			return $this->clone_target_exists_error( $name, $repo_path );
 		}
 
 		// Ensure workspace exists.
@@ -489,16 +490,27 @@ class Workspace {
 			return $ensure;
 		}
 
-		// Clone.
-		$escaped_url  = escapeshellarg( $url );
-		$escaped_path = escapeshellarg( $repo_path );
-		$command      = sprintf( 'git clone %s %s 2>&1', $escaped_url, $escaped_path );
+		$partial_clone     = ! (bool) ( $options['full'] ?? false ) && $this->should_use_partial_clone( $url );
+		$progress_callback = is_callable( $options['progress_callback'] ?? null ) ? $options['progress_callback'] : null;
+		$started_at        = microtime( true );
 
-		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
-		exec( $command, $output, $exit_code );
+		$this->emit_clone_progress(
+			$progress_callback,
+			'start',
+			sprintf(
+				'Cloning %s into %s%s.',
+				$url,
+				$repo_path,
+				$partial_clone ? ' using partial clone (--filter=blob:none)' : ''
+			),
+			$started_at
+		);
 
-		if ( 0 !== $exit_code ) {
-			return new \WP_Error( 'clone_failed', sprintf( 'Git clone failed (exit %d): %s', $exit_code, implode( "\n", $output ) ), array( 'status' => 500 ) );
+		$command = $this->build_clone_command( $url, $repo_path, $partial_clone );
+		$result  = $this->run_clone_command( $command, $progress_callback, $started_at );
+
+		if ( is_wp_error( $result ) ) {
+			return $this->clone_failed_error( $result, $name, $repo_path, $url );
 		}
 
 		$this->emit_workspace_changed( 'clone', $name, $name, $repo_path );
@@ -508,6 +520,207 @@ class Workspace {
 			'name'    => $name,
 			'path'    => $repo_path,
 			'message' => sprintf( 'Cloned %s into workspace as "%s".', $url, $name ),
+		);
+	}
+
+	/**
+	 * Build a git clone command.
+	 *
+	 * @param string $url           Git clone URL.
+	 * @param string $repo_path     Destination path.
+	 * @param bool   $partial_clone Whether to request blobless partial clone.
+	 * @return string Shell command.
+	 */
+	private function build_clone_command( string $url, string $repo_path, bool $partial_clone ): string {
+		$args = array( 'clone', '--progress' );
+		if ( $partial_clone ) {
+			$args[] = '--filter=blob:none';
+		}
+
+		$args[] = escapeshellarg( $url );
+		$args[] = escapeshellarg( $repo_path );
+
+		return 'GIT_TERMINAL_PROMPT=0 git ' . implode( ' ', $args );
+	}
+
+	/**
+	 * Remote HTTP(S) and SSH hosts generally support safe blobless clones; local
+	 * paths and file URLs often do not, and are usually test fixtures anyway.
+	 *
+	 * @param string $url Git clone URL.
+	 * @return bool True when a partial clone should be attempted.
+	 */
+	private function should_use_partial_clone( string $url ): bool {
+		return (bool) preg_match( '#^(https?://|git@|ssh://)#', $url );
+	}
+
+	/**
+	 * Stream a clone command to an optional progress callback.
+	 *
+	 * @param string        $command           Shell command.
+	 * @param callable|null $progress_callback Optional progress callback.
+	 * @param float         $started_at        Clone start timestamp.
+	 * @return array{success: true, output: string}|\WP_Error
+	 */
+	private function run_clone_command( string $command, ?callable $progress_callback, float $started_at ): array|\WP_Error {
+		$descriptor_spec = array(
+			1 => array( 'pipe', 'w' ),
+			2 => array( 'pipe', 'w' ),
+		);
+
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_proc_open
+		$process = proc_open( $command, $descriptor_spec, $pipes );
+		if ( ! is_resource( $process ) ) {
+			return new \WP_Error( 'clone_failed', 'Git clone failed to start.', array( 'status' => 500 ) );
+		}
+
+		stream_set_blocking( $pipes[1], false );
+		stream_set_blocking( $pipes[2], false );
+
+		$output = '';
+		$exit_code = null;
+		while ( true ) {
+			$chunk = (string) stream_get_contents( $pipes[1] ) . (string) stream_get_contents( $pipes[2] );
+			if ( '' !== $chunk ) {
+				$output .= $chunk;
+				$this->emit_clone_output( $progress_callback, $chunk, $started_at );
+			}
+
+			$status = proc_get_status( $process );
+			if ( empty( $status['running'] ) ) {
+				$exit_code = isset( $status['exitcode'] ) ? (int) $status['exitcode'] : null;
+				break;
+			}
+
+			usleep( 100000 );
+		}
+
+		$output .= (string) stream_get_contents( $pipes[1] ) . (string) stream_get_contents( $pipes[2] );
+		foreach ( $pipes as $pipe ) {
+			fclose( $pipe );
+		}
+
+		$close_code = proc_close( $process );
+		if ( null === $exit_code ) {
+			$exit_code = $close_code;
+		}
+		$output    = trim( str_replace( "\r", "\n", $output ) );
+		if ( 0 !== $exit_code ) {
+			return new \WP_Error(
+				'clone_failed',
+				sprintf( 'Git clone failed (exit %d): %s', $exit_code, $output ),
+				array(
+					'status' => 500,
+					'output' => $output,
+				)
+			);
+		}
+
+		return array(
+			'success' => true,
+			'output'  => $output,
+		);
+	}
+
+	/**
+	 * Emit normalized clone output chunks.
+	 *
+	 * @param callable|null $progress_callback Optional progress callback.
+	 * @param string        $chunk             Raw process output chunk.
+	 * @param float         $started_at        Clone start timestamp.
+	 */
+	private function emit_clone_output( ?callable $progress_callback, string $chunk, float $started_at ): void {
+		$lines = preg_split( '/[\r\n]+/', $chunk );
+		if ( ! is_array( $lines ) ) {
+			return;
+		}
+
+		foreach ( $lines as $line ) {
+			$line = trim( $line );
+			if ( '' === $line ) {
+				continue;
+			}
+
+			$this->emit_clone_progress( $progress_callback, 'git', $line, $started_at );
+		}
+	}
+
+	/**
+	 * Emit one structured clone progress message.
+	 *
+	 * @param callable|null $progress_callback Optional progress callback.
+	 * @param string        $phase             Progress phase.
+	 * @param string        $message           Progress message.
+	 * @param float         $started_at        Clone start timestamp.
+	 */
+	private function emit_clone_progress( ?callable $progress_callback, string $phase, string $message, float $started_at ): void {
+		if ( null === $progress_callback ) {
+			return;
+		}
+
+		$progress_callback(
+			array(
+				'phase'   => $phase,
+				'elapsed' => max( 0.0, microtime( true ) - $started_at ),
+				'message' => $message,
+			)
+		);
+	}
+
+	/**
+	 * Build a recovery-focused error when a clone target exists already.
+	 *
+	 * @param string $name      Workspace repo name.
+	 * @param string $repo_path Target path.
+	 * @return \WP_Error Error with remediation data.
+	 */
+	private function clone_target_exists_error( string $name, string $repo_path ): \WP_Error {
+		$looks_like_git = is_dir( $repo_path . '/.git' );
+		$state          = $looks_like_git ? 'existing checkout' : 'partial or non-git directory';
+		$next_steps     = array(
+			sprintf( 'Inspect the target: %s', $repo_path ),
+			sprintf( 'If it is safe to discard, remove it explicitly: wp datamachine-code workspace remove %s', $name ),
+			'Then retry the clone command.',
+		);
+
+		return new \WP_Error(
+			'repo_exists',
+			sprintf( 'Clone target already exists as %s: %s. Next steps: %s', $state, $repo_path, implode( ' ', $next_steps ) ),
+			array(
+				'status'     => 400,
+				'path'       => $repo_path,
+				'state'      => $state,
+				'next_steps' => $next_steps,
+			)
+		);
+	}
+
+	/**
+	 * Add recovery guidance to git clone failures.
+	 *
+	 * @param \WP_Error $error     Clone process error.
+	 * @param string    $name      Workspace repo name.
+	 * @param string    $repo_path Target path.
+	 * @param string    $url       Git clone URL.
+	 * @return \WP_Error Error with remediation data.
+	 */
+	private function clone_failed_error( \WP_Error $error, string $name, string $repo_path, string $url ): \WP_Error {
+		$next_steps = array(
+			sprintf( 'Confirm the repository URL is reachable: %s', $url ),
+			sprintf( 'Inspect any partial target: %s', $repo_path ),
+			sprintf( 'If the target is safe to discard, remove it explicitly: wp datamachine-code workspace remove %s', $name ),
+			'Then retry the clone command.',
+		);
+
+		$data                 = (array) $error->get_error_data();
+		$data['path']         = $repo_path;
+		$data['next_steps']   = $next_steps;
+		$data['partial_path'] = is_dir( $repo_path ) ? $repo_path : null;
+
+		return new \WP_Error(
+			'clone_failed',
+			$error->get_error_message() . ' Next steps: ' . implode( ' ', $next_steps ),
+			$data
 		);
 	}
 

--- a/tests/smoke-workspace-clone-ux.php
+++ b/tests/smoke-workspace-clone-ux.php
@@ -1,0 +1,212 @@
+<?php
+/**
+ * Pure-PHP smoke test for workspace clone UX helpers.
+ *
+ * Run: php tests/smoke-workspace-clone-ux.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace {
+	$root      = sys_get_temp_dir() . '/dmc-clone-ux-' . getmypid();
+	$workspace = $root . '/workspace';
+	mkdir( $workspace, 0755, true );
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	if ( ! defined( 'DATAMACHINE_WORKSPACE_PATH' ) ) {
+		define( 'DATAMACHINE_WORKSPACE_PATH', $workspace );
+	}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			private string $code;
+			private string $message;
+			private $data;
+
+			public function __construct( string $code = '', string $message = '', $data = array() ) {
+				$this->code    = $code;
+				$this->message = $message;
+				$this->data    = $data;
+			}
+
+			public function get_error_code(): string {
+				return $this->code;
+			}
+
+			public function get_error_message(): string {
+				return $this->message;
+			}
+
+			public function get_error_data() {
+				return $this->data;
+			}
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $thing ): bool {
+			return $thing instanceof \WP_Error;
+		}
+	}
+
+	if ( ! function_exists( 'wp_mkdir_p' ) ) {
+		function wp_mkdir_p( string $path ): bool {
+			return is_dir( $path ) || mkdir( $path, 0755, true );
+		}
+	}
+
+	if ( ! function_exists( 'get_option' ) ) {
+		function get_option( string $_name, $default = false ) {
+			return $default;
+		}
+	}
+
+	if ( ! function_exists( 'size_format' ) ) {
+		function size_format( $bytes ): string {
+			return (string) $bytes;
+		}
+	}
+
+	if ( ! function_exists( 'do_action' ) ) {
+		function do_action( string $_hook, array $_payload ): void {}
+	}
+
+	require __DIR__ . '/../inc/Workspace/Workspace.php';
+
+	$failures = 0;
+	$total    = 0;
+
+	$assert = function ( bool $condition, string $message ) use ( &$failures, &$total ): void {
+		$total++;
+		if ( $condition ) {
+			echo "  [PASS] {$message}\n";
+			return;
+		}
+
+		$failures++;
+		echo "  [FAIL] {$message}\n";
+	};
+
+	$assert_same = function ( $expected, $actual, string $message ) use ( &$failures, &$total ): void {
+		$total++;
+		if ( $expected === $actual ) {
+			echo "  [PASS] {$message}\n";
+			return;
+		}
+
+		$failures++;
+		echo "  [FAIL] {$message}\n";
+		echo '    expected: ' . var_export( $expected, true ) . "\n";
+		echo '    actual:   ' . var_export( $actual, true ) . "\n";
+	};
+
+	$run = function ( string $command ): void {
+		exec( $command . ' 2>&1', $output, $exit_code );
+		if ( 0 !== $exit_code ) {
+			throw new \RuntimeException( sprintf( "Command failed (%d): %s\n%s", $exit_code, $command, implode( "\n", $output ) ) );
+		}
+	};
+
+	$rm_rf = function ( string $path ) use ( &$rm_rf ): void {
+		if ( ! file_exists( $path ) ) {
+			return;
+		}
+
+		if ( is_file( $path ) || is_link( $path ) ) {
+			unlink( $path );
+			return;
+		}
+
+		foreach ( scandir( $path ) ?: array() as $entry ) {
+			if ( '.' === $entry || '..' === $entry ) {
+				continue;
+			}
+
+			$rm_rf( $path . '/' . $entry );
+		}
+
+		rmdir( $path );
+	};
+
+	try {
+		echo "=== smoke-workspace-clone-ux ===\n";
+
+		$workspace_object = new \DataMachineCode\Workspace\Workspace();
+		$reflection       = new \ReflectionClass( $workspace_object );
+		$build_command    = $reflection->getMethod( 'build_clone_command' );
+		$partial_decision = $reflection->getMethod( 'should_use_partial_clone' );
+
+		echo "\n[1] Clone command construction\n";
+		$remote_command = $build_command->invoke( $workspace_object, 'https://github.com/Extra-Chill/data-machine-code.git', $workspace . '/remote', true );
+		$local_command  = $build_command->invoke( $workspace_object, $root . '/upstream', $workspace . '/local', false );
+		$assert( str_contains( $remote_command, '--progress' ), 'remote command requests git progress' );
+		$assert( str_contains( $remote_command, '--filter=blob:none' ), 'remote command uses blobless partial clone' );
+		$assert( ! str_contains( $local_command, '--filter=blob:none' ), 'local command omits partial clone filter' );
+		$assert_same( true, $partial_decision->invoke( $workspace_object, 'git@github.com:Extra-Chill/data-machine-code.git' ), 'ssh remotes use partial clone' );
+		$assert_same( false, $partial_decision->invoke( $workspace_object, $root . '/upstream' ), 'local paths skip partial clone' );
+
+		echo "\n[2] Existing partial target recovery guidance\n";
+		mkdir( $workspace . '/partial-target', 0755, true );
+		$exists = $workspace_object->clone_repo( 'https://github.com/Extra-Chill/data-machine-code.git', 'partial-target' );
+		$assert( is_wp_error( $exists ), 'clone_repo reports existing target as error' );
+		$assert_same( 'repo_exists', $exists->get_error_code(), 'existing target uses repo_exists code' );
+		$assert( str_contains( $exists->get_error_message(), 'partial or non-git directory' ), 'existing target message describes partial state' );
+		$assert( str_contains( $exists->get_error_message(), 'workspace remove partial-target' ), 'existing target message includes cleanup command' );
+		$assert( is_array( $exists->get_error_data()['next_steps'] ?? null ), 'existing target includes structured next steps' );
+
+		echo "\n[3] Local clone streams progress events\n";
+		$upstream = $root . '/upstream';
+		mkdir( $upstream, 0755, true );
+		$run( 'git -C ' . escapeshellarg( $upstream ) . ' init -q' );
+		file_put_contents( $upstream . '/README.md', "# fixture\n" );
+		$run( 'git -C ' . escapeshellarg( $upstream ) . ' add README.md' );
+		$run( 'git -C ' . escapeshellarg( $upstream ) . ' -c user.name=Test -c user.email=test@example.com commit -q -m init' );
+
+		$events = array();
+		$clone  = $workspace_object->clone_repo(
+			$upstream,
+			'fixture-clone',
+			array(
+				'progress_callback' => function ( array $event ) use ( &$events ): void {
+					$events[] = $event;
+				},
+			)
+		);
+
+		$assert( ! is_wp_error( $clone ), 'local clone succeeds' );
+		$assert( is_dir( $workspace . '/fixture-clone/.git' ), 'clone target contains .git directory' );
+		$assert( count( $events ) > 0, 'progress callback receives events' );
+		$assert_same( 'start', $events[0]['phase'] ?? null, 'first progress event has start phase' );
+		$assert( str_contains( $events[0]['message'] ?? '', 'Cloning' ), 'start progress includes clone context' );
+
+		$remote_url = getenv( 'REMOTE_CLONE_URL' );
+		if ( is_string( $remote_url ) && '' !== trim( $remote_url ) ) {
+			echo "\n[4] Remote clone smoke\n";
+			$remote_events = array();
+			$remote_clone  = $workspace_object->clone_repo(
+				trim( $remote_url ),
+				'remote-fixture-clone',
+				array(
+					'progress_callback' => function ( array $event ) use ( &$remote_events ): void {
+						$remote_events[] = $event;
+					},
+				)
+			);
+
+			$assert( ! is_wp_error( $remote_clone ), 'remote clone succeeds' );
+			$assert( is_dir( $workspace . '/remote-fixture-clone/.git' ), 'remote clone target contains .git directory' );
+			$assert( count( $remote_events ) > 1, 'remote clone emits progress events' );
+			$assert( str_contains( $remote_events[0]['message'] ?? '', '--filter=blob:none' ), 'remote clone start event documents partial clone' );
+		}
+	} finally {
+		$rm_rf( $root );
+	}
+
+	echo "\nResult: " . ( $total - $failures ) . "/{$total} passed\n";
+	exit( $failures > 0 ? 1 : 0 );
+}


### PR DESCRIPTION
## Summary
- Streams `git clone --progress` output from `workspace clone` so long-running clones show visible phase/elapsed context in WP-CLI logs.
- Uses blobless partial clone (`--filter=blob:none`) by default for remote HTTP/SSH URLs, with `--full` to opt out when needed.
- Adds recovery-focused errors for failed or partial clone targets with explicit inspect/remove/retry next steps.

Fixes #292.
Fixes #293.

## Testing
- `php -l inc/Workspace/Workspace.php && php -l inc/Cli/Commands/WorkspaceCommand.php && php -l inc/Abilities/WorkspaceAbilities.php && php -l tests/smoke-workspace-clone-ux.php`
- `php tests/smoke-workspace-clone-ux.php`
- `php tests/smoke-workspace-path-diagnostics.php`
- `REMOTE_CLONE_URL=https://github.com/octocat/Hello-World.git php tests/smoke-workspace-clone-ux.php`
- `homeboy lint --path . --changed-only --errors-only`
- `homeboy test --path .` (passes; no PHPUnit files discovered by the runner)

## Notes
- `homeboy lint --path .` still reports the existing repository-wide PHPCS baseline, including unrelated pre-existing errors outside this change. Changed-only error lint passes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and tested the workspace clone progress/recovery implementation and PR description; Chris remains responsible for review and merge.