### PR TITLE
feat: add remote workspace backend

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -83,6 +83,7 @@ function datamachine_code_bootstrap() {
 	new \DataMachineCode\Abilities\WorkspaceAbilities();
 	new \DataMachineCode\Abilities\GitSyncAbilities();
 	new \DataMachineCode\Abilities\CodeTaskAbilities();
+	( new \DataMachineCode\Bundle\WorkspacePreloadArtifact() )->register();
 
 	// Load Handlers (they self-register).
 	new \DataMachineCode\Handlers\GitHub\GitHub();

--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -16,6 +16,7 @@ namespace DataMachineCode\Abilities;
 
 use DataMachine\Abilities\PermissionHelper;
 use DataMachineCode\Workspace\CleanupRunService;
+use DataMachineCode\Workspace\RemoteWorkspaceBackend;
 use DataMachineCode\Workspace\Workspace;
 use DataMachineCode\Workspace\WorkspaceReader;
 use DataMachineCode\Workspace\WorkspaceWriter;
@@ -1805,15 +1806,18 @@ class WorkspaceAbilities {
 	public static function getCapabilities( array $input ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 		$workspace   = new Workspace();
 		$diagnostic  = GitRunner::diagnose();
+		$backend     = RemoteWorkspaceBackend::should_handle() ? 'github_api' : 'local_git';
 		$remediation = 'Run workspace abilities in a host runtime with local git access, or provide a Data Machine Code workspace backend that executes these operations outside the constrained PHP sandbox.';
 
 		return array_merge(
+			$diagnostic,
 			array(
 				'success'        => true,
+				'backend'        => $backend,
+				'local_backend'  => $diagnostic['backend'] ?? 'local_git',
 				'workspace_path' => $workspace->get_path(),
 				'remediation'    => $remediation,
-			),
-			$diagnostic
+			)
 		);
 	}
 
@@ -1835,6 +1839,16 @@ class WorkspaceAbilities {
 	 * @return array Result.
 	 */
 	public static function readFile( array $input ): array|\WP_Error {
+		if ( RemoteWorkspaceBackend::should_handle() ) {
+			return ( new RemoteWorkspaceBackend() )->read_file(
+				$input['repo'] ?? '',
+				$input['path'] ?? '',
+				isset( $input['max_size'] ) ? (int) $input['max_size'] : Workspace::MAX_READ_SIZE,
+				isset( $input['offset'] ) ? (int) $input['offset'] : null,
+				isset( $input['limit'] ) ? (int) $input['limit'] : null
+			);
+		}
+
 		$workspace = new Workspace();
 		$reader    = new WorkspaceReader( $workspace );
 
@@ -1854,6 +1868,13 @@ class WorkspaceAbilities {
 	 * @return array Result.
 	 */
 	public static function listDirectory( array $input ): array|\WP_Error {
+		if ( RemoteWorkspaceBackend::should_handle() ) {
+			return ( new RemoteWorkspaceBackend() )->list_directory(
+				$input['repo'] ?? '',
+				$input['path'] ?? null
+			);
+		}
+
 		$workspace = new Workspace();
 		$reader    = new WorkspaceReader( $workspace );
 
@@ -1870,6 +1891,13 @@ class WorkspaceAbilities {
 	 * @return array Result.
 	 */
 	public static function cloneRepo( array $input ): array|\WP_Error {
+		if ( RemoteWorkspaceBackend::should_handle() ) {
+			return ( new RemoteWorkspaceBackend() )->clone_repo(
+				$input['url'] ?? '',
+				$input['name'] ?? null
+			);
+		}
+
 		$workspace = new Workspace();
 		return $workspace->clone_repo(
 			$input['url'] ?? '',
@@ -1910,6 +1938,14 @@ class WorkspaceAbilities {
 	 * @return array Result.
 	 */
 	public static function writeFile( array $input ): array|\WP_Error {
+		if ( RemoteWorkspaceBackend::should_handle() ) {
+			return ( new RemoteWorkspaceBackend() )->write_file(
+				$input['repo'] ?? '',
+				$input['path'] ?? '',
+				$input['content'] ?? ''
+			);
+		}
+
 		$workspace = new Workspace();
 		$writer    = new WorkspaceWriter( $workspace );
 
@@ -1927,6 +1963,16 @@ class WorkspaceAbilities {
 	 * @return array Result.
 	 */
 	public static function editFile( array $input ): array|\WP_Error {
+		if ( RemoteWorkspaceBackend::should_handle() ) {
+			return ( new RemoteWorkspaceBackend() )->edit_file(
+				$input['repo'] ?? '',
+				$input['path'] ?? '',
+				$input['old_string'] ?? '',
+				$input['new_string'] ?? '',
+				! empty( $input['replace_all'] )
+			);
+		}
+
 		$workspace = new Workspace();
 		$writer    = new WorkspaceWriter( $workspace );
 
@@ -1963,6 +2009,10 @@ class WorkspaceAbilities {
 	 * @return array
 	 */
 	public static function gitStatus( array $input ): array|\WP_Error {
+		if ( RemoteWorkspaceBackend::should_handle() ) {
+			return ( new RemoteWorkspaceBackend() )->git_status( $input['name'] ?? '' );
+		}
+
 		$workspace = new Workspace();
 		return $workspace->git_status( $input['name'] ?? '' );
 	}
@@ -1989,6 +2039,14 @@ class WorkspaceAbilities {
 	 * @return array
 	 */
 	public static function gitAdd( array $input ): array|\WP_Error {
+		if ( RemoteWorkspaceBackend::should_handle() ) {
+			$paths = $input['paths'] ?? array();
+			return ( new RemoteWorkspaceBackend() )->git_add(
+				$input['name'] ?? '',
+				is_array( $paths ) ? $paths : array()
+			);
+		}
+
 		$workspace = new Workspace();
 		$paths     = $input['paths'] ?? array();
 
@@ -2023,6 +2081,13 @@ class WorkspaceAbilities {
 	 * @return array
 	 */
 	public static function gitCommit( array $input ): array|\WP_Error {
+		if ( RemoteWorkspaceBackend::should_handle() ) {
+			return ( new RemoteWorkspaceBackend() )->git_commit(
+				$input['name'] ?? '',
+				$input['message'] ?? ''
+			);
+		}
+
 		$workspace = new Workspace();
 		return $workspace->git_commit(
 			$input['name'] ?? '',
@@ -2038,6 +2103,14 @@ class WorkspaceAbilities {
 	 * @return array
 	 */
 	public static function gitPush( array $input ): array|\WP_Error {
+		if ( RemoteWorkspaceBackend::should_handle() ) {
+			return ( new RemoteWorkspaceBackend() )->git_push(
+				$input['name'] ?? '',
+				$input['remote'] ?? 'origin',
+				$input['branch'] ?? null
+			);
+		}
+
 		$workspace = new Workspace();
 		return $workspace->git_push(
 			$input['name'] ?? '',
@@ -2054,6 +2127,14 @@ class WorkspaceAbilities {
 	 * @return array
 	 */
 	public static function worktreeAdd( array $input ): array|\WP_Error {
+		if ( RemoteWorkspaceBackend::should_handle() ) {
+			return ( new RemoteWorkspaceBackend() )->worktree_add(
+				$input['repo'] ?? '',
+				$input['branch'] ?? '',
+				$input['from'] ?? null
+			);
+		}
+
 		$workspace = new Workspace();
 		// Default inject_context=true; only false when explicitly provided.
 		$inject_context = array_key_exists( 'inject_context', $input ) ? (bool) $input['inject_context'] : true;

--- a/inc/Bundle/WorkspacePreloadArtifact.php
+++ b/inc/Bundle/WorkspacePreloadArtifact.php
@@ -1,0 +1,233 @@
+<?php
+/**
+ * Agent bundle workspace preload artifact support.
+ *
+ * @package DataMachineCode\Bundle
+ */
+
+namespace DataMachineCode\Bundle;
+
+use DataMachineCode\Abilities\WorkspaceAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Applies plugin-owned bundle artifacts that preload DMC workspaces.
+ */
+final class WorkspacePreloadArtifact {
+
+	public const ARTIFACT_TYPE = 'datamachine-code/workspace_preload';
+
+	/**
+	 * @var callable|null
+	 */
+	private $clone_callback;
+
+	/**
+	 * @param callable|null $clone_callback Optional clone callback for tests.
+	 */
+	public function __construct( ?callable $clone_callback = null ) {
+		$this->clone_callback = $clone_callback;
+	}
+
+	/**
+	 * Register Data Machine bundle extension hooks.
+	 */
+	public function register(): void {
+		add_filter( 'datamachine_agent_bundle_artifact_types', array( $this, 'register_artifact_type' ), 10, 1 );
+		add_filter( 'datamachine_agent_bundle_apply_artifact', array( $this, 'apply_artifact' ), 10, 4 );
+	}
+
+	/**
+	 * Register the DMC workspace preload artifact type.
+	 *
+	 * @param string[] $types Registered bundle artifact types.
+	 * @return string[]
+	 */
+	public function register_artifact_type( array $types ): array {
+		$types[] = self::ARTIFACT_TYPE;
+		return $types;
+	}
+
+	/**
+	 * Apply a workspace preload artifact.
+	 *
+	 * @param mixed               $result   Existing plugin result, or null.
+	 * @param array<string,mixed> $artifact Artifact envelope.
+	 * @param array<string,mixed> $agent    Agent row.
+	 * @param array<string,mixed> $context  Apply context.
+	 * @return array<string,mixed>|\WP_Error|null
+	 */
+	public function apply_artifact( mixed $result, array $artifact, array $agent = array(), array $context = array() ): array|\WP_Error|null {
+		unset( $agent, $context );
+
+		if ( self::ARTIFACT_TYPE !== (string) ( $artifact['artifact_type'] ?? '' ) ) {
+			return $result;
+		}
+
+		$repositories = $this->validate_repositories( $artifact['payload'] ?? null );
+		if ( is_wp_error( $repositories ) ) {
+			return $repositories;
+		}
+
+		$results = array();
+		foreach ( $repositories as $repository ) {
+			$clone_result = $this->clone_repository( $repository );
+			if ( is_wp_error( $clone_result ) ) {
+				$results[] = $this->error_result( $repository, $clone_result );
+				return new \WP_Error(
+					'datamachine_code_workspace_preload_failed',
+					sprintf( 'Failed to preload workspace repository %s: %s', $repository['url'], $clone_result->get_error_message() ),
+					array(
+						'status'        => 500,
+						'artifact_type' => self::ARTIFACT_TYPE,
+						'artifact_id'   => (string) ( $artifact['artifact_id'] ?? '' ),
+						'repositories'  => $results,
+					)
+				);
+			}
+
+			$results[] = $this->success_result( $repository, $clone_result );
+		}
+
+		return array(
+			'success'       => true,
+			'artifact_type' => self::ARTIFACT_TYPE,
+			'artifact_id'   => (string) ( $artifact['artifact_id'] ?? '' ),
+			'repositories'  => $results,
+		);
+	}
+
+	/**
+	 * Validate and normalize artifact repositories.
+	 *
+	 * @param mixed $payload Artifact payload.
+	 * @return array<int,array<string,mixed>>|\WP_Error
+	 */
+	private function validate_repositories( mixed $payload ): array|\WP_Error {
+		if ( ! is_array( $payload ) || ! isset( $payload['repositories'] ) || ! is_array( $payload['repositories'] ) || array() === $payload['repositories'] || ! array_is_list( $payload['repositories'] ) ) {
+			return new \WP_Error( 'datamachine_code_workspace_preload_invalid_payload', 'Workspace preload payload.repositories must be a non-empty list.', array( 'status' => 400 ) );
+		}
+
+		$repositories = array();
+		foreach ( $payload['repositories'] as $index => $repository ) {
+			if ( ! is_array( $repository ) ) {
+				return new \WP_Error( 'datamachine_code_workspace_preload_invalid_repository', sprintf( 'Workspace preload repository at index %d must be an object.', (int) $index ), array( 'status' => 400 ) );
+			}
+
+			$url = trim( (string) ( $repository['url'] ?? '' ) );
+			if ( '' === $url || ! $this->is_valid_git_source( $url ) ) {
+				return new \WP_Error( 'datamachine_code_workspace_preload_invalid_url', sprintf( 'Workspace preload repository at index %d must declare a valid git URL or local git source.', (int) $index ), array( 'status' => 400 ) );
+			}
+
+			$normalized = array( 'url' => $url );
+			if ( isset( $repository['name'] ) ) {
+				$name = trim( (string) $repository['name'] );
+				if ( '' === $name ) {
+					return new \WP_Error( 'datamachine_code_workspace_preload_invalid_name', sprintf( 'Workspace preload repository at index %d has an empty name.', (int) $index ), array( 'status' => 400 ) );
+				}
+				$normalized['name'] = $name;
+			}
+
+			if ( isset( $repository['full'] ) ) {
+				$normalized['full'] = (bool) $repository['full'];
+			}
+
+			$repositories[] = $normalized;
+		}
+
+		return $repositories;
+	}
+
+	/**
+	 * Validate a git source string before passing it to the clone ability.
+	 */
+	private function is_valid_git_source( string $source ): bool {
+		if ( preg_match( '/[\x00-\x1F\x7F]/', $source ) || str_starts_with( $source, '-' ) ) {
+			return false;
+		}
+
+		$scheme = wp_parse_url( $source, PHP_URL_SCHEME );
+		if ( is_string( $scheme ) && '' !== $scheme ) {
+			return in_array( strtolower( $scheme ), array( 'https', 'ssh', 'git', 'file' ), true ) && false !== filter_var( $source, FILTER_VALIDATE_URL );
+		}
+
+		if ( preg_match( '/^[A-Za-z0-9._-]+@[A-Za-z0-9._-]+:.+$/', $source ) ) {
+			return true;
+		}
+
+		return ! str_contains( $source, '..' ) && file_exists( $source );
+	}
+
+	/**
+	 * Clone or register one repository via the DMC workspace ability.
+	 *
+	 * @param array<string,mixed> $repository Repository config.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private function clone_repository( array $repository ): array|\WP_Error {
+		$input = array( 'url' => $repository['url'] );
+		if ( isset( $repository['name'] ) ) {
+			$input['name'] = $repository['name'];
+		}
+		if ( isset( $repository['full'] ) ) {
+			$input['full'] = $repository['full'];
+		}
+
+		$callback = $this->clone_callback ?: array( WorkspaceAbilities::class, 'cloneRepo' );
+		$result   = call_user_func( $callback, $input );
+
+		if ( is_wp_error( $result ) && 'repo_exists' === $result->get_error_code() ) {
+			$data = (array) $result->get_error_data();
+			if ( 'existing checkout' === (string) ( $data['state'] ?? '' ) ) {
+				return array(
+					'success'        => true,
+					'already_exists' => true,
+					'name'           => $input['name'] ?? null,
+					'path'           => $data['path'] ?? null,
+					'message'        => $result->get_error_message(),
+				);
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Build a normalized successful per-repo result.
+	 *
+	 * @param array<string,mixed> $repository Repository config.
+	 * @param array<string,mixed> $result     Clone result.
+	 * @return array<string,mixed>
+	 */
+	private function success_result( array $repository, array $result ): array {
+		return array(
+			'success'        => true,
+			'url'            => $repository['url'],
+			'name'           => $result['name'] ?? $repository['name'] ?? null,
+			'path'           => $result['path'] ?? null,
+			'already_exists' => (bool) ( $result['already_exists'] ?? false ),
+			'result'         => $result,
+		);
+	}
+
+	/**
+	 * Build a normalized failed per-repo result.
+	 *
+	 * @param array<string,mixed> $repository Repository config.
+	 * @param \WP_Error           $error      Clone error.
+	 * @return array<string,mixed>
+	 */
+	private function error_result( array $repository, \WP_Error $error ): array {
+		return array(
+			'success' => false,
+			'url'     => $repository['url'],
+			'name'    => $repository['name'] ?? null,
+			'error'   => array(
+				'code'    => $error->get_error_code(),
+				'message' => $error->get_error_message(),
+				'data'    => $error->get_error_data(),
+			),
+		);
+	}
+}

--- a/inc/Tools/WorkspaceTools.php
+++ b/inc/Tools/WorkspaceTools.php
@@ -304,8 +304,11 @@ class WorkspaceTools extends BaseTool {
 			'method'      => 'handleCapabilities',
 			'description' => 'Inspect whether the current Data Machine Code workspace backend can run local git operations in this runtime.',
 			'parameters'  => array(
-				'type'       => 'object',
-				'properties' => array(),
+				'include_diagnostics' => array(
+					'type'        => 'boolean',
+					'required'    => false,
+					'description' => 'Include workspace backend diagnostics. Defaults to true.',
+				),
 			),
 		);
 	}

--- a/inc/Workspace/RemoteWorkspaceBackend.php
+++ b/inc/Workspace/RemoteWorkspaceBackend.php
@@ -49,11 +49,14 @@ class RemoteWorkspaceBackend {
 		$this->save_state( $state );
 
 		return array(
-			'success' => true,
-			'backend' => 'github_api',
-			'name'    => $name,
-			'path'    => 'github://' . $repo,
-			'message' => sprintf( 'Registered %s as remote workspace "%s".', $repo, $name ),
+			'success'            => true,
+			'backend'            => 'github_api',
+			'name'               => $name,
+			'path'               => 'github://' . $repo,
+			'message'            => sprintf( 'Registered %s as remote workspace "%s".', $repo, $name ),
+			'conversation_state' => 'incomplete',
+			'next_required_tool' => 'workspace_worktree_add',
+			'next_required_args' => array( 'repo' => $name ),
 		);
 	}
 
@@ -88,14 +91,17 @@ class RemoteWorkspaceBackend {
 		$this->save_state( $state );
 
 		return array(
-			'success'        => true,
-			'backend'        => 'github_api',
-			'handle'         => $handle,
-			'path'           => 'github://' . $repo . '#' . $branch,
-			'branch'         => $branch,
-			'slug'           => $slug,
-			'created_branch' => true,
-			'message'        => sprintf( 'Registered remote workspace %s for %s.', $handle, $repo ),
+			'success'            => true,
+			'backend'            => 'github_api',
+			'handle'             => $handle,
+			'path'               => 'github://' . $repo . '#' . $branch,
+			'branch'             => $branch,
+			'slug'               => $slug,
+			'created_branch'     => true,
+			'message'            => sprintf( 'Registered remote workspace %s for %s.', $handle, $repo ),
+			'conversation_state' => 'incomplete',
+			'next_required_tool' => 'workspace_read or workspace_edit or workspace_write',
+			'next_required_args' => array( 'repo' => $handle ),
 		);
 	}
 
@@ -224,11 +230,14 @@ class RemoteWorkspaceBackend {
 		$this->save_state( $state );
 
 		return array(
-			'success' => true,
-			'backend' => 'github_api',
-			'path'    => $path,
-			'size'    => strlen( $content ),
-			'created' => true,
+			'success'            => true,
+			'backend'            => 'github_api',
+			'path'               => $path,
+			'size'               => strlen( $content ),
+			'created'            => true,
+			'conversation_state' => 'incomplete',
+			'next_required_tool' => 'workspace_git_status',
+			'next_required_args' => array( 'name' => $context['handle'] ),
 		);
 	}
 
@@ -238,6 +247,11 @@ class RemoteWorkspaceBackend {
 	 * @return array<string,mixed>|\WP_Error
 	 */
 	public function edit_file( string $handle, string $path, string $old_string, string $new_string, bool $replace_all = false ): array|\WP_Error {
+		$context = $this->resolve_handle( $handle );
+		if ( is_wp_error( $context ) ) {
+			return $context;
+		}
+
 		$current = $this->read_file( $handle, $path, PHP_INT_MAX );
 		if ( is_wp_error( $current ) ) {
 			return $current;
@@ -262,10 +276,13 @@ class RemoteWorkspaceBackend {
 		}
 
 		return array(
-			'success'      => true,
-			'backend'      => 'github_api',
-			'path'         => $write['path'],
-			'replacements' => $replace_all ? $count : 1,
+			'success'            => true,
+			'backend'            => 'github_api',
+			'path'               => $write['path'],
+			'replacements'       => $replace_all ? $count : 1,
+			'conversation_state' => 'incomplete',
+			'next_required_tool' => 'workspace_git_status',
+			'next_required_args' => array( 'name' => $context['handle'] ),
 		);
 	}
 
@@ -282,17 +299,20 @@ class RemoteWorkspaceBackend {
 
 		$files = array_values( array_unique( array_values( (array) $context['changed_files'] ) ) );
 		return array(
-			'success'     => true,
-			'backend'     => 'github_api',
-			'name'        => $handle,
-			'repo'        => $context['repo_name'],
-			'is_worktree' => true,
-			'path'        => 'github://' . $context['repo'] . '#' . $context['branch'],
-			'branch'      => $context['branch'],
-			'remote'      => 'https://github.com/' . $context['repo'] . '.git',
-			'commit'      => $context['last_commit_sha'] ?: null,
-			'dirty'       => count( $files ),
-			'files'       => $files,
+			'success'            => true,
+			'backend'            => 'github_api',
+			'name'               => $handle,
+			'repo'               => $context['repo_name'],
+			'is_worktree'        => true,
+			'path'               => 'github://' . $context['repo'] . '#' . $context['branch'],
+			'branch'             => $context['branch'],
+			'remote'             => 'https://github.com/' . $context['repo'] . '.git',
+			'commit'             => $context['last_commit_sha'] ?: null,
+			'dirty'              => count( $files ),
+			'files'              => $files,
+			'conversation_state' => 'incomplete',
+			'next_required_tool' => count( $files ) > 0 ? 'workspace_git_commit' : 'workspace_edit or workspace_write',
+			'next_required_args' => array( 'name' => $handle ),
 		);
 	}
 
@@ -358,11 +378,14 @@ class RemoteWorkspaceBackend {
 		$this->save_state( $state );
 
 		return array(
-			'success' => true,
-			'backend' => 'github_api',
-			'name'    => $handle,
-			'commit'  => $last_sha,
-			'message' => sprintf( 'Committed remote workspace changes to %s.', $context['branch'] ),
+			'success'            => true,
+			'backend'            => 'github_api',
+			'name'               => $handle,
+			'commit'             => $last_sha,
+			'message'            => sprintf( 'Committed remote workspace changes to %s.', $context['branch'] ),
+			'conversation_state' => 'incomplete',
+			'next_required_tool' => 'workspace_git_push',
+			'next_required_args' => array( 'name' => $handle, 'branch' => $context['branch'] ),
 		);
 	}
 
@@ -378,12 +401,15 @@ class RemoteWorkspaceBackend {
 		}
 
 		return array(
-			'success' => true,
-			'backend' => 'github_api',
-			'name'    => $handle,
-			'remote'  => $remote,
-			'branch'  => $branch ?: $context['branch'],
-			'message' => 'Remote workspace branch already updated via GitHub API.',
+			'success'            => true,
+			'backend'            => 'github_api',
+			'name'               => $handle,
+			'remote'             => $remote,
+			'branch'             => $branch ?: $context['branch'],
+			'message'            => 'Remote workspace branch already updated via GitHub API.',
+			'conversation_state' => 'incomplete',
+			'next_required_tool' => 'create_github_pull_request',
+			'next_required_args' => array( 'repo' => $context['repo'], 'head' => $branch ?: $context['branch'] ),
 		);
 	}
 

--- a/inc/Workspace/RemoteWorkspaceBackend.php
+++ b/inc/Workspace/RemoteWorkspaceBackend.php
@@ -1,0 +1,484 @@
+<?php
+/**
+ * GitHub-backed workspace backend for constrained PHP runtimes.
+ *
+ * @package DataMachineCode\Workspace
+ */
+
+namespace DataMachineCode\Workspace;
+
+use DataMachineCode\Abilities\GitHubAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+class RemoteWorkspaceBackend {
+
+	private const OPTION = 'datamachine_code_remote_workspace_state';
+
+	/**
+	 * Whether the remote backend should handle workspace operations.
+	 */
+	public static function should_handle(): bool {
+		return ! \DataMachineCode\Support\GitRunner::is_available();
+	}
+
+	/**
+	 * Clone/register a GitHub repository as a remote workspace primary.
+	 *
+	 * @param string      $url  GitHub repository URL.
+	 * @param string|null $name Optional workspace repo name.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function clone_repo( string $url, ?string $name = null ): array|\WP_Error {
+		$repo = $this->repo_from_url( $url );
+		if ( is_wp_error( $repo ) ) {
+			return $repo;
+		}
+
+		$name = $this->sanitize_name( $name ?: basename( (string) $repo ) );
+		if ( '' === $name ) {
+			return new \WP_Error( 'invalid_clone_name', 'Could not derive a workspace name for the remote repository.', array( 'status' => 400 ) );
+		}
+
+		$state                    = $this->state();
+		$state['repos'][ $name ]   = array(
+			'repo' => $repo,
+			'url'  => $url,
+		);
+		$state['repo_names'][ $repo ] = $name;
+		$this->save_state( $state );
+
+		return array(
+			'success' => true,
+			'backend' => 'github_api',
+			'name'    => $name,
+			'path'    => 'github://' . $repo,
+			'message' => sprintf( 'Registered %s as remote workspace "%s".', $repo, $name ),
+		);
+	}
+
+	/**
+	 * Create/register a remote worktree branch.
+	 *
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function worktree_add( string $repo_name, string $branch, ?string $from = null ): array|\WP_Error {
+		$repo = $this->resolve_repo( $repo_name );
+		if ( is_wp_error( $repo ) ) {
+			return $repo;
+		}
+
+		$branch = trim( $branch );
+		if ( '' === $branch ) {
+			return new \WP_Error( 'missing_branch', 'Branch is required.', array( 'status' => 400 ) );
+		}
+
+		$slug   = $this->branch_slug( $branch );
+		$handle = $repo_name . '@' . $slug;
+		$state  = $this->state();
+		$state['worktrees'][ $handle ] = array(
+			'repo_name'      => $repo_name,
+			'repo'           => $repo,
+			'branch'         => $branch,
+			'base_ref'       => $from ?: '',
+			'pending_files'  => array(),
+			'changed_files'  => array(),
+			'last_commit_sha' => '',
+		);
+		$this->save_state( $state );
+
+		return array(
+			'success'        => true,
+			'backend'        => 'github_api',
+			'handle'         => $handle,
+			'path'           => 'github://' . $repo . '#' . $branch,
+			'branch'         => $branch,
+			'slug'           => $slug,
+			'created_branch' => true,
+			'message'        => sprintf( 'Registered remote workspace %s for %s.', $handle, $repo ),
+		);
+	}
+
+	/**
+	 * Read a file from GitHub or pending remote workspace state.
+	 *
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function read_file( string $handle, string $path, int $max_size, ?int $offset = null, ?int $limit = null ): array|\WP_Error {
+		$context = $this->resolve_handle( $handle );
+		if ( is_wp_error( $context ) ) {
+			return $context;
+		}
+
+		$path = $this->normalize_path( $path );
+		if ( is_wp_error( $path ) ) {
+			return $path;
+		}
+
+		$content = $context['pending_files'][ $path ] ?? null;
+		if ( null === $content ) {
+			$file = GitHubAbilities::getFileContents(
+				array(
+					'repo' => $context['repo'],
+					'path' => $path,
+					'ref'  => $context['read_ref'],
+				)
+			);
+			if ( is_wp_error( $file ) && $context['read_ref'] !== '' ) {
+				$file = GitHubAbilities::getFileContents( array( 'repo' => $context['repo'], 'path' => $path ) );
+			}
+			if ( is_wp_error( $file ) ) {
+				return $file;
+			}
+			$content = (string) ( $file['file']['content'] ?? '' );
+		}
+
+		$size = strlen( $content );
+		if ( $size > $max_size ) {
+			return new \WP_Error( 'file_too_large', sprintf( 'File too large: %s.', $path ), array( 'status' => 400 ) );
+		}
+
+		$result_content = $content;
+		if ( null !== $offset || null !== $limit ) {
+			$start_line     = max( 1, (int) ( $offset ?? 1 ) );
+			$lines          = explode( "\n", $content );
+			$lines          = array_slice( $lines, $start_line - 1, null === $limit ? null : max( 0, $limit ) );
+			$result_content = implode( "\n", $lines );
+		}
+
+		return array(
+			'success' => true,
+			'backend' => 'github_api',
+			'content' => $result_content,
+			'path'    => $path,
+			'size'    => $size,
+		);
+	}
+
+	/**
+	 * List repository files under a path prefix.
+	 *
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function list_directory( string $handle, ?string $path = null ): array|\WP_Error {
+		$context = $this->resolve_handle( $handle );
+		if ( is_wp_error( $context ) ) {
+			return $context;
+		}
+
+		$prefix = null === $path ? '' : trim( ltrim( $path, '/' ), '/' );
+		$tree   = GitHubAbilities::getRepoTree( array( 'repo' => $context['repo'], 'ref' => $context['read_ref'] ) );
+		if ( is_wp_error( $tree ) && $context['read_ref'] !== '' ) {
+			$tree = GitHubAbilities::getRepoTree( array( 'repo' => $context['repo'] ) );
+		}
+		if ( is_wp_error( $tree ) ) {
+			return $tree;
+		}
+
+		$entries = array();
+		foreach ( (array) ( $tree['files'] ?? array() ) as $file ) {
+			$file_path = (string) ( $file['path'] ?? '' );
+			if ( '' !== $prefix && ! str_starts_with( $file_path, $prefix . '/' ) ) {
+				continue;
+			}
+
+			$relative = '' === $prefix ? $file_path : substr( $file_path, strlen( $prefix ) + 1 );
+			if ( '' === $relative || str_contains( $relative, '/' ) ) {
+				continue;
+			}
+
+			$entries[] = array(
+				'name' => $relative,
+				'type' => (string) ( $file['type'] ?? 'file' ),
+				'size' => (int) ( $file['size'] ?? 0 ),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'backend' => 'github_api',
+			'repo'    => $handle,
+			'path'    => '' === $prefix ? '/' : $prefix,
+			'entries' => $entries,
+		);
+	}
+
+	/**
+	 * Stage file content in the remote workspace.
+	 *
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function write_file( string $handle, string $path, string $content ): array|\WP_Error {
+		$context = $this->resolve_handle( $handle );
+		if ( is_wp_error( $context ) ) {
+			return $context;
+		}
+		$path = $this->normalize_path( $path );
+		if ( is_wp_error( $path ) ) {
+			return $path;
+		}
+
+		$state = $this->state();
+		$state['worktrees'][ $context['handle'] ]['pending_files'][ $path ] = $content;
+		$state['worktrees'][ $context['handle'] ]['changed_files'][ $path ] = $path;
+		$this->save_state( $state );
+
+		return array(
+			'success' => true,
+			'backend' => 'github_api',
+			'path'    => $path,
+			'size'    => strlen( $content ),
+			'created' => true,
+		);
+	}
+
+	/**
+	 * Stage a find-and-replace edit in the remote workspace.
+	 *
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function edit_file( string $handle, string $path, string $old_string, string $new_string, bool $replace_all = false ): array|\WP_Error {
+		$current = $this->read_file( $handle, $path, PHP_INT_MAX );
+		if ( is_wp_error( $current ) ) {
+			return $current;
+		}
+
+		$content = (string) ( $current['content'] ?? '' );
+		$count   = substr_count( $content, $old_string );
+		if ( 0 === $count ) {
+			return new \WP_Error( 'string_not_found', 'old_string not found in file content.', array( 'status' => 400 ) );
+		}
+		if ( $count > 1 && ! $replace_all ) {
+			return new \WP_Error( 'multiple_matches', sprintf( 'Found %d matches for old_string.', $count ), array( 'status' => 400 ) );
+		}
+
+		$new_content = $replace_all
+			? str_replace( $old_string, $new_string, $content )
+			: substr_replace( $content, $new_string, strpos( $content, $old_string ), strlen( $old_string ) );
+
+		$write = $this->write_file( $handle, $path, $new_content );
+		if ( is_wp_error( $write ) ) {
+			return $write;
+		}
+
+		return array(
+			'success'      => true,
+			'backend'      => 'github_api',
+			'path'         => $write['path'],
+			'replacements' => $replace_all ? $count : 1,
+		);
+	}
+
+	/**
+	 * Return pending remote workspace changes.
+	 *
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function git_status( string $handle ): array|\WP_Error {
+		$context = $this->resolve_handle( $handle );
+		if ( is_wp_error( $context ) ) {
+			return $context;
+		}
+
+		$files = array_values( array_unique( array_values( (array) $context['changed_files'] ) ) );
+		return array(
+			'success'     => true,
+			'backend'     => 'github_api',
+			'name'        => $handle,
+			'repo'        => $context['repo_name'],
+			'is_worktree' => true,
+			'path'        => 'github://' . $context['repo'] . '#' . $context['branch'],
+			'branch'      => $context['branch'],
+			'remote'      => 'https://github.com/' . $context['repo'] . '.git',
+			'commit'      => $context['last_commit_sha'] ?: null,
+			'dirty'       => count( $files ),
+			'files'       => $files,
+		);
+	}
+
+	/**
+	 * Compatibility no-op: files are tracked by pending remote workspace state.
+	 *
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function git_add( string $handle, array $paths ): array|\WP_Error {
+		$context = $this->resolve_handle( $handle );
+		if ( is_wp_error( $context ) ) {
+			return $context;
+		}
+
+		return array(
+			'success' => true,
+			'backend' => 'github_api',
+			'name'    => $handle,
+			'paths'   => array_values( array_map( 'strval', $paths ) ),
+			'message' => 'Remote workspace changes are staged automatically.',
+		);
+	}
+
+	/**
+	 * Commit pending remote workspace changes through GitHub Contents API.
+	 *
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function git_commit( string $handle, string $message ): array|\WP_Error {
+		$context = $this->resolve_handle( $handle );
+		if ( is_wp_error( $context ) ) {
+			return $context;
+		}
+		if ( '' === trim( $message ) ) {
+			return new \WP_Error( 'missing_commit_message', 'Commit message is required.', array( 'status' => 400 ) );
+		}
+
+		$pending = (array) $context['pending_files'];
+		if ( empty( $pending ) ) {
+			return new \WP_Error( 'nothing_to_commit', 'No remote workspace changes to commit.', array( 'status' => 400 ) );
+		}
+
+		$last_sha = '';
+		foreach ( $pending as $path => $content ) {
+			$result = GitHubAbilities::createOrUpdateFile(
+				array(
+					'repo'           => $context['repo'],
+					'file_path'      => $path,
+					'content'        => (string) $content,
+					'commit_message' => $message,
+					'branch'         => $context['branch'],
+				)
+			);
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+			$last_sha = (string) ( $result['commit']['sha'] ?? $last_sha );
+		}
+
+		$state = $this->state();
+		$state['worktrees'][ $context['handle'] ]['pending_files']   = array();
+		$state['worktrees'][ $context['handle'] ]['last_commit_sha'] = $last_sha;
+		$this->save_state( $state );
+
+		return array(
+			'success' => true,
+			'backend' => 'github_api',
+			'name'    => $handle,
+			'commit'  => $last_sha,
+			'message' => sprintf( 'Committed remote workspace changes to %s.', $context['branch'] ),
+		);
+	}
+
+	/**
+	 * Compatibility no-op: commit already wrote to the remote branch.
+	 *
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function git_push( string $handle, string $remote = 'origin', ?string $branch = null ): array|\WP_Error {
+		$context = $this->resolve_handle( $handle );
+		if ( is_wp_error( $context ) ) {
+			return $context;
+		}
+
+		return array(
+			'success' => true,
+			'backend' => 'github_api',
+			'name'    => $handle,
+			'remote'  => $remote,
+			'branch'  => $branch ?: $context['branch'],
+			'message' => 'Remote workspace branch already updated via GitHub API.',
+		);
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	private function resolve_handle( string $handle ): array|\WP_Error {
+		$state = $this->state();
+		if ( isset( $state['worktrees'][ $handle ] ) ) {
+			$worktree = (array) $state['worktrees'][ $handle ];
+			$worktree['handle']   = $handle;
+			$worktree['read_ref'] = (string) ( $worktree['branch'] ?? '' );
+			return $worktree;
+		}
+
+		$repo = $this->resolve_repo( $handle );
+		if ( is_wp_error( $repo ) ) {
+			return $repo;
+		}
+
+		return array(
+			'handle'          => $handle,
+			'repo_name'       => $handle,
+			'repo'            => $repo,
+			'branch'          => '',
+			'read_ref'        => '',
+			'pending_files'   => array(),
+			'changed_files'   => array(),
+			'last_commit_sha' => '',
+		);
+	}
+
+	private function resolve_repo( string $repo_name ): string|\WP_Error {
+		$state = $this->state();
+		if ( isset( $state['repos'][ $repo_name ]['repo'] ) ) {
+			return (string) $state['repos'][ $repo_name ]['repo'];
+		}
+
+		if ( str_contains( $repo_name, '/' ) ) {
+			return $repo_name;
+		}
+
+		return new \WP_Error( 'remote_workspace_repo_not_found', sprintf( 'Remote workspace repository "%s" is not registered. Call workspace_clone first.', $repo_name ), array( 'status' => 404 ) );
+	}
+
+	private function repo_from_url( string $url ): string|\WP_Error {
+		$url = trim( $url );
+		if ( preg_match( '#github\.com[:/]([^/]+)/([^/.]+)(?:\.git)?$#', $url, $matches ) ) {
+			return $matches[1] . '/' . $matches[2];
+		}
+
+		return new \WP_Error( 'unsupported_remote_workspace_url', 'Remote workspace backend currently supports GitHub repository URLs only.', array( 'status' => 400 ) );
+	}
+
+	private function normalize_path( string $path ): string|\WP_Error {
+		$path = trim( ltrim( $path, '/' ) );
+		if ( '' === $path ) {
+			return new \WP_Error( 'missing_path', 'File path is required.', array( 'status' => 400 ) );
+		}
+		foreach ( explode( '/', $path ) as $part ) {
+			if ( '.' === $part || '..' === $part || '' === $part ) {
+				return new \WP_Error( 'path_traversal', 'Path traversal detected. Access denied.', array( 'status' => 403 ) );
+			}
+		}
+		return $path;
+	}
+
+	private function sanitize_name( string $name ): string {
+		return trim( strtolower( preg_replace( '/[^a-zA-Z0-9._-]+/', '-', $name ) ), '-' );
+	}
+
+	private function branch_slug( string $branch ): string {
+		return trim( strtolower( preg_replace( '/[^a-zA-Z0-9._-]+/', '-', $branch ) ), '-' );
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	private function state(): array {
+		$state = function_exists( 'get_option' ) ? get_option( self::OPTION, array() ) : array();
+		if ( ! is_array( $state ) ) {
+			$state = array();
+		}
+		$state['repos']      = is_array( $state['repos'] ?? null ) ? $state['repos'] : array();
+		$state['repo_names'] = is_array( $state['repo_names'] ?? null ) ? $state['repo_names'] : array();
+		$state['worktrees']  = is_array( $state['worktrees'] ?? null ) ? $state['worktrees'] : array();
+		return $state;
+	}
+
+	/**
+	 * @param array<string,mixed> $state State to persist.
+	 */
+	private function save_state( array $state ): void {
+		if ( function_exists( 'update_option' ) ) {
+			update_option( self::OPTION, $state, false );
+		}
+	}
+}

--- a/tests/smoke-remote-workspace-backend.php
+++ b/tests/smoke-remote-workspace-backend.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Pure-PHP smoke for the GitHub-backed remote workspace backend.
+ *
+ * Run: php tests/smoke-remote-workspace-backend.php
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachineCode\Abilities {
+	class GitHubAbilities {
+		public static array $files = array(
+			'chubes4/example:main:src/example.php' => "<?php\nreturn 'old';\n",
+		);
+		public static array $commits = array();
+
+		public static function getFileContents( array $input ): array|\WP_Error {
+			$repo = (string) ( $input['repo'] ?? '' );
+			$path = (string) ( $input['path'] ?? '' );
+			$ref  = (string) ( $input['ref'] ?? 'main' );
+			$key  = $repo . ':' . $ref . ':' . $path;
+			if ( ! isset( self::$files[ $key ] ) ) {
+				return new \WP_Error( 'github_not_found', 'Not found.', array( 'status' => 404 ) );
+			}
+			return array(
+				'success' => true,
+				'file'    => array(
+					'path'    => $path,
+					'size'    => strlen( self::$files[ $key ] ),
+					'content' => self::$files[ $key ],
+				),
+			);
+		}
+
+		public static function getRepoTree( array $input ): array|\WP_Error {
+			return array(
+				'success' => true,
+				'files'   => array(
+					array( 'path' => 'src/example.php', 'type' => 'file', 'size' => 20 ),
+				),
+			);
+		}
+
+		public static function createOrUpdateFile( array $input ): array|\WP_Error {
+			$repo = (string) ( $input['repo'] ?? '' );
+			$path = (string) ( $input['file_path'] ?? '' );
+			$branch = (string) ( $input['branch'] ?? 'main' );
+			$sha = 'commit-' . ( count( self::$commits ) + 1 );
+			self::$files[ $repo . ':' . $branch . ':' . $path ] = (string) ( $input['content'] ?? '' );
+			self::$commits[] = array( 'sha' => $sha, 'message' => (string) ( $input['commit_message'] ?? '' ) );
+			return array(
+				'success' => true,
+				'commit'  => array( 'sha' => $sha, 'html_url' => 'https://github.com/' . $repo . '/commit/' . $sha ),
+				'content' => array( 'path' => $path ),
+			);
+		}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', sys_get_temp_dir() . '/dmc-remote-workspace-backend/' );
+	}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			public function __construct( private string $code, private string $message, private array $data = array() ) {}
+
+			public function get_error_code(): string { return $this->code; }
+			public function get_error_message(): string { return $this->message; }
+			public function get_error_data(): array { return $this->data; }
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $value ): bool { return $value instanceof WP_Error; }
+	}
+
+	$GLOBALS['dmc_remote_workspace_options'] = array();
+	if ( ! function_exists( 'get_option' ) ) {
+		function get_option( string $key, mixed $default = false ): mixed {
+			return $GLOBALS['dmc_remote_workspace_options'][ $key ] ?? $default;
+		}
+	}
+	if ( ! function_exists( 'update_option' ) ) {
+		function update_option( string $key, mixed $value, bool $autoload = true ): bool {
+			unset( $autoload );
+			$GLOBALS['dmc_remote_workspace_options'][ $key ] = $value;
+			return true;
+		}
+	}
+
+	require __DIR__ . '/../inc/Support/GitRunner.php';
+	require __DIR__ . '/../inc/Workspace/RemoteWorkspaceBackend.php';
+
+	use DataMachineCode\Abilities\GitHubAbilities;
+	use DataMachineCode\Workspace\RemoteWorkspaceBackend;
+
+	$failures = array();
+	$total    = 0;
+	$assert   = function ( string $label, bool $condition ) use ( &$failures, &$total ): void {
+		++$total;
+		if ( $condition ) {
+			echo "  ok {$label}\n";
+			return;
+		}
+		$failures[] = $label;
+		echo "  fail {$label}\n";
+	};
+
+	echo "Remote workspace backend - smoke\n";
+
+	$backend = new RemoteWorkspaceBackend();
+	$clone = $backend->clone_repo( 'https://github.com/chubes4/example.git' );
+	$assert( 'clone registers remote repo', ! is_wp_error( $clone ) && 'example' === $clone['name'] && 'github_api' === $clone['backend'] );
+
+	$worktree = $backend->worktree_add( 'example', 'fix/example' );
+	$assert( 'worktree add returns DMC handle', ! is_wp_error( $worktree ) && 'example@fix-example' === $worktree['handle'] );
+
+	$read = $backend->read_file( 'example@fix-example', 'src/example.php', 1000000 );
+	$assert( 'read falls back to default branch content', ! is_wp_error( $read ) && str_contains( $read['content'], 'old' ) );
+
+	$edit = $backend->edit_file( 'example@fix-example', 'src/example.php', 'old', 'new' );
+	$assert( 'edit stages pending content', ! is_wp_error( $edit ) && 1 === $edit['replacements'] );
+
+	$status = $backend->git_status( 'example@fix-example' );
+	$assert( 'status reports pending file as dirty', ! is_wp_error( $status ) && 1 === $status['dirty'] && array( 'src/example.php' ) === $status['files'] );
+
+	$commit = $backend->git_commit( 'example@fix-example', 'fix: update example' );
+	$assert( 'commit writes via GitHub API', ! is_wp_error( $commit ) && 'commit-1' === $commit['commit'] );
+	$assert( 'commit uses requested message', 'fix: update example' === GitHubAbilities::$commits[0]['message'] );
+
+	$push = $backend->git_push( 'example@fix-example' );
+	$assert( 'push is successful compatibility no-op', ! is_wp_error( $push ) && 'fix/example' === $push['branch'] );
+
+	if ( ! empty( $failures ) ) {
+		echo "\nFAIL: " . count( $failures ) . " assertion(s) failed out of {$total}\n";
+		foreach ( $failures as $failure ) {
+			echo "  - {$failure}\n";
+		}
+		exit( 1 );
+	}
+
+	echo "\nOK ({$total} assertions)\n";
+	exit( 0 );
+}

--- a/tests/smoke-workspace-clone-ux.php
+++ b/tests/smoke-workspace-clone-ux.php
@@ -76,6 +76,7 @@ namespace {
 		function do_action( string $_hook, array $_payload ): void {}
 	}
 
+	require __DIR__ . '/../inc/Support/GitRunner.php';
 	require __DIR__ . '/../inc/Workspace/Workspace.php';
 
 	$failures = 0;

--- a/tests/smoke-workspace-preload-artifact.php
+++ b/tests/smoke-workspace-preload-artifact.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Pure-PHP smoke test for DMC bundle workspace preload artifacts.
+ *
+ * Run: php tests/smoke-workspace-preload-artifact.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			public function __construct( private string $code, private string $message, private mixed $data = array() ) {}
+
+			public function get_error_code(): string { return $this->code; }
+			public function get_error_message(): string { return $this->message; }
+			public function get_error_data(): mixed { return $this->data; }
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( mixed $value ): bool { return $value instanceof WP_Error; }
+	}
+
+	if ( ! function_exists( 'wp_parse_url' ) ) {
+		function wp_parse_url( string $url, int $component = -1 ): mixed {
+			return -1 === $component ? parse_url( $url ) : parse_url( $url, $component );
+		}
+	}
+
+	require __DIR__ . '/../inc/Bundle/WorkspacePreloadArtifact.php';
+
+	use DataMachineCode\Bundle\WorkspacePreloadArtifact;
+
+	$failures = array();
+	$total    = 0;
+	$assert   = function ( string $label, bool $condition ) use ( &$failures, &$total ): void {
+		++$total;
+		if ( $condition ) {
+			echo "  ok {$label}\n";
+			return;
+		}
+
+		$failures[] = $label;
+		echo "  fail {$label}\n";
+	};
+
+	echo "Workspace preload artifact - smoke\n";
+
+	$clones   = array();
+	$artifact = new WorkspacePreloadArtifact(
+		static function ( array $input ) use ( &$clones ): array {
+			$clones[] = $input;
+			return array(
+				'success' => true,
+				'name'    => $input['name'] ?? basename( (string) $input['url'], '.git' ),
+				'path'    => '/workspace/' . ( $input['name'] ?? basename( (string) $input['url'], '.git' ) ),
+			);
+		}
+	);
+
+	$types = $artifact->register_artifact_type( array( 'agent' ) );
+	$assert( 'registers DMC workspace preload artifact type', in_array( WorkspacePreloadArtifact::ARTIFACT_TYPE, $types, true ) );
+
+	$ignored = $artifact->apply_artifact( null, array( 'artifact_type' => 'other/plugin', 'artifact_id' => 'noop' ) );
+	$assert( 'ignores other artifact types', null === $ignored );
+
+	$invalid = $artifact->apply_artifact(
+		null,
+		array(
+			'artifact_type' => WorkspacePreloadArtifact::ARTIFACT_TYPE,
+			'artifact_id'   => 'bad',
+			'payload'       => array( 'repositories' => array() ),
+		)
+	);
+	$assert( 'rejects empty repositories list', is_wp_error( $invalid ) && 'datamachine_code_workspace_preload_invalid_payload' === $invalid->get_error_code() );
+
+	$applied = $artifact->apply_artifact(
+		null,
+		array(
+			'artifact_type' => WorkspacePreloadArtifact::ARTIFACT_TYPE,
+			'artifact_id'   => 'transformer-repos',
+			'payload'       => array(
+				'repositories' => array(
+					array(
+						'name' => 'static-site-importer',
+						'url'  => 'https://github.com/chubes4/static-site-importer.git',
+					),
+					array(
+						'name' => 'block-format-bridge',
+						'url'  => 'git@github.com:chubes4/block-format-bridge.git',
+						'full' => true,
+					),
+				),
+			),
+		)
+	);
+	$assert( 'applies valid preload artifact', ! is_wp_error( $applied ) && true === ( $applied['success'] ?? false ) );
+	$assert( 'calls clone path for each repository', 2 === count( $clones ) );
+	$assert( 'passes name and full option to clone path', true === ( $clones[1]['full'] ?? false ) && 'block-format-bridge' === ( $clones[1]['name'] ?? '' ) );
+	$assert( 'returns per-repo results', ! is_wp_error( $applied ) && 2 === count( $applied['repositories'] ?? array() ) );
+
+	$exists_artifact = new WorkspacePreloadArtifact(
+		static function ( array $input ): WP_Error {
+			return new WP_Error(
+				'repo_exists',
+				'Clone target already exists.',
+				array(
+					'state' => 'existing checkout',
+					'path'  => '/workspace/' . ( $input['name'] ?? 'repo' ),
+				)
+			);
+		}
+	);
+	$exists = $exists_artifact->apply_artifact(
+		null,
+		array(
+			'artifact_type' => WorkspacePreloadArtifact::ARTIFACT_TYPE,
+			'artifact_id'   => 'existing',
+			'payload'       => array(
+				'repositories' => array(
+					array(
+						'name' => 'static-site-importer',
+						'url'  => 'https://github.com/chubes4/static-site-importer.git',
+					),
+				),
+			),
+		)
+	);
+	$assert( 'treats existing checkout as idempotent success', ! is_wp_error( $exists ) && true === ( $exists['repositories'][0]['already_exists'] ?? false ) );
+
+	if ( array() !== $failures ) {
+		echo "\nFailures:\n";
+		foreach ( $failures as $failure ) {
+			echo " - {$failure}\n";
+		}
+	}
+
+	echo "\nResult: " . ( $total - count( $failures ) ) . "/{$total} passed\n";
+	exit( array() === $failures ? 0 : 1 );
+}


### PR DESCRIPTION
## Summary
- Adds a GitHub-backed remote workspace backend that activates when the PHP runtime cannot execute local `git`.
- Keeps the existing DMC `workspace_*` ability contract intact for constrained runtimes like WordPress Playground: clone/register, worktree add, read/list, write/edit staging, status, commit, and push compatibility.
- Commits pending remote workspace changes through the GitHub Contents API during `workspace_git_commit`, so downstream agents can still call DMC workspace tools instead of direct GitHub file tools.
- Registers the `datamachine-code/workspace_preload` bundle artifact type so agent bundles can declare workspace repositories that DMC preloads through `WorkspaceAbilities::cloneRepo()` before the agent runs.

## Verification
- `php -l inc/Workspace/RemoteWorkspaceBackend.php && php -l inc/Abilities/WorkspaceAbilities.php && php -l tests/smoke-remote-workspace-backend.php`
- `php tests/smoke-remote-workspace-backend.php`
- `php tests/smoke-workspace-git-capabilities.php`
- `git diff --check`
- `php -l inc/Bundle/WorkspacePreloadArtifact.php && php -l data-machine-code.php && php -l tests/smoke-workspace-preload-artifact.php`
- `php tests/smoke-workspace-preload-artifact.php`
- `php tests/smoke-workspace-clone-ux.php`

## Notes
- This is the first executable constrained-runtime backend. It intentionally covers the PR-first iterator subset instead of every DMC workspace operation.
- Local runtimes with `git` continue using the existing filesystem/worktree backend.
- Workspace preload artifacts fail fast when a declared repository cannot be cloned or registered, because the agent development environment is unsafe to run partially prepared.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the remote workspace backend, workspace preload artifact handler, and smoke coverage; Chris remains responsible for review and merge.