### PR TITLE
fix: expose workspace git capability diagnostics

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -19,6 +19,7 @@ use DataMachineCode\Workspace\CleanupRunService;
 use DataMachineCode\Workspace\Workspace;
 use DataMachineCode\Workspace\WorkspaceReader;
 use DataMachineCode\Workspace\WorkspaceWriter;
+use DataMachineCode\Support\GitRunner;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -108,6 +109,35 @@ class WorkspaceAbilities {
 						),
 					),
 					'execute_callback'    => array( self::class, 'listRepos' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/workspace-capabilities',
+				array(
+					'label'               => 'Inspect Workspace Capabilities',
+					'description'         => 'Inspect the current Data Machine Code workspace backend and whether local git operations can execute in this runtime.',
+					'category'            => 'datamachine-code-workspace',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'             => array( 'type' => 'boolean' ),
+							'backend'             => array( 'type' => 'string' ),
+							'workspace_path'      => array( 'type' => 'string' ),
+							'git_available'       => array( 'type' => 'boolean' ),
+							'exec_available'      => array( 'type' => 'boolean' ),
+							'proc_open_available' => array( 'type' => 'boolean' ),
+							'git_path'            => array( 'type' => 'string' ),
+							'remediation'         => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'getCapabilities' ),
 					'permission_callback' => fn() => PermissionHelper::can_manage(),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
@@ -1764,6 +1794,27 @@ class WorkspaceAbilities {
 	public static function listRepos( array $input ): array|\WP_Error { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 		$workspace = new Workspace();
 		return $workspace->list_repos();
+	}
+
+	/**
+	 * Inspect workspace runtime capabilities.
+	 *
+	 * @param array $input Input parameters.
+	 * @return array<string,mixed>
+	 */
+	public static function getCapabilities( array $input ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+		$workspace   = new Workspace();
+		$diagnostic  = GitRunner::diagnose();
+		$remediation = 'Run workspace abilities in a host runtime with local git access, or provide a Data Machine Code workspace backend that executes these operations outside the constrained PHP sandbox.';
+
+		return array_merge(
+			array(
+				'success'        => true,
+				'workspace_path' => $workspace->get_path(),
+				'remediation'    => $remediation,
+			),
+			$diagnostic
+		);
 	}
 
 	/**

--- a/inc/Support/GitRunner.php
+++ b/inc/Support/GitRunner.php
@@ -21,6 +21,97 @@ defined( 'ABSPATH' ) || exit;
 final class GitRunner {
 
 	/**
+	 * Cached runtime capability probe.
+	 *
+	 * @var array<string,mixed>|null
+	 */
+	private static ?array $diagnostic = null;
+
+	/**
+	 * Inspect whether the current PHP runtime can execute local git commands.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public static function diagnose(): array {
+		if ( null !== self::$diagnostic ) {
+			return self::$diagnostic;
+		}
+
+		$exec_available      = function_exists( 'exec' );
+		$proc_open_available = function_exists( 'proc_open' );
+		$output              = array();
+		$exit_code           = 127;
+		$git_path            = '';
+
+		if ( $exec_available ) {
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
+			exec( 'command -v git 2>/dev/null', $output, $exit_code );
+			$git_path = trim( (string) ( $output[0] ?? '' ) );
+		}
+
+		self::$diagnostic = array(
+			'backend'             => 'local_git',
+			'exec_available'      => $exec_available,
+			'proc_open_available' => $proc_open_available,
+			'git_available'       => 0 === $exit_code && '' !== $git_path,
+			'git_path'            => $git_path,
+			'probe_exit_code'     => $exit_code,
+		);
+
+		return self::$diagnostic;
+	}
+
+	/**
+	 * Whether local git commands can run in the current PHP runtime.
+	 */
+	public static function is_available(): bool {
+		$diagnostic = self::diagnose();
+		return ! empty( $diagnostic['git_available'] );
+	}
+
+	/**
+	 * Whether streaming command execution is available for long-running git ops.
+	 */
+	public static function supports_streaming(): bool {
+		$diagnostic = self::diagnose();
+		return ! empty( $diagnostic['git_available'] ) && ! empty( $diagnostic['proc_open_available'] );
+	}
+
+	/**
+	 * Build the standard local-git-unavailable error.
+	 *
+	 * @param string $operation Human-readable operation being attempted.
+	 * @param bool   $requires_streaming Whether the operation needs proc_open streaming.
+	 * @return \WP_Error
+	 */
+	public static function unavailable_error( string $operation = 'Git workspace operation', bool $requires_streaming = false ): \WP_Error {
+		$diagnostic = self::diagnose();
+		$reason     = empty( $diagnostic['exec_available'] )
+			? 'PHP exec() is unavailable.'
+			: 'The git binary is unavailable to the PHP runtime.';
+
+		if ( $requires_streaming && ! empty( $diagnostic['git_available'] ) && empty( $diagnostic['proc_open_available'] ) ) {
+			$reason = 'PHP proc_open() is unavailable for streaming git operations.';
+		}
+
+		$remediation = 'Run workspace abilities in a host runtime with local git access, or provide a Data Machine Code workspace backend that executes these operations outside the constrained PHP sandbox.';
+
+		return new \WP_Error(
+			'datamachine_workspace_git_unavailable',
+			sprintf( '%s cannot run with the current workspace backend. %s %s', $operation, $reason, $remediation ),
+			array_merge(
+				$diagnostic,
+				array(
+					'status'             => 500,
+					'operation'          => $operation,
+					'requires_streaming' => $requires_streaming,
+					'remediation'        => $remediation,
+				)
+			)
+		);
+	}
+
+	/**
 	 * Run a git command inside a repository working tree.
 	 *
 	 * `$path` is assumed to have already been validated for containment by the
@@ -33,6 +124,14 @@ final class GitRunner {
 	 * @return array{success: true, output: string}|\WP_Error
 	 */
 	public static function run( string $path, string $args, int $timeout_seconds = 0 ): array|\WP_Error {
+		if ( ! self::is_available() ) {
+			return self::unavailable_error();
+		}
+
+		if ( $timeout_seconds > 0 && ! self::supports_streaming() ) {
+			return self::unavailable_error( 'Timed git workspace operation', true );
+		}
+
 		$escaped = escapeshellarg( $path );
 		$command = sprintf( 'git -C %s %s 2>&1', $escaped, $args );
 

--- a/inc/Tools/WorkspaceTools.php
+++ b/inc/Tools/WorkspaceTools.php
@@ -36,6 +36,7 @@ class WorkspaceTools extends BaseTool {
 	public function check_configuration( $configured, $tool_id ) {
 		$workspace_tools = array(
 			'workspace_path',
+			'workspace_capabilities',
 			'workspace_list',
 			'workspace_show',
 			'workspace_ls',
@@ -55,6 +56,7 @@ class WorkspaceTools extends BaseTool {
 	public function __construct() {
 		$contexts = array( 'chat', 'pipeline' );
 		$this->registerTool( 'workspace_path', array( $this, 'getPathDefinition' ), $contexts, array( 'ability' => 'datamachine/workspace-path' ) );
+		$this->registerTool( 'workspace_capabilities', array( $this, 'getCapabilitiesDefinition' ), $contexts, array( 'ability' => 'datamachine/workspace-capabilities' ) );
 		$this->registerTool( 'workspace_list', array( $this, 'getListDefinition' ), $contexts, array( 'ability' => 'datamachine/workspace-list' ) );
 		$this->registerTool( 'workspace_show', array( $this, 'getShowDefinition' ), $contexts, array( 'ability' => 'datamachine/workspace-show' ) );
 		$this->registerTool( 'workspace_ls', array( $this, 'getLsDefinition' ), $contexts, array( 'ability' => 'datamachine/workspace-ls' ) );
@@ -105,6 +107,31 @@ class WorkspaceTools extends BaseTool {
 			'success'   => true,
 			'data'      => $result,
 			'tool_name' => 'workspace_path',
+		);
+	}
+
+	/**
+	 * Handle workspace_capabilities tool call.
+	 *
+	 * @return array
+	 */
+	public function handleCapabilities(): array {
+		$ability = wp_get_ability( 'datamachine/workspace-capabilities' );
+
+		if ( ! $ability ) {
+			return $this->buildErrorResponse( 'Workspace capabilities ability not available.', 'workspace_capabilities' );
+		}
+
+		$result = $ability->execute( array() );
+
+		if ( is_wp_error( $result ) ) {
+			return $this->buildErrorResponse( $result->get_error_message(), 'workspace_capabilities' );
+		}
+
+		return array(
+			'success'   => true,
+			'data'      => $result,
+			'tool_name' => 'workspace_capabilities',
 		);
 	}
 
@@ -262,6 +289,23 @@ class WorkspaceTools extends BaseTool {
 					'required'    => false,
 					'description' => 'Create the workspace directory if it does not exist (default false).',
 				),
+			),
+		);
+	}
+
+	/**
+	 * Get workspace_capabilities tool definition.
+	 *
+	 * @return array Tool definition.
+	 */
+	public function getCapabilitiesDefinition(): array {
+		return array(
+			'class'       => self::class,
+			'method'      => 'handleCapabilities',
+			'description' => 'Inspect whether the current Data Machine Code workspace backend can run local git operations in this runtime.',
+			'parameters'  => array(
+				'type'       => 'object',
+				'properties' => array(),
 			),
 		);
 	}

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -511,6 +511,10 @@ class Workspace {
 			return $ensure;
 		}
 
+		if ( ! GitRunner::supports_streaming() ) {
+			return GitRunner::unavailable_error( 'Clone workspace repository', true );
+		}
+
 		$partial_clone     = ! (bool) ( $options['full'] ?? false ) && $this->should_use_partial_clone( $url );
 		$progress_callback = is_callable( $options['progress_callback'] ?? null ) ? $options['progress_callback'] : null;
 		$started_at        = microtime( true );

--- a/tests/smoke-workspace-git-capabilities.php
+++ b/tests/smoke-workspace-git-capabilities.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Pure-PHP smoke for explicit workspace git runtime capability diagnostics.
+ *
+ * Run: php tests/smoke-workspace-git-capabilities.php
+ */
+
+declare( strict_types=1 );
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', sys_get_temp_dir() . '/dmc-workspace-git-capabilities/' );
+}
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code, private string $message, private array $data = array() ) {}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+
+		public function get_error_data(): array {
+			return $this->data;
+		}
+	}
+}
+
+require __DIR__ . '/../inc/Support/GitRunner.php';
+
+use DataMachineCode\Support\GitRunner;
+
+$failures = array();
+$total    = 0;
+$assert   = function ( string $label, bool $condition ) use ( &$failures, &$total ): void {
+	++$total;
+	if ( $condition ) {
+		echo "  ok {$label}\n";
+		return;
+	}
+
+	$failures[] = $label;
+	echo "  fail {$label}\n";
+};
+
+echo "Workspace git capabilities - smoke\n";
+
+$diagnostic = GitRunner::diagnose();
+$assert( 'diagnostic identifies backend', 'local_git' === ( $diagnostic['backend'] ?? '' ) );
+$assert( 'diagnostic reports exec availability', array_key_exists( 'exec_available', $diagnostic ) && is_bool( $diagnostic['exec_available'] ) );
+$assert( 'diagnostic reports proc_open availability', array_key_exists( 'proc_open_available', $diagnostic ) && is_bool( $diagnostic['proc_open_available'] ) );
+$assert( 'diagnostic reports git availability', array_key_exists( 'git_available', $diagnostic ) && is_bool( $diagnostic['git_available'] ) );
+
+$error = GitRunner::unavailable_error( 'Test workspace operation', true );
+$assert( 'unavailable error has stable code', 'datamachine_workspace_git_unavailable' === $error->get_error_code() );
+$assert( 'unavailable error names operation', str_contains( $error->get_error_message(), 'Test workspace operation' ) );
+$assert( 'unavailable error carries remediation', str_contains( $error->get_error_message(), 'workspace backend' ) );
+$assert( 'unavailable error data carries backend', 'local_git' === ( $error->get_error_data()['backend'] ?? '' ) );
+
+if ( ! empty( $failures ) ) {
+	echo "\nFAIL: " . count( $failures ) . " assertion(s) failed out of {$total}\n";
+	foreach ( $failures as $failure ) {
+		echo "  - {$failure}\n";
+	}
+	exit( 1 );
+}
+
+echo "\nOK ({$total} assertions)\n";
+exit( 0 );


### PR DESCRIPTION
## Summary
- Adds a DMC workspace capability diagnostic that reports whether the current runtime can execute local git commands.
- Returns a stable `datamachine_workspace_git_unavailable` error before workspace git operations try to run in constrained PHP sandboxes.
- Exposes the diagnostic as a workspace ability and AI-visible read tool so downstream agents can keep the DMC workspace contract instead of inventing GitHub API bypasses.

## Verification
- `php -l inc/Support/GitRunner.php && php -l inc/Workspace/Workspace.php && php -l inc/Abilities/WorkspaceAbilities.php && php -l inc/Tools/WorkspaceTools.php && php -l tests/smoke-workspace-git-capabilities.php`
- `php tests/smoke-workspace-git-capabilities.php`
- `git diff --check`

## Not fully run
- `homeboy test --path . --extension wordpress` failed during Data Machine bootstrap before DMC tests ran: `Class \"WP_Agent_Memory_Layer\" not found` in `DataMachine\\Engine\\AI\\MemoryFileRegistry`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the DMC workspace runtime diagnostic and targeted smoke coverage; Chris remains responsible for review and merge.