### PR TITLE
Use canonical AI tool schemas

### DIFF
--- a/inc/Tools/GitHubIssueTool.php
+++ b/inc/Tools/GitHubIssueTool.php
@@ -126,38 +126,36 @@ class GitHubIssueTool extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => $description,
 			'parameters'  => array(
-				'title'  => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Issue title.',
+				'type'       => 'object',
+				'properties' => array(
+					'title'     => array(
+						'type'        => 'string',
+						'description' => 'Issue title.',
+					),
+					'repo'      => array(
+						'type'        => 'string',
+						'description' => 'Repository in owner/repo format. Falls back to default repo, then first registered repo.',
+					),
+					'body'      => array(
+						'type'        => 'string',
+						'description' => 'Issue body content. Supports GitHub Markdown.',
+					),
+					'labels'    => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'string' ),
+						'description' => 'Labels to apply to the issue.',
+					),
+					'assignees' => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'string' ),
+						'description' => 'GitHub usernames to assign to the issue.',
+					),
+					'milestone' => array(
+						'type'        => 'integer',
+						'description' => 'Milestone number to attach to the issue.',
+					),
 				),
-				'repo'   => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Repository in owner/repo format. Falls back to default repo, then first registered repo.',
-				),
-				'body'   => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Issue body content. Supports GitHub Markdown.',
-				),
-				'labels' => array(
-					'type'        => 'array',
-					'items'       => array( 'type' => 'string' ),
-					'required'    => false,
-					'description' => 'Labels to apply to the issue.',
-				),
-				'assignees' => array(
-					'type'        => 'array',
-					'items'       => array( 'type' => 'string' ),
-					'required'    => false,
-					'description' => 'GitHub usernames to assign to the issue.',
-				),
-				'milestone' => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Milestone number to attach to the issue.',
-				),
+				'required'   => array( 'title' ),
 			),
 		);
 	}

--- a/inc/Tools/GitHubPullRequestTool.php
+++ b/inc/Tools/GitHubPullRequestTool.php
@@ -108,47 +108,43 @@ class GitHubPullRequestTool extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => $description,
 			'parameters'  => array(
-				'repo'                  => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Repository in owner/repo format.',
+				'type'       => 'object',
+				'properties' => array(
+					'repo'                  => array(
+						'type'        => 'string',
+						'description' => 'Repository in owner/repo format.',
+					),
+					'title'                 => array(
+						'type'        => 'string',
+						'description' => 'Pull request title.',
+					),
+					'head'                  => array(
+						'type'        => 'string',
+						'description' => 'Branch where changes are implemented. Use owner:branch for cross-fork PRs.',
+					),
+					'base'                  => array(
+						'type'        => 'string',
+						'description' => 'Branch to merge into. Defaults to the repository default branch.',
+					),
+					'body'                  => array(
+						'type'        => 'string',
+						'description' => 'Pull request description. Supports GitHub Markdown.',
+					),
+					'draft'                 => array(
+						'type'        => 'boolean',
+						'description' => 'Whether to open the pull request as a draft. Default: false.',
+					),
+					'labels'                => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'string' ),
+						'description' => 'Labels to attach to the pull request after creation.',
+					),
+					'maintainer_can_modify' => array(
+						'type'        => 'boolean',
+						'description' => 'Whether maintainers can modify the pull request. Default: true.',
+					),
 				),
-				'title'                 => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Pull request title.',
-				),
-				'head'                  => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Branch where changes are implemented. Use owner:branch for cross-fork PRs.',
-				),
-				'base'                  => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Branch to merge into. Defaults to the repository default branch.',
-				),
-				'body'                  => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Pull request description. Supports GitHub Markdown.',
-				),
-				'draft'                 => array(
-					'type'        => 'boolean',
-					'required'    => false,
-					'description' => 'Whether to open the pull request as a draft. Default: false.',
-				),
-				'labels'                => array(
-					'type'        => 'array',
-					'items'       => array( 'type' => 'string' ),
-					'required'    => false,
-					'description' => 'Labels to attach to the pull request after creation.',
-				),
-				'maintainer_can_modify' => array(
-					'type'        => 'boolean',
-					'required'    => false,
-					'description' => 'Whether maintainers can modify the pull request. Default: true.',
-				),
+				'required'   => array( 'repo', 'title', 'head' ),
 			),
 		);
 	}

--- a/inc/Tools/GitHubTools.php
+++ b/inc/Tools/GitHubTools.php
@@ -200,26 +200,26 @@ class GitHubTools extends BaseTool {
 			'method'      => 'handleListIssues',
 			'description' => 'List issues from a GitHub repository. Returns issue numbers, titles, states, labels, and assignees. Use to review open issues, track progress, or find specific issues by label.',
 			'parameters'  => array(
-				'repo'     => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Repository in owner/repo format (e.g., Extra-Chill/data-machine).',
+				'type'       => 'object',
+				'properties' => array(
+					'repo'     => array(
+						'type'        => 'string',
+						'description' => 'Repository in owner/repo format (e.g., Extra-Chill/data-machine).',
+					),
+					'state'    => array(
+						'type'        => 'string',
+						'description' => 'Issue state: open, closed, or all. Default: open.',
+					),
+					'labels'   => array(
+						'type'        => 'string',
+						'description' => 'Comma-separated label names to filter by.',
+					),
+					'per_page' => array(
+						'type'        => 'integer',
+						'description' => 'Results per page (max: 100). Default: 30.',
+					),
 				),
-				'state'    => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Issue state: open, closed, or all. Default: open.',
-				),
-				'labels'   => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Comma-separated label names to filter by.',
-				),
-				'per_page' => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Results per page (max: 100). Default: 30.',
-				),
+				'required'   => array( 'repo' ),
 			),
 		);
 	}
@@ -260,16 +260,18 @@ class GitHubTools extends BaseTool {
 			'method'      => 'handleGetIssue',
 			'description' => 'Get a single GitHub issue with full details including body, labels, assignees, and comment count.',
 			'parameters'  => array(
-				'repo'         => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Repository in owner/repo format.',
+				'type'       => 'object',
+				'properties' => array(
+					'repo'         => array(
+						'type'        => 'string',
+						'description' => 'Repository in owner/repo format.',
+					),
+					'issue_number' => array(
+						'type'        => 'integer',
+						'description' => 'Issue number.',
+					),
 				),
-				'issue_number' => array(
-					'type'        => 'integer',
-					'required'    => true,
-					'description' => 'Issue number.',
-				),
+				'required'   => array( 'repo', 'issue_number' ),
 			),
 		);
 	}
@@ -322,37 +324,35 @@ class GitHubTools extends BaseTool {
 			'method'      => 'handleManageIssue',
 			'description' => 'Update, close, or comment on a GitHub issue. Use action "update" to change title/body/labels, "close" to close the issue, or "comment" to add a comment.',
 			'parameters'  => array(
-				'repo'         => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Repository in owner/repo format.',
+				'type'       => 'object',
+				'properties' => array(
+					'repo'         => array(
+						'type'        => 'string',
+						'description' => 'Repository in owner/repo format.',
+					),
+					'issue_number' => array(
+						'type'        => 'integer',
+						'description' => 'Issue number.',
+					),
+					'action'       => array(
+						'type'        => 'string',
+						'description' => 'Action: update, close, or comment.',
+					),
+					'title'        => array(
+						'type'        => 'string',
+						'description' => 'New issue title (update action).',
+					),
+					'body'         => array(
+						'type'        => 'string',
+						'description' => 'New issue body (update action) or comment text (comment action).',
+					),
+					'labels'       => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'string' ),
+						'description' => 'Labels to set (update action). Replaces existing labels.',
+					),
 				),
