### PR TITLE
Guard GitHub file writes by path scope

### DIFF
--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -1167,25 +1167,30 @@ class GitHubAbilities {
 						'type'       => 'object',
 						'required'   => array( 'repo', 'file_path', 'content', 'commit_message' ),
 						'properties' => array(
-							'repo'           => array(
+							'repo'               => array(
 								'type'        => 'string',
 								'description' => 'Repository in owner/repo format.',
 							),
-							'file_path'      => array(
+							'file_path'          => array(
 								'type'        => 'string',
 								'description' => 'Path within the repository (e.g., docs/getting-started.md).',
 							),
-							'content'        => array(
+							'content'            => array(
 								'type'        => 'string',
 								'description' => 'File content (will be base64-encoded automatically).',
 							),
-							'commit_message' => array(
+							'commit_message'     => array(
 								'type'        => 'string',
 								'description' => 'Commit message for the change.',
 							),
-							'branch'         => array(
+							'branch'             => array(
 								'type'        => 'string',
 								'description' => 'Target branch. Defaults to the repository\'s default branch.',
+							),
+							'allowed_file_paths' => array(
+								'type'        => 'array',
+								'items'       => array( 'type' => 'string' ),
+								'description' => 'Optional allowlist of file paths or glob-like patterns this call may write, such as README.md or docs/**.',
 							),
 						),
 					),
@@ -3893,9 +3898,18 @@ class GitHubAbilities {
 			return new \WP_Error( 'missing_repo', 'Repository (owner/repo) is required or configure a default repo.', array( 'status' => 400 ) );
 		}
 
-		$file_path = sanitize_text_field( $input['file_path'] ?? '' );
+		$file_path = self::normalizeRepoWritePath( $input['file_path'] ?? '' );
+		if ( is_wp_error( $file_path ) ) {
+			return $file_path;
+		}
 		if ( empty( $file_path ) ) {
 			return new \WP_Error( 'missing_file_path', 'File path is required.', array( 'status' => 400 ) );
+		}
+
+		$allowed_file_paths = is_array( $input['allowed_file_paths'] ?? null ) ? $input['allowed_file_paths'] : array();
+		$scope_result       = self::validateAllowedFilePath( $file_path, $allowed_file_paths );
+		if ( is_wp_error( $scope_result ) ) {
+			return $scope_result;
 		}
 
 		$content = $input['content'] ?? '';
@@ -3976,6 +3990,82 @@ class GitHubAbilities {
 				$repo
 			),
 		);
+	}
+
+	/**
+	 * Normalize a repository write path without allowing traversal outside the repo.
+	 *
+	 * @param mixed $path Candidate repository-relative path.
+	 * @return string|\WP_Error Normalized path or validation error.
+	 */
+	private static function normalizeRepoWritePath( mixed $path ): string|\WP_Error {
+		$path = str_replace( '\\', '/', trim( is_scalar( $path ) ? (string) $path : '' ) );
+		$path = ltrim( $path, '/' );
+		if ( '' === $path ) {
+			return '';
+		}
+
+		$segments = explode( '/', $path );
+		foreach ( $segments as $segment ) {
+			if ( '' === $segment || '.' === $segment || '..' === $segment ) {
+				return new \WP_Error( 'invalid_file_path', 'File path must be repository-relative and must not contain traversal segments.', array( 'status' => 400 ) );
+			}
+		}
+
+		return implode( '/', array_map( 'sanitize_text_field', $segments ) );
+	}
+
+	/**
+	 * Validate a write path against caller-provided allowlist patterns.
+	 *
+	 * @param string $file_path          Repository-relative file path.
+	 * @param array  $allowed_file_paths Optional exact paths, directory prefixes, or glob-like patterns.
+	 * @return true|\WP_Error True when allowed, or an error when the path is outside scope.
+	 */
+	private static function validateAllowedFilePath( string $file_path, array $allowed_file_paths ): true|\WP_Error {
+		$patterns = array_values( array_filter( array_map( array( self::class, 'normalizeAllowedFilePathPattern' ), $allowed_file_paths ) ) );
+		if ( empty( $patterns ) ) {
+			return true;
+		}
+
+		foreach ( $patterns as $pattern ) {
+			if ( $file_path === $pattern || fnmatch( $pattern, $file_path ) ) {
+				return true;
+			}
+
+			$prefix = '';
+			if ( str_ends_with( $pattern, '/**' ) ) {
+				$prefix = substr( $pattern, 0, -2 );
+			} elseif ( str_ends_with( $pattern, '/' ) ) {
+				$prefix = $pattern;
+			}
+
+			if ( '' !== $prefix && str_starts_with( $file_path, $prefix ) ) {
+				return true;
+			}
+		}
+
+		return new \WP_Error(
+			'forbidden_file_path',
+			sprintf( 'File path %s is outside the allowed write scope.', $file_path ),
+			array( 'status' => 403, 'allowed_file_paths' => $patterns )
+		);
+	}
+
+	/**
+	 * Normalize an allowlist pattern for comparison against repository-relative paths.
+	 *
+	 * @param mixed $pattern Candidate allowlist pattern.
+	 * @return string Normalized pattern, or empty string when invalid.
+	 */
+	private static function normalizeAllowedFilePathPattern( mixed $pattern ): string {
+		$pattern = str_replace( '\\', '/', trim( is_scalar( $pattern ) ? (string) $pattern : '' ) );
+		$pattern = ltrim( $pattern, '/' );
+		if ( '' === $pattern || str_contains( $pattern, '../' ) || str_contains( $pattern, '/..' ) || '..' === $pattern ) {
+			return '';
+		}
+
+		return $pattern;
 	}
 
 	/**

--- a/inc/Tools/GitHubTools.php
+++ b/inc/Tools/GitHubTools.php
@@ -1227,25 +1227,30 @@ class GitHubTools extends BaseTool {
 			'parameters'  => array(
 				'type'       => 'object',
 				'properties' => array(
-					'repo'           => array(
+					'repo'               => array(
 						'type'        => 'string',
 						'description' => 'Repository in owner/repo format.',
 					),
-					'file_path'      => array(
+					'file_path'          => array(
 						'type'        => 'string',
 						'description' => 'Path within the repository.',
 					),
-					'content'        => array(
+					'content'            => array(
 						'type'        => 'string',
 						'description' => 'Full file content to write.',
 					),
-					'commit_message' => array(
+					'commit_message'     => array(
 						'type'        => 'string',
 						'description' => 'Commit message for the file change.',
 					),
-					'branch'         => array(
+					'branch'             => array(
 						'type'        => 'string',
 						'description' => 'Target branch. Defaults to the repository default branch. New branches are created from the default branch.',
+					),
+					'allowed_file_paths' => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'string' ),
+						'description' => 'Optional allowlist of writable file paths or glob-like patterns, such as README.md or docs/**.',
 					),
 				),
 				'required'   => array( 'repo', 'file_path', 'content', 'commit_message' ),

--- a/tests/smoke-github-create-abilities.php
+++ b/tests/smoke-github-create-abilities.php
@@ -200,6 +200,7 @@ namespace {
 
 	$issue_ability = $GLOBALS['dmc_registered_abilities']['datamachine/create-github-issue'] ?? null;
 	$pr_ability    = $GLOBALS['dmc_registered_abilities']['datamachine/create-github-pull-request'] ?? null;
+	$file_ability  = $GLOBALS['dmc_registered_abilities']['datamachine/create-or-update-github-file'] ?? null;
 
 	$assert( 'create-github-issue ability is registered', null !== $issue_ability );
 	$assert( 'create-github-issue uses createIssue execute_callback', array( GitHubAbilities::class, 'createIssue' ) === ( $issue_ability['execute_callback'] ?? null ) );
@@ -221,6 +222,10 @@ namespace {
 	$assert( 'create-github-pull-request labels schema declares string items', array( 'type' => 'string' ) === ( $pr_ability['input_schema']['properties']['labels']['items'] ?? null ) );
 	$assert( 'create-github-pull-request exposes maintainer_can_modify', array_key_exists( 'maintainer_can_modify', $pr_ability['input_schema']['properties'] ?? array() ) );
 	$assert( 'create-github-pull-request is hidden from REST', false === ( $pr_ability['meta']['show_in_rest'] ?? null ) );
+
+	$assert( 'create-or-update-github-file ability is registered', null !== $file_ability );
+	$assert( 'create-or-update-github-file exposes allowed_file_paths', array_key_exists( 'allowed_file_paths', $file_ability['input_schema']['properties'] ?? array() ) );
+	$assert( 'create-or-update-github-file allowed_file_paths declares string items', array( 'type' => 'string' ) === ( $file_ability['input_schema']['properties']['allowed_file_paths']['items'] ?? null ) );
 
 	// Permission gating uses PermissionHelper::can_manage().
 	$issue_permission = $issue_ability['permission_callback'] ?? null;
@@ -517,6 +522,28 @@ namespace {
 	$assert( 'createPullRequest 422 carries github_api_error code', $result instanceof WP_Error && 'github_api_error' === $result->get_error_code() );
 	$assert( 'createPullRequest 422 message includes GitHub message', $result instanceof WP_Error && str_contains( $result->get_error_message(), 'already exists' ) );
 
+	// ---- createOrUpdateFile: optional write scope guardrails reject out-of-scope paths before GitHub calls.
+	$reset_http();
+	$result = GitHubAbilities::createOrUpdateFile( array(
+		'repo'               => 'owner/repo',
+		'file_path'          => 'src/generated.php',
+		'content'            => '<?php echo "nope";',
+		'commit_message'     => 'chore: attempt out of scope write',
+		'allowed_file_paths' => array( 'README.md', 'docs/**' ),
+	) );
+	$assert( 'createOrUpdateFile rejects out-of-scope file path', $result instanceof WP_Error && 'forbidden_file_path' === $result->get_error_code() );
+	$assert( 'createOrUpdateFile rejects out-of-scope path before HTTP calls', 0 === count( $GLOBALS['dmc_http_calls'] ) );
+
+	$reset_http();
+	$result = GitHubAbilities::createOrUpdateFile( array(
+		'repo'           => 'owner/repo',
+		'file_path'      => '../README.md',
+		'content'        => 'Bad path',
+		'commit_message' => 'docs: bad path',
+	) );
+	$assert( 'createOrUpdateFile rejects traversal file path', $result instanceof WP_Error && 'invalid_file_path' === $result->get_error_code() );
+	$assert( 'createOrUpdateFile rejects traversal before HTTP calls', 0 === count( $GLOBALS['dmc_http_calls'] ) );
+
 	// ---- createOrUpdateFile: creates a missing target branch from the default branch.
 	$reset_http();
 	$queue_response( 404, array( 'message' => 'Not Found' ) );
@@ -536,11 +563,12 @@ namespace {
 		),
 	) );
 	$result = GitHubAbilities::createOrUpdateFile( array(
-		'repo'           => 'owner/repo',
-		'file_path'      => 'docs/generated.md',
-		'content'        => '# Generated',
-		'commit_message' => 'docs: add generated file',
-		'branch'         => 'store/new-doc',
+		'repo'               => 'owner/repo',
+		'file_path'          => 'docs/generated.md',
+		'content'            => '# Generated',
+		'commit_message'     => 'docs: add generated file',
+		'branch'             => 'store/new-doc',
+		'allowed_file_paths' => array( 'README.md', 'docs/**' ),
 	) );
 	$assert( 'createOrUpdateFile missing branch returns success=true', is_array( $result ) && true === ( $result['success'] ?? false ) );
 	$assert( 'createOrUpdateFile checks target branch ref first', is_string( $GLOBALS['dmc_http_calls'][0]['url'] ?? null ) && str_ends_with( $GLOBALS['dmc_http_calls'][0]['url'], '/repos/owner/repo/git/ref/heads/store%2Fnew-doc' ) );


### PR DESCRIPTION
## Summary
- Add optional `allowed_file_paths` to `datamachine/create-or-update-github-file` and the matching AI tool schema.
- Normalize repository-relative write paths and reject traversal before any GitHub request is made.
- Reject writes outside the caller-provided allowlist so reusable repo agents can be constrained to paths like `README.md` and `docs/**`.

## Testing
- `php -l inc/Abilities/GitHubAbilities.php && php -l inc/Tools/GitHubTools.php && php -l tests/smoke-github-create-abilities.php && git diff --check`
- `php tests/smoke-github-create-abilities.php`
- `php tests/smoke-tool-schemas.php`

Note: `homeboy lint --path . --extension wordpress` still reports pre-existing full-repo PHPCS findings outside this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the GitHub write-scope guardrail implementation and smoke coverage; Chris remains responsible for review and merge.