### PR TITLE
Render agent run artifact PR sections

### DIFF
--- a/inc/Support/RunArtifactPrSectionRenderer.php
+++ b/inc/Support/RunArtifactPrSectionRenderer.php
@@ -1,0 +1,380 @@
+<?php
+/**
+ * Render Data Machine run artifacts into stable PR markdown sections.
+ *
+ * @package DataMachineCode\Support
+ */
+
+namespace DataMachineCode\Support;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Converts artifact-like arrays into idempotent PR body/comment sections.
+ */
+class RunArtifactPrSectionRenderer {
+
+	public const START_MARKER = '<!-- datamachine-run-artifacts:start -->';
+	public const END_MARKER   = '<!-- datamachine-run-artifacts:end -->';
+	public const MODE_BODY_SECTION = 'body-section';
+	public const MODE_COMMENT      = 'comment';
+
+	/**
+	 * Render artifacts as a full managed markdown section.
+	 *
+	 * @param array<int|string, mixed> $artifacts Artifact-like records from Data Machine.
+	 * @return string Markdown section wrapped in stable markers.
+	 */
+	public static function render( array $artifacts ): string {
+		$sanitized = self::sanitizeValue( $artifacts );
+		if ( ! is_array( $sanitized ) ) {
+			$sanitized = array();
+		}
+
+		$journals   = self::collectJournalEntries( $sanitized );
+		$evidence   = self::collectCompletionEvidence( $sanitized );
+		$transcript = self::collectTranscriptSummaries( $sanitized );
+
+		$lines = array(
+			self::START_MARKER,
+			'## Agent Run Artifacts',
+			'',
+			'### Agent Journal',
+		);
+
+		if ( empty( $journals ) ) {
+			$lines[] = '_No agent journal artifacts provided._';
+		} else {
+			foreach ( $journals as $index => $entry ) {
+				if ( $index > 0 ) {
+					$lines[] = '';
+					$lines[] = '---';
+					$lines[] = '';
+				}
+				$lines[] = $entry;
+			}
+		}
+
+		$lines[] = '';
+		$lines[] = '### Completion Evidence';
+		if ( empty( $evidence ) ) {
+			$lines[] = '_No completion evidence artifacts provided._';
+		} else {
+			foreach ( $evidence as $label => $status ) {
+				$lines[] = sprintf( '- `%s`: %s', self::markdownInlineCode( (string) $label ), self::plainText( (string) $status ) );
+			}
+		}
+
+		if ( ! empty( $transcript ) ) {
+			$lines[] = '';
+			$lines[] = '### Transcript Summary';
+			foreach ( $transcript as $index => $summary ) {
+				if ( $index > 0 ) {
+					$lines[] = '';
+					$lines[] = '---';
+					$lines[] = '';
+				}
+				$lines[] = $summary;
+			}
+		}
+
+		$lines[] = self::END_MARKER;
+
+		return implode( "\n", $lines );
+	}
+
+	/**
+	 * Render artifacts as the managed body for a PR comment.
+	 *
+	 * Comment upsert is owned by GitHubAbilities; this method only prepares the
+	 * stable artifact markdown that can be passed to that disabled-by-default seam.
+	 *
+	 * @param array<int|string, mixed> $artifacts Artifact-like records from Data Machine.
+	 * @return string Markdown comment body wrapped in stable markers.
+	 */
+	public static function renderCommentBody( array $artifacts ): string {
+		return self::render( $artifacts );
+	}
+
+	/**
+	 * Render artifacts into the requested attachment mode without performing I/O.
+	 *
+	 * @param string                   $mode      Attachment mode: body-section or comment.
+	 * @param array<int|string, mixed> $artifacts Artifact-like records from Data Machine.
+	 * @param string                   $existing  Existing PR body text for body-section mode.
+	 * @return string Rendered PR body or comment body.
+	 */
+	public static function renderForMode( string $mode, array $artifacts, string $existing = '' ): string {
+		if ( self::MODE_COMMENT === $mode ) {
+			return self::renderCommentBody( $artifacts );
+		}
+
+		return self::replaceSection( $existing, $artifacts );
+	}
+
+	/**
+	 * Replace or append the managed artifact section in existing markdown.
+	 *
+	 * @param string                   $body      Existing PR body/comment text.
+	 * @param array<int|string, mixed> $artifacts Artifact-like records from Data Machine.
+	 * @return string Updated markdown.
+	 */
+	public static function replaceSection( string $body, array $artifacts ): string {
+		$section = self::render( $artifacts );
+		$pattern = '/' . preg_quote( self::START_MARKER, '/' ) . '.*?' . preg_quote( self::END_MARKER, '/' ) . '/s';
+
+		if ( preg_match( $pattern, $body ) ) {
+			return preg_replace( $pattern, $section, $body, 1 ) ?? $body;
+		}
+
+		$body = rtrim( $body );
+		if ( '' === $body ) {
+			return $section;
+		}
+
+		return $body . "\n\n" . $section;
+	}
+
+	/**
+	 * @param array<int|string, mixed> $artifacts Sanitized artifacts.
+	 * @return array<int, string>
+	 */
+	private static function collectJournalEntries( array $artifacts ): array {
+		$entries = array();
+		self::walkArtifactRecords(
+			$artifacts,
+			static function ( array $record ) use ( &$entries ): void {
+				$type = self::artifactType( $record );
+				if ( ! self::isJournalType( $type ) ) {
+					return;
+				}
+
+				$content = self::firstString( $record, array( 'content', 'markdown', 'body', 'text', 'entry', 'daily_memory', 'journal' ) );
+				if ( '' === $content && isset( $record['data'] ) && is_array( $record['data'] ) ) {
+					$content = self::firstString( $record['data'], array( 'content', 'markdown', 'body', 'text', 'entry', 'daily_memory', 'journal' ) );
+				}
+
+				if ( '' !== $content ) {
+					$entries[] = self::markdownBlockText( $content );
+				}
+			}
+		);
+
+		return $entries;
+	}
+
+	/**
+	 * @param array<int|string, mixed> $artifacts Sanitized artifacts.
+	 * @return array<string, string>
+	 */
+	private static function collectCompletionEvidence( array $artifacts ): array {
+		$evidence = array();
+		self::walkArtifactRecords(
+			$artifacts,
+			static function ( array $record ) use ( &$evidence ): void {
+				$type = self::artifactType( $record );
+				if ( ! self::isCompletionEvidenceType( $type ) ) {
+					return;
+				}
+
+				$items = self::completionItemsFromRecord( $record );
+				foreach ( $items as $label => $status ) {
+					if ( '' !== $label && '' !== $status ) {
+						$evidence[ $label ] = $status;
+					}
+				}
+			}
+		);
+
+		return $evidence;
+	}
+
+	/**
+	 * @param array<int|string, mixed> $record Artifact record.
+	 * @return array<string, string>
+	 */
+	private static function completionItemsFromRecord( array $record ): array {
+		$candidates = array();
+		foreach ( array( 'evidence', 'completion_evidence', 'completion_assertions', 'assertions', 'tools' ) as $key ) {
+			if ( isset( $record[ $key ] ) && is_array( $record[ $key ] ) ) {
+				$candidates[] = $record[ $key ];
+			}
+			if ( isset( $record['data'][ $key ] ) && is_array( $record['data'][ $key ] ) ) {
+				$candidates[] = $record['data'][ $key ];
+			}
+		}
+
+		if ( empty( $candidates ) ) {
+			$candidates[] = $record;
+		}
+
+		$items = array();
+		foreach ( $candidates as $candidate ) {
+			if ( self::isList( $candidate ) ) {
+				foreach ( $candidate as $item ) {
+					if ( is_array( $item ) ) {
+						$label  = self::firstString( $item, array( 'tool', 'tool_name', 'ability', 'name', 'label', 'assertion' ) );
+						$status = self::firstString( $item, array( 'status', 'state', 'result', 'value' ) );
+						if ( '' === $status && isset( $item['satisfied'] ) ) {
+							$status = $item['satisfied'] ? 'satisfied' : 'not satisfied';
+						}
+						$items[ $label ] = $status;
+					} elseif ( is_string( $item ) && '' !== trim( $item ) ) {
+						$items[ trim( $item ) ] = 'satisfied';
+					}
+				}
+				continue;
+			}
+
+			foreach ( $candidate as $key => $value ) {
+				if ( is_array( $value ) ) {
+					$label = self::firstString( $value, array( 'tool', 'tool_name', 'ability', 'name', 'label', 'assertion' ) );
+					if ( '' === $label ) {
+						$label = is_string( $key ) ? $key : '';
+					}
+					$status = self::firstString( $value, array( 'status', 'state', 'result', 'value' ) );
+					if ( '' === $status && isset( $value['satisfied'] ) ) {
+						$status = $value['satisfied'] ? 'satisfied' : 'not satisfied';
+					}
+					$items[ $label ] = $status;
+				} elseif ( is_string( $key ) ) {
+					$items[ $key ] = is_bool( $value ) ? ( $value ? 'satisfied' : 'not satisfied' ) : (string) $value;
+				}
+			}
+		}
+
+		return $items;
+	}
+
+	/**
+	 * @param array<int|string, mixed> $artifacts Sanitized artifacts.
+	 * @return array<int, string>
+	 */
+	private static function collectTranscriptSummaries( array $artifacts ): array {
+		$summaries = array();
+		self::walkArtifactRecords(
+			$artifacts,
+			static function ( array $record ) use ( &$summaries ): void {
+				$type = self::artifactType( $record );
+				if ( ! in_array( $type, array( 'transcript_summary', 'agent_transcript_summary' ), true ) ) {
+					return;
+				}
+
+				$summary = self::firstString( $record, array( 'summary', 'content', 'markdown', 'body', 'text' ) );
+				if ( '' === $summary && isset( $record['data'] ) && is_array( $record['data'] ) ) {
+					$summary = self::firstString( $record['data'], array( 'summary', 'content', 'markdown', 'body', 'text' ) );
+				}
+
+				if ( '' !== $summary ) {
+					$summaries[] = self::markdownBlockText( $summary );
+				}
+			}
+		);
+
+		return $summaries;
+	}
+
+	/**
+	 * @param array<int|string, mixed> $value Artifact array.
+	 * @param callable                 $callback Record callback.
+	 */
+	private static function walkArtifactRecords( array $value, callable $callback ): void {
+		if ( isset( $value['type'] ) || isset( $value['name'] ) || isset( $value['artifact_type'] ) ) {
+			$callback( $value );
+		}
+
+		foreach ( $value as $item ) {
+			if ( is_array( $item ) ) {
+				self::walkArtifactRecords( $item, $callback );
+			}
+		}
+	}
+
+	/**
+	 * @param array<int|string, mixed> $record Artifact record.
+	 */
+	private static function artifactType( array $record ): string {
+		$type = self::firstString( $record, array( 'type', 'name', 'artifact_type', 'kind' ) );
+		return strtolower( str_replace( '-', '_', $type ) );
+	}
+
+	private static function isJournalType( string $type ): bool {
+		return in_array( $type, array( 'agent_daily_memory', 'daily_memory', 'agent_journal', 'journal' ), true );
+	}
+
+	private static function isCompletionEvidenceType( string $type ): bool {
+		return in_array( $type, array( 'completion_evidence', 'completion_assertions', 'agent_completion_evidence', 'required_tools' ), true );
+	}
+
+	/**
+	 * @param array<int|string, mixed> $value Input value.
+	 * @return mixed Sanitized value.
+	 */
+	private static function sanitizeValue( mixed $value ): mixed {
+		if ( is_array( $value ) ) {
+			$sanitized = array();
+			foreach ( $value as $key => $item ) {
+				if ( is_string( $key ) && self::isSecretLikeKey( $key ) ) {
+					continue;
+				}
+				$sanitized[ $key ] = self::sanitizeValue( $item );
+			}
+			return $sanitized;
+		}
+
+		if ( is_string( $value ) ) {
+			return self::redactSecretLikeString( $value );
+		}
+
+		return $value;
+	}
+
+	private static function isSecretLikeKey( string $key ): bool {
+		return 1 === preg_match( '/(authorization|credential|secret|token|password|passwd|private[_-]?key|api[_-]?key|github[_-]?pat|bearer)/i', $key );
+	}
+
+	private static function redactSecretLikeString( string $value ): string {
+		$value = preg_replace( '/\b(gh[pousr]_[A-Za-z0-9_]{12,})\b/', '[redacted]', $value ) ?? $value;
+		$value = preg_replace( '/\b(sk-[A-Za-z0-9_-]{12,})\b/', '[redacted]', $value ) ?? $value;
+		$value = preg_replace( '/\b(xox[baprs]-[A-Za-z0-9-]{12,})\b/', '[redacted]', $value ) ?? $value;
+
+		return preg_replace( '/\b(authorization|token|password|secret|api[_-]?key)\s*[:=]\s*\S+/i', '$1: [redacted]', $value ) ?? $value;
+	}
+
+	/**
+	 * @param array<int|string, mixed> $value Source array.
+	 * @param array<int, string>       $keys  Candidate keys.
+	 */
+	private static function firstString( array $value, array $keys ): string {
+		foreach ( $keys as $key ) {
+			if ( isset( $value[ $key ] ) && is_scalar( $value[ $key ] ) ) {
+				$string = trim( (string) $value[ $key ] );
+				if ( '' !== $string ) {
+					return $string;
+				}
+			}
+		}
+
+		return '';
+	}
+
+	private static function markdownBlockText( string $value ): string {
+		return trim( str_replace( "\r\n", "\n", $value ) );
+	}
+
+	private static function markdownInlineCode( string $value ): string {
+		return str_replace( '`', '\\`', $value );
+	}
+
+	private static function plainText( string $value ): string {
+		$value = trim( preg_replace( '/\s+/', ' ', $value ) ?? $value );
+		return str_replace( array( "\r", "\n" ), ' ', $value );
+	}
+
+	/**
+	 * @param array<int|string, mixed> $value Array to inspect.
+	 */
+	private static function isList( array $value ): bool {
+		return array_keys( $value ) === range( 0, count( $value ) - 1 );
+	}
+}