-				'issue_number' => array(
-					'type'        => 'integer',
-					'required'    => true,
-					'description' => 'Issue number.',
-				),
-				'action'       => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Action: update, close, or comment.',
-				),
-				'title'        => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'New issue title (update action).',
-				),
-				'body'         => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'New issue body (update action) or comment text (comment action).',
-				),
-				'labels'       => array(
-					'type'        => 'array',
-					'items'       => array( 'type' => 'string' ),
-					'required'    => false,
-					'description' => 'Labels to set (update action). Replaces existing labels.',
-				),
+				'required'   => array( 'repo', 'issue_number', 'action' ),
 			),
 		);
 	}
@@ -393,26 +393,26 @@ class GitHubTools extends BaseTool {
 			'method'      => 'handleCommentPullRequest',
 			'description' => 'Comment on a GitHub pull request without granting broader issue update or close capabilities.',
 			'parameters'  => array(
-				'repo'        => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Repository in owner/repo format.',
+				'type'       => 'object',
+				'properties' => array(
+					'repo'        => array(
+						'type'        => 'string',
+						'description' => 'Repository in owner/repo format.',
+					),
+					'pull_number' => array(
+						'type'        => 'integer',
+						'description' => 'Pull request number.',
+					),
+					'body'        => array(
+						'type'        => 'string',
+						'description' => 'Comment body (supports GitHub Markdown).',
+					),
+					'marker'      => array(
+						'type'        => 'string',
+						'description' => 'Optional stable marker appended as an HTML comment for future update-by-marker support.',
+					),
 				),
-				'pull_number' => array(
-					'type'        => 'integer',
-					'required'    => true,
-					'description' => 'Pull request number.',
-				),
-				'body'        => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Comment body (supports GitHub Markdown).',
-				),
-				'marker'      => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Optional stable marker appended as an HTML comment for future update-by-marker support.',
-				),
+				'required'   => array( 'repo', 'pull_number', 'body' ),
 			),
 		);
 	}
@@ -438,36 +438,34 @@ class GitHubTools extends BaseTool {
 			'method'      => 'handleUpsertPullReviewComment',
 			'description' => 'Create or update one managed bot-authored GitHub pull request review comment identified by a hidden marker.',
 			'parameters'  => array(
-				'repo'        => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Repository in owner/repo format.',
+				'type'       => 'object',
+				'properties' => array(
+					'repo'        => array(
+						'type'        => 'string',
+						'description' => 'Repository in owner/repo format.',
+					),
+					'pull_number' => array(
+						'type'        => 'integer',
+						'description' => 'Pull request number.',
+					),
+					'body'        => array(
+						'type'        => 'string',
+						'description' => 'Review comment body (supports GitHub Markdown). Hidden marker text is appended automatically.',
+					),
+					'marker'      => array(
+						'type'        => 'string',
+						'description' => 'Hidden HTML comment marker used to find the managed comment. Default: <!-- datamachine-pr-review -->.',
+					),
+					'head_sha'    => array(
+						'type'        => 'string',
+						'description' => 'Optional pull request head SHA. Required to separate comments when mode is per_head_sha.',
+					),
+					'mode'        => array(
+						'type'        => 'string',
+						'description' => 'Comment policy: update_existing or per_head_sha. Default: update_existing.',
+					),
 				),
-				'pull_number' => array(
-					'type'        => 'integer',
-					'required'    => true,
-					'description' => 'Pull request number.',
-				),
-				'body'        => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Review comment body (supports GitHub Markdown). Hidden marker text is appended automatically.',
-				),
-				'marker'      => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Hidden HTML comment marker used to find the managed comment. Default: <!-- datamachine-pr-review -->.',
-				),
-				'head_sha'    => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Optional pull request head SHA. Required to separate comments when mode is per_head_sha.',
-				),
-				'mode'        => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Comment policy: update_existing or per_head_sha. Default: update_existing.',
-				),
+				'required'   => array( 'repo', 'pull_number', 'body' ),
 			),
 		);
 	}
@@ -493,26 +491,26 @@ class GitHubTools extends BaseTool {
 			'method'      => 'handleMergePullRequest',
 			'description' => 'Merge an open GitHub pull request only when its current head SHA exactly matches expected_head_sha. Defaults to squash merge.',
 			'parameters'  => array(
-				'repo'              => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Repository in owner/repo format.',
+				'type'       => 'object',
+				'properties' => array(
+					'repo'              => array(
+						'type'        => 'string',
+						'description' => 'Repository in owner/repo format.',
+					),
+					'pull_number'       => array(
+						'type'        => 'integer',
+						'description' => 'Pull request number.',
+					),
+					'expected_head_sha' => array(
+						'type'        => 'string',
+						'description' => 'Exact head SHA expected immediately before merge.',
+					),
+					'merge_method'      => array(
+						'type'        => 'string',
+						'description' => 'GitHub merge method: merge, squash, or rebase. Default: squash.',
+					),
 				),
-				'pull_number'       => array(
-					'type'        => 'integer',
-					'required'    => true,
-					'description' => 'Pull request number.',
-				),
-				'expected_head_sha' => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Exact head SHA expected immediately before merge.',
-				),
-				'merge_method'      => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'GitHub merge method: merge, squash, or rebase. Default: squash.',
-				),
+				'required'   => array( 'repo', 'pull_number', 'expected_head_sha' ),
 			),
 		);
 	}
@@ -553,16 +551,18 @@ class GitHubTools extends BaseTool {
 			'method'      => 'handleListPulls',
 			'description' => 'List pull requests from a GitHub repository. Returns PR numbers, titles, states, branches, and merge status.',
 			'parameters'  => array(
-				'repo'  => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Repository in owner/repo format.',
+				'type'       => 'object',
+				'properties' => array(
+					'repo'  => array(
+						'type'        => 'string',
+						'description' => 'Repository in owner/repo format.',
+					),
+					'state' => array(
+						'type'        => 'string',
+						'description' => 'PR state: open, closed, or all. Default: open.',
+					),
 				),
-				'state' => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'PR state: open, closed, or all. Default: open.',
-				),
+				'required'   => array( 'repo' ),
 			),
 		);
 	}
@@ -622,16 +622,18 @@ class GitHubTools extends BaseTool {
 			'method'      => 'handleGetPull',
 			'description' => 'Get one GitHub pull request with normalized title, body, branch, SHA, labels, and merge metadata.',
 			'parameters'  => array(
-				'repo'        => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Repository in owner/repo format.',
+				'type'       => 'object',
+				'properties' => array(
+					'repo'        => array(
+						'type'        => 'string',
+						'description' => 'Repository in owner/repo format.',
+					),
+					'pull_number' => array(
+						'type'        => 'integer',
+						'description' => 'Pull request number.',
+					),
 				),
-				'pull_number' => array(
-					'type'        => 'integer',
-					'required'    => true,
-					'description' => 'Pull request number.',
-				),
+				'required'   => array( 'repo', 'pull_number' ),
 			),
 		);
 	}
