### PR TITLE
Declare no-argument tool schemas

### DIFF
--- a/inc/Tools/WordPressRuntimeTools.php
+++ b/inc/Tools/WordPressRuntimeTools.php
@@ -86,7 +86,11 @@ class WordPressRuntimeTools extends BaseTool {
 			'class'       => __CLASS__,
 			'method'      => 'handleInventory',
 			'description' => 'Inspect the live WordPress runtime inventory: WP/PHP versions, active theme, installed plugins/themes, mu-plugins, drop-ins, and safe source-root policy metadata.',
-			'parameters'  => array(),
+			'parameters'  => array(
+				'type'       => 'object',
+				'properties' => array(),
+				'required'   => array(),
+			),
 		);
 	}
 

--- a/inc/Tools/WorkspaceTools.php
+++ b/inc/Tools/WorkspaceTools.php
@@ -374,7 +374,11 @@ class WorkspaceTools extends BaseTool {
 			'class'       => __CLASS__,
 			'method'      => 'handleList',
 			'description' => 'List repositories currently present in the Data Machine workspace.',
-			'parameters'  => array(),
+			'parameters'  => array(
+				'type'       => 'object',
+				'properties' => array(),
+				'required'   => array(),
+			),
 		);
 	}
 

--- a/tests/smoke-tool-schemas.php
+++ b/tests/smoke-tool-schemas.php
@@ -91,11 +91,16 @@ namespace {
 
 		foreach ( $methods as $method ) {
 			$definition = $instance->{$method}();
-			if ( empty( $definition['parameters'] ) || ! is_array( $definition['parameters'] ) ) {
+			if ( ! array_key_exists( 'parameters', $definition ) ) {
 				continue;
 			}
 
 			$path = $class . '::' . $method . '.parameters';
+			$assert( is_array( $definition['parameters'] ), $path . ' is an array' );
+			if ( ! is_array( $definition['parameters'] ) ) {
+				continue;
+			}
+
 			$assert( 'object' === ( $definition['parameters']['type'] ?? null ), $path . ' uses canonical object schema' );
 			$assert( isset( $definition['parameters']['properties'] ) && is_array( $definition['parameters']['properties'] ), $path . ' declares properties' );
 			$assert_schema( $definition['parameters'], $path );


### PR DESCRIPTION
## Summary
- Use canonical empty object schemas for no-argument AI tools instead of `parameters: []`.
- Strengthen the tool schema smoke test so empty parameter arrays fail instead of being skipped.

## Testing
- `php -l inc/Tools/WordPressRuntimeTools.php && php -l inc/Tools/WorkspaceTools.php && php -l tests/smoke-tool-schemas.php`
- `php tests/smoke-tool-schemas.php`
- `homeboy lint --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the World Creator OpenAI schema rejection, drafted the DMC schema fix, and ran local validation; Chris remains responsible for review and merge.