--- a/tests/smoke-run-artifact-pr-section-renderer.php
+++ b/tests/smoke-run-artifact-pr-section-renderer.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Pure-PHP smoke test for run artifact PR section rendering.
+ *
+ * Run: php tests/smoke-run-artifact-pr-section-renderer.php
+ */
+
+declare( strict_types=1 );
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+require __DIR__ . '/../inc/Support/RunArtifactPrSectionRenderer.php';
+
+use DataMachineCode\Support\RunArtifactPrSectionRenderer;
+
+$failures = array();
+$assert   = static function ( string $label, bool $condition ) use ( &$failures ): void {
+	if ( $condition ) {
+		echo "  ok {$label}\n";
+		return;
+	}
+
+	$failures[] = $label;
+	echo "  fail {$label}\n";
+};
+
+$artifacts = array(
+	array(
+		'type'    => 'agent_daily_memory',
+		'content' => "2026-05-09\n- Created branch and implemented renderer.\n- token=ghp_abcdefghijklmnopqrstuvwxyz123456",
+		'secret'  => 'never-render-me',
+	),
+	array(
+		'type' => 'completion_evidence',
+		'data' => array(
+			'completion_assertions' => array(
+				array(
+					'tool'      => 'create_or_update_github_file',
+					'satisfied' => true,
+				),
+				array(
+					'tool_name' => 'create_github_pull_request',
+					'status'    => 'satisfied',
+				),
+				'agent_daily_memory' => 'satisfied',
+			),
+			'api_key' => 'sk-test-secret-value',
+		),
+	),
+	array(
+		'name' => 'transcript_summary',
+		'data' => array(
+			'summary'     => 'Ran smoke tests and PHP syntax checks.',
+			'private_key' => '-----BEGIN PRIVATE KEY-----',
+		),
+	),
+);
+
+echo "Run artifact PR section renderer - smoke\n";
+
+$section = RunArtifactPrSectionRenderer::render( $artifacts );
+
+$assert( 'renders start marker', str_contains( $section, RunArtifactPrSectionRenderer::START_MARKER ) );
+$assert( 'renders end marker', str_contains( $section, RunArtifactPrSectionRenderer::END_MARKER ) );
+$assert( 'renders agent journal heading', str_contains( $section, '### Agent Journal' ) );
+$assert( 'renders journal content', str_contains( $section, 'Created branch and implemented renderer.' ) );
+$assert( 'renders completion evidence heading', str_contains( $section, '### Completion Evidence' ) );
+$assert( 'renders boolean completion assertion as satisfied', str_contains( $section, '- `create_or_update_github_file`: satisfied' ) );
+$assert( 'renders explicit completion status', str_contains( $section, '- `create_github_pull_request`: satisfied' ) );
+$assert( 'renders keyed completion assertion', str_contains( $section, '- `agent_daily_memory`: satisfied' ) );
+$assert( 'renders transcript summary when provided', str_contains( $section, 'Ran smoke tests and PHP syntax checks.' ) );
+$assert( 'omits secret-like keys', ! str_contains( $section, 'never-render-me' ) && ! str_contains( $section, 'BEGIN PRIVATE KEY' ) );
+$assert( 'redacts secret-like strings', str_contains( $section, 'token: [redacted]' ) && ! str_contains( $section, 'ghp_abcdefghijklmnopqrstuvwxyz123456' ) );
+$assert( 'does not leak api key values', ! str_contains( $section, 'sk-test-secret-value' ) );
+
+$body    = "# Existing PR\n\nHuman-authored description.";
+$updated = RunArtifactPrSectionRenderer::replaceSection( $body, $artifacts );
+$assert( 'appends section to body without existing markers', str_starts_with( $updated, $body ) && str_contains( $updated, RunArtifactPrSectionRenderer::START_MARKER ) );
+
+$rerendered = RunArtifactPrSectionRenderer::replaceSection(
+	$updated,
+	array(
+		array(
+			'type'    => 'agent_daily_memory',
+			'content' => 'Replacement journal entry.',
+		),
+		array(
+			'type'     => 'completion_evidence',
+			'evidence' => array(
+				'agent_daily_memory' => 'satisfied',
+			),
+		),
+	)
+);
+
+$assert( 'replacement preserves existing body prefix', str_starts_with( $rerendered, $body ) );
+$assert( 'replacement removes stale artifact content', ! str_contains( $rerendered, 'Created branch and implemented renderer.' ) );
+$assert( 'replacement adds fresh artifact content', str_contains( $rerendered, 'Replacement journal entry.' ) );
+$assert( 'replacement is idempotent with one section', 1 === substr_count( $rerendered, RunArtifactPrSectionRenderer::START_MARKER ) && 1 === substr_count( $rerendered, RunArtifactPrSectionRenderer::END_MARKER ) );
+
+$comment_body = RunArtifactPrSectionRenderer::replaceSection( '', $artifacts );
+$assert( 'empty comment mode body renders just the managed section', str_starts_with( $comment_body, RunArtifactPrSectionRenderer::START_MARKER ) );
+
+$mode_body = RunArtifactPrSectionRenderer::renderForMode( RunArtifactPrSectionRenderer::MODE_BODY_SECTION, $artifacts, $body );
+$assert( 'body-section mode updates existing PR body', str_starts_with( $mode_body, $body ) && str_contains( $mode_body, RunArtifactPrSectionRenderer::START_MARKER ) );
+
+$mode_comment = RunArtifactPrSectionRenderer::renderForMode( RunArtifactPrSectionRenderer::MODE_COMMENT, $artifacts, $body );
+$assert( 'comment mode returns only managed comment body', str_starts_with( $mode_comment, RunArtifactPrSectionRenderer::START_MARKER ) && ! str_starts_with( $mode_comment, $body ) );
+
+if ( ! empty( $failures ) ) {
+	echo "\nFAIL: " . count( $failures ) . " assertion(s)\n";
+	foreach ( $failures as $failure ) {
+		echo "  - {$failure}\n";
+	}
+	exit( 1 );
+}
+
+echo "\nOK\n";
+exit( 0 );