@@ -657,26 +659,26 @@ class GitHubTools extends BaseTool {
 			'method'      => 'handlePullFiles',
 			'description' => 'List files changed by a GitHub pull request, including filename, status, additions, deletions, and patch when available.',
 			'parameters'  => array(
-				'repo'        => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Repository in owner/repo format.',
+				'type'       => 'object',
+				'properties' => array(
+					'repo'        => array(
+						'type'        => 'string',
+						'description' => 'Repository in owner/repo format.',
+					),
+					'pull_number' => array(
+						'type'        => 'integer',
+						'description' => 'Pull request number.',
+					),
+					'per_page'    => array(
+						'type'        => 'integer',
+						'description' => 'Results per page (max: 100). Default: 100.',
+					),
+					'page'        => array(
+						'type'        => 'integer',
+						'description' => 'Page number. Default: 1.',
+					),
 				),
-				'pull_number' => array(
-					'type'        => 'integer',
-					'required'    => true,
-					'description' => 'Pull request number.',
-				),
-				'per_page'    => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Results per page (max: 100). Default: 100.',
-				),
-				'page'        => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Page number. Default: 1.',
-				),
+				'required'   => array( 'repo', 'pull_number' ),
 			),
 		);
 	}
@@ -702,26 +704,26 @@ class GitHubTools extends BaseTool {
 			'method'      => 'handleCheckRuns',
 			'description' => 'Get GitHub check runs for a commit SHA or ref, including aggregate state and failing check names/URLs.',
 			'parameters'  => array(
-				'repo'                 => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Repository in owner/repo format.',
+				'type'       => 'object',
+				'properties' => array(
+					'repo'                 => array(
+						'type'        => 'string',
+						'description' => 'Repository in owner/repo format.',
+					),
+					'sha'                  => array(
+						'type'        => 'string',
+						'description' => 'Commit SHA, branch, or tag ref.',
+					),
+					'per_page'             => array(
+						'type'        => 'integer',
+						'description' => 'Results per page (max: 100). Default: 30.',
+					),
+					'include_check_output' => array(
+						'type'        => 'boolean',
+						'description' => 'Include bounded check output summaries and text.',
+					),
 				),
-				'sha'                  => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Commit SHA, branch, or tag ref.',
-				),
-				'per_page'             => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Results per page (max: 100). Default: 30.',
-				),
-				'include_check_output' => array(
-					'type'        => 'boolean',
-					'required'    => false,
-					'description' => 'Include bounded check output summaries and text.',
-				),
+				'required'   => array( 'repo', 'sha' ),
 			),
 		);
 	}
@@ -767,16 +769,18 @@ class GitHubTools extends BaseTool {
 			'method'      => 'handleCommitStatuses',
 			'description' => 'Get unmanaged GitHub commit statuses for a commit SHA or ref, including aggregate state and failing contexts.',
 			'parameters'  => array(
-				'repo' => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Repository in owner/repo format.',
+				'type'       => 'object',
+				'properties' => array(
+					'repo' => array(
+						'type'        => 'string',
+						'description' => 'Repository in owner/repo format.',
+					),
+					'sha'  => array(
+						'type'        => 'string',
+						'description' => 'Commit SHA, branch, or tag ref.',
+					),
 				),
-				'sha'  => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Commit SHA, branch, or tag ref.',
-				),
+				'required'   => array( 'repo', 'sha' ),
 			),
 		);
 	}
@@ -792,36 +796,34 @@ class GitHubTools extends BaseTool {
 			'method'      => 'handleActionsArtifact',
 			'description' => 'Download a GitHub Actions artifact by artifact name for a pull request or commit SHA and return generic artifact metadata plus parsed JSON files. Does not interpret producer-specific payload semantics.',
 			'parameters'  => array(
-				'repo'               => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Repository in owner/repo format.',
+				'type'       => 'object',
+				'properties' => array(
+					'repo'               => array(
+						'type'        => 'string',
+						'description' => 'Repository in owner/repo format.',
+					),
+					'head_sha'           => array(
+						'type'        => 'string',
+						'description' => 'Commit SHA to match the artifact against.',
+					),
+					'pull_number'        => array(
+						'type'        => 'integer',
+						'description' => 'Pull request number. Used to resolve head_sha when head_sha is omitted.',
+					),
+					'artifact_name'      => array(
+						'type'        => 'string',
+						'description' => 'GitHub Actions artifact name.',
+					),
+					'max_artifact_bytes' => array(
+						'type'        => 'integer',
+						'description' => 'Maximum artifact ZIP bytes to download. Default: 2000000.',
+					),
+					'include_json'       => array(
+						'type'        => 'boolean',
+						'description' => 'Parse and include JSON files from the artifact ZIP. Default: true.',
+					),
 				),
-				'head_sha'           => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Commit SHA to match the artifact against.',
-				),
-				'pull_number'        => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Pull request number. Used to resolve head_sha when head_sha is omitted.',
-				),
-				'artifact_name'      => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'GitHub Actions artifact name.',
-				),
-				'max_artifact_bytes' => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Maximum artifact ZIP bytes to download. Default: 2000000.',
-				),
-				'include_json'       => array(
-					'type'        => 'boolean',
-					'required'    => false,
-					'description' => 'Parse and include JSON files from the artifact ZIP. Default: true.',
-				),
+				'required'   => array( 'repo', 'artifact_name' ),
 			),
 		);
 	}
@@ -837,36 +839,34 @@ class GitHubTools extends BaseTool {
 			'method'      => 'handleHomeboyCiResults',
 			'description' => 'Download and summarize the Homeboy CI results artifact for a pull request or commit SHA. Uses GitHub Actions artifacts, preferring review.json and falling back to audit/lint/test JSON files.',
 			'parameters'  => array(
-				'repo'               => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Repository in owner/repo format.',
+				'type'       => 'object',
+				'properties' => array(
+					'repo'               => array(
+						'type'        => 'string',
+						'description' => 'Repository in owner/repo format.',
+					),
+					'head_sha'           => array(
+						'type'        => 'string',
+						'description' => 'Commit SHA to match the Homeboy artifact against.',
+					),
+					'pull_number'        => array(
+						'type'        => 'integer',
+						'description' => 'Pull request number. Used to resolve head_sha when head_sha is omitted.',
+					),
+					'artifact_name'      => array(
+						'type'        => 'string',
+						'description' => 'GitHub Actions artifact name. Default: homeboy-ci-results.',
+					),
+					'max_artifact_bytes' => array(
+						'type'        => 'integer',
+						'description' => 'Maximum artifact ZIP bytes to download. Default: 2000000.',
+					),
+					'include_raw'        => array(
+						'type'        => 'boolean',
+						'description' => 'Include bounded raw parsed JSON payloads.',
+					),
 				),
-				'head_sha'           => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Commit SHA to match the Homeboy artifact against.',
-				),
-				'pull_number'        => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Pull request number. Used to resolve head_sha when head_sha is omitted.',
-				),
-				'artifact_name'      => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'GitHub Actions artifact name. Default: homeboy-ci-results.',
-				),
-				'max_artifact_bytes' => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Maximum artifact ZIP bytes to download. Default: 2000000.',
-				),
-				'include_raw'        => array(
-					'type'        => 'boolean',
-					'required'    => false,
-					'description' => 'Include bounded raw parsed JSON payloads.',
-				),
+				'required'   => array( 'repo' ),
 			),
 		);
 	}
