### PR TITLE
Add WordPress runtime inspection tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Sibling extensions like `data-machine-socials` and `data-machine-business` are *
 
 ### AI Agent Tools
 - GitHub and workspace chat tools for read-only context gathering plus managed PR review comments
+- WordPress runtime inspection tools for read-only perception of live versions, plugins/themes, drop-ins, and allowlisted source files
 - Async GitHub issue creation via system tasks
 - All tools register through Data Machine's tool system, which means they're equally available to external runtimes (via MCP/REST/WP-CLI) and to in-process / CI drivers (via direct AI-step tool calls)
 

--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -83,6 +83,7 @@ function datamachine_code_bootstrap() {
 	new \DataMachineCode\Abilities\WorkspaceAbilities();
 	new \DataMachineCode\Abilities\GitSyncAbilities();
 	new \DataMachineCode\Abilities\CodeTaskAbilities();
+	new \DataMachineCode\Abilities\WordPressRuntimeAbilities();
 	( new \DataMachineCode\Bundle\WorkspacePreloadArtifact() )->register();
 
 	// Load Handlers (they self-register).
@@ -219,6 +220,14 @@ function datamachine_code_register_ability_categories() {
 			'description' => __( 'Create isolated coding tasks from structured source evidence packets.', 'data-machine-code' ),
 		)
 	);
