### PR TITLE
Add guarded GitHub PR merge ability

### DIFF
--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -464,6 +464,54 @@ class GitHubAbilities {
 			);
 
 			wp_register_ability(
+				'datamachine/merge-github-pull-request',
+				array(
+					'label'               => 'Merge GitHub Pull Request',
+					'description'         => 'Merge an open GitHub pull request after verifying the expected head SHA',
+					'category'            => 'datamachine-code-github',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'repo', 'pull_number', 'expected_head_sha' ),
+						'properties' => array(
+							'repo'              => array(
+								'type'        => 'string',
+								'description' => 'Repository in owner/repo format.',
+							),
+							'pull_number'       => array(
+								'type'        => 'integer',
+								'description' => 'Pull request number.',
+							),
+							'expected_head_sha' => array(
+								'type'        => 'string',
+								'description' => 'Exact pull request head SHA expected immediately before merge.',
+							),
+							'merge_method'      => array(
+								'type'        => 'string',
+								'enum'        => array( 'merge', 'squash', 'rebase' ),
+								'description' => 'GitHub merge method. Default: squash.',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'     => array( 'type' => 'boolean' ),
+							'repo'        => array( 'type' => 'string' ),
+							'pull_number' => array( 'type' => 'integer' ),
+							'merged'      => array( 'type' => 'boolean' ),
+							'sha'         => array( 'type' => 'string' ),
+							'message'     => array( 'type' => 'string' ),
+							'html_url'    => array( 'type' => 'string' ),
+							'error'       => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'mergePullRequest' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
 				'datamachine/list-github-pulls',
 				array(
 					'label'               => 'List GitHub Pull Requests',
@@ -1560,6 +1608,76 @@ class GitHubAbilities {
 
 	public static function commentOnPullRequest( array $input ): array|\WP_Error {
 		return self::commentOnIssue( self::buildPullRequestCommentInput( $input ) );
+	}
+
+	/**
+	 * Merge an open pull request after re-checking the head SHA.
+	 *
+	 * Calls `GET /repos/{owner}/{repo}/pulls/{pull_number}` immediately before
+	 * `PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge`.
+	 *
+	 * @param array         $input       Required: repo, pull_number, expected_head_sha. Optional: merge_method.
+	 * @param callable|null $api_get     Optional test seam: fn(string $url, array $query, string $pat): array|WP_Error.
+	 * @param callable|null $api_request Optional test seam: fn(string $method, string $url, array $body, string $pat): array|WP_Error.
+	 * @return array|\WP_Error Success payload or error.
+	 */
+	public static function mergePullRequest( array $input, ?callable $api_get = null, ?callable $api_request = null ): array|\WP_Error {
+		$repo              = sanitize_text_field( $input['repo'] ?? '' );
+		$pull_number       = (int) ( $input['pull_number'] ?? 0 );
+		$expected_head_sha = sanitize_text_field( $input['expected_head_sha'] ?? '' );
+		$merge_method      = sanitize_text_field( $input['merge_method'] ?? 'squash' );
+
+		if ( empty( $repo ) || $pull_number <= 0 || '' === $expected_head_sha ) {
+			return new \WP_Error( 'missing_params', 'Repository, pull_number, and expected_head_sha are required.', array( 'status' => 400 ) );
+		}
+
+		if ( ! in_array( $merge_method, array( 'merge', 'squash', 'rebase' ), true ) ) {
+			return new \WP_Error( 'invalid_merge_method', 'merge_method must be merge, squash, or rebase.', array( 'status' => 400 ) );
+		}
+
+		$pat = self::getPatForRepo( $repo );
+		if ( empty( $pat ) ) {
+			return self::patError();
+		}
+
+		$api_get     = $api_get ?? array( self::class, 'apiGet' );
+		$api_request = $api_request ?? array( self::class, 'apiRequest' );
+		$pull_url    = sprintf( '%s/repos/%s/pulls/%d', self::API_BASE, $repo, $pull_number );
+
+		$pull_response = $api_get( $pull_url, array(), $pat );
+		if ( is_wp_error( $pull_response ) ) {
+			return $pull_response;
+		}
+
+		$pull = is_array( $pull_response['data'] ?? null ) ? $pull_response['data'] : array();
+		if ( 'open' !== (string) ( $pull['state'] ?? '' ) ) {
+			return new \WP_Error( 'pull_request_not_open', 'Pull request must be open before merge.', array( 'status' => 409 ) );
+		}
+
+		$current_head_sha = sanitize_text_field( $pull['head']['sha'] ?? '' );
+		if ( '' === $current_head_sha || $current_head_sha !== $expected_head_sha ) {
+			return new \WP_Error( 'pull_request_head_sha_mismatch', 'Pull request head SHA does not match expected_head_sha.', array( 'status' => 409 ) );
+		}
+
+		$merge_url = sprintf( '%s/repos/%s/pulls/%d/merge', self::API_BASE, $repo, $pull_number );
+		$response  = $api_request( 'PUT', $merge_url, array( 'merge_method' => $merge_method ), $pat );
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$data = is_array( $response['data'] ?? null ) ? $response['data'] : array();
+
+		return array(
+			'success'          => true,
+			'repo'             => $repo,
+			'pull_number'      => $pull_number,
+			'merged'           => (bool) ( $data['merged'] ?? false ),
+			'sha'              => (string) ( $data['sha'] ?? '' ),
+			'message'          => (string) ( $data['message'] ?? '' ),
+			'html_url'         => (string) ( $pull['html_url'] ?? '' ),
+			'pull_request_url' => (string) ( $pull['html_url'] ?? '' ),
+			'merge_method'     => $merge_method,
+		);
 	}
 
 	/**

--- a/inc/Tools/GitHubTools.php
+++ b/inc/Tools/GitHubTools.php
@@ -32,6 +32,10 @@ class GitHubTools extends BaseTool {
 			'access_level' => 'editor',
 			'ability'      => 'datamachine/upsert-github-pull-review-comment',
 		) );
+		$this->registerTool( 'merge_github_pull_request', array( $this, 'getMergePullRequestDefinition' ), $contexts, array(
+			'access_level' => 'editor',
+			'ability'      => 'datamachine/merge-github-pull-request',
+		) );
 		$this->registerTool( 'list_github_pulls', array( $this, 'getListPullsDefinition' ), $contexts, array( 'access_level' => 'editor' ) );
 		$this->registerTool( 'get_github_pull', array( $this, 'getGetPullDefinition' ), $contexts, array(
 			'access_level' => 'editor',
@@ -113,6 +117,7 @@ class GitHubTools extends BaseTool {
 			'manage_github_issue',
 			'comment_github_pull_request',
 			'upsert_github_pull_review_comment',
+			'merge_github_pull_request',
 			'list_github_pulls',
 			'get_github_pull',
 			'get_github_pull_files',
@@ -457,6 +462,51 @@ class GitHubTools extends BaseTool {
 					'type'        => 'string',
 					'required'    => false,
 					'description' => 'Comment policy: update_existing or per_head_sha. Default: update_existing.',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Handle merge_github_pull_request tool call.
+	 *
+	 * @param array $parameters Tool parameters.
+	 * @return array
+	 */
+	public function handleMergePullRequest( array $parameters ): array {
+		return $this->executeGitHubAbility( 'datamachine/merge-github-pull-request', 'merge_github_pull_request', $parameters );
+	}
+
+	/**
+	 * Get tool definition for merge_github_pull_request.
+	 *
+	 * @return array
+	 */
+	public function getMergePullRequestDefinition(): array {
+		return array(
+			'class'       => __CLASS__,
+			'method'      => 'handleMergePullRequest',
+			'description' => 'Merge an open GitHub pull request only when its current head SHA exactly matches expected_head_sha. Defaults to squash merge.',
+			'parameters'  => array(
+				'repo'              => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Repository in owner/repo format.',
+				),
+				'pull_number'       => array(
+					'type'        => 'integer',
+					'required'    => true,
+					'description' => 'Pull request number.',
+				),
+				'expected_head_sha' => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Exact head SHA expected immediately before merge.',
+				),
+				'merge_method'      => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'GitHub merge method: merge, squash, or rebase. Default: squash.',
 				),
 			),
 		);

--- a/tests/smoke-github-merge-pull-request.php
+++ b/tests/smoke-github-merge-pull-request.php
@@ -1,0 +1,347 @@
+<?php
+/**
+ * Pure-PHP smoke test for the GitHub pull request merge ability and tool.
+ *
+ * Run: php tests/smoke-github-merge-pull-request.php
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Abilities {
+	class PermissionHelper {
+		public static bool $can_manage_result = true;
+
+		public static function can_manage(): bool {
+			return self::$can_manage_result;
+		}
+	}
+}
+
+namespace DataMachine\Core {
+	class PluginSettings {
+		public static function get( string $key, $default_value = '' ) {
+			return $default_value;
+		}
+	}
+}
+
+namespace DataMachine\Engine\AI\Tools {
+	class BaseTool {
+		public array $registered = array();
+
+		protected function registerTool( string $name, array $definition_callback, array $contexts, array $options = array() ): void {
+			$this->registered[ $name ] = array(
+				'definition_callback' => $definition_callback,
+				'contexts'            => $contexts,
+				'options'             => $options,
+			);
+		}
+
+		protected function buildErrorResponse( string $message, string $tool_name ): array {
+			return array(
+				'success'   => false,
+				'error'     => $message,
+				'tool_name' => $tool_name,
+			);
+		}
+	}
+}
+
+namespace DataMachineCode\Support {
+	class GitHubCredentialResolver {
+		public static array $selectors = array();
+		public static $resolution = null;
+
+		public static function resolve( ?callable $http_request = null, ?int $now = null, ?array $selector = null ) {
+			self::$selectors[] = $selector;
+			if ( null !== self::$resolution ) {
+				return self::$resolution;
+			}
+
+			return array(
+				'mode'          => 'pat',
+				'token'         => 'test-token',
+				'authorization' => 'token test-token',
+				'profile_id'    => 'default',
+			);
+		}
+
+		public static function isConfigured(): bool {
+			return true;
+		}
+
+		public static function status(): array {
+			return array( 'configured' => true );
+		}
+
+		public static function mode(): string {
+			return 'pat';
+		}
+	}
+}
+
+namespace DataMachineCode\GitHub {
+	class PrReviewEscalationPolicy {}
+	class PrHomeboyReviewRunner {}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	class WP_Ability {}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			public array $error_data;
+			public function __construct( private string $code = '', private string $message = '', array $data = array() ) {
+				$this->error_data = $data;
+			}
+			public function get_error_message(): string { return $this->message; }
+			public function get_error_code(): string { return $this->code; }
+			public function get_error_data() { return $this->error_data; }
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $thing ): bool { return $thing instanceof WP_Error; }
+	}
+
+	if ( ! function_exists( 'sanitize_text_field' ) ) {
+		function sanitize_text_field( $value ): string {
+			return is_string( $value ) ? trim( $value ) : '';
+		}
+	}
+
+	if ( ! function_exists( 'wp_json_encode' ) ) {
+		function wp_json_encode( $data, int $flags = 0 ): string { return json_encode( $data, $flags ); }
+	}
+
+	if ( ! function_exists( 'add_query_arg' ) ) {
+		function add_query_arg( array $args, string $url ): string {
+			$separator = str_contains( $url, '?' ) ? '&' : '?';
+			return $url . $separator . http_build_query( $args );
+		}
+	}
+
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( string $hook, $value ) { return $value; }
+	}
+
+	$GLOBALS['dmc_registered_abilities'] = array();
+	$GLOBALS['dmc_tool_ability_calls']   = array();
+
+	function wp_register_ability( string $name, array $definition ): void {
+		$GLOBALS['dmc_registered_abilities'][ $name ] = $definition;
+	}
+
+	function doing_action( string $hook ): bool { return 'wp_abilities_api_init' === $hook; }
+	function did_action( string $hook ): int { return 0; }
+	function add_action( string $hook, callable $callback ): void {}
+
+	class DMC_Test_Ability {
+		public function __construct( private string $name ) {}
+
+		public function execute( array $input ): array {
+			$GLOBALS['dmc_tool_ability_calls'][] = array(
+				'name'  => $this->name,
+				'input' => $input,
+			);
+
+			return array(
+				'success'     => true,
+				'pull_number' => $input['pull_number'] ?? 0,
+				'merged'      => true,
+			);
+		}
+	}
+
+	function wp_get_ability( string $name ): ?DMC_Test_Ability {
+		if ( 'datamachine/merge-github-pull-request' === $name ) {
+			return new DMC_Test_Ability( $name );
+		}
+
+		return null;
+	}
+
+	require __DIR__ . '/../inc/Abilities/GitHubAbilities.php';
+	require __DIR__ . '/../inc/Tools/GitHubTools.php';
+
+	use DataMachine\Abilities\PermissionHelper;
+	use DataMachineCode\Abilities\GitHubAbilities;
+	use DataMachineCode\Support\GitHubCredentialResolver;
+	use DataMachineCode\Tools\GitHubTools;
+
+	$failures = array();
+	$assert   = function ( string $label, bool $cond ) use ( &$failures ): void {
+		if ( $cond ) {
+			echo "  ok {$label}\n";
+			return;
+		}
+
+		$failures[] = $label;
+		echo "  fail {$label}\n";
+	};
+
+	$open_pull = static function ( string $sha = 'abc123' ): array {
+		return array(
+			'success' => true,
+			'data'    => array(
+				'number'   => 42,
+				'state'    => 'open',
+				'html_url' => 'https://github.com/owner/repo/pull/42',
+				'head'     => array( 'sha' => $sha ),
+			),
+		);
+	};
+
+	$merge_response = array(
+		'success' => true,
+		'data'    => array(
+			'merged'  => true,
+			'sha'     => 'merge-sha',
+			'message' => 'Pull Request successfully merged',
+		),
+	);
+
+	echo "GitHub merge pull request - smoke\n";
+
+	new GitHubAbilities();
+	$ability = $GLOBALS['dmc_registered_abilities']['datamachine/merge-github-pull-request'] ?? null;
+	$assert( 'merge ability is registered', null !== $ability );
+	$assert( 'merge ability uses mergePullRequest execute_callback', array( GitHubAbilities::class, 'mergePullRequest' ) === ( $ability['execute_callback'] ?? null ) );
+	$assert( 'merge ability requires repo, pull_number, expected_head_sha', array( 'repo', 'pull_number', 'expected_head_sha' ) === ( $ability['input_schema']['required'] ?? array() ) );
+	$assert( 'merge ability limits merge_method enum', array( 'merge', 'squash', 'rebase' ) === ( $ability['input_schema']['properties']['merge_method']['enum'] ?? array() ) );
+
+	$permission = $ability['permission_callback'] ?? null;
+	PermissionHelper::$can_manage_result = false;
+	$assert( 'merge ability denies non-can_manage users', is_callable( $permission ) && false === $permission() );
+	PermissionHelper::$can_manage_result = true;
+
+	$result = GitHubAbilities::mergePullRequest( array() );
+	$assert( 'mergePullRequest rejects missing params', $result instanceof WP_Error && 'missing_params' === $result->get_error_code() );
+
+	$result = GitHubAbilities::mergePullRequest( array(
+		'repo'              => 'owner/repo',
+		'pull_number'       => 42,
+		'expected_head_sha' => 'abc123',
+		'merge_method'      => 'ff-only',
+	) );
+	$assert( 'mergePullRequest rejects invalid merge method', $result instanceof WP_Error && 'invalid_merge_method' === $result->get_error_code() );
+
+	GitHubCredentialResolver::$selectors = array();
+	$calls = array();
+	$result = GitHubAbilities::mergePullRequest(
+		array(
+			'repo'              => 'owner/repo',
+			'pull_number'       => 42,
+			'expected_head_sha' => 'abc123',
+		),
+		static function ( string $url, array $query, string $pat ) use ( &$calls, $open_pull ): array {
+			$calls[] = array( 'method' => 'GET', 'url' => $url, 'query' => $query, 'pat' => $pat );
+			return $open_pull();
+		},
+		static function ( string $method, string $url, array $body, string $pat ) use ( &$calls, $merge_response ): array {
+			$calls[] = array( 'method' => $method, 'url' => $url, 'body' => $body, 'pat' => $pat );
+			return $merge_response;
+		}
+	);
+	$assert( 'mergePullRequest success returns merged=true', is_array( $result ) && true === ( $result['merged'] ?? false ) );
+	$assert( 'mergePullRequest returns PR URL', is_array( $result ) && 'https://github.com/owner/repo/pull/42' === ( $result['pull_request_url'] ?? '' ) );
+	$assert( 'mergePullRequest selects credential by repo', array( 'repo' => 'owner/repo' ) === ( GitHubCredentialResolver::$selectors[0] ?? null ) );
+	$assert( 'mergePullRequest fetches PR before merge', 'GET' === ( $calls[0]['method'] ?? '' ) && str_ends_with( $calls[0]['url'] ?? '', '/repos/owner/repo/pulls/42' ) );
+	$assert( 'mergePullRequest calls GitHub merge endpoint', 'PUT' === ( $calls[1]['method'] ?? '' ) && str_ends_with( $calls[1]['url'] ?? '', '/repos/owner/repo/pulls/42/merge' ) );
+	$assert( 'mergePullRequest defaults to squash', 'squash' === ( $calls[1]['body']['merge_method'] ?? '' ) );
+
+	$calls = array();
+	$result = GitHubAbilities::mergePullRequest(
+		array(
+			'repo'              => 'owner/repo',
+			'pull_number'       => 42,
+			'expected_head_sha' => 'abc123',
+			'merge_method'      => 'rebase',
+		),
+		static fn(): array => $open_pull(),
+		static function ( string $method, string $url, array $body, string $pat ) use ( &$calls, $merge_response ): array {
+			$calls[] = compact( 'method', 'url', 'body', 'pat' );
+			return $merge_response;
+		}
+	);
+	$assert( 'mergePullRequest forwards explicit rebase method', is_array( $result ) && 'rebase' === ( $calls[0]['body']['merge_method'] ?? '' ) );
+
+	$result = GitHubAbilities::mergePullRequest(
+		array(
+			'repo'              => 'owner/repo',
+			'pull_number'       => 42,
+			'expected_head_sha' => 'abc123',
+		),
+		static fn(): array => array( 'success' => true, 'data' => array( 'state' => 'closed', 'head' => array( 'sha' => 'abc123' ) ) ),
+		static fn(): array => $merge_response
+	);
+	$assert( 'mergePullRequest rejects closed PR', $result instanceof WP_Error && 'pull_request_not_open' === $result->get_error_code() );
+
+	$merge_called = false;
+	$result = GitHubAbilities::mergePullRequest(
+		array(
+			'repo'              => 'owner/repo',
+			'pull_number'       => 42,
+			'expected_head_sha' => 'abc123',
+		),
+		static fn(): array => $open_pull( 'different-sha' ),
+		static function () use ( &$merge_called ): array {
+			$merge_called = true;
+			return array( 'success' => true, 'data' => array() );
+		}
+	);
+	$assert( 'mergePullRequest rejects head SHA mismatch', $result instanceof WP_Error && 'pull_request_head_sha_mismatch' === $result->get_error_code() );
+	$assert( 'mergePullRequest does not merge after SHA mismatch', false === $merge_called );
+
+	$tools = new GitHubTools();
+	$assert( 'merge_github_pull_request tool is registered', isset( $tools->registered['merge_github_pull_request'] ) );
+	$assert( 'merge tool links to merge ability', 'datamachine/merge-github-pull-request' === ( $tools->registered['merge_github_pull_request']['options']['ability'] ?? '' ) );
+	$definition = $tools->getMergePullRequestDefinition();
+	$params     = $definition['parameters'] ?? array();
+	$assert( 'merge tool requires expected_head_sha', true === ( $params['expected_head_sha']['required'] ?? false ) );
+	$tool_result = $tools->handle_tool_call(
+		array(
+			'repo'              => 'owner/repo',
+			'pull_number'       => 42,
+			'expected_head_sha' => 'abc123',
+		),
+		$definition
+	);
+	$assert( 'merge tool returns direct ability success', true === ( $tool_result['success'] ?? false ) );
+	$assert( 'merge tool response names tool', 'merge_github_pull_request' === ( $tool_result['tool_name'] ?? '' ) );
+	$tool_call = $GLOBALS['dmc_tool_ability_calls'][0] ?? array();
+	$assert( 'merge tool calls merge ability', 'datamachine/merge-github-pull-request' === ( $tool_call['name'] ?? '' ) );
+
+	$scaffold_source = file_get_contents( __DIR__ . '/../inc/GitHub/PrReviewFlowScaffold.php' );
+	$assert( 'PR review scaffold does not enable merge tool', ! str_contains( $scaffold_source, 'merge_github_pull_request' ) );
+	$wc_merge_exposures = array();
+	$repo_iterator      = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( dirname( __DIR__ ) ) );
+	foreach ( $repo_iterator as $file ) {
+		if ( ! $file->isFile() || ! in_array( $file->getExtension(), array( 'php', 'json', 'yml', 'yaml', 'md' ), true ) ) {
+			continue;
+		}
+		if ( str_contains( $file->getPathname(), DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR ) ) {
+			continue;
+		}
+		$contents = file_get_contents( $file->getPathname() );
+		if ( is_string( $contents ) && str_contains( $contents, 'wc-site-generator' ) && str_contains( $contents, 'merge_github_pull_request' ) ) {
+			$wc_merge_exposures[] = $file->getPathname();
+		}
+	}
+	$assert( 'wc-site-generator references do not expose merge tool', empty( $wc_merge_exposures ) );
+
+	if ( ! empty( $failures ) ) {
+		echo "\nFAIL: " . count( $failures ) . " assertion(s)\n";
+		foreach ( $failures as $failure ) {
+			echo "  - {$failure}\n";
+		}
+		exit( 1 );
+	}
+
+	echo "\nOK\n";
+	exit( 0 );
+}


### PR DESCRIPTION
## Summary
- Add `datamachine/merge-github-pull-request`, which fetches the PR immediately before merge, requires it to be open, and verifies `expected_head_sha` before calling GitHub's merge endpoint.
- Add the `merge_github_pull_request` AI tool wrapper linked to the new ability.
- Add a pure-PHP smoke test covering registration, validation, default/explicit merge methods, SHA mismatch protection, credential repo selection, endpoint calls, and WC exposure safety.

## Tests
- `php -l inc/Abilities/GitHubAbilities.php`
- `php -l inc/Tools/GitHubTools.php`
- `php -l tests/smoke-github-merge-pull-request.php`
- `php tests/smoke-github-merge-pull-request.php`
- `php tests/smoke-github-create-abilities.php`
- `php tests/smoke-github-create-tools.php`
- `php tests/smoke-github-pr-review-flow-scaffold.php`
- `git diff --check`
- `git grep -n "merge_github_pull_request" -- . ':!tests/smoke-github-merge-pull-request.php'`
- `git grep -n -E "wc-site-generator.*merge_github_pull_request|merge_github_pull_request.*wc-site-generator" -- .` returned no matches.

## Notes
- `homeboy test --path . --extension wordpress` did not reach plugin tests because the prepared Data Machine dependency failed during bootstrap: `Class "WP_Agent_Memory_Layer" not found` in `MemoryFileRegistry.php`.
- `homeboy lint --path . --extension wordpress` reports existing repo-wide PHPCS findings outside this change, including errors in `inc/Cleanup/DataMachineJobCleanupRunEvidenceStore.php` and `inc/Workspace/WorktreeContextInjector.php`.
- Existing WC / `wc-site-generator` references do not expose `merge_github_pull_request`; the new smoke asserts this for non-test files, and the local grep above returned no WC merge-tool exposure.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the merge primitive/tool wrapper, drafting the smoke coverage, and running local validation. Chris remains responsible for review and merge.