### PR TITLE
Fix remote workspace edits before branch materialization

### DIFF
--- a/inc/Workspace/RemoteWorkspaceBackend.php
+++ b/inc/Workspace/RemoteWorkspaceBackend.php
@@ -124,23 +124,7 @@ class RemoteWorkspaceBackend {
 
 		$content = $context['pending_files'][ $path ] ?? null;
 		if ( null === $content ) {
-			$file_input = array(
-				'repo' => $context['repo'],
-				'path' => $path,
-			);
-			if ( '' !== $context['read_ref'] ) {
-				$file_input['ref'] = $context['read_ref'];
-			}
-
-			$file = GitHubAbilities::getFileContents( $file_input );
-			if ( is_wp_error( $file ) && '' !== $context['read_ref'] ) {
-				$file = GitHubAbilities::getFileContents(
-					array(
-						'repo' => $context['repo'],
-						'path' => $path,
-					)
-				);
-			}
+			$file = $this->get_file_contents_with_fallback( $context, $path );
 			if ( is_wp_error( $file ) ) {
 				return $file;
 			}
@@ -523,21 +507,7 @@ class RemoteWorkspaceBackend {
 	 * @param array<string,mixed> $context Remote workspace context.
 	 */
 	private function file_sha_for_commit( array $context, string $path ): string|\WP_Error {
-		$file = GitHubAbilities::getFileContents(
-			array(
-				'repo' => $context['repo'],
-				'path' => $path,
-				'ref'  => $context['read_ref'],
-			)
-		);
-		if ( is_wp_error( $file ) && '' !== $context['read_ref'] ) {
-			$file = GitHubAbilities::getFileContents(
-				array(
-					'repo' => $context['repo'],
-					'path' => $path,
-				)
-			);
-		}
+		$file = $this->get_file_contents_with_fallback( $context, $path );
 		if ( is_wp_error( $file ) ) {
 			$status = (int) ( $file->get_error_data()['status'] ?? 0 );
 			if ( 404 === $status ) {
@@ -556,6 +526,57 @@ class RemoteWorkspaceBackend {
 		}
 
 		return (string) ( $file['files'][0]['sha'] ?? '' );
+	}
+
+	/**
+	 * Read GitHub contents for a worktree path, falling back to the default branch
+	 * when the remote worktree branch has not been materialized yet.
+	 *
+	 * @param array<string,mixed> $context Remote workspace context.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private function get_file_contents_with_fallback( array $context, string $path ): array|\WP_Error {
+		$file_input = array(
+			'repo' => $context['repo'],
+			'path' => $path,
+		);
+		if ( '' !== $context['read_ref'] ) {
+			$file_input['ref'] = $context['read_ref'];
+		}
+
+		$file = GitHubAbilities::getFileContents( $file_input );
+		if ( '' === $context['read_ref'] || ! $this->should_retry_default_ref( $file ) ) {
+			return $file;
+		}
+
+		return GitHubAbilities::getFileContents(
+			array(
+				'repo' => $context['repo'],
+				'path' => $path,
+			)
+		);
+	}
+
+	/**
+	 * GitHub file reads can report missing refs either as a WP_Error or as a
+	 * normalized `{ success: false, files: [], errors: [...] }` payload.
+	 */
+	private function should_retry_default_ref( array|\WP_Error $file ): bool {
+		if ( is_wp_error( $file ) ) {
+			return 404 === (int) ( $file->get_error_data()['status'] ?? 0 );
+		}
+
+		if ( ! empty( $file['files'][0] ) ) {
+			return false;
+		}
+
+		foreach ( (array) ( $file['errors'] ?? array() ) as $error ) {
+			if ( 404 === (int) ( $error['status'] ?? 0 ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/tests/smoke-remote-workspace-backend.php
+++ b/tests/smoke-remote-workspace-backend.php
@@ -23,17 +23,33 @@ namespace DataMachineCode\Abilities {
 			$ref  = (string) ( $input['ref'] ?? 'main' );
 			$key  = $repo . ':' . $ref . ':' . $path;
 			if ( ! isset( self::$files[ $key ] ) ) {
-				return new \WP_Error( 'github_not_found', 'Not found.', array( 'status' => 404 ) );
+				return array(
+					'success' => false,
+					'files'   => array(),
+					'errors'  => array(
+						array(
+							'path'    => $path,
+							'code'    => 'github_not_found',
+							'message' => 'No commit found for the ref ' . $ref,
+							'status'  => 404,
+						),
+					),
+					'count'   => 0,
+				);
 			}
 			$file = self::$files[ $key ];
 			return array(
 				'success' => true,
-				'file'    => array(
-					'path'    => $path,
-					'size'    => strlen( $file['content'] ),
-					'sha'     => $file['sha'],
-					'content' => $file['content'],
+				'files'   => array(
+					array(
+						'path'    => $path,
+						'size'    => strlen( $file['content'] ),
+						'sha'     => $file['sha'],
+						'content' => $file['content'],
+					),
 				),
+				'errors'  => array(),
+				'count'   => 1,
 			);
 		}
 


### PR DESCRIPTION
## Summary
- Retries remote workspace file reads against the repository default branch when a newly registered worktree branch has not been materialized yet.
- Applies the same fallback when resolving file SHAs for GitHub Contents API commits.
- Updates the remote workspace smoke to match the real `getFileContents()` payload shape for missing refs.

## Why
The wc-site-generator PHP transformer iterator registered remote worktrees successfully, but `workspace_edit` failed immediately with `No commit found for the ref ...` because the remote backend tried to read from a branch that did not exist until the first commit.

## Evidence
- Iterator run: https://github.com/chubes4/wc-site-generator/actions/runs/25612641042
- Source callback: https://github.com/chubes4/wc-site-generator/pull/152#issuecomment-4413753516
- Fallback issue created instead of PR: https://github.com/chubes4/static-site-importer/issues/190

## Testing
- `php tests/smoke-remote-workspace-backend.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine-code@fix-remote-workspace-ref-resolution --extension wordpress --file inc/Workspace/RemoteWorkspaceBackend.php --summary`
- `homeboy lint --path /Users/chubes/Developer/data-machine-code@fix-remote-workspace-ref-resolution --extension wordpress --file tests/smoke-remote-workspace-backend.php --summary`
- `php -l inc/Workspace/RemoteWorkspaceBackend.php && php -l tests/smoke-remote-workspace-backend.php`

## Notes
- Full local `homeboy test` is blocked by a local Playground bootstrap dependency issue: `Class \"WP_Agent_Memory_Layer\" not found` while loading Data Machine. The focused remote workspace smoke covers this regression directly.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the iterator logs, reproduced the remote workspace failure in smoke coverage, implemented the fallback, and ran targeted verification.