+
+	wp_register_ability_category(
+		'datamachine-code-runtime',
+		array(
+			'label'       => __( 'WordPress Runtime', 'data-machine-code' ),
+			'description' => __( 'Read-only inspection of the live WordPress runtime and allowlisted source roots.', 'data-machine-code' ),
+		)
+	);
 }
 
 /**
@@ -255,6 +264,7 @@ function datamachine_code_load_chat_tools() {
 	new \DataMachineCode\Tools\GitHubPullRequestTool();
 	new \DataMachineCode\Tools\GitHubTools();
 	new \DataMachineCode\Tools\WorkspaceTools();
+	new \DataMachineCode\Tools\WordPressRuntimeTools();
 }
 add_action( 'plugins_loaded', 'datamachine_code_load_chat_tools', 25 );
 

--- a/docs/wordpress-runtime-inspection.md
+++ b/docs/wordpress-runtime-inspection.md
@@ -1,0 +1,38 @@
+# WordPress Runtime Inspection
+
+DMC exposes a read-only runtime perception layer for agents running inside WordPress:
+
+- `wordpress_runtime_inventory` / `datamachine-code/wordpress-runtime-inventory`
+- `wordpress_runtime_ls` / `datamachine-code/wordpress-runtime-ls`
+- `wordpress_runtime_read` / `datamachine-code/wordpress-runtime-read`
+
+These tools are for discovery, not durable memory. Agents should inspect the live runtime when they need current facts, then intentionally write durable memory only for facts that should persist beyond the session.
+
+## Security Model
+
+Runtime file access is default-deny and read-only.
+
+Allowed source roots:
+
+- `wp-content/plugins`
+- `wp-content/themes`
+- `wp-includes`
+- `wp-admin`
+
+Denied by policy:
+
+- `wp-config.php`
+- `.env`, credentials, secrets, tokens, key files, and certificate files
+- `wp-content/uploads` by default
+- `logs`, `cache`, `private`, and `secrets` directories
+- SQLite/MySQL dump/database files and log files
+- path traversal such as `../`
+- arbitrary absolute filesystem reads
+
+`wordpress_runtime_read` is bounded by `max_size`, `offset`, and `limit`, and rejects binary files before returning content.
+
+## Intended Use
+
+Use inventory to understand the live install: WordPress/PHP version, active theme, installed themes/plugins, plugin active/network-active state, mu-plugins, drop-ins, safe constants, and readable source-root metadata.
+
+Use `ls` and `read` only for allowlisted source inspection. Use the existing Data Machine memory surface when an agent decides a discovered fact should become durable context.

--- a/inc/Abilities/WordPressRuntimeAbilities.php
+++ b/inc/Abilities/WordPressRuntimeAbilities.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * WordPress runtime inspection abilities.
+ *
+ * @package DataMachineCode\Abilities
+ */
+
+namespace DataMachineCode\Abilities;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachineCode\Runtime\WordPressRuntimeInspector;
+
+defined( 'ABSPATH' ) || exit;
+
+class WordPressRuntimeAbilities {
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->registerAbilities();
+		self::$registered = true;
+	}
+
+	private function registerAbilities(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine-code/wordpress-runtime-inventory',
+				array(
+					'label'               => 'Inspect WordPress Runtime Inventory',
+					'description'         => 'Read-only inventory of the live WordPress runtime: versions, active theme, installed plugins/themes, mu-plugins, drop-ins, and safe source-root metadata.',
+					'category'            => 'datamachine-code-runtime',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'    => array( 'type' => 'boolean' ),
+							'wordpress'  => array( 'type' => 'object' ),
+							'theme'      => array( 'type' => 'object' ),
+							'themes'     => array( 'type' => 'array' ),
+							'plugins'    => array( 'type' => 'array' ),
+							'mu_plugins' => array( 'type' => 'array' ),
+							'drop_ins'   => array( 'type' => 'array' ),
+							'roots'      => array( 'type' => 'array' ),
+							'policy'     => array( 'type' => 'object' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'inventory' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine-code/wordpress-runtime-ls',
+				array(
+					'label'               => 'List WordPress Runtime Directory',
+					'description'         => 'Read-only directory listing under allowlisted WordPress source roots only.',
+					'category'            => 'datamachine-code-runtime',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'path'        => array(
+								'type'        => 'string',
+								'description' => 'Runtime path relative to ABSPATH. Must be under wp-content/plugins, wp-content/themes, wp-includes, or wp-admin.',
+							),
+							'max_entries' => array(
+								'type'        => 'integer',
+								'description' => 'Maximum entries to return (default 200, max 1000).',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'   => array( 'type' => 'boolean' ),
+							'path'      => array( 'type' => 'string' ),
+							'root'      => array( 'type' => 'string' ),
+							'entries'   => array( 'type' => 'array' ),
+							'count'     => array( 'type' => 'integer' ),
+							'truncated' => array( 'type' => 'boolean' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'ls' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine-code/wordpress-runtime-read',
+				array(
+					'label'               => 'Read WordPress Runtime File',
+					'description'         => 'Read a bounded text file under allowlisted WordPress source roots only. Denies sensitive paths, traversal, oversized files, and binary files.',
+					'category'            => 'datamachine-code-runtime',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'path'     => array(
+								'type'        => 'string',
+								'description' => 'Runtime file path relative to ABSPATH. Must be under an allowlisted source root.',
+							),
+							'max_size' => array(
+								'type'        => 'integer',
+								'description' => 'Maximum file size in bytes (default/max 1MB).',
+							),
+							'offset'   => array(
+								'type'        => 'integer',
+								'description' => 'Line number to start reading from (1-indexed).',
+							),
+							'limit'    => array(
+								'type'        => 'integer',
+								'description' => 'Maximum number of lines to return (default 500, max 2000).',
+							),
+						),
+						'required'   => array( 'path' ),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'     => array( 'type' => 'boolean' ),
+							'path'        => array( 'type' => 'string' ),
+							'root'        => array( 'type' => 'string' ),
+							'size'        => array( 'type' => 'integer' ),
+							'offset'      => array( 'type' => 'integer' ),
+							'limit'       => array( 'type' => 'integer' ),
+							'lines_read'  => array( 'type' => 'integer' ),
+							'total_lines' => array( 'type' => 'integer' ),
+							'truncated'   => array( 'type' => 'boolean' ),
+							'content'     => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'read' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( function_exists( 'doing_action' ) && doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+			return;
+		}
+
+		add_action( 'wp_abilities_api_init', $register_callback );
+	}
+
+	/** @param array<string,mixed> $input Input parameters. @return array<string,mixed> */
+	public static function inventory( array $input ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+		return ( new WordPressRuntimeInspector() )->inventory();
+	}
+
+	/** @param array<string,mixed> $input Input parameters. @return array<string,mixed>|\WP_Error */
+	public static function ls( array $input ): array|\WP_Error {
+		return ( new WordPressRuntimeInspector() )->ls( $input );
+	}
+
+	/** @param array<string,mixed> $input Input parameters. @return array<string,mixed>|\WP_Error */
+	public static function read( array $input ): array|\WP_Error {
+		return ( new WordPressRuntimeInspector() )->read( $input );
+	}
+}

--- a/inc/Runtime/WordPressRuntimeInspector.php
+++ b/inc/Runtime/WordPressRuntimeInspector.php
@@ -1,0 +1,449 @@
+<?php
+/**
+ * Read-only WordPress runtime inspection primitives.
+ *
+ * @package DataMachineCode\Runtime
+ */
+
+namespace DataMachineCode\Runtime;
+
+defined( 'ABSPATH' ) || exit;
+
+final class WordPressRuntimeInspector {
+
+	private const DEFAULT_MAX_READ_SIZE = 1048576;
+	private const DEFAULT_LINE_LIMIT    = 500;
+	private const MAX_LINE_LIMIT        = 2000;
+	private const DEFAULT_MAX_ENTRIES   = 200;
+	private const MAX_ENTRIES           = 1000;
+
+	/** @return array<string,mixed> */
+	public function inventory(): array {
+		$this->maybeLoadPluginFunctions();
+
+		return array(
+			'success'    => true,
+			'wordpress'  => array(
+				'version'     => $this->getWordPressVersion(),
+				'php_version' => PHP_VERSION,
+				'multisite'   => function_exists( 'is_multisite' ) ? is_multisite() : false,
+			),
+			'theme'      => $this->getThemeInventory(),
+			'themes'     => $this->getInstalledThemes(),
+			'plugins'    => $this->getInstalledPlugins(),
+			'mu_plugins' => $this->getMustUsePlugins(),
+			'drop_ins'   => $this->getDropIns(),
+			'constants'  => $this->getSafeConstants(),
+			'roots'      => $this->getRootMetadata(),
+			'policy'     => array(
+				'read_only'         => true,
+				'allowed_roots'     => array_keys( $this->getAllowedRoots() ),
+				'denied_by_default' => array(
+					'wp-config.php',
+					'.env and credential files',
+					'uploads',
+					'logs/cache directories',
+					'database files',
+				),
+			),
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $input Input parameters.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function ls( array $input ): array|\WP_Error {
+		$path        = (string) ( $input['path'] ?? 'wp-content/plugins' );
+		$max_entries = $this->clampInt( $input['max_entries'] ?? self::DEFAULT_MAX_ENTRIES, 1, self::MAX_ENTRIES );
+		$resolved    = $this->resolveAllowedPath( $path );
+
+		if ( is_wp_error( $resolved ) ) {
+			return $resolved;
+		}
+
+		if ( ! is_dir( $resolved['real_path'] ) ) {
+			return new \WP_Error( 'datamachine_runtime_not_directory', 'Path is not a directory.' );
+		}
+
+		$handle = @opendir( $resolved['real_path'] );
+		if ( false === $handle ) {
+			return new \WP_Error( 'datamachine_runtime_unreadable', 'Directory is not readable.' );
+		}
+
+		$entries   = array();
+		$truncated = false;
+		while ( false !== ( $name = readdir( $handle ) ) ) {
+			if ( '.' === $name || '..' === $name ) {
+				continue;
+			}
+
+			$child_real = realpath( $resolved['real_path'] . DIRECTORY_SEPARATOR . $name );
+			if ( false === $child_real ) {
+				continue;
+			}
+
+			$entries[] = array(
+				'name'     => $name,
+				'path'     => $this->relativeFromAbsolute( $child_real ),
+				'type'     => is_dir( $child_real ) ? 'directory' : ( is_file( $child_real ) ? 'file' : 'other' ),
+				'size'     => is_file( $child_real ) ? (int) filesize( $child_real ) : null,
+				'readable' => is_readable( $child_real ),
+			);
+
+			if ( count( $entries ) >= $max_entries ) {
+				$truncated = true;
+				break;
+			}
+		}
+		closedir( $handle );
+
+		usort(
+			$entries,
+			static fn( array $a, array $b ): int => ( $a['type'] === $b['type'] ? strcmp( $a['name'], $b['name'] ) : strcmp( $a['type'], $b['type'] ) )
+		);
+
+		return array(
+			'success'     => true,
+			'path'        => $resolved['relative_path'],
+			'root'        => $resolved['root'],
+			'entries'     => $entries,
+			'count'       => count( $entries ),
+			'truncated'   => $truncated,
+			'max_entries' => $max_entries,
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $input Input parameters.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function read( array $input ): array|\WP_Error {
+		$path     = (string) ( $input['path'] ?? '' );
+		$max_size = $this->clampInt( $input['max_size'] ?? self::DEFAULT_MAX_READ_SIZE, 1, self::DEFAULT_MAX_READ_SIZE );
+		$offset   = $this->clampInt( $input['offset'] ?? 1, 1, PHP_INT_MAX );
+		$limit    = $this->clampInt( $input['limit'] ?? self::DEFAULT_LINE_LIMIT, 1, self::MAX_LINE_LIMIT );
+		$resolved = $this->resolveAllowedPath( $path );
+
+		if ( is_wp_error( $resolved ) ) {
+			return $resolved;
+		}
+
+		if ( ! is_file( $resolved['real_path'] ) ) {
+			return new \WP_Error( 'datamachine_runtime_not_file', 'Path is not a file.' );
+		}
+
+		$size = (int) filesize( $resolved['real_path'] );
+		if ( $size > $max_size ) {
+			return new \WP_Error( 'datamachine_runtime_file_too_large', 'File exceeds the requested max_size.', array( 'path' => $resolved['relative_path'], 'size' => $size, 'max_size' => $max_size ) );
+		}
+
+		$sample = @file_get_contents( $resolved['real_path'], false, null, 0, min( $size, 8192 ) );
+		if ( false === $sample ) {
+			return new \WP_Error( 'datamachine_runtime_unreadable', 'File is not readable.' );
+		}
+
+		if ( $this->isBinary( $sample ) ) {
+			return new \WP_Error( 'datamachine_runtime_binary_file', 'Binary file reading is denied.', array( 'path' => $resolved['relative_path'] ) );
+		}
+
+		$lines = @file( $resolved['real_path'], FILE_IGNORE_NEW_LINES );
+		if ( false === $lines ) {
+			return new \WP_Error( 'datamachine_runtime_unreadable', 'File is not readable.' );
+		}
+
+		$total_lines = count( $lines );
+		$slice       = array_slice( $lines, max( 0, $offset - 1 ), $limit );
+
+		return array(
+			'success'     => true,
+			'path'        => $resolved['relative_path'],
+			'root'        => $resolved['root'],
+			'size'        => $size,
+			'offset'      => $offset,
+			'limit'       => $limit,
+			'lines_read'  => count( $slice ),
+			'total_lines' => $total_lines,
+			'truncated'   => $offset + count( $slice ) - 1 < $total_lines,
+			'content'     => implode( "\n", $slice ),
+		);
+	}
+
+	/** @return array{relative_path:string,real_path:string,root:string}|\WP_Error */
+	private function resolveAllowedPath( string $path ): array|\WP_Error {
+		$relative = $this->normalizeRelativePath( $path );
+
+		if ( '' === $relative ) {
+			return new \WP_Error( 'datamachine_runtime_path_required', 'A runtime path is required.' );
+		}
+
+		if ( $this->hasTraversal( $relative ) ) {
+			return new \WP_Error( 'datamachine_runtime_path_traversal', 'Path traversal detected. Access denied.' );
+		}
+
+		if ( $this->isDeniedPath( $relative ) ) {
+			return new \WP_Error( 'datamachine_runtime_path_denied', 'Path is denied by runtime inspection policy.' );
+		}
+
+		$real = realpath( $this->rootPath() . DIRECTORY_SEPARATOR . $relative );
+		if ( false === $real ) {
+			return new \WP_Error( 'datamachine_runtime_path_missing', 'Path does not exist.' );
+		}
+
+		foreach ( $this->getAllowedRoots() as $root => $root_path ) {
+			$root_real = realpath( $root_path );
+			if ( false === $root_real ) {
+				continue;
+			}
+
+			if ( $real === $root_real || str_starts_with( $real, $root_real . DIRECTORY_SEPARATOR ) ) {
+				if ( ! is_readable( $real ) ) {
+					return new \WP_Error( 'datamachine_runtime_unreadable', 'Path is not readable.' );
+				}
+
+				return array(
+					'relative_path' => $this->relativeFromAbsolute( $real ),
+					'real_path'     => $real,
+					'root'          => $root,
+				);
+			}
+		}
+
+		return new \WP_Error( 'datamachine_runtime_path_not_allowed', 'Path is outside the allowlisted WordPress runtime roots.' );
+	}
+
+	/** @return array<string,string> */
+	private function getAllowedRoots(): array {
+		$root = $this->rootPath();
+
+		return array(
+			'wp-content/plugins' => $root . '/wp-content/plugins',
+			'wp-content/themes'  => $root . '/wp-content/themes',
+			'wp-includes'        => $root . '/wp-includes',
+			'wp-admin'           => $root . '/wp-admin',
+		);
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	private function getRootMetadata(): array {
+		$roots = array();
+		foreach ( $this->getAllowedRoots() as $relative => $absolute ) {
+			$real    = realpath( $absolute );
+			$roots[] = array(
+				'root'     => $relative,
+				'exists'   => false !== $real,
+				'readable' => false !== $real && is_readable( $real ),
+				'path'     => false !== $real ? $this->relativeFromAbsolute( $real ) : $relative,
+			);
+		}
+
+		return $roots;
+	}
+
+	/** @return array<string,mixed> */
+	private function getThemeInventory(): array {
+		$theme = function_exists( 'wp_get_theme' ) ? wp_get_theme() : null;
+
+		return array(
+			'name'       => $theme && method_exists( $theme, 'get' ) ? (string) $theme->get( 'Name' ) : '',
+			'version'    => $theme && method_exists( $theme, 'get' ) ? (string) $theme->get( 'Version' ) : '',
+			'template'   => function_exists( 'get_template' ) ? (string) get_template() : '',
+			'stylesheet' => function_exists( 'get_stylesheet' ) ? (string) get_stylesheet() : '',
+		);
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	private function getInstalledThemes(): array {
+		if ( ! function_exists( 'wp_get_themes' ) ) {
+			return array();
+		}
+
+		$themes = array();
+		foreach ( wp_get_themes() as $stylesheet => $theme ) {
+			$themes[] = array(
+				'stylesheet' => (string) $stylesheet,
+				'name'       => method_exists( $theme, 'get' ) ? (string) $theme->get( 'Name' ) : (string) $stylesheet,
+				'version'    => method_exists( $theme, 'get' ) ? (string) $theme->get( 'Version' ) : '',
+				'active'     => function_exists( 'get_stylesheet' ) && get_stylesheet() === (string) $stylesheet,
+			);
+		}
+
+		return $themes;
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	private function getInstalledPlugins(): array {
+		$plugins = function_exists( 'get_plugins' ) ? get_plugins() : array();
+		$active  = function_exists( 'get_option' ) ? (array) get_option( 'active_plugins', array() ) : array();
+		$items   = array();
+
+		foreach ( $plugins as $file => $plugin ) {
+			$items[] = array(
+				'file'           => (string) $file,
+				'name'           => (string) ( $plugin['Name'] ?? $file ),
+				'version'        => (string) ( $plugin['Version'] ?? '' ),
+				'active'         => function_exists( 'is_plugin_active' ) ? is_plugin_active( $file ) : in_array( $file, $active, true ),
+				'network_active' => function_exists( 'is_plugin_active_for_network' ) ? is_plugin_active_for_network( $file ) : false,
+			);
+		}
+
+		return $items;
+	}
+
+	/** @return array<int,array<string,string>> */
+	private function getMustUsePlugins(): array {
+		if ( ! function_exists( 'get_mu_plugins' ) ) {
+			return array();
+		}
+
+		$items = array();
+		foreach ( get_mu_plugins() as $file => $plugin ) {
+			$items[] = array(
+				'file'    => (string) $file,
+				'name'    => (string) ( $plugin['Name'] ?? $file ),
+				'version' => (string) ( $plugin['Version'] ?? '' ),
+			);
+		}
+
+		return $items;
+	}
+
+	/** @return array<int,array<string,string>> */
+	private function getDropIns(): array {
+		$drop_ins = function_exists( 'get_dropins' ) ? get_dropins() : array();
+		$items    = array();
+
+		foreach ( $drop_ins as $file => $drop_in ) {
+			$items[] = array(
+				'file'        => (string) $file,
+				'name'        => (string) ( $drop_in['Name'] ?? $file ),
+				'description' => (string) ( $drop_in['Description'] ?? '' ),
+			);
+		}
+
+		return $items;
+	}
+
+	/** @return array<string,mixed> */
+	private function getSafeConstants(): array {
+		$constants = array( 'WP_DEBUG', 'WP_ENVIRONMENT_TYPE', 'SCRIPT_DEBUG', 'WP_CONTENT_DIR', 'WP_PLUGIN_DIR', 'WPMU_PLUGIN_DIR' );
+		$safe      = array();
+
+		foreach ( $constants as $constant ) {
+			if ( ! defined( $constant ) ) {
+				continue;
+			}
+
+			$value = constant( $constant );
+			if ( is_string( $value ) && $this->isAbsolutePath( $value ) ) {
+				$value = $this->relativeFromAbsolute( $value );
+			}
+
+			$safe[ $constant ] = $value;
+		}
+
+		return $safe;
+	}
+
+	private function maybeLoadPluginFunctions(): void {
+		$plugin_file = $this->rootPath() . '/wp-admin/includes/plugin.php';
+		if ( ( ! function_exists( 'get_plugins' ) || ! function_exists( 'get_mu_plugins' ) || ! function_exists( 'get_dropins' ) ) && is_readable( $plugin_file ) ) {
+			require_once $plugin_file;
+		}
+	}
+
+	private function getWordPressVersion(): string {
+		if ( function_exists( 'get_bloginfo' ) ) {
+			$version = get_bloginfo( 'version' );
+			if ( is_string( $version ) && '' !== $version ) {
+				return $version;
+			}
+		}
+
+		global $wp_version;
+		return is_string( $wp_version ?? null ) ? $wp_version : '';
+	}
+
+	private function normalizeRelativePath( string $path ): string {
+		$path = str_replace( '\\', '/', trim( $path ) );
+		$path = preg_replace( '#/+#', '/', $path ) ?? $path;
+		return trim( $path, '/' );
+	}
+
+	private function hasTraversal( string $path ): bool {
+		foreach ( explode( '/', $path ) as $part ) {
+			if ( '.' === $part || '..' === $part ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private function isDeniedPath( string $path ): bool {
+		$normalized = strtolower( $this->normalizeRelativePath( $path ) );
+		$basename   = basename( $normalized );
+		$segments   = explode( '/', $normalized );
+
+		if ( 'wp-config.php' === $basename || str_starts_with( $basename, '.env' ) ) {
+			return true;
+		}
+
+		foreach ( $segments as $segment ) {
+			if ( in_array( $segment, array( 'uploads', 'cache', 'logs', 'log', 'secrets', 'private' ), true ) ) {
+				return true;
+			}
+		}
+
+		if ( preg_match( '/(^|[._-])(secret|secrets|credential|credentials|token|tokens|key|keys)([._-]|$)/', $basename ) ) {
+			return true;
+		}
+
+		if ( preg_match( '/\.(sqlite|sqlite3|db|sql|log|pem|key|crt|p12|pfx)$/', $basename ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private function isBinary( string $content ): bool {
+		if ( str_contains( $content, "\0" ) ) {
+			return true;
+		}
+
+		if ( '' === $content ) {
+			return false;
+		}
+
+		$non_text = preg_match_all( '/[^\x09\x0A\x0D\x20-\x7E]/', $content );
+		return false !== $non_text && ( $non_text / strlen( $content ) ) > 0.30;
+	}
+
+	private function clampInt( mixed $value, int $min, int $max ): int {
+		$value = is_numeric( $value ) ? (int) $value : $min;
+		return max( $min, min( $max, $value ) );
+	}
+
+	private function rootPath(): string {
+		return rtrim( str_replace( '\\', '/', ABSPATH ), '/' );
+	}
+
+	private function relativeFromAbsolute( string $path ): string {
+		$path = str_replace( '\\', '/', $path );
+		$root = $this->rootPath();
+
+		if ( $path === $root ) {
+			return '';
+		}
+
+		if ( str_starts_with( $path, $root . '/' ) ) {
+			return substr( $path, strlen( $root ) + 1 );
+		}
+
+		return basename( $path );
+	}
+
+	private function isAbsolutePath( string $path ): bool {
+		return str_starts_with( $path, '/' ) || preg_match( '/^[A-Za-z]:[\\\\\/]/', $path );
+	}
+}

--- a/inc/Tools/WordPressRuntimeTools.php
+++ b/inc/Tools/WordPressRuntimeTools.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * AI tools for read-only WordPress runtime inspection.
+ *
+ * @package DataMachineCode\Tools
+ */
+
+namespace DataMachineCode\Tools;
+
+use DataMachine\Engine\AI\Tools\BaseTool;
+
+defined( 'ABSPATH' ) || exit;
+
+class WordPressRuntimeTools extends BaseTool {
+
+	public function __construct() {
+		$contexts = array( 'chat', 'pipeline' );
+		$options  = array( 'access_level' => 'editor' );
+
+		$this->registerTool( 'wordpress_runtime_inventory', array( $this, 'getInventoryDefinition' ), $contexts, $options + array( 'ability' => 'datamachine-code/wordpress-runtime-inventory' ) );
+		$this->registerTool( 'wordpress_runtime_ls', array( $this, 'getLsDefinition' ), $contexts, $options + array( 'ability' => 'datamachine-code/wordpress-runtime-ls' ) );
+		$this->registerTool( 'wordpress_runtime_read', array( $this, 'getReadDefinition' ), $contexts, $options + array( 'ability' => 'datamachine-code/wordpress-runtime-read' ) );
+	}
+
+	public static function is_configured(): bool {
+		return (bool) wp_get_ability( 'datamachine-code/wordpress-runtime-inventory' );
+	}
+
+	public function check_configuration( $configured, $tool_id ) {
+		$runtime_tools = array( 'wordpress_runtime_inventory', 'wordpress_runtime_ls', 'wordpress_runtime_read' );
+		if ( ! in_array( $tool_id, $runtime_tools, true ) ) {
+			return $configured;
+		}
+
+		return self::is_configured();
+	}
+
+	/** @param array<string,mixed> $parameters Tool parameters. @param array<string,mixed> $tool_def Tool definition. @return array<string,mixed> */
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		$method = $tool_def['method'] ?? '';
+		if ( ! method_exists( $this, $method ) ) {
+			return $this->buildErrorResponse( "Unknown WordPress runtime tool method: {$method}", 'wordpress_runtime' );
+		}
+
+		return $this->{$method}( $parameters );
+	}
+
+	/** @return array<string,mixed> */
+	public function handleInventory(): array {
+		return $this->executeAbility( 'datamachine-code/wordpress-runtime-inventory', array(), 'wordpress_runtime_inventory' );
+	}
+
+	/** @param array<string,mixed> $parameters Tool parameters. @return array<string,mixed> */
+	public function handleLs( array $parameters ): array {
+		$input = array();
+		if ( isset( $parameters['path'] ) ) {
+			$input['path'] = (string) $parameters['path'];
+		}
+		if ( isset( $parameters['max_entries'] ) ) {
+			$input['max_entries'] = (int) $parameters['max_entries'];
+		}
+
+		return $this->executeAbility( 'datamachine-code/wordpress-runtime-ls', $input, 'wordpress_runtime_ls' );
+	}
+
+	/** @param array<string,mixed> $parameters Tool parameters. @return array<string,mixed> */
+	public function handleRead( array $parameters ): array {
+		$input = array( 'path' => (string) ( $parameters['path'] ?? '' ) );
+		foreach ( array( 'max_size', 'offset', 'limit' ) as $key ) {
+			if ( isset( $parameters[ $key ] ) ) {
+				$input[ $key ] = (int) $parameters[ $key ];
+			}
+		}
+
+		return $this->executeAbility( 'datamachine-code/wordpress-runtime-read', $input, 'wordpress_runtime_read' );
+	}
+
+	/** @return array<string,mixed> */
+	public function getToolDefinition(): array {
+		return $this->getInventoryDefinition();
+	}
+
+	/** @return array<string,mixed> */
+	public function getInventoryDefinition(): array {
+		return array(
+			'class'       => __CLASS__,
+			'method'      => 'handleInventory',
+			'description' => 'Inspect the live WordPress runtime inventory: WP/PHP versions, active theme, installed plugins/themes, mu-plugins, drop-ins, and safe source-root policy metadata.',
+			'parameters'  => array(),
+		);
+	}
+
+	/** @return array<string,mixed> */
+	public function getLsDefinition(): array {
+		return array(
+			'class'       => __CLASS__,
+			'method'      => 'handleLs',
+			'description' => 'List files/directories under allowlisted WordPress runtime source roots only. Default path is wp-content/plugins.',
+			'parameters'  => array(
+				'path'        => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Runtime directory path relative to ABSPATH. Must be under wp-content/plugins, wp-content/themes, wp-includes, or wp-admin.',
+				),
+				'max_entries' => array(
+					'type'        => 'integer',
+					'required'    => false,
+					'description' => 'Maximum entries to return (default 200, max 1000).',
+				),
+			),
+		);
+	}
+
+	/** @return array<string,mixed> */
+	public function getReadDefinition(): array {
+		return array(
+			'class'       => __CLASS__,
+			'method'      => 'handleRead',
+			'description' => 'Read a bounded text file under allowlisted WordPress runtime source roots only. Denies sensitive paths, traversal, oversized files, and binary files.',
+			'parameters'  => array(
+				'path'     => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Runtime file path relative to ABSPATH.',
+				),
+				'max_size' => array(
+					'type'        => 'integer',
+					'required'    => false,
+					'description' => 'Maximum file size in bytes (default/max 1MB).',
+				),
+				'offset'   => array(
+					'type'        => 'integer',
+					'required'    => false,
+					'description' => 'Line number to start reading from (1-indexed).',
+				),
+				'limit'    => array(
+					'type'        => 'integer',
+					'required'    => false,
+					'description' => 'Maximum number of lines to return (default 500, max 2000).',
+				),
+			),
+		);
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed> */
+	private function executeAbility( string $ability_name, array $input, string $tool_name ): array {
+		$ability = wp_get_ability( $ability_name );
+		if ( ! $ability ) {
+			return $this->buildErrorResponse( 'WordPress runtime ability not available.', $tool_name );
+		}
+
+		$result = $ability->execute( $input );
+		if ( is_wp_error( $result ) ) {
+			return $this->buildErrorResponse( $result->get_error_message(), $tool_name );
+		}
+
+		return array(
+			'success'   => true,
+			'data'      => $result,
+			'tool_name' => $tool_name,
+		);
+	}
+}

--- a/tests/smoke-wordpress-runtime-inspection.php
+++ b/tests/smoke-wordpress-runtime-inspection.php
@@ -1,0 +1,213 @@
+<?php
+/**
+ * Pure-PHP smoke test for WordPress runtime inspection abilities and tools.
+ *
+ * Run: php tests/smoke-wordpress-runtime-inspection.php
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Abilities {
+	class PermissionHelper {
+		public static function can_manage(): bool {
+			return true;
+		}
+	}
+}
+
+namespace DataMachine\Engine\AI\Tools {
+	class BaseTool {
+		public array $registered = array();
+
+		protected function registerTool( string $name, array $definition_callback, array $contexts, array $options = array() ): void {
+			$this->registered[ $name ] = array(
+				'definition_callback' => $definition_callback,
+				'contexts'            => $contexts,
+				'options'             => $options,
+			);
+		}
+
+		protected function buildErrorResponse( string $message, string $tool_name ): array {
+			return array(
+				'success'   => false,
+				'error'     => $message,
+				'tool_name' => $tool_name,
+			);
+		}
+	}
+}
+
+namespace {
+	$root = sys_get_temp_dir() . '/dmc-runtime-inspection-' . getmypid();
+	mkdir( $root . '/wp-content/plugins/sample', 0777, true );
+	mkdir( $root . '/wp-content/themes/twentytwentyfour', 0777, true );
+	mkdir( $root . '/wp-content/uploads', 0777, true );
+	mkdir( $root . '/wp-includes', 0777, true );
+	mkdir( $root . '/wp-admin', 0777, true );
+	file_put_contents( $root . '/wp-content/plugins/sample/sample.php', "<?php\n// sample plugin\nfunction sample_plugin() {}\n" );
+	file_put_contents( $root . '/wp-content/plugins/sample/.env', "SECRET=value\n" );
+	file_put_contents( $root . '/wp-content/plugins/sample/large.php', str_repeat( 'a', 128 ) );
+	file_put_contents( $root . '/wp-content/plugins/sample/binary.dat', "abc\0def" );
+	file_put_contents( $root . '/wp-config.php', "<?php\ndefine('DB_PASSWORD', 'secret');\n" );
+	file_put_contents( $root . '/wp-content/uploads/leak.txt', 'upload' );
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', $root . '/' );
+	}
+	define( 'WP_CONTENT_DIR', $root . '/wp-content' );
+	define( 'WP_PLUGIN_DIR', $root . '/wp-content/plugins' );
+	define( 'WPMU_PLUGIN_DIR', $root . '/wp-content/mu-plugins' );
+	define( 'WP_DEBUG', true );
+
+	class WP_Ability {}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			public function __construct( private string $code = '', private string $message = '', private array $data = array() ) {}
+			public function get_error_code(): string { return $this->code; }
+			public function get_error_message(): string { return $this->message; }
+			public function get_error_data(): array { return $this->data; }
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $thing ): bool { return $thing instanceof WP_Error; }
+	}
+
+	$GLOBALS['dmc_registered_abilities'] = array();
+	$GLOBALS['dmc_executed_abilities']   = array();
+
+	function wp_register_ability( string $name, array $definition ): void {
+		$GLOBALS['dmc_registered_abilities'][ $name ] = $definition;
+	}
+
+	function doing_action( string $hook ): bool { return 'wp_abilities_api_init' === $hook; }
+	function add_action( string $hook, callable $callback ): void {}
+	function get_bloginfo( string $show ): string { return 'version' === $show ? '6.9-test' : ''; }
+	function is_multisite(): bool { return false; }
+	function get_template(): string { return 'twentytwentyfour'; }
+	function get_stylesheet(): string { return 'twentytwentyfour'; }
+	function get_option( string $name, mixed $default = null ): mixed { return 'active_plugins' === $name ? array( 'sample/sample.php' ) : $default; }
+	function is_plugin_active( string $plugin ): bool { return 'sample/sample.php' === $plugin; }
+	function is_plugin_active_for_network( string $plugin ): bool { return 'network/network.php' === $plugin; }
+	function get_plugins(): array { return array( 'sample/sample.php' => array( 'Name' => 'Sample Plugin', 'Version' => '1.2.3' ) ); }
+	function get_mu_plugins(): array { return array( 'loader.php' => array( 'Name' => 'MU Loader', 'Version' => '0.1.0' ) ); }
+	function get_dropins(): array { return array( 'db.php' => array( 'Name' => 'SQLite integration', 'Description' => 'Database drop-in' ) ); }
+	function wp_get_theme(): object {
+		return new class() {
+			public function get( string $key ): string { return array( 'Name' => 'Twenty Twenty-Four', 'Version' => '1.0' )[ $key ] ?? ''; }
+		};
+	}
+	function wp_get_themes(): array {
+		return array(
+			'twentytwentyfour' => new class() {
+				public function get( string $key ): string { return array( 'Name' => 'Twenty Twenty-Four', 'Version' => '1.0' )[ $key ] ?? ''; }
+			},
+		);
+	}
+
+	function wp_get_ability( string $name ) {
+		if ( ! isset( $GLOBALS['dmc_registered_abilities'][ $name ] ) ) {
+			return null;
+		}
+
+		return new class( $name ) {
+			public function __construct( private string $name ) {}
+			public function execute( array $parameters ): array|WP_Error {
+				$GLOBALS['dmc_executed_abilities'][ $this->name ] = $parameters;
+				$callback = $GLOBALS['dmc_registered_abilities'][ $this->name ]['execute_callback'];
+				return call_user_func( $callback, $parameters );
+			}
+		};
+	}
+
+	require __DIR__ . '/../inc/Runtime/WordPressRuntimeInspector.php';
+	require __DIR__ . '/../inc/Abilities/WordPressRuntimeAbilities.php';
+	require __DIR__ . '/../inc/Tools/WordPressRuntimeTools.php';
+
+	use DataMachineCode\Abilities\WordPressRuntimeAbilities;
+	use DataMachineCode\Runtime\WordPressRuntimeInspector;
+	use DataMachineCode\Tools\WordPressRuntimeTools;
+
+	$failures = array();
+	$total    = 0;
+	$assert   = function ( string $label, bool $condition ) use ( &$failures, &$total ): void {
+		++$total;
+		if ( $condition ) {
+			echo "  ok {$label}\n";
+			return;
+		}
+
+		$failures[] = $label;
+		echo "  fail {$label}\n";
+	};
+
+	echo "WordPress runtime inspection - smoke\n";
+
+	new WordPressRuntimeAbilities();
+	$tools     = new WordPressRuntimeTools();
+	$inspector = new WordPressRuntimeInspector();
+
+	foreach ( array(
+		'wordpress_runtime_inventory' => 'datamachine-code/wordpress-runtime-inventory',
+		'wordpress_runtime_ls'        => 'datamachine-code/wordpress-runtime-ls',
+		'wordpress_runtime_read'      => 'datamachine-code/wordpress-runtime-read',
+	) as $tool_name => $ability_name ) {
+		$tool = $tools->registered[ $tool_name ] ?? null;
+		$assert( "{$ability_name} ability registered", isset( $GLOBALS['dmc_registered_abilities'][ $ability_name ] ) );
+		$assert( "{$tool_name} tool registered", null !== $tool );
+		$assert( "{$tool_name} available in chat", in_array( 'chat', $tool['contexts'] ?? array(), true ) );
+		$assert( "{$tool_name} available in pipeline", in_array( 'pipeline', $tool['contexts'] ?? array(), true ) );
+		$assert( "{$tool_name} is policy gated", 'editor' === ( $tool['options']['access_level'] ?? '' ) );
+		$assert( "{$tool_name} records ability", $ability_name === ( $tool['options']['ability'] ?? '' ) );
+	}
+
+	$inventory = $inspector->inventory();
+	$assert( 'inventory succeeds', true === ( $inventory['success'] ?? false ) );
+	$assert( 'inventory exposes wp version', '6.9-test' === ( $inventory['wordpress']['version'] ?? '' ) );
+	$assert( 'inventory exposes active theme', 'twentytwentyfour' === ( $inventory['theme']['stylesheet'] ?? '' ) );
+	$assert( 'inventory exposes active plugin', true === ( $inventory['plugins'][0]['active'] ?? false ) );
+	$assert( 'inventory exposes mu plugins', 'MU Loader' === ( $inventory['mu_plugins'][0]['name'] ?? '' ) );
+	$assert( 'inventory exposes drop-ins', 'db.php' === ( $inventory['drop_ins'][0]['file'] ?? '' ) );
+	$assert( 'inventory exposes allowed roots', in_array( 'wp-content/plugins', $inventory['policy']['allowed_roots'] ?? array(), true ) );
+
+	$ls = $inspector->ls( array( 'path' => 'wp-content/plugins/sample' ) );
+	$assert( 'allowlisted ls succeeds', ! is_wp_error( $ls ) && true === ( $ls['success'] ?? false ) );
+	$assert( 'allowlisted ls returns file', ! is_wp_error( $ls ) && in_array( 'sample.php', array_column( $ls['entries'], 'name' ), true ) );
+
+	$read = $inspector->read( array( 'path' => 'wp-content/plugins/sample/sample.php', 'offset' => 2, 'limit' => 1 ) );
+	$assert( 'allowlisted read succeeds', ! is_wp_error( $read ) && true === ( $read['success'] ?? false ) );
+	$assert( 'allowlisted read honors line bounds', ! is_wp_error( $read ) && '// sample plugin' === ( $read['content'] ?? '' ) );
+
+	$sensitive = $inspector->read( array( 'path' => 'wp-content/plugins/sample/.env' ) );
+	$assert( 'sensitive path denied', is_wp_error( $sensitive ) && 'datamachine_runtime_path_denied' === $sensitive->get_error_code() );
+
+	$wp_config = $inspector->read( array( 'path' => 'wp-config.php' ) );
+	$assert( 'wp-config denied before arbitrary read', is_wp_error( $wp_config ) && 'datamachine_runtime_path_denied' === $wp_config->get_error_code() );
+
+	$uploads = $inspector->read( array( 'path' => 'wp-content/uploads/leak.txt' ) );
+	$assert( 'uploads denied by default', is_wp_error( $uploads ) && 'datamachine_runtime_path_denied' === $uploads->get_error_code() );
+
+	$traversal = $inspector->ls( array( 'path' => 'wp-content/plugins/../themes' ) );
+	$assert( 'path traversal rejected', is_wp_error( $traversal ) && 'datamachine_runtime_path_traversal' === $traversal->get_error_code() );
+
+	$oversized = $inspector->read( array( 'path' => 'wp-content/plugins/sample/large.php', 'max_size' => 10 ) );
+	$assert( 'oversized file rejected', is_wp_error( $oversized ) && 'datamachine_runtime_file_too_large' === $oversized->get_error_code() );
+
+	$binary = $inspector->read( array( 'path' => 'wp-content/plugins/sample/binary.dat' ) );
+	$assert( 'binary file rejected', is_wp_error( $binary ) && 'datamachine_runtime_binary_file' === $binary->get_error_code() );
+
+	$tool_response = $tools->handle_tool_call( array( 'path' => 'wp-content/plugins/sample/sample.php' ), $tools->getReadDefinition() );
+	$assert( 'tool delegates to ability', true === ( $tool_response['success'] ?? false ) && isset( $GLOBALS['dmc_executed_abilities']['datamachine-code/wordpress-runtime-read'] ) );
+
+	if ( ! empty( $failures ) ) {
+		echo "\nFAIL: " . count( $failures ) . " assertion(s) failed out of {$total}\n";
+		foreach ( $failures as $failure ) {
+			echo "  - {$failure}\n";
+		}
+		exit( 1 );
+	}
+
+	echo "\nOK ({$total} assertions)\n";
+	exit( 0 );
+}


### PR DESCRIPTION
## Summary
- Add read-only WordPress runtime inventory, directory listing, and file reading abilities plus chat/pipeline tools.
- Restrict runtime file inspection to allowlisted WordPress source roots with traversal, sensitive path, upload, cache/log, database, oversized, and binary-file protections.
- Document the security model and intended perception-first use, with focused smoke coverage for inventory/read policy behavior.

## Tests
- `php tests/smoke-wordpress-runtime-inspection.php`
- `php -l inc/Runtime/WordPressRuntimeInspector.php && php -l inc/Abilities/WordPressRuntimeAbilities.php && php -l inc/Tools/WordPressRuntimeTools.php && php -l tests/smoke-wordpress-runtime-inspection.php`
- `php -l data-machine-code.php`

## Notes
- `php tests/smoke-github-readonly-tools.php` currently fails because `GitHubTools.php` already exposes `create_or_update_github_file`, which violates that test's existing read-only assertion outside this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the runtime inspection abilities/tools, tests, and documentation from issue #302; Chris remains responsible for review and merge decisions.