### PR DESCRIPTION
## Summary
- Add a standalone `RunArtifactPrSectionRenderer` for Data Machine run artifact-like arrays.
- Render agent journals, completion evidence, and optional transcript summaries under stable `datamachine-run-artifacts` markers.
- Support idempotent body-section replacement and comment-body rendering without wiring into live PR creation by default.

## Integration points
- #311 can call `RunArtifactPrSectionRenderer::renderForMode( 'body-section', $artifacts, $existing_body )` before updating a PR body, or `renderForMode( 'comment', $artifacts )` before passing the body to the existing managed PR comment upsert seam.
- #313 can produce the same artifact-shaped arrays after repo-file artifact writes, allowing PR evidence rendering to stay independent from the file-write implementation.
- The helper deliberately accepts sample artifact-like arrays so it is not coupled to the final Data Machine artifact API shape.

## Testing
- `php -l inc/Support/RunArtifactPrSectionRenderer.php`
- `php -l tests/smoke-run-artifact-pr-section-renderer.php`
- `php tests/smoke-run-artifact-pr-section-renderer.php`
- `php tests/smoke-github-pr-publish-handler.php`
- `php tests/smoke-github-pr-review-comment-upsert.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the renderer/helper, smoke coverage, and PR description; Chris remains responsible for reviewing and testing before merge.

Closes #314.