@@ -902,87 +902,75 @@ class GitHubTools extends BaseTool {
 			'method'      => 'handlePullReviewContext',
 			'description' => 'Build a review-ready context packet for a GitHub pull request, including normalized PR metadata and changed-file patches.',
 			'parameters'  => array(
-				'repo'                    => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Repository in owner/repo format.',
+				'type'       => 'object',
+				'properties' => array(
+					'repo'                    => array(
+						'type'        => 'string',
+						'description' => 'Repository in owner/repo format.',
+					),
+					'pull_number'             => array(
+						'type'        => 'integer',
+						'description' => 'Pull request number.',
+					),
+					'head_sha'                => array(
+						'type'        => 'string',
+						'description' => 'Optional expected pull request head SHA. Returns an error if GitHub reports a different head SHA.',
+					),
+					'max_patch_chars'         => array(
+						'type'        => 'integer',
+						'description' => 'Maximum cumulative patch characters to include. Default: 200000.',
+					),
+					'include_file_contents'   => array(
+						'type'        => 'boolean',
+						'description' => 'Opt in to bounded full-file contents for changed files.',
+					),
+					'include_base_contents'   => array(
+						'type'        => 'boolean',
+						'description' => 'When changed file contents are enabled, also include bounded base-branch contents for comparison.',
+					),
+					'context_paths'           => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'string' ),
+						'description' => 'Additional repository paths to include from the PR head ref.',
+					),
+					'max_file_content_chars'  => array(
+						'type'        => 'integer',
+						'description' => 'Maximum characters included per expanded file content block. Default: 20000.',
+					),
+					'max_context_files'       => array(
+						'type'        => 'integer',
+						'description' => 'Maximum number of files included in expanded PR review context. Default: 10.',
+					),
+					'max_total_context_chars' => array(
+						'type'        => 'integer',
+						'description' => 'Maximum cumulative characters included across expanded PR review context files. Default: 100000.',
+					),
+					'include_checks'          => array(
+						'type'        => 'boolean',
+						'description' => 'Include GitHub check runs for the PR head SHA.',
+					),
+					'include_statuses'        => array(
+						'type'        => 'boolean',
+						'description' => 'Include classic commit statuses for the PR head SHA.',
+					),
+					'max_check_runs'          => array(
+						'type'        => 'integer',
+						'description' => 'Maximum check runs to include. Default: 30.',
+					),
+					'include_check_output'    => array(
+						'type'        => 'boolean',
+						'description' => 'Include bounded check output summaries and text.',
+					),
+					'include_homeboy_ci'      => array(
+						'type'        => 'boolean',
+						'description' => 'Include parsed Homeboy CI result artifact data for the PR head SHA.',
+					),
+					'artifact_name'           => array(
+						'type'        => 'string',
+						'description' => 'GitHub Actions artifact name for Homeboy CI results. Default: homeboy-ci-results.',
+					),
 				),
-				'pull_number'             => array(
-					'type'        => 'integer',
-					'required'    => true,
-					'description' => 'Pull request number.',
-				),
-				'head_sha'                => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Optional expected pull request head SHA. Returns an error if GitHub reports a different head SHA.',
-				),
-				'max_patch_chars'         => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Maximum cumulative patch characters to include. Default: 200000.',
-				),
-				'include_file_contents'   => array(
-					'type'        => 'boolean',
-					'required'    => false,
-					'description' => 'Opt in to bounded full-file contents for changed files.',
-				),
-				'include_base_contents'   => array(
-					'type'        => 'boolean',
-					'required'    => false,
-					'description' => 'When changed file contents are enabled, also include bounded base-branch contents for comparison.',
-				),
-				'context_paths'           => array(
-					'type'        => 'array',
-					'items'       => array( 'type' => 'string' ),
-					'required'    => false,
-					'description' => 'Additional repository paths to include from the PR head ref.',
-				),
-				'max_file_content_chars'  => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Maximum characters included per expanded file content block. Default: 20000.',
-				),
-				'max_context_files'       => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Maximum number of files included in expanded PR review context. Default: 10.',
-				),
-				'max_total_context_chars' => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Maximum cumulative characters included across expanded PR review context files. Default: 100000.',
-				),
-				'include_checks'          => array(
-					'type'        => 'boolean',
-					'required'    => false,
-					'description' => 'Include GitHub check runs for the PR head SHA.',
-				),
-				'include_statuses'        => array(
-					'type'        => 'boolean',
-					'required'    => false,
-					'description' => 'Include classic commit statuses for the PR head SHA.',
-				),
-				'max_check_runs'          => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Maximum check runs to include. Default: 30.',
-				),
-				'include_check_output'    => array(
-					'type'        => 'boolean',
-					'required'    => false,
-					'description' => 'Include bounded check output summaries and text.',
-				),
-				'include_homeboy_ci'      => array(
-					'type'        => 'boolean',
-					'required'    => false,
-					'description' => 'Include parsed Homeboy CI result artifact data for the PR head SHA.',
-				),
-				'artifact_name'           => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'GitHub Actions artifact name for Homeboy CI results. Default: homeboy-ci-results.',
-				),
+				'required'   => array( 'repo', 'pull_number' ),
 			),
 		);
 	}
