### PR TITLE
Write run artifacts to PR branches

### DIFF
--- a/inc/Handlers/GitHub/GitHubPullRequestPublish.php
+++ b/inc/Handlers/GitHub/GitHubPullRequestPublish.php
@@ -10,6 +10,7 @@ namespace DataMachineCode\Handlers\GitHub;
 use DataMachine\Core\Steps\HandlerRegistrationTrait;
 use DataMachine\Core\Steps\Publish\Handlers\PublishHandler;
 use DataMachineCode\Abilities\GitHubAbilities;
+use DataMachineCode\Support\RunArtifactBundleFileWriter;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -79,7 +80,7 @@ class GitHubPullRequestPublish extends PublishHandler {
 					),
 					'files'                 => array(
 						'type'        => 'array',
-						'description' => 'Optional files to commit to the head branch before opening the pull request.',
+						'description' => 'Optional files to commit to the head branch before opening the pull request. Data Machine run artifacts with bundle-file egress are appended automatically when job_id is available.',
 						'items'       => array(
 							'type'       => 'object',
 							'required'   => array( 'file_path', 'content' ),
@@ -102,6 +103,14 @@ class GitHubPullRequestPublish extends PublishHandler {
 					'commit_message'        => array(
 						'type'        => 'string',
 						'description' => 'Default commit message for files committed during publish.',
+					),
+					'run_artifacts'         => array(
+						'type'        => 'object',
+						'description' => 'Optional Data Machine job artifact payload. Normally discovered from job_id; provided here for tests or external callers.',
+					),
+					'bundle_root'           => array(
+						'type'        => 'string',
+						'description' => 'Repository-relative bundle root for bundle-file artifacts. Defaults to bundles/{agent_slug}. Supports {agent_slug}, {bundle_slug}, and date placeholders.',
 					),
 					'labels'                => array(
 						'type'        => 'array',
@@ -151,6 +160,8 @@ class GitHubPullRequestPublish extends PublishHandler {
 
 		$committed_files = array();
 		$files           = is_array( $parameters['files'] ?? null ) ? $parameters['files'] : array();
+		$artifact_files  = $this->bundleFileArtifactsForPublish( $parameters, $handler_config );
+		$files           = array_merge( $files, $artifact_files );
 		foreach ( $files as $file ) {
 			if ( ! is_array( $file ) ) {
 				return $this->errorResponse( 'GitHub Pull Request: each files item must be an object.', array( 'job_id' => $parameters['job_id'] ?? null ) );
@@ -242,6 +253,65 @@ class GitHubPullRequestPublish extends PublishHandler {
 		}
 
 		return $this->successResponse( $response_data );
+	}
+
+	/**
+	 * Resolve Data Machine run artifacts that should be written into the PR branch.
+	 *
+	 * @param array $parameters     Tool parameters.
+	 * @param array $handler_config Handler configuration.
+	 * @return array<int,array<string,mixed>> File records accepted by the normal files loop.
+	 */
+	private function bundleFileArtifactsForPublish( array $parameters, array $handler_config ): array {
+		$artifacts = is_array( $parameters['run_artifacts'] ?? null ) ? $parameters['run_artifacts'] : $this->jobArtifactsForPublish( (int) ( $parameters['job_id'] ?? 0 ) );
+		if ( empty( $artifacts ) ) {
+			return array();
+		}
+
+		$policy = is_array( $parameters['run_artifact_egress_policy'] ?? null ) ? $parameters['run_artifact_egress_policy'] : array();
+		if ( empty( $policy ) ) {
+			$policy = $this->jobRunArtifactEgressPolicy( (int) ( $parameters['job_id'] ?? 0 ) );
+		}
+		if ( empty( $policy ) && is_array( $artifacts['run_artifact_egress_policy'] ?? null ) ) {
+			$policy = $artifacts['run_artifact_egress_policy'];
+		}
+
+		$bundle_root = (string) ( $parameters['bundle_root'] ?? $handler_config['bundle_root'] ?? '' );
+
+		return RunArtifactBundleFileWriter::fileWritesFromArtifacts( $artifacts, $policy, $bundle_root );
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	private function jobArtifactsForPublish( int $job_id ): array {
+		if ( $job_id <= 0 || ! class_exists( '\\DataMachine\\Core\\JobArtifacts' ) ) {
+			return array();
+		}
+
+		$result = ( new \DataMachine\Core\JobArtifacts() )->get( $job_id );
+		if ( empty( $result['success'] ) || ! is_array( $result['artifacts'] ?? null ) ) {
+			return array();
+		}
+
+		return $result['artifacts'];
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	private function jobRunArtifactEgressPolicy( int $job_id ): array {
+		if ( $job_id <= 0 || ! class_exists( '\\DataMachine\\Core\\Database\\Jobs\\Jobs' ) ) {
+			return array();
+		}
+
+		$jobs = new \DataMachine\Core\Database\Jobs\Jobs();
+		if ( ! method_exists( $jobs, 'retrieve_engine_data' ) ) {
+			return array();
+		}
+
+		$engine_data = $jobs->retrieve_engine_data( $job_id );
+		return is_array( $engine_data['run_artifact_egress_policy'] ?? null ) ? $engine_data['run_artifact_egress_policy'] : array();
 	}
 
 	/**

--- a/inc/Handlers/GitHub/GitHubPullRequestPublishSettings.php
+++ b/inc/Handlers/GitHub/GitHubPullRequestPublishSettings.php
@@ -40,6 +40,12 @@ class GitHubPullRequestPublishSettings extends SettingsHandler {
 				'description' => __( 'Comma-separated labels to apply to opened pull requests by default. The AI step can override these.', 'data-machine-code' ),
 				'required'    => false,
 			),
+			'bundle_root'           => array(
+				'type'        => 'text',
+				'label'       => __( 'Bundle Root', 'data-machine-code' ),
+				'description' => __( 'Repository-relative bundle root for run artifacts with bundle-file egress. Defaults to bundles/{agent_slug}.', 'data-machine-code' ),
+				'required'    => false,
+			),
 			'draft'                 => array(
 				'type'        => 'checkbox',
 				'label'       => __( 'Open as Draft', 'data-machine-code' ),

--- a/inc/Support/RunArtifactBundleFileWriter.php
+++ b/inc/Support/RunArtifactBundleFileWriter.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * Prepare Data Machine run artifacts for repository bundle-file writes.
+ *
+ * @package DataMachineCode\Support
+ */
+
+namespace DataMachineCode\Support;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Converts artifact payloads plus egress policy into GitHub file-write inputs.
+ */
+class RunArtifactBundleFileWriter {
+
+	/**
+	 * Build file write records for artifacts whose policy enables bundle-file egress.
+	 *
+	 * @param array<string,mixed> $artifact_payload Data Machine job artifact payload.
+	 * @param array<string,mixed> $egress_policy    Normalized run_artifact_egress_policy.
+	 * @param string              $bundle_root      Repo-relative bundle root. Supports placeholders.
+	 * @return array<int,array{file_path:string,content:string,commit_message:string,artifact_type:string}>
+	 */
+	public static function fileWritesFromArtifacts( array $artifact_payload, array $egress_policy, string $bundle_root = '' ): array {
+		$records = self::artifactRecords( $artifact_payload );
+		if ( empty( $records ) ) {
+			return array();
+		}
+
+		$writes = array();
+		foreach ( $records as $record ) {
+			$source = self::artifactSource( $record );
+			if ( '' === $source || ! self::policyAllowsBundleFile( $source, $egress_policy, $record ) ) {
+				continue;
+			}
+
+			$content = isset( $record['content'] ) ? (string) $record['content'] : '';
+			if ( '' === $content ) {
+				continue;
+			}
+
+			$file_path = self::artifactRepoPath( $record, $bundle_root );
+			if ( '' === $file_path ) {
+				continue;
+			}
+
+			$writes[] = array(
+				'file_path'      => $file_path,
+				'content'        => $content,
+				'commit_message' => self::commitMessageForArtifact( $record ),
+				'artifact_type'  => (string) ( $record['type'] ?? $source ),
+			);
+		}
+
+		return self::dedupeWritesByPath( $writes );
+	}
+
+	/**
+	 * @param array<string,mixed> $artifact_payload Data Machine artifact payload.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function artifactRecords( array $artifact_payload ): array {
+		$candidates = array();
+		foreach ( array( 'daily_memory_artifacts', 'artifacts', 'run_artifacts' ) as $key ) {
+			if ( isset( $artifact_payload[ $key ] ) && is_array( $artifact_payload[ $key ] ) ) {
+				$candidates[] = $artifact_payload[ $key ];
+			}
+		}
+
+		if ( isset( $artifact_payload['type'] ) ) {
+			$candidates[] = array( $artifact_payload );
+		}
+
+		$records = array();
+		foreach ( $candidates as $candidate ) {
+			foreach ( $candidate as $record ) {
+				if ( is_array( $record ) ) {
+					$records[] = $record;
+				}
+			}
+		}
+
+		return $records;
+	}
+
+	/**
+	 * Resolve an artifact record into the policy source key.
+	 *
+	 * @param array<string,mixed> $record Artifact record.
+	 */
+	private static function artifactSource( array $record ): string {
+		$type   = sanitize_key( (string) ( $record['type'] ?? $record['source_type'] ?? '' ) );
+		$source = sanitize_key( (string) ( $record['artifact_source'] ?? '' ) );
+
+		if ( '' !== $source ) {
+			return $source;
+		}
+		if ( in_array( $type, array( 'agent_daily_memory', 'daily_memory' ), true ) ) {
+			return 'daily_memory';
+		}
+		if ( in_array( $type, array( 'completion_assertions', 'completion_evidence' ), true ) ) {
+			return 'completion_assertions';
+		}
+		if ( in_array( $type, array( 'transcript_summary', 'transcript' ), true ) ) {
+			return 'transcript_summary';
+		}
+
+		return $type;
+	}
+
+	/**
+	 * @param array<string,mixed> $egress_policy Normalized egress policy.
+	 * @param array<string,mixed> $record        Artifact record.
+	 */
+	private static function policyAllowsBundleFile( string $source, array $egress_policy, array $record ): bool {
+		$source_policy = is_array( $egress_policy[ $source ] ?? null ) ? $egress_policy[ $source ] : array();
+		$egress        = is_array( $source_policy['egress'] ?? null ) ? $source_policy['egress'] : array();
+
+		if ( in_array( 'bundle-file', $egress, true ) ) {
+			return true;
+		}
+
+		$record_egress = is_array( $record['egress'] ?? null ) ? $record['egress'] : array();
+		return in_array( 'bundle-file', $record_egress, true );
+	}
+
+	/**
+	 * @param array<string,mixed> $record Artifact record.
+	 */
+	private static function artifactRepoPath( array $record, string $bundle_root ): string {
+		$repo_path = self::normalizeRelativePath( (string) ( $record['repo_path'] ?? $record['file_path'] ?? '' ) );
+		if ( '' !== $repo_path ) {
+			return $repo_path;
+		}
+
+		$bundle_relative_path = self::normalizeRelativePath( (string) ( $record['bundle_relative_path'] ?? '' ) );
+		if ( '' === $bundle_relative_path ) {
+			return '';
+		}
+
+		$root = self::normalizeRelativePath( self::expandPlaceholders( '' !== $bundle_root ? $bundle_root : 'bundles/{agent_slug}', $record ) );
+		if ( '' === $root ) {
+			return '';
+		}
+
+		return self::normalizeRelativePath( $root . '/' . $bundle_relative_path );
+	}
+
+	/**
+	 * @param array<string,mixed> $record Artifact record.
+	 */
+	private static function commitMessageForArtifact( array $record ): string {
+		$type = sanitize_key( (string) ( $record['type'] ?? '' ) );
+		if ( in_array( $type, array( 'agent_daily_memory', 'daily_memory' ), true ) ) {
+			return 'chore: persist agent daily memory';
+		}
+
+		return 'chore: persist Data Machine run artifact';
+	}
+
+	/**
+	 * @param array<string,mixed> $record Artifact record.
+	 */
+	private static function expandPlaceholders( string $path, array $record ): string {
+		$date  = (string) ( $record['date'] ?? '' );
+		$parts = preg_match( '/^(\d{4})-(\d{2})-(\d{2})$/', $date, $matches ) ? $matches : array( '', '', '', '' );
+
+		$replacements = array(
+			'{agent_slug}'  => sanitize_title( (string) ( $record['agent_slug'] ?? '' ) ),
+			'{bundle_slug}' => sanitize_title( (string) ( $record['bundle_slug'] ?? $record['agent_slug'] ?? '' ) ),
+			'{yyyy}'        => $parts[1],
+			'{mm}'          => $parts[2],
+			'{dd}'          => $parts[3],
+		);
+
+		return strtr( $path, $replacements );
+	}
+
+	private static function normalizeRelativePath( string $path ): string {
+		$path = str_replace( '\\', '/', trim( $path ) );
+		$path = preg_replace( '#/+#', '/', $path );
+		$path = ltrim( is_string( $path ) ? $path : '', '/' );
+
+		if ( '' === $path || str_contains( $path, '../' ) || str_starts_with( $path, '..' ) ) {
+			return '';
+		}
+
+		return $path;
+	}
+
+	/**
+	 * @param array<int,array{file_path:string,content:string,commit_message:string,artifact_type:string}> $writes File writes.
+	 * @return array<int,array{file_path:string,content:string,commit_message:string,artifact_type:string}>
+	 */
+	private static function dedupeWritesByPath( array $writes ): array {
+		$by_path = array();
+		foreach ( $writes as $write ) {
+			$by_path[ $write['file_path'] ] = $write;
+		}
+
+		ksort( $by_path, SORT_STRING );
+		return array_values( $by_path );
+	}
+}

--- a/tests/smoke-github-pr-publish-handler.php
+++ b/tests/smoke-github-pr-publish-handler.php
@@ -35,6 +35,9 @@ $assert( false !== strpos( $handler, "'files'" ) && false !== strpos( $handler, 
 $assert( false !== strpos( $handler, 'GitHubAbilities::createOrUpdateFile' ), 'handler commits files before opening the PR' );
 $assert( false !== strpos( $handler, '\'branch\'         => $input[\'head\']' ), 'handler commits files to the PR head branch' );
 $assert( false !== strpos( $handler, '\'files\'          => $committed_files' ), 'handler returns committed file metadata' );
+$assert( false !== strpos( $handler, 'RunArtifactBundleFileWriter' ), 'handler prepares Data Machine run artifacts for bundle-file writes' );
+$assert( false !== strpos( $handler, 'run_artifact_egress_policy' ), 'handler honors run artifact egress policy' );
+$assert( false !== strpos( $settings, "'bundle_root'" ), 'settings expose bundle_root for repo bundle artifact placement' );
 $assert( false !== strpos( $handler, "'labels'                => array(" ), 'tool schema exposes labels parameter' );
 $assert( false !== strpos( $handler, 'GitHubAbilities::addLabels' ), 'handler applies labels via GitHubAbilities::addLabels' );
 $assert( false !== strpos( $handler, "'applied_labels' => \$applied_labels" ), 'handler returns applied_labels in result' );

--- a/tests/smoke-github-pr-publish-labels.php
+++ b/tests/smoke-github-pr-publish-labels.php
@@ -138,6 +138,21 @@ namespace {
 		}
 	}
 
+	if ( ! function_exists( 'sanitize_key' ) ) {
+		function sanitize_key( $key ): string {
+			$key = strtolower( (string) $key );
+			return preg_replace( '/[^a-z0-9_\-]/', '', $key ) ?? '';
+		}
+	}
+
+	if ( ! function_exists( 'sanitize_title' ) ) {
+		function sanitize_title( $title ): string {
+			$title = strtolower( trim( (string) $title ) );
+			$title = preg_replace( '/[^a-z0-9]+/', '-', $title ) ?? '';
+			return trim( $title, '-' );
+		}
+	}
+
 	if ( ! function_exists( 'is_wp_error' ) ) {
 		function is_wp_error( $thing ): bool {
 			return $thing instanceof \WP_Error;
@@ -152,6 +167,7 @@ namespace {
 		}
 	}
 
+	require_once __DIR__ . '/../inc/Support/RunArtifactBundleFileWriter.php';
 	require_once __DIR__ . '/../inc/Handlers/GitHub/GitHubPullRequestPublish.php';
 
 	use DataMachineCode\Abilities\GitHubAbilities;
@@ -305,6 +321,40 @@ namespace {
 		'comma-separated string label parameter is parsed',
 		array( 'one', 'two', 'three' ) === ( GitHubAbilities::$addLabelsCalls[0]['labels'] ?? array() )
 	);
+
+	// --- Test 7: bundle-file run artifacts are committed to the PR head branch ---
+	GitHubAbilities::reset();
+	$handler = new TestablePullRequestPublish();
+
+	$result = $handler->callExecutePublish(
+		array(
+			'title'                      => 'Memory artifact PR',
+			'head'                       => 'agent/memory-artifact',
+			'run_artifacts'              => array(
+				'daily_memory_artifacts' => array(
+					array(
+						'type'                 => 'agent_daily_memory',
+						'agent_slug'           => 'world-creator',
+						'date'                 => '2026-05-09',
+						'bundle_relative_path' => 'memory/agent/daily/2026/05/09.md',
+						'content'              => "# 2026-05-09\n\n- Preserved memory.\n",
+					),
+				),
+			),
+			'run_artifact_egress_policy' => array(
+				'daily_memory' => array( 'egress' => array( 'bundle-file' ) ),
+			),
+		),
+		array(
+			'repo' => 'Extra-Chill/data-machine-code',
+		)
+	);
+
+	$assert( 'run artifact publish succeeds', true === ( $result['success'] ?? false ) );
+	$assert( 'bundle-file artifact creates one GitHub file write', 1 === count( GitHubAbilities::$createOrUpdateFileCalls ) );
+	$assert( 'artifact write targets PR head branch', 'agent/memory-artifact' === ( GitHubAbilities::$createOrUpdateFileCalls[0]['branch'] ?? '' ) );
+	$assert( 'artifact write uses bundle-relative path under default bundle root', 'bundles/world-creator/memory/agent/daily/2026/05/09.md' === ( GitHubAbilities::$createOrUpdateFileCalls[0]['file_path'] ?? '' ) );
+	$assert( 'artifact write is reported in response files', 'bundles/world-creator/memory/agent/daily/2026/05/09.md' === ( $result['data']['files'][0]['file_path'] ?? '' ) );
 
 	if ( ! empty( $failures ) ) {
 		echo "\nFAIL: " . count( $failures ) . " assertion(s)\n";

--- a/tests/smoke-run-artifact-bundle-file-writer.php
+++ b/tests/smoke-run-artifact-bundle-file-writer.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Pure-PHP smoke test for run artifact bundle-file write preparation.
+ *
+ * Run: php tests/smoke-run-artifact-bundle-file-writer.php
+ */
+
+declare( strict_types=1 );
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ): string {
+		$key = strtolower( (string) $key );
+		return preg_replace( '/[^a-z0-9_\-]/', '', $key ) ?? '';
+	}
+}
+
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( $title ): string {
+		$title = strtolower( trim( (string) $title ) );
+		$title = preg_replace( '/[^a-z0-9]+/', '-', $title ) ?? '';
+		return trim( $title, '-' );
+	}
+}
+
+require __DIR__ . '/../inc/Support/RunArtifactBundleFileWriter.php';
+
+use DataMachineCode\Support\RunArtifactBundleFileWriter;
+
+$failures = array();
+$assert   = static function ( string $label, bool $condition ) use ( &$failures ): void {
+	if ( $condition ) {
+		echo "  ok {$label}\n";
+		return;
+	}
+
+	$failures[] = $label;
+	echo "  fail {$label}\n";
+};
+
+echo "Run artifact bundle-file writer - smoke\n";
+
+$payload = array(
+	'job_id'                 => 844,
+	'daily_memory_artifacts' => array(
+		array(
+			'type'                 => 'agent_daily_memory',
+			'agent_slug'           => 'world-creator',
+			'date'                 => '2026-05-09',
+			'bundle_relative_path' => 'memory/agent/daily/2026/05/09.md',
+			'content'              => "# 2026-05-09\n\n- Cooked memory artifacts.\n",
+		),
+	),
+);
+
+$disabled = RunArtifactBundleFileWriter::fileWritesFromArtifacts(
+	$payload,
+	array(
+		'daily_memory' => array( 'egress' => array( 'pr-body' ) ),
+	)
+);
+$assert( 'does not write without bundle-file egress', array() === $disabled );
+
+$writes = RunArtifactBundleFileWriter::fileWritesFromArtifacts(
+	$payload,
+	array(
+		'daily_memory' => array( 'egress' => array( 'bundle-file', 'pr-body' ) ),
+	)
+);
+
+$assert( 'creates one file write', 1 === count( $writes ) );
+$assert( 'uses default bundles/{agent_slug} root', 'bundles/world-creator/memory/agent/daily/2026/05/09.md' === ( $writes[0]['file_path'] ?? '' ) );
+$assert( 'preserves artifact content', str_contains( (string) ( $writes[0]['content'] ?? '' ), 'Cooked memory artifacts.' ) );
+$assert( 'uses memory-specific commit message', 'chore: persist agent daily memory' === ( $writes[0]['commit_message'] ?? '' ) );
+
+$custom_root = RunArtifactBundleFileWriter::fileWritesFromArtifacts(
+	$payload,
+	array(
+		'daily_memory' => array( 'egress' => array( 'bundle-file' ) ),
+	),
+	'agent-bundles/{agent_slug}'
+);
+$assert( 'supports configured placeholder bundle root', 'agent-bundles/world-creator/memory/agent/daily/2026/05/09.md' === ( $custom_root[0]['file_path'] ?? '' ) );
+
+$repo_path_payload = array(
+	'artifacts' => array(
+		array(
+			'type'      => 'daily_memory',
+			'repo_path' => 'bundles/custom/memory/agent/daily/2026/05/09.md',
+			'content'   => 'repo path wins',
+		),
+	),
+);
+$repo_path_writes = RunArtifactBundleFileWriter::fileWritesFromArtifacts(
+	$repo_path_payload,
+	array(
+		'daily_memory' => array( 'egress' => array( 'bundle-file' ) ),
+	)
+);
+$assert( 'accepts explicit repo path artifacts', 'bundles/custom/memory/agent/daily/2026/05/09.md' === ( $repo_path_writes[0]['file_path'] ?? '' ) );
+
+$unsafe_payload = array(
+	'daily_memory_artifacts' => array(
+		array(
+			'type'                 => 'agent_daily_memory',
+			'agent_slug'           => 'world-creator',
+			'bundle_relative_path' => '../outside.md',
+			'content'              => 'nope',
+		),
+	),
+);
+$unsafe_writes = RunArtifactBundleFileWriter::fileWritesFromArtifacts(
+	$unsafe_payload,
+	array(
+		'daily_memory' => array( 'egress' => array( 'bundle-file' ) ),
+	)
+);
+$assert( 'rejects unsafe relative paths', array() === $unsafe_writes );
+
+if ( ! empty( $failures ) ) {
+	echo "\nFAIL: " . count( $failures ) . " assertion(s)\n";
+	foreach ( $failures as $failure ) {
+		echo "  - {$failure}\n";
+	}
+	exit( 1 );
+}
+
+echo "\nOK\n";
+exit( 0 );


### PR DESCRIPTION
## Summary
- Write Data Machine run artifacts into the PR head branch when `bundle-file` egress is enabled.
- Add a generic bundle-file artifact adapter that uses artifact-provided repo paths or bundle-relative paths under a configurable bundle root.
- Cover the behavior with pure artifact writer smoke coverage and the stubbed GitHub PR publish flow.

Fixes #313.

## Tests
- `php -l inc/Support/RunArtifactBundleFileWriter.php`
- `php -l inc/Handlers/GitHub/GitHubPullRequestPublish.php`
- `php -l inc/Handlers/GitHub/GitHubPullRequestPublishSettings.php`
- `php -l tests/smoke-run-artifact-bundle-file-writer.php`
- `php -l tests/smoke-github-pr-publish-labels.php`
- `php -l tests/smoke-github-pr-publish-handler.php`
- `php tests/smoke-run-artifact-bundle-file-writer.php`
- `php tests/smoke-github-pr-publish-labels.php`
- `php tests/smoke-github-pr-publish-handler.php`
- `php tests/smoke-run-artifact-pr-section-renderer.php`
- `git diff --check`
- `homeboy audit --path /Users/chubes/Developer/data-machine-code@write-memory-artifacts-to-pr-branches wordpress --changed-since main`
- `homeboy lint --path /Users/chubes/Developer/data-machine-code@write-memory-artifacts-to-pr-branches --extension wordpress --file <changed-file> --errors-only` for each changed PHP file

## Notes
- Repo-wide `homeboy lint --changed-since main` still reports existing warnings in unrelated files, mainly `inc/Workspace/Workspace.php` alignment and existing structural/duplication findings.
- Repo-wide `homeboy test --changed-since main` failed before running tests because the Playground dependency bootstrap could not find `WP_Agent_Memory_Layer` while loading Data Machine.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the artifact branch write implementation, smoke coverage, and PR description; Chris remains responsible for review and merge.