### PR TITLE
Attach Data Machine run artifacts to agent PRs

### DIFF
--- a/inc/Handlers/GitHub/GitHubPullRequestPublish.php
+++ b/inc/Handlers/GitHub/GitHubPullRequestPublish.php
@@ -10,6 +10,7 @@ namespace DataMachineCode\Handlers\GitHub;
 use DataMachine\Core\Steps\HandlerRegistrationTrait;
 use DataMachine\Core\Steps\Publish\Handlers\PublishHandler;
 use DataMachineCode\Abilities\GitHubAbilities;
+use DataMachineCode\Support\RunArtifactPrSectionRenderer;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -149,6 +150,11 @@ class GitHubPullRequestPublish extends PublishHandler {
 			'maintainer_can_modify' => $this->resolveBool( $parameters['maintainer_can_modify'] ?? null, $handler_config['maintainer_can_modify'] ?? true ),
 		);
 
+		$run_artifact_attachment = $this->prepareRunArtifactAttachment( $parameters, $handler_config, $input['body'] );
+		if ( ! empty( $run_artifact_attachment['body'] ) ) {
+			$input['body'] = (string) $run_artifact_attachment['body'];
+		}
+
 		$committed_files = array();
 		$files           = is_array( $parameters['files'] ?? null ) ? $parameters['files'] : array();
 		foreach ( $files as $file ) {
@@ -241,7 +247,141 @@ class GitHubPullRequestPublish extends PublishHandler {
 			$response_data['label_error'] = $label_error;
 		}
 
+		if ( ! empty( $run_artifact_attachment['comment_body'] ) && $pull_number > 0 ) {
+			$comment_result = GitHubAbilities::upsertPullReviewComment( array(
+				'repo'        => $repo,
+				'pull_number' => $pull_number,
+				'body'        => $run_artifact_attachment['comment_body'],
+				'marker'      => 'datamachine-run-artifacts',
+			) );
+
+			if ( is_wp_error( $comment_result ) ) {
+				$response_data['run_artifact_comment_error'] = $comment_result->get_error_message();
+				$this->log(
+					'warning',
+					'GitHub Pull Request opened but failed to attach run artifact comment: ' . $comment_result->get_error_message(),
+					array(
+						'job_id'      => $parameters['job_id'] ?? null,
+						'repo'        => $repo,
+						'pull_number' => $pull_number,
+					)
+				);
+			} else {
+				$response_data['run_artifact_comment'] = array(
+					'action'     => $comment_result['action'] ?? '',
+					'comment_id' => $comment_result['comment_id'] ?? 0,
+					'html_url'   => $comment_result['html_url'] ?? '',
+				);
+			}
+		}
+
 		return $this->successResponse( $response_data );
+	}
+
+	/**
+	 * Prepare optional run artifact PR body/comment content from Data Machine policy.
+	 *
+	 * @param array  $parameters     Tool parameters.
+	 * @param array  $handler_config Handler configuration.
+	 * @param string $body           Existing PR body.
+	 * @return array{body?: string, comment_body?: string}
+	 */
+	private function prepareRunArtifactAttachment( array $parameters, array $handler_config, string $body ): array {
+		$job_id = (int) ( $parameters['job_id'] ?? 0 );
+		if ( $job_id <= 0 || ! class_exists( '\\DataMachine\\Core\\JobArtifacts' ) ) {
+			return array();
+		}
+
+		$policy = $this->resolveRunArtifactPolicy( $parameters );
+		if ( empty( $policy ) ) {
+			return array();
+		}
+
+		$artifacts_result = ( new \DataMachine\Core\JobArtifacts() )->get( $job_id );
+		if ( empty( $artifacts_result['success'] ) || ! is_array( $artifacts_result['artifacts'] ?? null ) ) {
+			return array();
+		}
+
+		$artifacts = $this->filterRunArtifactsForTarget( $artifacts_result['artifacts'], $policy, 'pr-body' );
+		if ( empty( $artifacts ) ) {
+			return array();
+		}
+
+		$mode = $this->resolveRunArtifactAttachmentMode( $handler_config );
+		if ( RunArtifactPrSectionRenderer::MODE_COMMENT === $mode ) {
+			return array( 'comment_body' => RunArtifactPrSectionRenderer::renderForMode( $mode, $artifacts ) );
+		}
+
+		return array( 'body' => RunArtifactPrSectionRenderer::renderForMode( RunArtifactPrSectionRenderer::MODE_BODY_SECTION, $artifacts, $body ) );
+	}
+
+	/**
+	 * @param array $parameters Tool parameters.
+	 * @return array<string, array<string, mixed>>
+	 */
+	private function resolveRunArtifactPolicy( array $parameters ): array {
+		$engine = $parameters['engine'] ?? null;
+		if ( is_object( $engine ) && method_exists( $engine, 'get' ) ) {
+			$policy = $engine->get( 'run_artifact_egress_policy', array() );
+			return is_array( $policy ) ? $policy : array();
+		}
+
+		return array();
+	}
+
+	/**
+	 * @param array<string, mixed>                 $artifacts Data Machine job artifact payload.
+	 * @param array<string, array<string, mixed>> $policy    Run artifact egress policy.
+	 * @return array<string, mixed>
+	 */
+	private function filterRunArtifactsForTarget( array $artifacts, array $policy, string $target ): array {
+		$filtered = array();
+
+		if ( $this->policyAllowsTarget( $policy, 'daily_memory', $target ) && ! empty( $artifacts['daily_memory_artifacts'] ) ) {
+			$filtered['daily_memory_artifacts'] = $artifacts['daily_memory_artifacts'];
+		}
+
+		if ( $this->policyAllowsTarget( $policy, 'completion_assertions', $target ) ) {
+			foreach ( array( 'required_tool_names', 'satisfied_tool_names', 'successful_tool_calls' ) as $key ) {
+				if ( array_key_exists( $key, $artifacts ) ) {
+					$filtered[ $key ] = $artifacts[ $key ];
+				}
+			}
+
+			$satisfied = is_array( $filtered['satisfied_tool_names'] ?? null ) ? $filtered['satisfied_tool_names'] : array();
+			foreach ( array( 'github_pull_request_publish', 'create_github_pull_request' ) as $tool_name ) {
+				if ( ! in_array( $tool_name, $satisfied, true ) ) {
+					$satisfied[] = $tool_name;
+				}
+			}
+			$filtered['satisfied_tool_names'] = $satisfied;
+		}
+
+		if ( $this->policyAllowsTarget( $policy, 'transcript_summary', $target ) && ! empty( $artifacts['transcript'] ) ) {
+			$filtered['transcript'] = $artifacts['transcript'];
+		}
+
+		return $filtered;
+	}
+
+	/**
+	 * @param array<string, array<string, mixed>> $policy Run artifact egress policy.
+	 */
+	private function policyAllowsTarget( array $policy, string $source, string $target ): bool {
+		$egress = $policy[ $source ]['egress'] ?? array();
+		return is_array( $egress ) && in_array( $target, $egress, true );
+	}
+
+	/**
+	 * Resolve PR artifact attachment mode. Body sections are the default for Data
+	 * Machine's generic `pr-body` egress target; handler config may route that
+	 * same managed section to a comment without changing bundle policy.
+	 */
+	private function resolveRunArtifactAttachmentMode( array $handler_config ): string {
+		$config = is_array( $handler_config['github_pr_artifacts'] ?? null ) ? $handler_config['github_pr_artifacts'] : array();
+		$mode   = sanitize_text_field( (string) ( $config['mode'] ?? $handler_config['run_artifact_attachment_mode'] ?? RunArtifactPrSectionRenderer::MODE_BODY_SECTION ) );
+
+		return RunArtifactPrSectionRenderer::MODE_COMMENT === $mode ? RunArtifactPrSectionRenderer::MODE_COMMENT : RunArtifactPrSectionRenderer::MODE_BODY_SECTION;
 	}
 
 	/**

--- a/inc/Handlers/GitHub/GitHubPullRequestPublishSettings.php
+++ b/inc/Handlers/GitHub/GitHubPullRequestPublishSettings.php
@@ -22,19 +22,19 @@ class GitHubPullRequestPublishSettings extends SettingsHandler {
 	 */
 	public static function get_fields(): array {
 		return array(
-			'repo'                  => array(
+			'repo'                         => array(
 				'type'        => 'text',
 				'label'       => __( 'Repository', 'data-machine-code' ),
 				'description' => __( 'GitHub repository in owner/repo format. Falls back to the default repo in settings.', 'data-machine-code' ),
 				'required'    => false,
 			),
-			'base'                  => array(
+			'base'                         => array(
 				'type'        => 'text',
 				'label'       => __( 'Base Branch', 'data-machine-code' ),
 				'description' => __( 'Default base branch for pull requests. Leave blank for repository default.', 'data-machine-code' ),
 				'required'    => false,
 			),
-			'labels'                => array(
+			'labels'                       => array(
 				'type'        => 'text',
 				'label'       => __( 'Labels', 'data-machine-code' ),
 				'description' => __( 'Comma-separated labels to apply to opened pull requests by default. The AI step can override these.', 'data-machine-code' ),
@@ -51,14 +51,14 @@ class GitHubPullRequestPublishSettings extends SettingsHandler {
 					'comment'      => __( 'Managed PR comment', 'data-machine-code' ),
 				),
 			),
-			'draft'                 => array(
+			'draft'                        => array(
 				'type'        => 'checkbox',
 				'label'       => __( 'Open as Draft', 'data-machine-code' ),
 				'description' => __( 'Open pull requests as drafts by default.', 'data-machine-code' ),
 				'required'    => false,
 				'default'     => false,
 			),
-			'maintainer_can_modify' => array(
+			'maintainer_can_modify'        => array(
 				'type'        => 'checkbox',
 				'label'       => __( 'Allow Maintainer Edits', 'data-machine-code' ),
 				'description' => __( 'Allow maintainers to modify the pull request branch.', 'data-machine-code' ),

--- a/inc/Handlers/GitHub/GitHubPullRequestPublishSettings.php
+++ b/inc/Handlers/GitHub/GitHubPullRequestPublishSettings.php
@@ -40,6 +40,17 @@ class GitHubPullRequestPublishSettings extends SettingsHandler {
 				'description' => __( 'Comma-separated labels to apply to opened pull requests by default. The AI step can override these.', 'data-machine-code' ),
 				'required'    => false,
 			),
+			'run_artifact_attachment_mode' => array(
+				'type'        => 'select',
+				'label'       => __( 'Run Artifact Attachment Mode', 'data-machine-code' ),
+				'description' => __( 'Where to attach Data Machine run artifacts when the bundle run artifact policy includes pr-body egress.', 'data-machine-code' ),
+				'required'    => false,
+				'default'     => 'body-section',
+				'options'     => array(
+					'body-section' => __( 'PR body section', 'data-machine-code' ),
+					'comment'      => __( 'Managed PR comment', 'data-machine-code' ),
+				),
+			),
 			'draft'                 => array(
 				'type'        => 'checkbox',
 				'label'       => __( 'Open as Draft', 'data-machine-code' ),

--- a/inc/Support/RunArtifactPrSectionRenderer.php
+++ b/inc/Support/RunArtifactPrSectionRenderer.php
@@ -168,7 +168,7 @@ class RunArtifactPrSectionRenderer {
 	 * @return array<string, string>
 	 */
 	private static function collectCompletionEvidence( array $artifacts ): array {
-		$evidence = array();
+		$evidence  = array();
 		$required  = isset( $artifacts['required_tool_names'] ) && is_array( $artifacts['required_tool_names'] ) ? $artifacts['required_tool_names'] : array();
 		$satisfied = isset( $artifacts['satisfied_tool_names'] ) && is_array( $artifacts['satisfied_tool_names'] ) ? $artifacts['satisfied_tool_names'] : array();
 		foreach ( $required as $tool_name ) {

--- a/inc/Support/RunArtifactPrSectionRenderer.php
+++ b/inc/Support/RunArtifactPrSectionRenderer.php
@@ -14,8 +14,8 @@ defined( 'ABSPATH' ) || exit;
  */
 class RunArtifactPrSectionRenderer {
 
-	public const START_MARKER = '<!-- datamachine-run-artifacts:start -->';
-	public const END_MARKER   = '<!-- datamachine-run-artifacts:end -->';
+	public const START_MARKER      = '<!-- datamachine-run-artifacts:start -->';
+	public const END_MARKER        = '<!-- datamachine-run-artifacts:end -->';
 	public const MODE_BODY_SECTION = 'body-section';
 	public const MODE_COMMENT      = 'comment';
 
@@ -169,6 +169,15 @@ class RunArtifactPrSectionRenderer {
 	 */
 	private static function collectCompletionEvidence( array $artifacts ): array {
 		$evidence = array();
+		$required  = isset( $artifacts['required_tool_names'] ) && is_array( $artifacts['required_tool_names'] ) ? $artifacts['required_tool_names'] : array();
+		$satisfied = isset( $artifacts['satisfied_tool_names'] ) && is_array( $artifacts['satisfied_tool_names'] ) ? $artifacts['satisfied_tool_names'] : array();
+		foreach ( $required as $tool_name ) {
+			$tool_name = trim( (string) $tool_name );
+			if ( '' !== $tool_name ) {
+				$evidence[ $tool_name ] = in_array( $tool_name, $satisfied, true ) ? 'satisfied' : 'not satisfied';
+			}
+		}
+
 		self::walkArtifactRecords(
 			$artifacts,
 			static function ( array $record ) use ( &$evidence ): void {
@@ -252,6 +261,13 @@ class RunArtifactPrSectionRenderer {
 	 */
 	private static function collectTranscriptSummaries( array $artifacts ): array {
 		$summaries = array();
+		if ( isset( $artifacts['transcript'] ) && is_array( $artifacts['transcript'] ) ) {
+			$summary = self::transcriptMetadataSummary( $artifacts['transcript'] );
+			if ( '' !== $summary ) {
+				$summaries[] = $summary;
+			}
+		}
+
 		self::walkArtifactRecords(
 			$artifacts,
 			static function ( array $record ) use ( &$summaries ): void {
@@ -369,6 +385,36 @@ class RunArtifactPrSectionRenderer {
 	private static function plainText( string $value ): string {
 		$value = trim( preg_replace( '/\s+/', ' ', $value ) ?? $value );
 		return str_replace( array( "\r", "\n" ), ' ', $value );
+	}
+
+	/**
+	 * @param array<string, mixed> $transcript Data Machine transcript metadata.
+	 */
+	private static function transcriptMetadataSummary( array $transcript ): string {
+		if ( ! empty( $transcript['missing'] ) ) {
+			$session_id = self::firstString( $transcript, array( 'session_id' ) );
+			return '' === $session_id ? 'Transcript session was not found.' : sprintf( 'Transcript session `%s` was not found.', self::markdownInlineCode( $session_id ) );
+		}
+
+		$parts = array();
+		foreach ( array( 'session_id', 'provider', 'model', 'mode' ) as $key ) {
+			$value = self::firstString( $transcript, array( $key ) );
+			if ( '' !== $value ) {
+				$parts[] = sprintf( '%s: `%s`', str_replace( '_', ' ', $key ), self::markdownInlineCode( $value ) );
+			}
+		}
+
+		foreach ( array( 'message_count', 'turn_count' ) as $key ) {
+			if ( isset( $transcript[ $key ] ) && is_numeric( $transcript[ $key ] ) ) {
+				$parts[] = sprintf( '%s: %d', str_replace( '_', ' ', $key ), (int) $transcript[ $key ] );
+			}
+		}
+
+		if ( isset( $transcript['completed'] ) ) {
+			$parts[] = 'completed: ' . ( $transcript['completed'] ? 'yes' : 'no' );
+		}
+
+		return implode( "\n", array_map( static fn( string $part ): string => '- ' . $part, $parts ) );
 	}
 
 	/**

--- a/tests/smoke-github-pr-publish-labels.php
+++ b/tests/smoke-github-pr-publish-labels.php
@@ -60,11 +60,25 @@ namespace DataMachine\Core\Steps\Publish\Handlers {
 	}
 }
 
+namespace DataMachine\Core {
+	class JobArtifacts {
+		public static array $artifacts = array();
+
+		public function get( int $job_id ): array {
+			return array(
+				'success'   => true,
+				'artifacts' => self::$artifacts,
+			);
+		}
+	}
+}
+
 namespace DataMachineCode\Abilities {
 	class GitHubAbilities {
 		public static array $createPullRequestCalls = array();
 		public static array $addLabelsCalls         = array();
 		public static array $createOrUpdateFileCalls = array();
+		public static array $upsertPullReviewCommentCalls = array();
 		/** @var callable|null */
 		public static $createPullRequestImpl = null;
 		/** @var callable|null */
@@ -76,6 +90,7 @@ namespace DataMachineCode\Abilities {
 			self::$createPullRequestCalls   = array();
 			self::$addLabelsCalls           = array();
 			self::$createOrUpdateFileCalls  = array();
+			self::$upsertPullReviewCommentCalls = array();
 			self::$createPullRequestImpl    = null;
 			self::$addLabelsImpl            = null;
 			self::$createOrUpdateFileImpl   = null;
@@ -124,6 +139,15 @@ namespace DataMachineCode\Abilities {
 				'commit'  => array( 'sha' => 'deadbeef' ),
 			);
 		}
+
+		public static function upsertPullReviewComment( array $input ): array|\WP_Error {
+			self::$upsertPullReviewCommentCalls[] = $input;
+			return array(
+				'action'     => 'created',
+				'comment_id' => 99,
+				'html_url'   => 'https://example.test/pull/4242#issuecomment-99',
+			);
+		}
 	}
 }
 
@@ -152,10 +176,20 @@ namespace {
 		}
 	}
 
+	require_once __DIR__ . '/../inc/Support/RunArtifactPrSectionRenderer.php';
 	require_once __DIR__ . '/../inc/Handlers/GitHub/GitHubPullRequestPublish.php';
 
+	use DataMachine\Core\JobArtifacts;
 	use DataMachineCode\Abilities\GitHubAbilities;
 	use DataMachineCode\Handlers\GitHub\GitHubPullRequestPublish;
+
+	class TestEngineData {
+		public function __construct( private array $data ) {}
+
+		public function get( string $key, mixed $default = null ): mixed {
+			return array_key_exists( $key, $this->data ) ? $this->data[ $key ] : $default;
+		}
+	}
 
 	/**
 	 * Test subclass exposing executePublish for direct invocation.
@@ -305,6 +339,82 @@ namespace {
 		'comma-separated string label parameter is parsed',
 		array( 'one', 'two', 'three' ) === ( GitHubAbilities::$addLabelsCalls[0]['labels'] ?? array() )
 	);
+
+	// --- Test 7: Data Machine run artifacts attach to PR body when policy requests pr-body ---
+	GitHubAbilities::reset();
+	JobArtifacts::$artifacts = array(
+		'required_tool_names'    => array( 'agent_daily_memory', 'create_github_pull_request' ),
+		'satisfied_tool_names'   => array( 'agent_daily_memory' ),
+		'daily_memory_artifacts' => array(
+			array(
+				'type'    => 'agent_daily_memory',
+				'content' => 'Daily memory entry for the generated PR.',
+			),
+		),
+		'transcript'             => array(
+			'session_id'    => 'pipeline-abc',
+			'provider'      => 'openai',
+			'model'         => 'gpt-5.5',
+			'message_count' => 8,
+			'completed'     => true,
+		),
+	);
+	$handler = new TestablePullRequestPublish();
+
+	$result = $handler->callExecutePublish(
+		array(
+			'job_id' => 123,
+			'engine' => new TestEngineData(
+				array(
+					'run_artifact_egress_policy' => array(
+						'daily_memory'          => array( 'egress' => array( 'pr-body' ) ),
+						'completion_assertions' => array( 'egress' => array( 'pr-body' ) ),
+						'transcript_summary'    => array( 'egress' => array( 'pr-body' ) ),
+					),
+				)
+			),
+			'title'  => 'Artifact PR',
+			'head'   => 'agent/artifacts',
+			'body'   => 'Original body.',
+		),
+		array( 'repo' => 'Extra-Chill/data-machine-code' )
+	);
+
+	$body = GitHubAbilities::$createPullRequestCalls[0]['body'] ?? '';
+	$assert( 'run artifact PR publish succeeds', true === ( $result['success'] ?? false ) );
+	$assert( 'run artifact section appended to PR body', str_contains( $body, '## Agent Run Artifacts' ) && str_contains( $body, 'Daily memory entry for the generated PR.' ) );
+	$assert( 'completion assertions rendered from Data Machine artifact payload', str_contains( $body, '- `agent_daily_memory`: satisfied' ) );
+	$assert( 'current PR publish tool is marked satisfied in attached evidence', str_contains( $body, '- `create_github_pull_request`: satisfied' ) );
+	$assert( 'transcript metadata rendered when policy requests transcript_summary', str_contains( $body, 'session id: `pipeline-abc`' ) && str_contains( $body, 'model: `gpt-5.5`' ) );
+	$assert( 'body mode does not create a run artifact comment', 0 === count( GitHubAbilities::$upsertPullReviewCommentCalls ) );
+
+	// --- Test 8: handler config can route the managed artifact section to a PR comment ---
+	GitHubAbilities::reset();
+	$handler = new TestablePullRequestPublish();
+	$result  = $handler->callExecutePublish(
+		array(
+			'job_id' => 123,
+			'engine' => new TestEngineData(
+				array(
+					'run_artifact_egress_policy' => array(
+						'daily_memory' => array( 'egress' => array( 'pr-body' ) ),
+					),
+				)
+			),
+			'title'  => 'Artifact comment PR',
+			'head'   => 'agent/artifact-comment',
+			'body'   => 'Original body.',
+		),
+		array(
+			'repo'                         => 'Extra-Chill/data-machine-code',
+			'run_artifact_attachment_mode' => 'comment',
+		)
+	);
+
+	$assert( 'comment mode PR publish succeeds', true === ( $result['success'] ?? false ) );
+	$assert( 'comment mode preserves original PR body', 'Original body.' === ( GitHubAbilities::$createPullRequestCalls[0]['body'] ?? '' ) );
+	$assert( 'comment mode upserts one managed artifact comment', 1 === count( GitHubAbilities::$upsertPullReviewCommentCalls ) );
+	$assert( 'comment mode uses run artifact marker', 'datamachine-run-artifacts' === ( GitHubAbilities::$upsertPullReviewCommentCalls[0]['marker'] ?? '' ) );
 
 	if ( ! empty( $failures ) ) {
 		echo "\nFAIL: " . count( $failures ) . " assertion(s)\n";


### PR DESCRIPTION
## Summary
- Wire GitHub PR publishing to Data Machine job artifacts when `run_artifact_egress_policy` requests `pr-body` egress.
- Render daily memory, completion evidence, and transcript metadata into the stable run artifact PR section added by #316.
- Add handler config support to route the managed artifact section to a PR comment instead of the body when desired.

Closes #311.

## Testing
- `php -l inc/Handlers/GitHub/GitHubPullRequestPublish.php && php -l inc/Handlers/GitHub/GitHubPullRequestPublishSettings.php && php -l inc/Support/RunArtifactPrSectionRenderer.php && php -l tests/smoke-github-pr-publish-labels.php`
- `php tests/smoke-github-pr-publish-handler.php`
- `php tests/smoke-github-pr-publish-labels.php`
- `php tests/smoke-run-artifact-pr-section-renderer.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine-code@attach-datamachine-run-artifacts --extension wordpress --changed-since origin/main`

## Notes
- `homeboy test --path /Users/chubes/Developer/data-machine-code@attach-datamachine-run-artifacts --extension wordpress --changed-since origin/main` is blocked before tests run by the existing Playground dependency bootstrap failure: `Class "WP_Agent_Memory_Layer" not found` while loading Data Machine.
- `homeboy audit --path /Users/chubes/Developer/data-machine-code@attach-datamachine-run-artifacts data-machine-code` reports existing repository-wide convention/test-coverage drift unrelated to this patch.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the DMC artifact attachment wiring, renderer payload support, smoke coverage, and PR description for Chris to review.