@@ -1008,36 +996,34 @@ class GitHubTools extends BaseTool {
 			'method'      => 'handleRepoReviewProfile',
 			'description' => 'Build bounded repository-level review context from AGENTS.md, README, contributing docs, Homeboy config, and small architecture/development docs. Use before reviewing to learn repo-specific rules and conventions.',
 			'parameters'  => array(
-				'repo'                  => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Repository in owner/repo format.',
+				'type'       => 'object',
+				'properties' => array(
+					'repo'                  => array(
+						'type'        => 'string',
+						'description' => 'Repository in owner/repo format.',
+					),
+					'ref'                   => array(
+						'type'        => 'string',
+						'description' => 'Branch, tag, or commit SHA. Defaults to HEAD.',
+					),
+					'max_profile_files'     => array(
+						'type'        => 'integer',
+						'description' => 'Maximum profile files to include. Default: 14.',
+					),
+					'max_file_chars'        => array(
+						'type'        => 'integer',
+						'description' => 'Maximum characters per profile file. Default: 12000.',
+					),
+					'max_total_chars'       => array(
+						'type'        => 'integer',
+						'description' => 'Maximum cumulative profile characters. Default: 60000.',
+					),
+					'max_architecture_docs' => array(
+						'type'        => 'integer',
+						'description' => 'Maximum docs/** architecture/development files to include. Default: 8.',
+					),
 				),
-				'ref'                   => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Branch, tag, or commit SHA. Defaults to HEAD.',
-				),
-				'max_profile_files'     => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Maximum profile files to include. Default: 14.',
-				),
-				'max_file_chars'        => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Maximum characters per profile file. Default: 12000.',
-				),
-				'max_total_chars'       => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Maximum cumulative profile characters. Default: 60000.',
-				),
-				'max_architecture_docs' => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Maximum docs/** architecture/development files to include. Default: 8.',
-				),
+				'required'   => array( 'repo' ),
 			),
 		);
 	}
@@ -1053,26 +1039,26 @@ class GitHubTools extends BaseTool {
 			'method'      => 'handleRunPrHomeboyReview',
 			'description' => 'Run checkout-backed Homeboy review checks for a pull request in an isolated DMC workspace worktree. Does not post comments or mutate the pull request.',
 			'parameters'  => array(
-				'repo'        => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Repository in owner/repo format.',
+				'type'       => 'object',
+				'properties' => array(
+					'repo'        => array(
+						'type'        => 'string',
+						'description' => 'Repository in owner/repo format.',
+					),
+					'pull_number' => array(
+						'type'        => 'integer',
+						'description' => 'Pull request number.',
+					),
+					'head_sha'    => array(
+						'type'        => 'string',
+						'description' => 'Expected pull request head SHA. Execution fails closed if GitHub reports a different head.',
+					),
+					'base_ref'    => array(
+						'type'        => 'string',
+						'description' => 'Optional base ref. Defaults to the pull request base ref.',
+					),
 				),
-				'pull_number' => array(
-					'type'        => 'integer',
-					'required'    => true,
-					'description' => 'Pull request number.',
-				),
-				'head_sha'    => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Expected pull request head SHA. Execution fails closed if GitHub reports a different head.',
-				),
-				'base_ref'    => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Optional base ref. Defaults to the pull request base ref.',
-				),
+				'required'   => array( 'repo', 'pull_number', 'head_sha' ),
 			),
 		);
 	}
@@ -1098,32 +1084,31 @@ class GitHubTools extends BaseTool {
 			'method'      => 'handlePullDocumentationImpact',
 			'description' => 'Build a heuristic documentation-impact packet for a GitHub pull request. Use this before documentation/content freshness workflows to identify changed command, ability/tool, REST/webhook, settings, and public PHP surfaces with evidence.',
 			'parameters'  => array(
-				'repo'        => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Repository in owner/repo format.',
+				'type'       => 'object',
+				'properties' => array(
+					'repo'        => array(
+						'type'        => 'string',
+						'description' => 'Repository in owner/repo format.',
+					),
+					'pull_number' => array(
+						'type'        => 'integer',
+						'description' => 'Pull request number.',
+					),
+					'head_sha'    => array(
+						'type'        => 'string',
+						'description' => 'Optional expected pull request head SHA. Returns an error if GitHub reports a different head SHA.',
+					),
+					'base_ref'    => array(
+						'type'        => 'string',
+						'description' => 'Optional base ref used for docs tree lookup. Defaults to the PR base ref.',
+					),
+					'docs_paths'  => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'string' ),
+						'description' => 'Optional documentation path allow-list used when suggesting likely stale docs.',
+					),
 				),
-				'pull_number' => array(
-					'type'        => 'integer',
-					'required'    => true,
-					'description' => 'Pull request number.',
-				),
-				'head_sha'    => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Optional expected pull request head SHA. Returns an error if GitHub reports a different head SHA.',
-				),
-				'base_ref'    => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Optional base ref used for docs tree lookup. Defaults to the PR base ref.',
-				),
-				'docs_paths'  => array(
-					'type'        => 'array',
-					'items'       => array( 'type' => 'string' ),
-					'required'    => false,
-					'description' => 'Optional documentation path allow-list used when suggesting likely stale docs.',
-				),
+				'required'   => array( 'repo', 'pull_number' ),
 			),
 		);
 	}
@@ -1149,21 +1134,22 @@ class GitHubTools extends BaseTool {
 			'method'      => 'handleListTree',
 			'description' => 'List files in a GitHub repository tree at a branch, tag, or commit SHA. Optionally filter to a path prefix.',
 			'parameters'  => array(
-				'repo' => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Repository in owner/repo format.',
+				'type'       => 'object',
+				'properties' => array(
+					'repo' => array(
+						'type'        => 'string',
+						'description' => 'Repository in owner/repo format.',
+					),
+					'ref'  => array(
+						'type'        => 'string',
+						'description' => 'Branch, tag, or commit SHA. Defaults to HEAD.',
+					),
+					'path' => array(
+						'type'        => 'string',
+						'description' => 'Optional path prefix to filter returned files.',
+					),
 				),
-				'ref'  => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Branch, tag, or commit SHA. Defaults to HEAD.',
-				),
-				'path' => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Optional path prefix to filter returned files.',
-				),
+				'required'   => array( 'repo' ),
 			),
 		);
 	}
@@ -1189,21 +1175,22 @@ class GitHubTools extends BaseTool {
 			'method'      => 'handleGetFile',
 			'description' => 'Get decoded content for a single file from a GitHub repository.',
 			'parameters'  => array(
-				'repo' => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Repository in owner/repo format.',
+				'type'       => 'object',
+				'properties' => array(
+					'repo' => array(
+						'type'        => 'string',
+						'description' => 'Repository in owner/repo format.',
+					),
+					'path' => array(
+						'type'        => 'string',
+						'description' => 'File path within the repository.',
+					),
+					'ref'  => array(
+						'type'        => 'string',
+						'description' => 'Branch, tag, or commit SHA. Defaults to the repository default branch.',
+					),
 				),
-				'path' => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'File path within the repository.',
-				),
-				'ref'  => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Branch, tag, or commit SHA. Defaults to the repository default branch.',
-				),
+				'required'   => array( 'repo', 'path' ),
 			),
 		);
 	}
@@ -1229,31 +1216,30 @@ class GitHubTools extends BaseTool {
 			'method'      => 'handleCreateOrUpdateFile',
 			'description' => 'Create or update a file in a GitHub repository using the Contents API. If branch is provided and does not exist, it is created from the repository default branch before committing.',
 			'parameters'  => array(
-				'repo'           => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Repository in owner/repo format.',
+				'type'       => 'object',
+				'properties' => array(
+					'repo'           => array(
+						'type'        => 'string',
+						'description' => 'Repository in owner/repo format.',
+					),
+					'file_path'      => array(
+						'type'        => 'string',
+						'description' => 'Path within the repository.',
+					),
+					'content'        => array(
+						'type'        => 'string',
+						'description' => 'Full file content to write.',
+					),
+					'commit_message' => array(
+						'type'        => 'string',
+						'description' => 'Commit message for the file change.',
+					),
+					'branch'         => array(
+						'type'        => 'string',
+						'description' => 'Target branch. Defaults to the repository default branch. New branches are created from the default branch.',
+					),
 				),
-				'file_path'      => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Path within the repository.',
-				),
-				'content'        => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Full file content to write.',
-				),
-				'commit_message' => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Commit message for the file change.',
-				),
-				'branch'         => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Target branch. Defaults to the repository default branch. New branches are created from the default branch.',
-				),
+				'required'   => array( 'repo', 'file_path', 'content', 'commit_message' ),
 			),
 		);
 	}
@@ -1294,16 +1280,18 @@ class GitHubTools extends BaseTool {
 			'method'      => 'handleListRepos',
 			'description' => 'List GitHub repositories for a user or organization. Shows repo names, languages, stars, open issues, and last push date.',
 			'parameters'  => array(
-				'owner' => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'GitHub user or organization name.',
+				'type'       => 'object',
+				'properties' => array(
+					'owner' => array(
+						'type'        => 'string',
+						'description' => 'GitHub user or organization name.',
+					),
+					'sort'  => array(
+						'type'        => 'string',
+						'description' => 'Sort by: created, updated, pushed, full_name. Default: updated.',
+					),
 				),
-				'sort'  => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Sort by: created, updated, pushed, full_name. Default: updated.',
-				),
+				'required'   => array( 'owner' ),
 			),
 		);
 	}

--- a/inc/Tools/WordPressRuntimeTools.php
+++ b/inc/Tools/WordPressRuntimeTools.php
@@ -97,16 +97,18 @@ class WordPressRuntimeTools extends BaseTool {
 			'method'      => 'handleLs',
 			'description' => 'List files/directories under allowlisted WordPress runtime source roots only. Default path is wp-content/plugins.',
 			'parameters'  => array(
-				'path'        => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Runtime directory path relative to ABSPATH. Must be under wp-content/plugins, wp-content/themes, wp-includes, or wp-admin.',
+				'type'       => 'object',
+				'properties' => array(
+					'path'        => array(
+						'type'        => 'string',
+						'description' => 'Runtime directory path relative to ABSPATH. Must be under wp-content/plugins, wp-content/themes, wp-includes, or wp-admin.',
+					),
+					'max_entries' => array(
+						'type'        => 'integer',
+						'description' => 'Maximum entries to return (default 200, max 1000).',
+					),
 				),
-				'max_entries' => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Maximum entries to return (default 200, max 1000).',
-				),
+				'required'   => array(),
 			),
 		);
 	}
@@ -118,26 +120,26 @@ class WordPressRuntimeTools extends BaseTool {
 			'method'      => 'handleRead',
 			'description' => 'Read a bounded text file under allowlisted WordPress runtime source roots only. Denies sensitive paths, traversal, oversized files, and binary files.',
 			'parameters'  => array(
-				'path'     => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Runtime file path relative to ABSPATH.',
+				'type'       => 'object',
+				'properties' => array(
+					'path'     => array(
+						'type'        => 'string',
+						'description' => 'Runtime file path relative to ABSPATH.',
+					),
+					'max_size' => array(
+						'type'        => 'integer',
+						'description' => 'Maximum file size in bytes (default/max 1MB).',
+					),
+					'offset'   => array(
+						'type'        => 'integer',
+						'description' => 'Line number to start reading from (1-indexed).',
+					),
+					'limit'    => array(
+						'type'        => 'integer',
+						'description' => 'Maximum number of lines to return (default 500, max 2000).',
+					),
 				),
-				'max_size' => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Maximum file size in bytes (default/max 1MB).',
-				),
-				'offset'   => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Line number to start reading from (1-indexed).',
-				),
-				'limit'    => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Maximum number of lines to return (default 500, max 2000).',
-				),
+				'required'   => array( 'path' ),
 			),
 		);
 	}

--- a/inc/Tools/WorkspaceDiffTools.php
+++ b/inc/Tools/WorkspaceDiffTools.php
@@ -64,11 +64,15 @@ class WorkspaceDiffTools extends BaseTool {
 			'method'      => 'handleDiffSummary',
 			'description' => 'Summarize changed files, additions/deletions, test-touch status, and compact git diff metadata for a workspace handle.',
 			'parameters'  => array(
-				'name'   => array( 'type' => 'string', 'required' => true, 'description' => 'Workspace repository directory name or worktree handle.' ),
-				'from'   => array( 'type' => 'string', 'required' => false, 'description' => 'Optional from git ref.' ),
-				'to'     => array( 'type' => 'string', 'required' => false, 'description' => 'Optional to git ref.' ),
-				'staged' => array( 'type' => 'boolean', 'required' => false, 'description' => 'Summarize staged changes only.' ),
-				'path'   => array( 'type' => 'string', 'required' => false, 'description' => 'Optional relative path filter.' ),
+				'type'       => 'object',
+				'properties' => array(
+					'name'   => array( 'type' => 'string', 'description' => 'Workspace repository directory name or worktree handle.' ),
+					'from'   => array( 'type' => 'string', 'description' => 'Optional from git ref.' ),
+					'to'     => array( 'type' => 'string', 'description' => 'Optional to git ref.' ),
+					'staged' => array( 'type' => 'boolean', 'description' => 'Summarize staged changes only.' ),
+					'path'   => array( 'type' => 'string', 'description' => 'Optional relative path filter.' ),
+				),
+				'required'   => array( 'name' ),
 			),
 		);
 	}
@@ -80,27 +84,30 @@ class WorkspaceDiffTools extends BaseTool {
 			'method'      => 'handleDiffValidate',
 			'description' => 'Validate workspace diff shape using allowed/denied path patterns and optional test-change requirements.',
 			'parameters'  => array(
-				'name'                  => array( 'type' => 'string', 'required' => true, 'description' => 'Workspace repository directory name or worktree handle.' ),
-				'allow'                 => array( 'type' => 'array', 'items' => array( 'type' => 'string' ), 'required' => false, 'description' => 'Optional path patterns every changed file must match.' ),
-				'deny'                  => array( 'type' => 'array', 'items' => array( 'type' => 'string' ), 'required' => false, 'description' => 'Optional path patterns that must not be changed.' ),
-				'include_any'           => array( 'type' => 'array', 'items' => array( 'type' => 'string' ), 'required' => false, 'description' => 'Optional path patterns where at least one changed file must match.' ),
-				'include_all'           => array( 'type' => 'array', 'items' => array( 'type' => 'string' ), 'required' => false, 'description' => 'Optional path patterns where each pattern must match at least one changed file.' ),
-				'require_tests'         => array( 'type' => 'boolean', 'required' => false, 'description' => 'Require at least one changed file that looks like test coverage.' ),
-				'require_changed_files' => array(
-					'type'        => 'object',
-					'required'    => false,
-					'description' => 'Compatibility object supporting allow, deny, include_any, and include_all.',
-					'properties'  => array(
-						'allow'       => array( 'type' => 'array', 'items' => array( 'type' => 'string' ), 'required' => false, 'description' => 'Optional path patterns every changed file must match.' ),
-						'deny'        => array( 'type' => 'array', 'items' => array( 'type' => 'string' ), 'required' => false, 'description' => 'Optional path patterns that must not be changed.' ),
-						'include_any' => array( 'type' => 'array', 'items' => array( 'type' => 'string' ), 'required' => false, 'description' => 'Optional path patterns where at least one changed file must match.' ),
-						'include_all' => array( 'type' => 'array', 'items' => array( 'type' => 'string' ), 'required' => false, 'description' => 'Optional path patterns where each pattern must match at least one changed file.' ),
+				'type'       => 'object',
+				'properties' => array(
+					'name'                  => array( 'type' => 'string', 'description' => 'Workspace repository directory name or worktree handle.' ),
+					'allow'                 => array( 'type' => 'array', 'items' => array( 'type' => 'string' ), 'description' => 'Optional path patterns every changed file must match.' ),
+					'deny'                  => array( 'type' => 'array', 'items' => array( 'type' => 'string' ), 'description' => 'Optional path patterns that must not be changed.' ),
+					'include_any'           => array( 'type' => 'array', 'items' => array( 'type' => 'string' ), 'description' => 'Optional path patterns where at least one changed file must match.' ),
+					'include_all'           => array( 'type' => 'array', 'items' => array( 'type' => 'string' ), 'description' => 'Optional path patterns where each pattern must match at least one changed file.' ),
+					'require_tests'         => array( 'type' => 'boolean', 'description' => 'Require at least one changed file that looks like test coverage.' ),
+					'require_changed_files' => array(
+						'type'        => 'object',
+						'description' => 'Compatibility object supporting allow, deny, include_any, and include_all.',
+						'properties'  => array(
+							'allow'       => array( 'type' => 'array', 'items' => array( 'type' => 'string' ), 'description' => 'Optional path patterns every changed file must match.' ),
+							'deny'        => array( 'type' => 'array', 'items' => array( 'type' => 'string' ), 'description' => 'Optional path patterns that must not be changed.' ),
+							'include_any' => array( 'type' => 'array', 'items' => array( 'type' => 'string' ), 'description' => 'Optional path patterns where at least one changed file must match.' ),
+							'include_all' => array( 'type' => 'array', 'items' => array( 'type' => 'string' ), 'description' => 'Optional path patterns where each pattern must match at least one changed file.' ),
+						),
 					),
+					'from'                  => array( 'type' => 'string', 'description' => 'Optional from git ref.' ),
+					'to'                    => array( 'type' => 'string', 'description' => 'Optional to git ref.' ),
+					'staged'                => array( 'type' => 'boolean', 'description' => 'Validate staged changes only.' ),
+					'path'                  => array( 'type' => 'string', 'description' => 'Optional relative path filter.' ),
 				),
-				'from'                  => array( 'type' => 'string', 'required' => false, 'description' => 'Optional from git ref.' ),
-				'to'                    => array( 'type' => 'string', 'required' => false, 'description' => 'Optional to git ref.' ),
-				'staged'                => array( 'type' => 'boolean', 'required' => false, 'description' => 'Validate staged changes only.' ),
-				'path'                  => array( 'type' => 'string', 'required' => false, 'description' => 'Optional relative path filter.' ),
+				'required'   => array( 'name' ),
 			),
 		);
 	}

--- a/inc/Tools/WorkspaceTools.php
+++ b/inc/Tools/WorkspaceTools.php
@@ -329,11 +329,14 @@ class WorkspaceTools extends BaseTool {
 			'method'      => 'handlePath',
 			'description' => 'Get the Data Machine workspace path. Optionally ensure it exists.',
 			'parameters'  => array(
-				'ensure' => array(
-					'type'        => 'boolean',
-					'required'    => false,
-					'description' => 'Create the workspace directory if it does not exist (default false).',
+				'type'       => 'object',
+				'properties' => array(
+					'ensure' => array(
+						'type'        => 'boolean',
+						'description' => 'Create the workspace directory if it does not exist (default false).',
+					),
 				),
+				'required'   => array(),
 			),
 		);
 	}
@@ -349,11 +352,14 @@ class WorkspaceTools extends BaseTool {
 			'method'      => 'handleCapabilities',
 			'description' => 'Inspect whether the current Data Machine Code workspace backend can run local git operations in this runtime.',
 			'parameters'  => array(
-				'include_diagnostics' => array(
-					'type'        => 'boolean',
-					'required'    => false,
-					'description' => 'Include workspace backend diagnostics. Defaults to true.',
+				'type'       => 'object',
+				'properties' => array(
+					'include_diagnostics' => array(
+						'type'        => 'boolean',
+						'description' => 'Include workspace backend diagnostics. Defaults to true.',
+					),
 				),
+				'required'   => array(),
 			),
 		);
 	}
@@ -383,11 +389,14 @@ class WorkspaceTools extends BaseTool {
 			'method'      => 'handleShow',
 			'description' => 'Show detailed information about a workspace repository (branch, remote, latest commit, dirty count).',
 			'parameters'  => array(
-				'name' => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Workspace repository directory name.',
+				'type'       => 'object',
+				'properties' => array(
+					'name' => array(
+						'type'        => 'string',
+						'description' => 'Workspace repository directory name.',
+					),
 				),
+				'required'   => array( 'name' ),
 			),
 		);
 	}
@@ -403,16 +412,18 @@ class WorkspaceTools extends BaseTool {
 			'method'      => 'handleLs',
 			'description' => 'List directory contents within a workspace repository.',
 			'parameters'  => array(
-				'repo' => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Workspace repository directory name.',
+				'type'       => 'object',
+				'properties' => array(
+					'repo' => array(
+						'type'        => 'string',
+						'description' => 'Workspace repository directory name.',
+					),
+					'path' => array(
+						'type'        => 'string',
+						'description' => 'Optional relative directory path inside the repo.',
+					),
 				),
-				'path' => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Optional relative directory path inside the repo.',
-				),
+				'required'   => array( 'repo' ),
 			),
 		);
 	}
@@ -428,31 +439,30 @@ class WorkspaceTools extends BaseTool {
 			'method'      => 'handleRead',
 			'description' => 'Read a text file from a workspace repository. Supports optional max_size, offset, and limit for large files.',
 			'parameters'  => array(
-				'repo'     => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Workspace repository directory name.',
+				'type'       => 'object',
+				'properties' => array(
+					'repo'     => array(
+						'type'        => 'string',
+						'description' => 'Workspace repository directory name.',
+					),
+					'path'     => array(
+						'type'        => 'string',
+						'description' => 'Relative file path inside the repository.',
+					),
+					'max_size' => array(
+						'type'        => 'integer',
+						'description' => 'Maximum readable size in bytes (default 1MB).',
+					),
+					'offset'   => array(
+						'type'        => 'integer',
+						'description' => 'Line offset to start reading from (1-indexed).',
+					),
+					'limit'    => array(
+						'type'        => 'integer',
+						'description' => 'Maximum number of lines to return.',
+					),
 				),
-				'path'     => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Relative file path inside the repository.',
-				),
-				'max_size' => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Maximum readable size in bytes (default 1MB).',
-				),
-				'offset'   => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Line offset to start reading from (1-indexed).',
-				),
-				'limit'    => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Maximum number of lines to return.',
-				),
+				'required'   => array( 'repo', 'path' ),
 			),
 		);
 	}
@@ -468,36 +478,34 @@ class WorkspaceTools extends BaseTool {
 			'method'      => 'handleGrep',
 			'description' => 'Search text files in a workspace repository using a regular expression pattern.',
 			'parameters'  => array(
-				'repo'          => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Workspace repository directory name or worktree handle.',
+				'type'       => 'object',
+				'properties' => array(
+					'repo'          => array(
+						'type'        => 'string',
+						'description' => 'Workspace repository directory name or worktree handle.',
+					),
+					'pattern'       => array(
+						'type'        => 'string',
+						'description' => 'Regular expression pattern to search for.',
+					),
+					'path'          => array(
+						'type'        => 'string',
+						'description' => 'Optional relative file or directory path inside the repository.',
+					),
+					'include'       => array(
+						'type'        => 'string',
+						'description' => 'Optional glob pattern to limit matching file paths.',
+					),
+					'max_results'   => array(
+						'type'        => 'integer',
+						'description' => 'Maximum number of matches to return (default 100, max 500).',
+					),
+					'context_lines' => array(
+						'type'        => 'integer',
+						'description' => 'Number of surrounding lines to include for each match (default 0, max 10).',
+					),
 				),
-				'pattern'       => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Regular expression pattern to search for.',
-				),
-				'path'          => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Optional relative file or directory path inside the repository.',
-				),
-				'include'       => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Optional glob pattern to limit matching file paths.',
-				),
-				'max_results'   => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Maximum number of matches to return (default 100, max 500).',
-				),
-				'context_lines' => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Number of surrounding lines to include for each match (default 0, max 10).',
-				),
+				'required'   => array( 'repo', 'pattern' ),
 			),
 		);
 	}

--- a/tests/smoke-tool-schemas.php
+++ b/tests/smoke-tool-schemas.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Smoke test for Data Machine Code AI tool schemas.
+ *
+ * Run: php tests/smoke-tool-schemas.php
+ */
+
+declare( strict_types=1 );
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+}
+
+namespace DataMachine\Engine\AI\Tools {
+	class BaseTool {
+		/** @param array<int,string> $contexts Context names. @param array<string,mixed> $options Tool options. */
+		protected function registerTool( string $tool_id, callable $definition_callback, array $contexts = array(), array $options = array() ): void {}
+	}
+}
+
+namespace DataMachineCode\Abilities {
+	class GitHubAbilities {
+		public static function getRegisteredRepos(): array {
+			return array();
+		}
+	}
+}
+
+namespace {
+	$failures = 0;
+	$total    = 0;
+
+	$assert = function ( bool $condition, string $message ) use ( &$failures, &$total ): void {
+		$total++;
+		if ( $condition ) {
+			echo "  ✓ {$message}\n";
+			return;
+		}
+
+		$failures++;
+		echo "  ✗ {$message}\n";
+	};
+
+	$assert_schema = function ( array $schema, string $path ) use ( &$assert, &$assert_schema ): void {
+		if ( array_key_exists( 'required', $schema ) ) {
+			$assert( is_array( $schema['required'] ), $path . ' required is an object-level array' );
+		}
+
+		if ( ( $schema['type'] ?? null ) === 'array' ) {
+			$assert( isset( $schema['items'] ) && is_array( $schema['items'] ), $path . ' array schema defines items' );
+		}
+
+		foreach ( $schema['properties'] ?? array() as $property => $property_schema ) {
+			if ( ! is_array( $property_schema ) ) {
+				$assert( false, $path . '.properties.' . $property . ' schema is an array' );
+				continue;
+			}
+
+			$assert( ! array_key_exists( 'required', $property_schema ) || is_array( $property_schema['required'] ), $path . '.properties.' . $property . ' avoids property-level required flags' );
+			$assert_schema( $property_schema, $path . '.properties.' . $property );
+		}
+
+		if ( isset( $schema['items'] ) && is_array( $schema['items'] ) ) {
+			$assert_schema( $schema['items'], $path . '.items' );
+		}
+	};
+
+	foreach ( glob( __DIR__ . '/../inc/Tools/*.php' ) ?: array() as $file ) {
+		require_once $file;
+	}
+
+	$classes = array(
+		\DataMachineCode\Tools\GitHubIssueTool::class,
+		\DataMachineCode\Tools\GitHubPullRequestTool::class,
+		\DataMachineCode\Tools\GitHubTools::class,
+		\DataMachineCode\Tools\WordPressRuntimeTools::class,
+		\DataMachineCode\Tools\WorkspaceDiffTools::class,
+		\DataMachineCode\Tools\WorkspaceTools::class,
+	);
+
+	echo "Data Machine Code tool schemas\n";
+
+	foreach ( $classes as $class ) {
+		$instance = new $class();
+		$methods  = array_filter(
+			get_class_methods( $class ),
+			static fn( string $method ): bool => str_starts_with( $method, 'get' ) && str_ends_with( $method, 'Definition' )
+		);
+
+		foreach ( $methods as $method ) {
+			$definition = $instance->{$method}();
+			if ( empty( $definition['parameters'] ) || ! is_array( $definition['parameters'] ) ) {
+				continue;
+			}
+
+			$path = $class . '::' . $method . '.parameters';
+			$assert( 'object' === ( $definition['parameters']['type'] ?? null ), $path . ' uses canonical object schema' );
+			$assert( isset( $definition['parameters']['properties'] ) && is_array( $definition['parameters']['properties'] ), $path . ' declares properties' );
+			$assert_schema( $definition['parameters'], $path );
+		}
+	}
+
+	if ( $failures > 0 ) {
+		echo "\n{$failures} of {$total} assertions failed.\n";
+		exit( 1 );
+	}
+
+	echo "\nAll {$total} DMC tool schema assertions passed.\n";
+}

