### PR TITLE
feat: add add_label_to_issue and remove_label_from_issue tools

### DIFF
--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -1116,20 +1116,20 @@ class GitHubAbilities {
 						'type'       => 'object',
 						'required'   => array( 'repo' ),
 						'properties' => array(
-							'repo' => array(
+							'repo'           => array(
 								'type'        => 'string',
 								'description' => 'Repository in owner/repo format.',
 							),
-							'path' => array(
+							'path'           => array(
 								'type'        => 'string',
 								'description' => 'Single file path within the repository. Use paths for multiple files.',
 							),
-							'paths' => array(
+							'paths'          => array(
 								'type'        => 'array',
 								'items'       => array( 'type' => 'string' ),
 								'description' => 'One or more file paths within the repository.',
 							),
-							'ref'  => array(
+							'ref'            => array(
 								'type'        => 'string',
 								'description' => 'Branch, tag, or commit SHA. Defaults to the repository default branch.',
 							),
@@ -1516,8 +1516,8 @@ class GitHubAbilities {
 			return $response;
 		}
 
-		$pull = self::normalizePull( $response['data'] );
-		$labels = self::mergeProvenanceLabels( isset( $input['labels'] ) && is_array( $input['labels'] ) ? $input['labels'] : array() );
+		$pull     = self::normalizePull( $response['data'] );
+		$labels   = self::mergeProvenanceLabels( isset( $input['labels'] ) && is_array( $input['labels'] ) ? $input['labels'] : array() );
 		$labeling = null;
 
 		if ( ! empty( $labels ) && ! empty( $pull['number'] ) ) {
@@ -1783,7 +1783,7 @@ class GitHubAbilities {
 			return '';
 		}
 
-		$agent = $agents_repo->get_agent( (int) $agent_id );
+		$agent      = $agents_repo->get_agent( (int) $agent_id );
 		$agent_slug = is_array( $agent ) ? (string) ( $agent['agent_slug'] ?? '' ) : '';
 
 		return '' !== trim( $agent_slug ) ? sanitize_text_field( $agent_slug ) : '';
@@ -1916,6 +1916,66 @@ class GitHubAbilities {
 			'success'        => true,
 			'applied_labels' => $applied,
 			'message'        => sprintf( 'Applied %d label(s) to #%d in %s.', count( $applied ), $number, $repo ),
+		);
+	}
+
+	/**
+	 * Remove a single label from an issue or pull request.
+	 *
+	 * GitHub treats pull requests as issues for labeling purposes, so this
+	 * single endpoint covers both. Calls
+	 * `DELETE /repos/{owner}/{repo}/issues/{number}/labels/{name}`, which is
+	 * surgical (removes one label, leaves all others untouched). If GitHub
+	 * returns 404 because the label is already absent, the desired state is
+	 * already achieved and this returns success.
+	 *
+	 * @param array $input {
+	 *     Required: repo, issue_number (or pull_number), label.
+	 * }
+	 * @return array|\WP_Error { success: bool, removed_label: string } or error.
+	 */
+	public static function removeLabel( array $input ): array|\WP_Error {
+		$repo   = self::resolveRepo( sanitize_text_field( $input['repo'] ?? '' ) );
+		$number = (int) ( $input['issue_number'] ?? $input['pull_number'] ?? 0 );
+
+		if ( empty( $repo ) ) {
+			return new \WP_Error( 'missing_repo', 'Repository (owner/repo) is required or configure a default repo.', array( 'status' => 400 ) );
+		}
+		if ( $number <= 0 ) {
+			return new \WP_Error( 'missing_number', 'issue_number or pull_number is required.', array( 'status' => 400 ) );
+		}
+
+		$label = sanitize_text_field( (string) ( $input['label'] ?? '' ) );
+		if ( '' === $label ) {
+			return new \WP_Error( 'missing_label', 'A single label is required.', array( 'status' => 400 ) );
+		}
+
+		$pat = self::getPatForRepo( $repo );
+		if ( empty( $pat ) ) {
+			return self::patError();
+		}
+
+		$url      = sprintf( '%s/repos/%s/issues/%d/labels/%s', self::API_BASE, $repo, $number, rawurlencode( $label ) );
+		$response = self::apiRequest( 'DELETE', $url, null, $pat );
+
+		if ( is_wp_error( $response ) ) {
+			$error_data = $response->get_error_data();
+			$status     = is_array( $error_data ) ? (int) ( $error_data['status'] ?? 0 ) : 0;
+			if ( 'github_not_found' === $response->get_error_code() || 404 === $status ) {
+				return array(
+					'success'       => true,
+					'removed_label' => $label,
+					'message'       => sprintf( 'Label %s was already absent from #%d in %s.', $label, $number, $repo ),
+				);
+			}
+
+			return $response;
+		}
+
+		return array(
+			'success'       => true,
+			'removed_label' => $label,
+			'message'       => sprintf( 'Removed label %s from #%d in %s.', $label, $number, $repo ),
 		);
 	}
 
@@ -4048,7 +4108,10 @@ class GitHubAbilities {
 		return new \WP_Error(
 			'forbidden_file_path',
 			sprintf( 'File path %s is outside the allowed write scope.', $file_path ),
-			array( 'status' => 403, 'allowed_file_paths' => $patterns )
+			array(
+				'status'             => 403,
+				'allowed_file_paths' => $patterns,
+			)
 		);
 	}
 
@@ -4221,7 +4284,7 @@ class GitHubAbilities {
 			$file = self::getSingleFileContent( $repo, $path, $query_params, $pat );
 			if ( is_wp_error( $file ) ) {
 				$error_data = $file->get_error_data();
-				$errors[] = array(
+				$errors[]   = array(
 					'path'    => $path,
 					'code'    => $file->get_error_code(),
 					'message' => $file->get_error_message(),
@@ -4334,13 +4397,18 @@ class GitHubAbilities {
 		return self::parseResponse( $response );
 	}
 
-	public static function apiRequest( string $method, string $url, array $body, string $pat ): array|\WP_Error {
-		$response = wp_remote_request( $url, array(
+	public static function apiRequest( string $method, string $url, ?array $body, string $pat ): array|\WP_Error {
+		$args = array(
 			'method'  => $method,
 			'headers' => self::getHeaders( $pat ),
-			'body'    => wp_json_encode( $body ),
 			'timeout' => 30,
-		) );
+		);
+
+		if ( null !== $body ) {
+			$args['body'] = wp_json_encode( $body );
+		}
+
+		$response = wp_remote_request( $url, $args );
 
 		return self::parseResponse( $response );
 	}

--- a/inc/Tools/GitHubTools.php
+++ b/inc/Tools/GitHubTools.php
@@ -27,6 +27,8 @@ class GitHubTools extends BaseTool {
 		$this->registerTool( 'list_github_issues', array( $this, 'getListIssuesDefinition' ), $contexts, array( 'access_level' => 'editor' ) );
 		$this->registerTool( 'get_github_issue', array( $this, 'getGetIssueDefinition' ), $contexts, array( 'access_level' => 'editor' ) );
 		$this->registerTool( 'manage_github_issue', array( $this, 'getManageIssueDefinition' ), $contexts, array( 'access_level' => 'editor' ) );
+		$this->registerTool( 'add_label_to_issue', array( $this, 'getAddLabelToIssueDefinition' ), $contexts, array( 'access_level' => 'editor' ) );
+		$this->registerTool( 'remove_label_from_issue', array( $this, 'getRemoveLabelFromIssueDefinition' ), $contexts, array( 'access_level' => 'editor' ) );
 		$this->registerTool( 'comment_github_pull_request', array( $this, 'getCommentPullRequestDefinition' ), $contexts, array( 'access_level' => 'editor' ) );
 		$this->registerTool( 'upsert_github_pull_review_comment', array( $this, 'getUpsertPullReviewCommentDefinition' ), $contexts, array(
 			'access_level' => 'editor',
@@ -119,6 +121,8 @@ class GitHubTools extends BaseTool {
 			'list_github_issues',
 			'get_github_issue',
 			'manage_github_issue',
+			'add_label_to_issue',
+			'remove_label_from_issue',
 			'comment_github_pull_request',
 			'upsert_github_pull_review_comment',
 			'merge_github_pull_request',
@@ -322,7 +326,7 @@ class GitHubTools extends BaseTool {
 		return array(
 			'class'       => __CLASS__,
 			'method'      => 'handleManageIssue',
-			'description' => 'Update, close, or comment on a GitHub issue. Use action "update" to change title/body/labels, "close" to close the issue, or "comment" to add a comment.',
+			'description' => 'Update, close, or comment on a GitHub issue. Use action "update" to change title/body or replace the full labels set, "close" to close the issue, or "comment" to add a comment. For surgical label edits that preserve other labels, use add_label_to_issue or remove_label_from_issue instead - action=update replaces the full label set.',
 			'parameters'  => array(
 				'type'       => 'object',
 				'properties' => array(
@@ -349,10 +353,122 @@ class GitHubTools extends BaseTool {
 					'labels'       => array(
 						'type'        => 'array',
 						'items'       => array( 'type' => 'string' ),
-						'description' => 'Labels to set (update action). Replaces existing labels.',
+						'description' => 'Labels to set (update action). REPLACES the entire existing label set. For surgical add/remove that preserves other labels, use add_label_to_issue / remove_label_from_issue.',
 					),
 				),
 				'required'   => array( 'repo', 'issue_number', 'action' ),
+			),
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Surgical Issue Labels
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Handle add_label_to_issue tool call.
+	 *
+	 * @param array $parameters Tool parameters.
+	 * @param array $tool_def   Tool definition.
+	 * @return array
+	 */
+	public function handleAddLabelToIssue( array $parameters, array $tool_def = array() ): array {
+		$result = GitHubAbilities::addLabels( array(
+			'repo'         => $parameters['repo'] ?? '',
+			'issue_number' => $parameters['issue_number'] ?? 0,
+			'labels'       => array( $parameters['label'] ?? '' ),
+		) );
+
+		if ( is_wp_error( $result ) ) {
+			return $this->buildErrorResponse( $result->get_error_message(), 'add_label_to_issue' );
+		}
+
+		return array(
+			'success'   => true,
+			'data'      => $result,
+			'tool_name' => 'add_label_to_issue',
+		);
+	}
+
+	/**
+	 * Get tool definition for add_label_to_issue.
+	 *
+	 * @return array
+	 */
+	public function getAddLabelToIssueDefinition(): array {
+		return array(
+			'class'       => __CLASS__,
+			'method'      => 'handleAddLabelToIssue',
+			'description' => 'Add a single label to an existing GitHub issue or pull request without replacing the rest of the label set. Use for surgical lifecycle transitions where preserving existing labels matters.',
+			'parameters'  => array(
+				'type'       => 'object',
+				'properties' => array(
+					'repo'         => array(
+						'type'        => 'string',
+						'description' => 'Repository in owner/repo format.',
+					),
+					'issue_number' => array(
+						'type'        => 'integer',
+						'description' => 'Issue or pull request number.',
+					),
+					'label'        => array(
+						'type'        => 'string',
+						'description' => 'Single label name to add. Existing labels are unchanged.',
+					),
+				),
+				'required'   => array( 'repo', 'issue_number', 'label' ),
+			),
+		);
+	}
+
+	/**
+	 * Handle remove_label_from_issue tool call.
+	 *
+	 * @param array $parameters Tool parameters.
+	 * @param array $tool_def   Tool definition.
+	 * @return array
+	 */
+	public function handleRemoveLabelFromIssue( array $parameters, array $tool_def = array() ): array {
+		$result = GitHubAbilities::removeLabel( $parameters );
+
+		if ( is_wp_error( $result ) ) {
+			return $this->buildErrorResponse( $result->get_error_message(), 'remove_label_from_issue' );
+		}
+
+		return array(
+			'success'   => true,
+			'data'      => $result,
+			'tool_name' => 'remove_label_from_issue',
+		);
+	}
+
+	/**
+	 * Get tool definition for remove_label_from_issue.
+	 *
+	 * @return array
+	 */
+	public function getRemoveLabelFromIssueDefinition(): array {
+		return array(
+			'class'       => __CLASS__,
+			'method'      => 'handleRemoveLabelFromIssue',
+			'description' => 'Remove a single label from an existing GitHub issue or pull request without touching the rest of the label set. Use for surgical lifecycle transitions where preserving other labels matters. Returns success even if the label was already absent.',
+			'parameters'  => array(
+				'type'       => 'object',
+				'properties' => array(
+					'repo'         => array(
+						'type'        => 'string',
+						'description' => 'Repository in owner/repo format.',
+					),
+					'issue_number' => array(
+						'type'        => 'integer',
+						'description' => 'Issue or pull request number.',
+					),
+					'label'        => array(
+						'type'        => 'string',
+						'description' => 'Single label name to remove. Other labels are unchanged.',
+					),
+				),
+				'required'   => array( 'repo', 'issue_number', 'label' ),
 			),
 		);
 	}

--- a/tests/smoke-github-create-abilities.php
+++ b/tests/smoke-github-create-abilities.php
@@ -470,6 +470,50 @@ namespace {
 	$assert( 'createPullRequest keeps success=true when post-create labeling fails', is_array( $result ) && true === ( $result['success'] ?? false ) );
 	$assert( 'createPullRequest returns explicit label failure metadata', is_array( $result ) && false === ( $result['labeling']['success'] ?? null ) && 'github_api_error' === ( $result['labeling']['error_code'] ?? '' ) );
 
+	// ---- removeLabel: surgical removal path URL-encodes the label segment and sends no request body.
+	$reset_http();
+	$queue_response( 200, array( array( 'name' => 'kept' ) ) );
+	$result = GitHubAbilities::removeLabel( array(
+		'repo'         => 'owner/repo',
+		'issue_number' => 42,
+		'label'        => 'status:idea ready',
+	) );
+	$call = $GLOBALS['dmc_http_calls'][0] ?? array();
+	$assert( 'removeLabel success path returns success=true', is_array( $result ) && true === ( $result['success'] ?? false ) );
+	$assert( 'removeLabel reports removed label', is_array( $result ) && 'status:idea ready' === ( $result['removed_label'] ?? '' ) );
+	$assert( 'removeLabel uses DELETE method', 'DELETE' === ( $call['method'] ?? '' ) );
+	$assert( 'removeLabel URL-encodes label path segment', is_string( $call['url'] ?? null ) && str_ends_with( $call['url'], '/repos/owner/repo/issues/42/labels/status%3Aidea%20ready' ) );
+	$assert( 'removeLabel does not send request body', ! array_key_exists( 'body', $call['args'] ?? array() ) );
+
+	// ---- removeLabel: missing label on GitHub is idempotent success.
+	$reset_http();
+	$queue_response( 404, array( 'message' => 'Label does not exist' ) );
+	$result = GitHubAbilities::removeLabel( array(
+		'repo'         => 'owner/repo',
+		'issue_number' => 42,
+		'label'        => 'status:idea-ready',
+	) );
+	$assert( 'removeLabel treats missing label as success', is_array( $result ) && true === ( $result['success'] ?? false ) );
+	$assert( 'removeLabel missing-label success preserves label name', is_array( $result ) && 'status:idea-ready' === ( $result['removed_label'] ?? '' ) );
+
+	// ---- removeLabel: required-field validation.
+	$reset_http();
+	$result = GitHubAbilities::removeLabel( array( 'repo' => 'owner/repo' ) );
+	$assert( 'removeLabel rejects missing issue or pull number', $result instanceof WP_Error && 'missing_number' === $result->get_error_code() );
+
+	$result = GitHubAbilities::removeLabel( array( 'repo' => 'owner/repo', 'issue_number' => 42 ) );
+	$assert( 'removeLabel rejects missing label', $result instanceof WP_Error && 'missing_label' === $result->get_error_code() );
+
+	$reset_http();
+	$queue_response( 200, array() );
+	$result = GitHubAbilities::removeLabel( array(
+		'repo'        => 'owner/repo',
+		'pull_number' => 77,
+		'label'       => 'status:idea-ready',
+	) );
+	$call = $GLOBALS['dmc_http_calls'][0] ?? array();
+	$assert( 'removeLabel accepts pull_number alias', is_array( $result ) && true === ( $result['success'] ?? false ) && is_string( $call['url'] ?? null ) && str_contains( $call['url'], '/issues/77/labels/' ) );
+
 	// ---- createPullRequest: explicit draft and maintainer_can_modify=false
 	$reset_http();
 	$queue_response( 201, array(

--- a/tests/smoke-github-create-tools.php
+++ b/tests/smoke-github-create-tools.php
@@ -31,6 +31,9 @@ namespace DataMachine\Engine\AI\Tools {
 
 namespace DataMachineCode\Abilities {
 	class GitHubAbilities {
+		public static array $addLabelsCalls = array();
+		public static array $removeLabelCalls = array();
+
 		public static function getRegisteredRepos(): array {
 			return array(
 				array(
@@ -38,6 +41,34 @@ namespace DataMachineCode\Abilities {
 					'repo'  => 'data-machine-code',
 					'label' => 'Data Machine Code',
 				),
+			);
+		}
+
+		public static function addLabels( array $input ): array|\WP_Error {
+			self::$addLabelsCalls[] = $input;
+
+			$labels = $input['labels'] ?? array();
+			if ( ! is_array( $labels ) || '' === (string) ( $labels[0] ?? '' ) ) {
+				return new \WP_Error( 'missing_labels', 'At least one label is required.' );
+			}
+
+			return array(
+				'success'        => true,
+				'applied_labels' => $labels,
+			);
+		}
+
+		public static function removeLabel( array $input ): array|\WP_Error {
+			self::$removeLabelCalls[] = $input;
+
+			$label = (string) ( $input['label'] ?? '' );
+			if ( '' === $label ) {
+				return new \WP_Error( 'missing_label', 'A single label is required.' );
+			}
+
+			return array(
+				'success'       => true,
+				'removed_label' => $label,
 			);
 		}
 	}
@@ -92,8 +123,17 @@ namespace {
 		return null;
 	}
 
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			public function __construct( private string $code = '', private string $message = '', private mixed $data = null ) {}
+			public function get_error_message(): string { return $this->message; }
+			public function get_error_code(): string { return $this->code; }
+			public function get_error_data(): mixed { return $this->data; }
+		}
+	}
+
 	function is_wp_error( $thing ): bool {
-		return false;
+		return $thing instanceof WP_Error;
 	}
 
 	require __DIR__ . '/../inc/Tools/GitHubIssueTool.php';
@@ -146,16 +186,24 @@ namespace {
 	$assert( 'create_github_pull_request is available in pipeline', in_array( 'pipeline', $pr_tool->registered['create_github_pull_request']['contexts'] ?? array(), true ) );
 	$assert( 'create_github_pull_request links to create PR ability', 'datamachine/create-github-pull-request' === ( $pr_tool->registered['create_github_pull_request']['options']['ability'] ?? '' ) );
 
+	$assert( 'add_label_to_issue tool is registered', isset( $github_tools->registered['add_label_to_issue'] ) );
+	$assert( 'add_label_to_issue is available in chat', in_array( 'chat', $github_tools->registered['add_label_to_issue']['contexts'] ?? array(), true ) );
+	$assert( 'add_label_to_issue is available in pipeline', in_array( 'pipeline', $github_tools->registered['add_label_to_issue']['contexts'] ?? array(), true ) );
+	$assert( 'remove_label_from_issue tool is registered', isset( $github_tools->registered['remove_label_from_issue'] ) );
+	$assert( 'remove_label_from_issue is available in chat', in_array( 'chat', $github_tools->registered['remove_label_from_issue']['contexts'] ?? array(), true ) );
+	$assert( 'remove_label_from_issue is available in pipeline', in_array( 'pipeline', $github_tools->registered['remove_label_from_issue']['contexts'] ?? array(), true ) );
+
 	$issue_definition = $issue_tool->getToolDefinition();
-	$issue_params     = $issue_definition['parameters'] ?? array();
+	$issue_params     = $issue_definition['parameters']['properties'] ?? array();
 	$assert( 'create_github_issue exposes assignees from ability schema', array_key_exists( 'assignees', $issue_params ) );
 	$assert( 'create_github_issue exposes milestone from ability schema', array_key_exists( 'milestone', $issue_params ) );
 
 	$pr_definition = $pr_tool->getToolDefinition();
-	$pr_params     = $pr_definition['parameters'] ?? array();
-	$assert( 'create_github_pull_request requires repo', true === ( $pr_params['repo']['required'] ?? false ) );
-	$assert( 'create_github_pull_request requires title', true === ( $pr_params['title']['required'] ?? false ) );
-	$assert( 'create_github_pull_request requires head', true === ( $pr_params['head']['required'] ?? false ) );
+	$pr_params     = $pr_definition['parameters']['properties'] ?? array();
+	$pr_required   = $pr_definition['parameters']['required'] ?? array();
+	$assert( 'create_github_pull_request requires repo', in_array( 'repo', $pr_required, true ) );
+	$assert( 'create_github_pull_request requires title', in_array( 'title', $pr_required, true ) );
+	$assert( 'create_github_pull_request requires head', in_array( 'head', $pr_required, true ) );
 	foreach ( array( 'repo', 'title', 'head', 'base', 'body', 'draft', 'labels', 'maintainer_can_modify' ) as $param ) {
 		$assert( "create_github_pull_request exposes {$param}", array_key_exists( $param, $pr_params ) );
 	}
@@ -206,6 +254,44 @@ namespace {
 		array( 'daily_memory' => array( 'egress' => array( 'bundle-file', 'pr-body' ) ) ) === ( $pr_call['input']['run_artifact_egress_policy'] ?? null )
 	);
 	$assert( 'create_github_pull_request forwards bundle root', 'bundles/world-creator' === ( $pr_call['input']['bundle_root'] ?? null ) );
+
+	$add_label_definition    = $github_tools->getAddLabelToIssueDefinition();
+	$remove_label_definition = $github_tools->getRemoveLabelFromIssueDefinition();
+	$manage_issue_definition = $github_tools->getManageIssueDefinition();
+	$assert( 'add_label_to_issue requires repo issue_number label', array( 'repo', 'issue_number', 'label' ) === ( $add_label_definition['parameters']['required'] ?? array() ) );
+	$assert( 'remove_label_from_issue requires repo issue_number label', array( 'repo', 'issue_number', 'label' ) === ( $remove_label_definition['parameters']['required'] ?? array() ) );
+	$assert( 'manage_github_issue warns update labels replace full set', str_contains( $manage_issue_definition['parameters']['properties']['labels']['description'] ?? '', 'REPLACES the entire existing label set' ) );
+	$assert( 'manage_github_issue points to surgical label tools', str_contains( $manage_issue_definition['description'] ?? '', 'add_label_to_issue' ) && str_contains( $manage_issue_definition['description'] ?? '', 'remove_label_from_issue' ) );
+
+	$add_label_result = $github_tools->handleAddLabelToIssue( array(
+		'repo'         => 'Extra-Chill/data-machine-code',
+		'issue_number' => 328,
+		'label'        => 'status:idea-ready',
+	) );
+	$assert( 'add_label_to_issue returns standard success envelope', true === ( $add_label_result['success'] ?? false ) && 'add_label_to_issue' === ( $add_label_result['tool_name'] ?? '' ) );
+	$assert( 'add_label_to_issue dispatches to addLabels with single label array', array( 'status:idea-ready' ) === ( \DataMachineCode\Abilities\GitHubAbilities::$addLabelsCalls[0]['labels'] ?? null ) );
+	$assert( 'add_label_to_issue forwards issue_number', 328 === (int) ( \DataMachineCode\Abilities\GitHubAbilities::$addLabelsCalls[0]['issue_number'] ?? 0 ) );
+
+	$remove_label_result = $github_tools->handleRemoveLabelFromIssue( array(
+		'repo'         => 'Extra-Chill/data-machine-code',
+		'issue_number' => 328,
+		'label'        => 'status:idea-ready',
+	) );
+	$assert( 'remove_label_from_issue returns standard success envelope', true === ( $remove_label_result['success'] ?? false ) && 'remove_label_from_issue' === ( $remove_label_result['tool_name'] ?? '' ) );
+	$assert( 'remove_label_from_issue dispatches to removeLabel', 'status:idea-ready' === ( \DataMachineCode\Abilities\GitHubAbilities::$removeLabelCalls[0]['label'] ?? '' ) );
+	$assert( 'remove_label_from_issue forwards issue_number', 328 === (int) ( \DataMachineCode\Abilities\GitHubAbilities::$removeLabelCalls[0]['issue_number'] ?? 0 ) );
+
+	$missing_add_label_result = $github_tools->handleAddLabelToIssue( array(
+		'repo'         => 'Extra-Chill/data-machine-code',
+		'issue_number' => 328,
+	) );
+	$assert( 'add_label_to_issue validation errors use error envelope', false === ( $missing_add_label_result['success'] ?? true ) && 'add_label_to_issue' === ( $missing_add_label_result['tool_name'] ?? '' ) );
+
+	$missing_remove_label_result = $github_tools->handleRemoveLabelFromIssue( array(
+		'repo'         => 'Extra-Chill/data-machine-code',
+		'issue_number' => 328,
+	) );
+	$assert( 'remove_label_from_issue validation errors use error envelope', false === ( $missing_remove_label_result['success'] ?? true ) && 'remove_label_from_issue' === ( $missing_remove_label_result['tool_name'] ?? '' ) );
 
 	$tool_definitions = array(
 		'create_github_issue'        => $issue_definition,


### PR DESCRIPTION
## Summary
- Added a surgical `GitHubAbilities::removeLabel()` path using GitHub's single-label DELETE endpoint, including idempotent success when the label is already absent.
- Registered `add_label_to_issue` and `remove_label_from_issue` chat/pipeline tools for additive and single-label removal lifecycle transitions.
- Tightened `manage_github_issue` guidance to make its full-label-set replacement semantics explicit.
- Added smoke coverage for the new ability behavior, tool registration, schemas, validation envelopes, and dispatch.

Closes #328

## Why
The wc-site-generator design-agent lifecycle flow needs to swap labels without racing or clobbering unrelated labels that other agents or humans may have applied. `manage_github_issue action=update` keeps its existing replace-set semantics for title/body/state/full-label edits, while these new tools handle surgical label edits that preserve the rest of the label set.

## Out of scope
- No batch add/remove tools.
- No PR-specific label tools; PRs are already labeled through the publish handler from PR #270.
- No schema migration.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the new removeLabel ability, registered the two surgical label tools, tightened manage_github_issue description, added smoke coverage, and ran validation. Chris remains responsible for review and merge decisions.