### PR TITLE
Fix remote workspace file updates

### DIFF
--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -3522,7 +3522,7 @@ class GitHubAbilities {
 	 *
 	 * @param array $input {
 	 *     Required: repo, file_path, content, commit_message.
-	 *     Optional: branch.
+	 *     Optional: branch, sha.
 	 * }
 	 * @return array|\WP_Error Success payload or error.
 	 */
@@ -3569,13 +3569,19 @@ class GitHubAbilities {
 
 		$existing = self::apiGet( $get_url, $get_params, $pat );
 
+		$current_sha = sanitize_text_field( $input['sha'] ?? '' );
+
 		$body = array(
 			'message' => $commit_message,
 			'content' => base64_encode( $content ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Required by GitHub API.
 		);
 
+		if ( '' !== $current_sha ) {
+			$body['sha'] = $current_sha;
+		}
+
 		// If the file exists, include its SHA for the update.
-		if ( ! is_wp_error( $existing ) && ! empty( $existing['data']['sha'] ) ) {
+		if ( empty( $body['sha'] ) && ! is_wp_error( $existing ) && ! empty( $existing['data']['sha'] ) ) {
 			$body['sha'] = $existing['data']['sha'];
 		}
 

--- a/inc/Workspace/RemoteWorkspaceBackend.php
+++ b/inc/Workspace/RemoteWorkspaceBackend.php
@@ -357,14 +357,24 @@ class RemoteWorkspaceBackend {
 
 		$last_sha = '';
 		foreach ( $pending as $path => $content ) {
+			$current_sha = $this->file_sha_for_commit( $context, (string) $path );
+			if ( is_wp_error( $current_sha ) ) {
+				return $current_sha;
+			}
+
+			$input = array(
+				'repo'           => $context['repo'],
+				'file_path'      => $path,
+				'content'        => (string) $content,
+				'commit_message' => $message,
+				'branch'         => $context['branch'],
+			);
+			if ( '' !== $current_sha ) {
+				$input['sha'] = $current_sha;
+			}
+
 			$result = GitHubAbilities::createOrUpdateFile(
-				array(
-					'repo'           => $context['repo'],
-					'file_path'      => $path,
-					'content'        => (string) $content,
-					'commit_message' => $message,
-					'branch'         => $context['branch'],
-				)
+				$input
 			);
 			if ( is_wp_error( $result ) ) {
 				return $result;
@@ -387,6 +397,34 @@ class RemoteWorkspaceBackend {
 			'next_required_tool' => 'workspace_git_push',
 			'next_required_args' => array( 'name' => $handle, 'branch' => $context['branch'] ),
 		);
+	}
+
+	/**
+	 * Resolve the current file SHA for a Contents API update.
+	 *
+	 * @param array<string,mixed> $context Remote workspace context.
+	 */
+	private function file_sha_for_commit( array $context, string $path ): string|\WP_Error {
+		$file = GitHubAbilities::getFileContents(
+			array(
+				'repo' => $context['repo'],
+				'path' => $path,
+				'ref'  => $context['read_ref'],
+			)
+		);
+		if ( is_wp_error( $file ) && '' !== $context['read_ref'] ) {
+			$file = GitHubAbilities::getFileContents( array( 'repo' => $context['repo'], 'path' => $path ) );
+		}
+		if ( is_wp_error( $file ) ) {
+			$status = (int) ( $file->get_error_data()['status'] ?? 0 );
+			if ( 404 === $status ) {
+				return '';
+			}
+
+			return $file;
+		}
+
+		return (string) ( $file['file']['sha'] ?? '' );
 	}
 
 	/**

--- a/inc/Workspace/RemoteWorkspaceBackend.php
+++ b/inc/Workspace/RemoteWorkspaceBackend.php
@@ -35,13 +35,13 @@ class RemoteWorkspaceBackend {
 			return $repo;
 		}
 
-		$name = $this->sanitize_name( $name ?: basename( (string) $repo ) );
+		$name = $this->sanitize_name( null !== $name && '' !== $name ? $name : basename( (string) $repo ) );
 		if ( '' === $name ) {
 			return new \WP_Error( 'invalid_clone_name', 'Could not derive a workspace name for the remote repository.', array( 'status' => 400 ) );
 		}
 
-		$state                    = $this->state();
-		$state['repos'][ $name ]   = array(
+		$state                        = $this->state();
+		$state['repos'][ $name ]      = array(
 			'repo' => $repo,
 			'url'  => $url,
 		);
@@ -76,16 +76,16 @@ class RemoteWorkspaceBackend {
 			return new \WP_Error( 'missing_branch', 'Branch is required.', array( 'status' => 400 ) );
 		}
 
-		$slug   = $this->branch_slug( $branch );
-		$handle = $repo_name . '@' . $slug;
-		$state  = $this->state();
+		$slug                          = $this->branch_slug( $branch );
+		$handle                        = $repo_name . '@' . $slug;
+		$state                         = $this->state();
 		$state['worktrees'][ $handle ] = array(
-			'repo_name'      => $repo_name,
-			'repo'           => $repo,
-			'branch'         => $branch,
-			'base_ref'       => $from ?: '',
-			'pending_files'  => array(),
-			'changed_files'  => array(),
+			'repo_name'       => $repo_name,
+			'repo'            => $repo,
+			'branch'          => $branch,
+			'base_ref'        => null !== $from && '' !== $from ? $from : '',
+			'pending_files'   => array(),
+			'changed_files'   => array(),
 			'last_commit_sha' => '',
 		);
 		$this->save_state( $state );
@@ -130,8 +130,13 @@ class RemoteWorkspaceBackend {
 					'ref'  => $context['read_ref'],
 				)
 			);
-			if ( is_wp_error( $file ) && $context['read_ref'] !== '' ) {
-				$file = GitHubAbilities::getFileContents( array( 'repo' => $context['repo'], 'path' => $path ) );
+			if ( is_wp_error( $file ) && '' !== $context['read_ref'] ) {
+				$file = GitHubAbilities::getFileContents(
+					array(
+						'repo' => $context['repo'],
+						'path' => $path,
+					)
+				);
 			}
 			if ( is_wp_error( $file ) ) {
 				return $file;
@@ -173,8 +178,13 @@ class RemoteWorkspaceBackend {
 		}
 
 		$prefix = null === $path ? '' : trim( ltrim( $path, '/' ), '/' );
-		$tree   = GitHubAbilities::getRepoTree( array( 'repo' => $context['repo'], 'ref' => $context['read_ref'] ) );
-		if ( is_wp_error( $tree ) && $context['read_ref'] !== '' ) {
+		$tree   = GitHubAbilities::getRepoTree(
+			array(
+				'repo' => $context['repo'],
+				'ref'  => $context['read_ref'],
+			)
+		);
+		if ( is_wp_error( $tree ) && '' !== $context['read_ref'] ) {
 			$tree = GitHubAbilities::getRepoTree( array( 'repo' => $context['repo'] ) );
 		}
 		if ( is_wp_error( $tree ) ) {
@@ -307,7 +317,7 @@ class RemoteWorkspaceBackend {
 			'path'               => 'github://' . $context['repo'] . '#' . $context['branch'],
 			'branch'             => $context['branch'],
 			'remote'             => 'https://github.com/' . $context['repo'] . '.git',
-			'commit'             => $context['last_commit_sha'] ?: null,
+			'commit'             => '' !== $context['last_commit_sha'] ? $context['last_commit_sha'] : null,
 			'dirty'              => count( $files ),
 			'files'              => $files,
 			'conversation_state' => 'incomplete',
@@ -395,7 +405,10 @@ class RemoteWorkspaceBackend {
 			'message'            => sprintf( 'Committed remote workspace changes to %s.', $context['branch'] ),
 			'conversation_state' => 'incomplete',
 			'next_required_tool' => 'workspace_git_push',
-			'next_required_args' => array( 'name' => $handle, 'branch' => $context['branch'] ),
+			'next_required_args' => array(
+				'name'   => $handle,
+				'branch' => $context['branch'],
+			),
 		);
 	}
 
@@ -413,7 +426,12 @@ class RemoteWorkspaceBackend {
 			)
 		);
 		if ( is_wp_error( $file ) && '' !== $context['read_ref'] ) {
-			$file = GitHubAbilities::getFileContents( array( 'repo' => $context['repo'], 'path' => $path ) );
+			$file = GitHubAbilities::getFileContents(
+				array(
+					'repo' => $context['repo'],
+					'path' => $path,
+				)
+			);
 		}
 		if ( is_wp_error( $file ) ) {
 			$status = (int) ( $file->get_error_data()['status'] ?? 0 );
@@ -438,16 +456,21 @@ class RemoteWorkspaceBackend {
 			return $context;
 		}
 
+		$push_branch = null !== $branch && '' !== $branch ? $branch : $context['branch'];
+
 		return array(
 			'success'            => true,
 			'backend'            => 'github_api',
 			'name'               => $handle,
 			'remote'             => $remote,
-			'branch'             => $branch ?: $context['branch'],
+			'branch'             => $push_branch,
 			'message'            => 'Remote workspace branch already updated via GitHub API.',
 			'conversation_state' => 'incomplete',
 			'next_required_tool' => 'create_github_pull_request',
-			'next_required_args' => array( 'repo' => $context['repo'], 'head' => $branch ?: $context['branch'] ),
+			'next_required_args' => array(
+				'repo' => $context['repo'],
+				'head' => $push_branch,
+			),
 		);
 	}
 
@@ -457,7 +480,7 @@ class RemoteWorkspaceBackend {
 	private function resolve_handle( string $handle ): array|\WP_Error {
 		$state = $this->state();
 		if ( isset( $state['worktrees'][ $handle ] ) ) {
-			$worktree = (array) $state['worktrees'][ $handle ];
+			$worktree             = (array) $state['worktrees'][ $handle ];
 			$worktree['handle']   = $handle;
 			$worktree['read_ref'] = (string) ( $worktree['branch'] ?? '' );
 			return $worktree;

--- a/tests/smoke-remote-workspace-backend.php
+++ b/tests/smoke-remote-workspace-backend.php
@@ -10,7 +10,10 @@ declare( strict_types=1 );
 namespace DataMachineCode\Abilities {
 	class GitHubAbilities {
 		public static array $files = array(
-			'chubes4/example:main:src/example.php' => "<?php\nreturn 'old';\n",
+			'chubes4/example:main:src/example.php' => array(
+				'content' => "<?php\nreturn 'old';\n",
+				'sha'     => 'file-sha-main-example',
+			),
 		);
 		public static array $commits = array();
 
@@ -22,12 +25,14 @@ namespace DataMachineCode\Abilities {
 			if ( ! isset( self::$files[ $key ] ) ) {
 				return new \WP_Error( 'github_not_found', 'Not found.', array( 'status' => 404 ) );
 			}
+			$file = self::$files[ $key ];
 			return array(
 				'success' => true,
 				'file'    => array(
 					'path'    => $path,
-					'size'    => strlen( self::$files[ $key ] ),
-					'content' => self::$files[ $key ],
+					'size'    => strlen( $file['content'] ),
+					'sha'     => $file['sha'],
+					'content' => $file['content'],
 				),
 			);
 		}
@@ -42,12 +47,21 @@ namespace DataMachineCode\Abilities {
 		}
 
 		public static function createOrUpdateFile( array $input ): array|\WP_Error {
-			$repo = (string) ( $input['repo'] ?? '' );
-			$path = (string) ( $input['file_path'] ?? '' );
+			$repo   = (string) ( $input['repo'] ?? '' );
+			$path   = (string) ( $input['file_path'] ?? '' );
 			$branch = (string) ( $input['branch'] ?? 'main' );
+			$key        = $repo . ':' . $branch . ':' . $path;
+			$source_key = $repo . ':main:' . $path;
+			$existing   = self::$files[ $key ] ?? self::$files[ $source_key ] ?? null;
+			if ( null !== $existing && (string) ( $input['sha'] ?? '' ) !== $existing['sha'] ) {
+				return new \WP_Error( 'github_sha_required', 'Invalid request. "sha" wasn\'t supplied.', array( 'status' => 422 ) );
+			}
 			$sha = 'commit-' . ( count( self::$commits ) + 1 );
-			self::$files[ $repo . ':' . $branch . ':' . $path ] = (string) ( $input['content'] ?? '' );
-			self::$commits[] = array( 'sha' => $sha, 'message' => (string) ( $input['commit_message'] ?? '' ) );
+			self::$files[ $key ] = array(
+				'content' => (string) ( $input['content'] ?? '' ),
+				'sha'     => 'file-sha-' . $sha,
+			);
+			self::$commits[] = array( 'sha' => $sha, 'message' => (string) ( $input['commit_message'] ?? '' ), 'input_sha' => (string) ( $input['sha'] ?? '' ) );
 			return array(
 				'success' => true,
 				'commit'  => array( 'sha' => $sha, 'html_url' => 'https://github.com/' . $repo . '/commit/' . $sha ),
@@ -129,6 +143,7 @@ namespace {
 	$commit = $backend->git_commit( 'example@fix-example', 'fix: update example' );
 	$assert( 'commit writes via GitHub API', ! is_wp_error( $commit ) && 'commit-1' === $commit['commit'] );
 	$assert( 'commit uses requested message', 'fix: update example' === GitHubAbilities::$commits[0]['message'] );
+	$assert( 'commit supplies current file sha', 'file-sha-main-example' === GitHubAbilities::$commits[0]['input_sha'] );
 
 	$push = $backend->git_push( 'example@fix-example' );
 	$assert( 'push is successful compatibility no-op', ! is_wp_error( $push ) && 'fix/example' === $push['branch'] );

--- a/tests/smoke-remote-workspace-backend.php
+++ b/tests/smoke-remote-workspace-backend.php
@@ -92,8 +92,8 @@ namespace {
 
 	$GLOBALS['dmc_remote_workspace_options'] = array();
 	if ( ! function_exists( 'get_option' ) ) {
-		function get_option( string $key, mixed $default = false ): mixed {
-			return $GLOBALS['dmc_remote_workspace_options'][ $key ] ?? $default;
+		function get_option( string $key, mixed $default_value = false ): mixed {
+			return $GLOBALS['dmc_remote_workspace_options'][ $key ] ?? $default_value;
 		}
 	}
 	if ( ! function_exists( 'update_option' ) ) {


### PR DESCRIPTION
## Summary
- Resolve the current GitHub Contents API file SHA before remote workspace commits update existing files.
- Allow `GitHubAbilities::createOrUpdateFile()` to accept an explicit SHA while preserving its existing fallback lookup.
- Add smoke coverage that fails if remote workspace commits omit the current file SHA.

Fixes Extra-Chill/data-machine-code#300.

## Testing
- `php tests/smoke-remote-workspace-backend.php`
- `php -l inc/Workspace/RemoteWorkspaceBackend.php && php -l inc/Abilities/GitHubAbilities.php && php -l tests/smoke-remote-workspace-backend.php`
- `git diff --check`
- `homeboy lint data-machine-code --path /Users/chubes/Developer/data-machine-code@fix-remote-workspace-commit-sha --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the remote workspace commit failure, drafting the code/test changes, and running local verification; Chris remains responsible for review and merge.