--- a/tests/smoke-workspace-diff-validation.php
+++ b/tests/smoke-workspace-diff-validation.php
@@ -86,12 +86,17 @@ namespace {
 	};
 
 	$assert_arrays_define_items = function ( array $schema, string $path ) use ( &$assert, &$assert_arrays_define_items ): void {
+		if ( array_key_exists( 'required', $schema ) ) {
+			$assert( true, is_array( $schema['required'] ), $path . ' required is an object-level array' );
+		}
+
 		if ( ( $schema['type'] ?? null ) === 'array' ) {
 			$assert( true, array_key_exists( 'items', $schema ), $path . ' array schema defines items' );
 		}
 
 		foreach ( $schema['properties'] ?? array() as $property => $property_schema ) {
 			if ( is_array( $property_schema ) ) {
+				$assert( false, array_key_exists( 'required', $property_schema ) && ! is_array( $property_schema['required'] ), $path . '.properties.' . $property . ' avoids property-level required flags' );
 				$assert_arrays_define_items( $property_schema, $path . '.properties.' . $property );
 			}
 		}
@@ -134,11 +139,9 @@ namespace {
 
 	require __DIR__ . '/../inc/Tools/WorkspaceDiffTools.php';
 	$tool_definition = ( new \DataMachineCode\Tools\WorkspaceDiffTools() )->getDiffValidateDefinition();
-	foreach ( $tool_definition['parameters'] ?? array() as $parameter => $parameter_schema ) {
-		if ( is_array( $parameter_schema ) ) {
-			$assert_arrays_define_items( $parameter_schema, 'workspace_diff_validate.parameters.' . $parameter );
-		}
-	}
+	$assert( 'object', $tool_definition['parameters']['type'] ?? null, 'workspace_diff_validate parameters use canonical object schema' );
+	$assert( array( 'name' ), $tool_definition['parameters']['required'] ?? null, 'workspace_diff_validate declares object-level required fields' );
+	$assert_arrays_define_items( $tool_definition['parameters'] ?? array(), 'workspace_diff_validate.parameters' );
 
 	$diff    = new \DataMachineCode\Workspace\WorkspaceDiff();
 	$summary = $diff->summary( 'demo@diff-check' );


### PR DESCRIPTION
## Summary
- Migrates Data Machine Code AI tool definitions to canonical JSON Schema object parameters with object-level `required` arrays.
- Removes property-level `required` flags from DMC tool schemas so they no longer depend on Data Machine request-time normalization.
- Adds smoke coverage for canonical DMC tool schema shape and recursive array `items` checks.

## Testing
- `php tests/smoke-tool-schemas.php`
- `php tests/smoke-workspace-diff-validation.php`
- `homeboy lint --path . --extension wordpress --changed-since origin/main --summary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Migrated DMC tool schemas to the canonical wp-ai-client JSON Schema contract, added guard coverage, and ran targeted checks for Chris to review.