### PR TITLE
fix: use temp workspace fallback in ephemeral runtimes

### DIFF
--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -85,7 +85,8 @@ class Workspace {
 	 * 1. DATAMACHINE_WORKSPACE_PATH constant (if defined)
 	 * 2. /var/lib/datamachine/workspace (if writable — typical on VPS)
 	 * 3. $HOME/.datamachine/workspace (local/macOS fallback)
-	 * 4. Empty string (no workspace available)
+	 * 4. sys_get_temp_dir()/datamachine/workspace (ephemeral CI/Playground fallback)
+	 * 5. Empty string (no workspace available)
 	 *
 	 * @return string Workspace path or empty string if unavailable.
 	 */
@@ -127,6 +128,26 @@ class Workspace {
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable
 			if ( ! file_exists( $home_base ) && is_writable( dirname( $home_base ) ) ) {
 				return $home_path;
+			}
+		}
+
+		$temp_path = rtrim( sys_get_temp_dir(), '/' ) . '/datamachine/workspace';
+		$temp_base = dirname( $temp_path );
+		$web_root  = defined( 'ABSPATH' ) ? realpath( ABSPATH ) : false;
+		$temp_root = realpath( sys_get_temp_dir() );
+
+		if (
+			false !== $temp_root &&
+			( false === $web_root || 0 !== strpos( $temp_root . '/', rtrim( $web_root, '/' ) . '/' ) )
+		) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable
+			if ( is_dir( $temp_base ) && is_writable( $temp_base ) ) {
+				return $temp_path;
+			}
+
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable
+			if ( ! file_exists( $temp_base ) && is_writable( dirname( $temp_base ) ) ) {
+				return $temp_path;
 			}
 		}
 
@@ -174,7 +195,7 @@ class Workspace {
 		if ( '' === $diagnostic['path'] ) {
 			return new \WP_Error(
 				'workspace_unavailable',
-				'Workspace unavailable: no writable path outside the web root. Define DATAMACHINE_WORKSPACE_PATH in wp-config.php, ensure /var/lib/datamachine/ is writable, or ensure $HOME is set.',
+				'Workspace unavailable: no writable path outside the web root. Define DATAMACHINE_WORKSPACE_PATH in wp-config.php, ensure /var/lib/datamachine/ is writable, ensure $HOME is set, or ensure the system temporary directory is writable.',
 				$this->workspace_visibility_error_data( $diagnostic )
 			);
 		}

--- a/tests/smoke-workspace-temp-fallback.php
+++ b/tests/smoke-workspace-temp-fallback.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Pure-PHP smoke test for the ephemeral temp workspace fallback.
+ *
+ * Run: php tests/smoke-workspace-temp-fallback.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Core\FilesRepository {
+	class FilesystemHelper {
+		public static function get() {
+			return null;
+		}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/fixtures/web-root/' );
+	}
+
+	putenv( 'HOME=' );
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			private string $code;
+			private string $message;
+			private $data;
+
+			public function __construct( string $code = '', string $message = '', $data = array() ) {
+				$this->code    = $code;
+				$this->message = $message;
+				$this->data    = $data;
+			}
+
+			public function get_error_code(): string {
+				return $this->code;
+			}
+
+			public function get_error_message(): string {
+				return $this->message;
+			}
+
+			public function get_error_data() {
+				return $this->data;
+			}
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $thing ): bool {
+			return $thing instanceof \WP_Error;
+		}
+	}
+
+	if ( ! function_exists( 'wp_mkdir_p' ) ) {
+		function wp_mkdir_p( string $path ): bool {
+			return is_dir( $path ) || mkdir( $path, 0755, true );
+		}
+	}
+
+	require __DIR__ . '/../inc/Workspace/Workspace.php';
+
+	$failures = 0;
+	$total    = 0;
+
+	$assert = function ( bool $condition, string $message ) use ( &$failures, &$total ): void {
+		$total++;
+		if ( $condition ) {
+			echo "  [PASS] {$message}\n";
+			return;
+		}
+
+		$failures++;
+		echo "  [FAIL] {$message}\n";
+	};
+
+	$assert_same = function ( $expected, $actual, string $message ) use ( &$failures, &$total ): void {
+		$total++;
+		if ( $expected === $actual ) {
+			echo "  [PASS] {$message}\n";
+			return;
+		}
+
+		$failures++;
+		echo "  [FAIL] {$message}\n";
+		echo '    expected: ' . var_export( $expected, true ) . "\n";
+		echo '    actual:   ' . var_export( $actual, true ) . "\n";
+	};
+
+	echo "=== smoke-workspace-temp-fallback ===\n";
+
+	$expected  = rtrim( sys_get_temp_dir(), '/' ) . '/datamachine/workspace';
+	$workspace = new \DataMachineCode\Workspace\Workspace();
+
+	echo "\n[1] Resolve temp fallback when no configured/system/home workspace is available\n";
+	$assert_same( $expected, $workspace->get_path(), 'workspace resolves to sys_get_temp_dir fallback' );
+	$assert( 0 !== strpos( $workspace->get_path() . '/', rtrim( ABSPATH, '/' ) . '/' ), 'fallback is outside ABSPATH' );
+
+	echo "\n[2] Workspace operations no longer fail as unavailable\n";
+	$list = $workspace->list_repos();
+	$assert( ! is_wp_error( $list ), 'list_repos does not return workspace_unavailable' );
+	$assert_same( $expected, $list['path'] ?? null, 'list_repos reports temp workspace path' );
+
+	echo "\n[3] Temp workspace can be created on demand\n";
+	$ensure = $workspace->ensure_exists();
+	$assert( ! is_wp_error( $ensure ), 'ensure_exists succeeds for temp fallback' );
+	$assert_same( $expected, $ensure['path'] ?? null, 'ensure_exists creates expected path' );
+	$assert( is_dir( $expected ), 'temp workspace directory exists' );
+
+	echo "\nResult: " . ( $total - $failures ) . "/{$total} passed\n";
+	exit( $failures > 0 ? 1 : 0 );
+}


### PR DESCRIPTION
## Summary
- Add a guarded `sys_get_temp_dir()/datamachine/workspace` fallback when no configured, system, or HOME workspace is available.
- Keep the fallback outside `ABSPATH` so DMC does not silently create writable repo workspaces under the web root.
- Add a pure-PHP smoke proving ephemeral runtimes can resolve and create the temp workspace.

## Why
WordPress Playground and CI agent runs may not expose `/var/lib/datamachine` or `$HOME`, which caused DMC workspace operations to fail before automation could create remediation branches/PRs. A temp fallback gives CI-native Data Machine agents a safe writable workspace substrate by default.

## Verification
- `php -l inc/Workspace/Workspace.php`
- `php tests/smoke-workspace-temp-fallback.php`
- `php tests/smoke-workspace-path-diagnostics.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the workspace fallback and smoke test under Chris's direction; Chris identified the CI/Playground automation gap and reviewed the intended architecture.