### PR TITLE
Label GitHub artifacts with agent provenance

### DIFF
--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -311,6 +311,11 @@ class GitHubAbilities {
 								'type'        => 'boolean',
 								'description' => 'Whether to open the pull request as a draft. Default: false.',
 							),
+							'labels'                => array(
+								'type'        => 'array',
+								'items'       => array( 'type' => 'string' ),
+								'description' => 'Labels to attach to the pull request after creation.',
+							),
 							'maintainer_can_modify' => array(
 								'type'        => 'boolean',
 								'description' => 'Whether maintainers can modify the pull request. Default: true.',
@@ -1376,8 +1381,9 @@ class GitHubAbilities {
 		if ( ! empty( $input['body'] ) ) {
 			$body['body'] = $input['body'];
 		}
-		if ( ! empty( $input['labels'] ) && is_array( $input['labels'] ) ) {
-			$body['labels'] = array_map( 'sanitize_text_field', $input['labels'] );
+		$labels = self::mergeProvenanceLabels( isset( $input['labels'] ) && is_array( $input['labels'] ) ? $input['labels'] : array() );
+		if ( ! empty( $labels ) ) {
+			$body['labels'] = $labels;
 		}
 		if ( ! empty( $input['assignees'] ) && is_array( $input['assignees'] ) ) {
 			$body['assignees'] = array_map( 'sanitize_text_field', $input['assignees'] );
@@ -1473,13 +1479,179 @@ class GitHubAbilities {
 		}
 
 		$pull = self::normalizePull( $response['data'] );
+		$labels = self::mergeProvenanceLabels( isset( $input['labels'] ) && is_array( $input['labels'] ) ? $input['labels'] : array() );
+		$labeling = null;
 
-		return array(
+		if ( ! empty( $labels ) && ! empty( $pull['number'] ) ) {
+			$label_response = self::applyLabelsToNumber( $repo, (int) $pull['number'], $labels, $pat );
+			if ( is_wp_error( $label_response ) ) {
+				$labeling = array(
+					'success'    => false,
+					'labels'     => $labels,
+					'error_code' => $label_response->get_error_code(),
+					'error'      => $label_response->get_error_message(),
+					'status'     => is_array( $label_response->get_error_data() ) ? ( $label_response->get_error_data()['status'] ?? null ) : null,
+				);
+			} else {
+				$labeling = array(
+					'success'        => true,
+					'labels'         => $labels,
+					'applied_labels' => $label_response['applied_labels'] ?? array(),
+				);
+			}
+		}
+
+		$result = array(
 			'success'      => true,
 			'pull_request' => $pull,
 			'pull_number'  => $pull['number'] ?? 0,
 			'html_url'     => $pull['html_url'] ?? '',
 			'message'      => sprintf( 'Pull request #%d opened in %s.', $pull['number'] ?? 0, $repo ),
+		);
+
+		if ( null !== $labeling ) {
+			$result['labeling'] = $labeling;
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Merge caller-provided labels with runtime agent provenance labels.
+	 *
+	 * @param array<int,mixed> $labels Caller-provided labels.
+	 * @return array<int,string>
+	 */
+	private static function mergeProvenanceLabels( array $labels ): array {
+		$merged = array();
+		foreach ( $labels as $label ) {
+			$label = sanitize_text_field( (string) $label );
+			if ( '' !== $label && ! in_array( $label, $merged, true ) ) {
+				$merged[] = $label;
+			}
+		}
+
+		$agent_slug = self::getCurrentAgentSlug();
+		if ( '' === $agent_slug ) {
+			return $merged;
+		}
+
+		foreach ( array( 'agent:' . $agent_slug, 'datamachine-agent' ) as $label ) {
+			if ( ! in_array( $label, $merged, true ) ) {
+				$merged[] = $label;
+			}
+		}
+
+		return $merged;
+	}
+
+	/**
+	 * Resolve the current Data Machine agent slug when running in agent context.
+	 */
+	private static function getCurrentAgentSlug(): string {
+		foreach ( array( 'get_runtime_context', 'runtime_context' ) as $method ) {
+			if ( method_exists( PermissionHelper::class, $method ) ) {
+				$agent_slug = self::agentSlugFromContext( call_user_func( array( PermissionHelper::class, $method ) ) );
+				if ( '' !== $agent_slug ) {
+					return $agent_slug;
+				}
+			}
+		}
+
+		if ( method_exists( PermissionHelper::class, 'get_execution_principal' ) ) {
+			$principal = PermissionHelper::get_execution_principal();
+			if ( is_object( $principal ) ) {
+				$agent_slug = self::agentSlugFromContext( method_exists( $principal, 'to_array' ) ? $principal->to_array() : get_object_vars( $principal ) );
+				if ( '' !== $agent_slug ) {
+					return $agent_slug;
+				}
+			}
+		}
+
+		if ( method_exists( PermissionHelper::class, 'get_acting_agent_slug' ) ) {
+			$agent_slug = PermissionHelper::get_acting_agent_slug();
+			if ( is_string( $agent_slug ) && '' !== trim( $agent_slug ) ) {
+				return sanitize_text_field( $agent_slug );
+			}
+		}
+
+		if ( ! method_exists( PermissionHelper::class, 'get_acting_agent_id' ) ) {
+			return '';
+		}
+
+		$agent_id = PermissionHelper::get_acting_agent_id();
+		if ( empty( $agent_id ) || ! class_exists( '\DataMachine\Core\Database\Agents\Agents' ) ) {
+			return '';
+		}
+
+		$agents_repo = new \DataMachine\Core\Database\Agents\Agents();
+		if ( ! method_exists( $agents_repo, 'get_agent' ) ) {
+			return '';
+		}
+
+		$agent = $agents_repo->get_agent( (int) $agent_id );
+		$agent_slug = is_array( $agent ) ? (string) ( $agent['agent_slug'] ?? '' ) : '';
+
+		return '' !== trim( $agent_slug ) ? sanitize_text_field( $agent_slug ) : '';
+	}
+
+	/**
+	 * Extract agent_slug from a runtime context-like shape.
+	 *
+	 * @param mixed $context Runtime context, principal array, or metadata.
+	 */
+	private static function agentSlugFromContext( mixed $context ): string {
+		if ( ! is_array( $context ) ) {
+			return '';
+		}
+
+		foreach ( array( 'agent_slug', 'current_agent_slug' ) as $key ) {
+			$agent_slug = $context[ $key ] ?? null;
+			if ( is_string( $agent_slug ) && '' !== trim( $agent_slug ) ) {
+				return sanitize_text_field( $agent_slug );
+			}
+		}
+
+		foreach ( array( 'runtime_context', 'request_metadata', 'metadata' ) as $key ) {
+			$agent_slug = self::agentSlugFromContext( $context[ $key ] ?? null );
+			if ( '' !== $agent_slug ) {
+				return $agent_slug;
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Apply labels to an issue or pull request number.
+	 *
+	 * @param string            $repo   owner/repo identifier.
+	 * @param int               $number Issue or pull request number.
+	 * @param array<int,string> $labels Labels to add.
+	 * @param string            $pat    GitHub token.
+	 * @return array|\WP_Error
+	 */
+	private static function applyLabelsToNumber( string $repo, int $number, array $labels, string $pat ): array|\WP_Error {
+		$url      = sprintf( '%s/repos/%s/issues/%d/labels', self::API_BASE, $repo, $number );
+		$response = self::apiRequest( 'POST', $url, array( 'labels' => $labels ), $pat );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$applied = array();
+		if ( is_array( $response['data'] ?? null ) ) {
+			foreach ( $response['data'] as $label ) {
+				$name = is_array( $label ) ? ( $label['name'] ?? '' ) : '';
+				if ( '' !== $name ) {
+					$applied[] = (string) $name;
+				}
+			}
+		}
+
+		return array(
+			'success'        => true,
+			'applied_labels' => $applied,
 		);
 	}
 

--- a/inc/Tools/GitHubPullRequestTool.php
+++ b/inc/Tools/GitHubPullRequestTool.php
@@ -46,6 +46,7 @@ class GitHubPullRequestTool extends BaseTool {
 			'head'                  => $parameters['head'] ?? '',
 			'base'                  => $parameters['base'] ?? '',
 			'body'                  => $parameters['body'] ?? '',
+			'labels'                => isset( $parameters['labels'] ) && is_array( $parameters['labels'] ) ? $parameters['labels'] : array(),
 			'draft'                 => $parameters['draft'] ?? false,
 			'maintainer_can_modify' => $parameters['maintainer_can_modify'] ?? true,
 		);
@@ -130,6 +131,12 @@ class GitHubPullRequestTool extends BaseTool {
 					'type'        => 'boolean',
 					'required'    => false,
 					'description' => 'Whether to open the pull request as a draft. Default: false.',
+				),
+				'labels'                => array(
+					'type'        => 'array',
+					'items'       => array( 'type' => 'string' ),
+					'required'    => false,
+					'description' => 'Labels to attach to the pull request after creation.',
 				),
 				'maintainer_can_modify' => array(
 					'type'        => 'boolean',

--- a/tests/smoke-github-create-abilities.php
+++ b/tests/smoke-github-create-abilities.php
@@ -16,10 +16,25 @@ namespace DataMachine\Abilities {
 	class PermissionHelper {
 		public static int $can_manage_calls = 0;
 		public static bool $can_manage_result = true;
+		public static ?string $acting_agent_slug = null;
+		public static ?int $acting_agent_id = null;
+		public static array $runtime_context = array();
 
 		public static function can_manage(): bool {
 			++self::$can_manage_calls;
 			return self::$can_manage_result;
+		}
+
+		public static function get_acting_agent_slug(): ?string {
+			return self::$acting_agent_slug;
+		}
+
+		public static function get_acting_agent_id(): ?int {
+			return self::$acting_agent_id;
+		}
+
+		public static function get_runtime_context(): array {
+			return self::$runtime_context;
 		}
 	}
 }
@@ -187,6 +202,8 @@ namespace {
 	$assert( 'create-github-pull-request requires repo, title, head', array( 'repo', 'title', 'head' ) === ( $pr_ability['input_schema']['required'] ?? array() ) );
 	$assert( 'create-github-pull-request exposes base', array_key_exists( 'base', $pr_ability['input_schema']['properties'] ?? array() ) );
 	$assert( 'create-github-pull-request exposes draft', array_key_exists( 'draft', $pr_ability['input_schema']['properties'] ?? array() ) );
+	$assert( 'create-github-pull-request exposes labels', array_key_exists( 'labels', $pr_ability['input_schema']['properties'] ?? array() ) );
+	$assert( 'create-github-pull-request labels schema declares string items', array( 'type' => 'string' ) === ( $pr_ability['input_schema']['properties']['labels']['items'] ?? null ) );
 	$assert( 'create-github-pull-request exposes maintainer_can_modify', array_key_exists( 'maintainer_can_modify', $pr_ability['input_schema']['properties'] ?? array() ) );
 	$assert( 'create-github-pull-request is hidden from REST', false === ( $pr_ability['meta']['show_in_rest'] ?? null ) );
 
@@ -237,8 +254,29 @@ namespace {
 	$body = is_string( $call['args']['body'] ?? null ) ? json_decode( $call['args']['body'], true ) : null;
 	$assert( 'createIssue posts to /repos/owner/repo/issues', is_string( $call['url'] ?? null ) && str_ends_with( $call['url'], '/repos/owner/repo/issues' ) );
 	$assert( 'createIssue forwards labels', is_array( $body ) && array( 'bug' ) === ( $body['labels'] ?? array() ) );
+	$assert( 'createIssue does not add provenance labels without agent context', is_array( $body ) && array( 'bug' ) === ( $body['labels'] ?? array() ) );
 	$assert( 'createIssue forwards assignees', is_array( $body ) && array( 'octocat' ) === ( $body['assignees'] ?? array() ) );
 	$assert( 'createIssue forwards milestone as int', is_array( $body ) && 7 === ( $body['milestone'] ?? null ) );
+
+	// ---- createIssue: agent context merges provenance labels with caller labels
+	$reset_http();
+	PermissionHelper::$runtime_context = array( 'agent_slug' => 'code-reviewer' );
+	$queue_response( 201, array(
+		'number'   => 44,
+		'title'    => 'Agent issue',
+		'html_url' => 'https://github.com/owner/repo/issues/44',
+	) );
+	GitHubAbilities::createIssue( array(
+		'repo'   => 'owner/repo',
+		'title'  => 'Agent issue',
+		'labels' => array( 'bug' ),
+	) );
+	$call = $GLOBALS['dmc_http_calls'][0] ?? array();
+	$body = is_string( $call['args']['body'] ?? null ) ? json_decode( $call['args']['body'], true ) : null;
+	$assert( 'createIssue preserves caller labels when adding provenance', is_array( $body ) && in_array( 'bug', $body['labels'] ?? array(), true ) );
+	$assert( 'createIssue adds agent slug provenance label', is_array( $body ) && in_array( 'agent:code-reviewer', $body['labels'] ?? array(), true ) );
+	$assert( 'createIssue adds datamachine-agent label', is_array( $body ) && in_array( 'datamachine-agent', $body['labels'] ?? array(), true ) );
+	PermissionHelper::$runtime_context = array();
 
 	// ---- createIssue: ignores null milestone
 	$reset_http();
@@ -302,6 +340,55 @@ namespace {
 	$assert( 'createPullRequest forwards head and base', is_array( $body ) && 'feature/x' === ( $body['head'] ?? '' ) && 'main' === ( $body['base'] ?? '' ) );
 	$assert( 'createPullRequest defaults maintainer_can_modify=true', is_array( $body ) && true === ( $body['maintainer_can_modify'] ?? null ) );
 	$assert( 'createPullRequest does not set draft when omitted', is_array( $body ) && ! array_key_exists( 'draft', $body ) );
+	$assert( 'createPullRequest does not call labels endpoint without labels or agent context', 1 === count( $GLOBALS['dmc_http_calls'] ) );
+
+	// ---- createPullRequest: agent context applies caller and provenance labels after creation
+	$reset_http();
+	PermissionHelper::$acting_agent_slug = 'code-reviewer';
+	$queue_response( 201, array(
+		'number'   => 91,
+		'html_url' => 'https://github.com/owner/repo/pull/91',
+		'head'     => array( 'ref' => 'feat/labels' ),
+		'base'     => array( 'ref' => 'main' ),
+	) );
+	$queue_response( 200, array(
+		array( 'name' => 'needs-review' ),
+		array( 'name' => 'agent:code-reviewer' ),
+		array( 'name' => 'datamachine-agent' ),
+	) );
+	$result = GitHubAbilities::createPullRequest( array(
+		'repo'   => 'owner/repo',
+		'title'  => 'Label PR',
+		'head'   => 'feat/labels',
+		'base'   => 'main',
+		'labels' => array( 'needs-review' ),
+	) );
+	$label_call = $GLOBALS['dmc_http_calls'][1] ?? array();
+	$label_body = is_string( $label_call['args']['body'] ?? null ) ? json_decode( $label_call['args']['body'], true ) : null;
+	$assert( 'createPullRequest labels PR through issues labels endpoint', is_string( $label_call['url'] ?? null ) && str_ends_with( $label_call['url'], '/repos/owner/repo/issues/91/labels' ) );
+	$assert( 'createPullRequest preserves caller label during post-create labeling', is_array( $label_body ) && in_array( 'needs-review', $label_body['labels'] ?? array(), true ) );
+	$assert( 'createPullRequest adds agent slug label during post-create labeling', is_array( $label_body ) && in_array( 'agent:code-reviewer', $label_body['labels'] ?? array(), true ) );
+	$assert( 'createPullRequest adds datamachine-agent during post-create labeling', is_array( $label_body ) && in_array( 'datamachine-agent', $label_body['labels'] ?? array(), true ) );
+	$assert( 'createPullRequest reports successful labeling metadata', is_array( $result ) && true === ( $result['labeling']['success'] ?? false ) && in_array( 'agent:code-reviewer', $result['labeling']['applied_labels'] ?? array(), true ) );
+
+	// ---- createPullRequest: labeling failure does not mask PR creation success
+	$reset_http();
+	$queue_response( 201, array(
+		'number'   => 92,
+		'html_url' => 'https://github.com/owner/repo/pull/92',
+		'head'     => array( 'ref' => 'feat/missing-label' ),
+		'base'     => array( 'ref' => 'main' ),
+	) );
+	$queue_response( 422, array( 'message' => 'Validation Failed' ) );
+	$result = GitHubAbilities::createPullRequest( array(
+		'repo'  => 'owner/repo',
+		'title' => 'Label failure PR',
+		'head'  => 'feat/missing-label',
+		'base'  => 'main',
+	) );
+	$assert( 'createPullRequest keeps success=true when post-create labeling fails', is_array( $result ) && true === ( $result['success'] ?? false ) );
+	$assert( 'createPullRequest returns explicit label failure metadata', is_array( $result ) && false === ( $result['labeling']['success'] ?? null ) && 'github_api_error' === ( $result['labeling']['error_code'] ?? '' ) );
+	PermissionHelper::$acting_agent_slug = null;
 
 	// ---- createPullRequest: explicit draft and maintainer_can_modify=false
 	$reset_http();

--- a/tests/smoke-github-create-tools.php
+++ b/tests/smoke-github-create-tools.php
@@ -145,7 +145,7 @@ namespace {
 	$assert( 'create_github_pull_request requires repo', true === ( $pr_params['repo']['required'] ?? false ) );
 	$assert( 'create_github_pull_request requires title', true === ( $pr_params['title']['required'] ?? false ) );
 	$assert( 'create_github_pull_request requires head', true === ( $pr_params['head']['required'] ?? false ) );
-	foreach ( array( 'repo', 'title', 'head', 'base', 'body', 'draft', 'maintainer_can_modify' ) as $param ) {
+	foreach ( array( 'repo', 'title', 'head', 'base', 'body', 'draft', 'labels', 'maintainer_can_modify' ) as $param ) {
 		$assert( "create_github_pull_request exposes {$param}", array_key_exists( $param, $pr_params ) );
 	}
 
@@ -166,6 +166,7 @@ namespace {
 		'head'                  => 'fix/github-pr-tool',
 		'base'                  => 'main',
 		'body'                  => 'PR body',
+		'labels'                => array( 'needs-review' ),
 		'draft'                 => true,
 		'maintainer_can_modify' => false,
 	) );
@@ -174,6 +175,7 @@ namespace {
 
 	$pr_call = $GLOBALS['dmc_tool_ability_calls'][1] ?? array();
 	$assert( 'create_github_pull_request calls PR ability', 'datamachine/create-github-pull-request' === ( $pr_call['name'] ?? '' ) );
+	$assert( 'create_github_pull_request forwards labels', array( 'needs-review' ) === ( $pr_call['input']['labels'] ?? null ) );
 	$assert( 'create_github_pull_request forwards maintainer_can_modify', false === ( $pr_call['input']['maintainer_can_modify'] ?? null ) );
 
 	$tool_definitions = array(


### PR DESCRIPTION
## Summary
- Add runtime agent provenance labels to GitHub issues created by DMC, preserving caller-provided labels.
- Add PR `labels` support and apply caller/provenance labels through the issues labels endpoint after PR creation.
- Return explicit `labeling` metadata when PR post-create labeling succeeds or fails without masking PR creation success.

Fixes #304.

## Tests
- `php tests/smoke-github-create-abilities.php`
- `php tests/smoke-github-create-tools.php`
- `php -l inc/Abilities/GitHubAbilities.php`
- `php -l inc/Tools/GitHubPullRequestTool.php`
- `php -l tests/smoke-github-create-abilities.php`
- `php -l tests/smoke-github-create-tools.php`
- `git diff --check`

## Blocked / not green
- `homeboy test --path /Users/chubes/Developer/data-machine-code@agent-provenance-labels --extension wordpress` fails during Playground bootstrap before DMC tests run: Data Machine cannot load `WP_Agent_Memory_Layer`.
- `homeboy lint --path /Users/chubes/Developer/data-machine-code@agent-provenance-labels --extension wordpress` reports existing repository-wide PHPCS findings outside the changed files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the DMC ability/tool changes and focused smoke test updates; Chris remains responsible for review and merge.