### PR TITLE
Return GitHub file reads as a batch

### DIFF
--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -1109,12 +1109,12 @@ class GitHubAbilities {
 			wp_register_ability(
 				'datamachine/get-github-file',
 				array(
-					'label'               => 'Get GitHub File',
-					'description'         => 'Get decoded content for a single file in a GitHub repository',
+					'label'               => 'Get GitHub Files',
+					'description'         => 'Get decoded content for one or more files in a GitHub repository',
 					'category'            => 'datamachine-code-github',
 					'input_schema'        => array(
 						'type'       => 'object',
-						'required'   => array( 'repo', 'path' ),
+						'required'   => array( 'repo' ),
 						'properties' => array(
 							'repo' => array(
 								'type'        => 'string',
@@ -1122,20 +1122,33 @@ class GitHubAbilities {
 							),
 							'path' => array(
 								'type'        => 'string',
-								'description' => 'File path within the repository.',
+								'description' => 'Single file path within the repository. Use paths for multiple files.',
+							),
+							'paths' => array(
+								'type'        => 'array',
+								'items'       => array( 'type' => 'string' ),
+								'description' => 'One or more file paths within the repository.',
 							),
 							'ref'  => array(
 								'type'        => 'string',
 								'description' => 'Branch, tag, or commit SHA. Defaults to the repository default branch.',
+							),
+							'max_total_size' => array(
+								'type'        => 'integer',
+								'description' => 'Maximum cumulative decoded bytes to return across files. Default: 500000.',
 							),
 						),
 					),
 					'output_schema'       => array(
 						'type'       => 'object',
 						'properties' => array(
-							'success' => array( 'type' => 'boolean' ),
-							'file'    => array( 'type' => 'object' ),
-							'error'   => array( 'type' => 'string' ),
+							'success'    => array( 'type' => 'boolean' ),
+							'files'      => array( 'type' => 'array' ),
+							'errors'     => array( 'type' => 'array' ),
+							'count'      => array( 'type' => 'integer' ),
+							'total_size' => array( 'type' => 'integer' ),
+							'truncated'  => array( 'type' => 'boolean' ),
+							'error'      => array( 'type' => 'string' ),
 						),
 					),
 					'execute_callback'    => array( self::class, 'getFileContents' ),
@@ -2519,7 +2532,7 @@ class GitHubAbilities {
 				continue;
 			}
 
-			$file                       = $file_result['file'] ?? $file_result;
+			$file                       = $file_result['files'][0] ?? $file_result;
 			$content                    = (string) ( $file['content'] ?? '' );
 			$entry                      = self::buildReviewProfileFileEntry( $file, $content, $limits['max_file_chars'], $remaining_chars );
 			$profile['profile_files'][] = $entry;
@@ -3171,7 +3184,7 @@ class GitHubAbilities {
 			);
 		}
 
-		$file     = $result['file'] ?? $result;
+		$file     = $result['files'][0] ?? $result;
 		$content  = (string) ( $file['content'] ?? '' );
 		$original = strlen( $content );
 		$limit    = min( $max_file_chars, $remaining_chars );
@@ -4079,22 +4092,22 @@ class GitHubAbilities {
 	}
 
 	/**
-	 * Get the decoded content of a single file from a repository.
+	 * Get decoded content for one or more files from a repository.
 	 *
 	 * Calls `GET /repos/{owner}/{repo}/contents/{path}`.
 	 * GitHub returns base64-encoded content for files ≤ 1 MB.
 	 *
 	 * @param array $input {
-	 *     Required: repo, path. Optional: branch.
+	 *     Required: repo and path or paths. Optional: ref, branch, max_total_size.
 	 * }
-	 * @return array|\WP_Error { success: bool, file: normalized } or error.
+	 * @return array|\WP_Error { success: bool, files: normalized[], errors: array[], count: int, total_size: int, truncated: bool } or error.
 	 */
 	public static function getFileContents( array $input ): array|\WP_Error {
-		$repo = sanitize_text_field( $input['repo'] ?? '' );
-		$path = sanitize_text_field( $input['path'] ?? '' );
+		$repo  = sanitize_text_field( $input['repo'] ?? '' );
+		$paths = self::normalizeFileContentPaths( $input );
 
-		if ( empty( $repo ) || empty( $path ) ) {
-			return new \WP_Error( 'missing_params', 'Repository (owner/repo) and file path are required.', array( 'status' => 400 ) );
+		if ( empty( $repo ) || empty( $paths ) ) {
+			return new \WP_Error( 'missing_params', 'Repository (owner/repo) and at least one file path are required.', array( 'status' => 400 ) );
 		}
 
 		$pat = self::getPatForRepo( $repo );
@@ -4108,6 +4121,85 @@ class GitHubAbilities {
 			$query_params['ref'] = $branch;
 		}
 
+		$max_total_size = max( 1, (int) ( $input['max_total_size'] ?? 500000 ) );
+		$files          = array();
+		$errors         = array();
+		$total_size     = 0;
+		$truncated      = false;
+
+		foreach ( $paths as $path ) {
+			$file = self::getSingleFileContent( $repo, $path, $query_params, $pat );
+			if ( is_wp_error( $file ) ) {
+				$error_data = $file->get_error_data();
+				$errors[] = array(
+					'path'    => $path,
+					'code'    => $file->get_error_code(),
+					'message' => $file->get_error_message(),
+					'status'  => is_array( $error_data ) ? (int) ( $error_data['status'] ?? 0 ) : 0,
+				);
+				continue;
+			}
+
+			$size = (int) ( $file['size'] ?? strlen( (string) ( $file['content'] ?? '' ) ) );
+			if ( $total_size + $size > $max_total_size ) {
+				$truncated = true;
+				$errors[]  = array(
+					'path'    => $path,
+					'code'    => 'max_total_size_exceeded',
+					'message' => sprintf( 'Skipping file because it would exceed max_total_size (%d bytes).', $max_total_size ),
+				);
+				continue;
+			}
+
+			$files[]     = $file;
+			$total_size += $size;
+		}
+
+		return array(
+			'success'    => empty( $errors ),
+			'files'      => $files,
+			'errors'     => $errors,
+			'count'      => count( $files ),
+			'total_size' => $total_size,
+			'truncated'  => $truncated,
+		);
+	}
+
+	/**
+	 * Normalize the clean one-or-many file path contract.
+	 *
+	 * @param array $input Raw ability input.
+	 * @return string[] Ordered, unique sanitized paths.
+	 */
+	private static function normalizeFileContentPaths( array $input ): array {
+		$raw_paths = array();
+		if ( isset( $input['paths'] ) ) {
+			$raw_paths = is_array( $input['paths'] ) ? $input['paths'] : array( $input['paths'] );
+		} elseif ( isset( $input['path'] ) ) {
+			$raw_paths = array( $input['path'] );
+		}
+
+		$paths = array();
+		foreach ( $raw_paths as $path ) {
+			$path = ltrim( sanitize_text_field( (string) $path ), '/' );
+			if ( '' !== $path && ! in_array( $path, $paths, true ) ) {
+				$paths[] = $path;
+			}
+		}
+
+		return $paths;
+	}
+
+	/**
+	 * Fetch and decode a single file from GitHub.
+	 *
+	 * @param string $repo         Repository in owner/repo format.
+	 * @param string $path         Repository file path.
+	 * @param array  $query_params GitHub query params.
+	 * @param string $pat          Token to use.
+	 * @return array|\WP_Error Normalized file or error.
+	 */
+	private static function getSingleFileContent( string $repo, string $path, array $query_params, string $pat ): array|\WP_Error {
 		$url      = sprintf( '%s/repos/%s/contents/%s', self::API_BASE, $repo, ltrim( $path, '/' ) );
 		$response = self::apiGet( $url, $query_params, $pat );
 
@@ -4132,10 +4224,7 @@ class GitHubAbilities {
 			return new \WP_Error( 'decode_failed', 'Failed to decode file content.', array( 'status' => 500 ) );
 		}
 
-		return array(
-			'success' => true,
-			'file'    => self::normalizeFileContent( $data, $decoded ),
-		);
+		return self::normalizeFileContent( $data, $decoded );
 	}
 
 	// -------------------------------------------------------------------------

--- a/inc/Handlers/GitHub/GitHub.php
+++ b/inc/Handlers/GitHub/GitHub.php
@@ -451,7 +451,11 @@ class GitHub extends FetchHandler {
 				continue;
 			}
 
-			$file_data = $file_result['file'];
+			$file_data = $file_result['files'][0] ?? array();
+			if ( empty( $file_data ) ) {
+				$context->log( 'debug', sprintf( 'GitHub: Skipped %s — no file content returned.', $file['path'] ) );
+				continue;
+			}
 			$guid      = sprintf( 'github_%s_files_%s', $repo, $file['sha'] );
 
 			$eligible_items[] = array(

--- a/inc/Tools/GitHubTools.php
+++ b/inc/Tools/GitHubTools.php
@@ -1173,7 +1173,7 @@ class GitHubTools extends BaseTool {
 		return array(
 			'class'       => __CLASS__,
 			'method'      => 'handleGetFile',
-			'description' => 'Get decoded content for a single file from a GitHub repository.',
+			'description' => 'Get decoded content for one or more files from a GitHub repository. Accepts path for one file or paths for one-or-many; always returns files[].',
 			'parameters'  => array(
 				'type'       => 'object',
 				'properties' => array(
@@ -1183,14 +1183,23 @@ class GitHubTools extends BaseTool {
 					),
 					'path' => array(
 						'type'        => 'string',
-						'description' => 'File path within the repository.',
+						'description' => 'Single file path within the repository. Use paths for multiple files.',
+					),
+					'paths' => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'string' ),
+						'description' => 'One or more file paths within the repository.',
 					),
 					'ref'  => array(
 						'type'        => 'string',
 						'description' => 'Branch, tag, or commit SHA. Defaults to the repository default branch.',
 					),
+					'max_total_size' => array(
+						'type'        => 'integer',
+						'description' => 'Maximum cumulative decoded bytes to return across files. Default: 500000.',
+					),
 				),
-				'required'   => array( 'repo', 'path' ),
+				'required'   => array( 'repo' ),
 			),
 		);
 	}

--- a/inc/Workspace/RemoteWorkspaceBackend.php
+++ b/inc/Workspace/RemoteWorkspaceBackend.php
@@ -144,7 +144,11 @@ class RemoteWorkspaceBackend {
 			if ( is_wp_error( $file ) ) {
 				return $file;
 			}
-			$content = (string) ( $file['file']['content'] ?? '' );
+			if ( empty( $file['files'][0] ) ) {
+				$error = $file['errors'][0]['message'] ?? sprintf( 'File not found: %s.', $path );
+				return new \WP_Error( 'remote_workspace_file_unavailable', $error, array( 'status' => 404 ) );
+			}
+			$content = (string) ( $file['files'][0]['content'] ?? '' );
 		}
 
 		$size = strlen( $content );
@@ -542,8 +546,16 @@ class RemoteWorkspaceBackend {
 
 			return $file;
 		}
+		if ( empty( $file['files'][0] ) ) {
+			$status = (int) ( $file['errors'][0]['status'] ?? 0 );
+			if ( 404 === $status ) {
+				return '';
+			}
 
-		return (string) ( $file['file']['sha'] ?? '' );
+			return new \WP_Error( 'remote_workspace_file_unavailable', $file['errors'][0]['message'] ?? sprintf( 'File not found: %s.', $path ), array( 'status' => 404 ) );
+		}
+
+		return (string) ( $file['files'][0]['sha'] ?? '' );
 	}
 
 	/**

--- a/tests/smoke-github-readonly-tools.php
+++ b/tests/smoke-github-readonly-tools.php
@@ -86,8 +86,12 @@ namespace {
 
 				return match ( $this->name ) {
 					'datamachine/get-github-file' => array(
-						'success' => true,
-						'file'    => array( 'path' => $parameters['path'] ?? '', 'content' => 'file body' ),
+						'success'    => true,
+						'files'      => array( array( 'path' => $parameters['path'] ?? ( $parameters['paths'][0] ?? '' ), 'content' => 'file body' ) ),
+						'errors'     => array(),
+						'count'      => 1,
+						'total_size' => 9,
+						'truncated'  => false,
 					),
 					'datamachine/list-github-tree' => array(
 						'success' => true,
@@ -164,6 +168,14 @@ namespace {
 		$failures[] = $label;
 		echo "  fail {$label}\n";
 	};
+	$param_exists = static function ( array $definition, string $param ): bool {
+		return array_key_exists( $param, $definition['parameters']['properties'] ?? array() )
+			|| array_key_exists( $param, $definition['parameters'] ?? array() );
+	};
+	$param_required = static function ( array $definition, string $param ) use ( $param_exists ): bool {
+		return in_array( $param, $definition['parameters']['required'] ?? array(), true )
+			|| true === ( $definition['parameters'][ $param ]['required'] ?? false );
+	};
 
 	echo "GitHub read-only tools - smoke\n";
 
@@ -175,8 +187,9 @@ namespace {
 			'ability'  => 'datamachine/get-github-file',
 			'method'   => 'handleGetFile',
 			'callback' => array( GitHubAbilities::class, 'getFileContents' ),
-			'required' => array( 'repo', 'path' ),
-			'params'   => array( 'repo' => 'Extra-Chill/data-machine-code', 'path' => 'README.md', 'ref' => 'main' ),
+			'required' => array( 'repo' ),
+			'optional' => array( 'path', 'paths', 'ref', 'max_total_size' ),
+			'params'   => array( 'repo' => 'Extra-Chill/data-machine-code', 'paths' => array( 'README.md', 'inc/Tools/GitHubTools.php' ), 'ref' => 'main', 'max_total_size' => 500000 ),
 		),
 		'list_github_tree'               => array(
 			'ability'  => 'datamachine/list-github-tree',
@@ -312,11 +325,11 @@ namespace {
 		$definition = call_user_func( $tool['definition_callback'] );
 		$assert( "{$tool_name} definition uses narrow handler", $spec['method'] === ( $definition['method'] ?? '' ) );
 		foreach ( $spec['required'] as $param ) {
-			$assert( "{$tool_name} requires {$param}", true === ( $definition['parameters'][ $param ]['required'] ?? false ) );
+			$assert( "{$tool_name} requires {$param}", $param_required( $definition, $param ) );
 		}
 		foreach ( $spec['optional'] ?? array() as $param ) {
-			$assert( "{$tool_name} exposes optional {$param}", array_key_exists( $param, $definition['parameters'] ?? array() ) );
-			$assert( "{$tool_name} does not require optional {$param}", false === ( $definition['parameters'][ $param ]['required'] ?? false ) );
+			$assert( "{$tool_name} exposes optional {$param}", $param_exists( $definition, $param ) );
+			$assert( "{$tool_name} does not require optional {$param}", ! $param_required( $definition, $param ) );
 			$assert( "{$tool_name} ability schema exposes optional {$param}", array_key_exists( $param, $GLOBALS['dmc_registered_abilities'][ $ability_name ]['input_schema']['properties'] ?? array() ) );
 		}
 
@@ -331,8 +344,11 @@ namespace {
 	$ability_source = file_get_contents( __DIR__ . '/../inc/Abilities/GitHubAbilities.php' );
 	$tool_source    = file_get_contents( __DIR__ . '/../inc/Tools/GitHubTools.php' );
 
-	$assert( 'read-only tools do not expose file writes', ! str_contains( $tool_source, "'commit_message'" ) );
-	$assert( 'get_github_file uses ref naming', str_contains( $ability_source, "'datamachine/get-github-file'" ) && str_contains( $tool_source, "'ref'" ) );
+	$get_file_definition = $tools->registered['get_github_file']['definition_callback'] ?? null;
+	$get_file_definition = $get_file_definition ? call_user_func( $get_file_definition ) : array();
+	$assert( 'get_github_file does not expose file writes', ! $param_exists( $get_file_definition, 'commit_message' ) );
+	$assert( 'get_github_file uses clean plural output', str_contains( $ability_source, "'datamachine/get-github-file'" ) && str_contains( $ability_source, "'files'" ) && str_contains( $ability_source, 'normalizeFileContentPaths' ) );
+	$assert( 'get_github_file supports path or paths', str_contains( $tool_source, "'paths'" ) && str_contains( $tool_source, "'path'" ) && str_contains( $tool_source, "'max_total_size'" ) );
 	$assert( 'list_github_tree supports optional path filtering', str_contains( $ability_source, '$path_prefix' ) );
 
 	if ( ! empty( $failures ) ) {


### PR DESCRIPTION
## Summary
- Updates `get_github_file` to accept either `path` or `paths` and normalize both through one batch read path.
- Changes the clean output contract to always return `files[]`, `errors[]`, `count`, `total_size`, and `truncated`.
- Updates internal callers and smoke coverage for the plural response shape.

## Validation
- `php -l inc/Abilities/GitHubAbilities.php`
- `php -l inc/Tools/GitHubTools.php`
- `php -l inc/Workspace/RemoteWorkspaceBackend.php`
- `php -l inc/Handlers/GitHub/GitHub.php`
- `php tests/smoke-github-readonly-tools.php`
- `git diff --check`
- `homeboy lint --changed-since origin/main` (reported no changed files)
- `homeboy test --changed-since origin/main` (no impacted tests selected)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the clean one-or-many GitHub file read contract, implementation, and smoke coverage; Chris specified the clean plural contract direction.