### PR TITLE
Omit empty run artifact PR sections

### DIFF
--- a/inc/Support/RunArtifactPrSectionRenderer.php
+++ b/inc/Support/RunArtifactPrSectionRenderer.php
@@ -34,17 +34,18 @@ class RunArtifactPrSectionRenderer {
 		$journals   = self::collectJournalEntries( $sanitized );
 		$evidence   = self::collectCompletionEvidence( $sanitized );
 		$transcript = self::collectTranscriptSummaries( $sanitized );
+		if ( empty( $journals ) && empty( $evidence ) && empty( $transcript ) ) {
+			return '';
+		}
 
 		$lines = array(
 			self::START_MARKER,
 			'## Agent Run Artifacts',
-			'',
-			'### Agent Journal',
 		);
 
-		if ( empty( $journals ) ) {
-			$lines[] = '_No agent journal artifacts provided._';
-		} else {
+		if ( ! empty( $journals ) ) {
+			$lines[] = '';
+			$lines[] = '### Agent Journal';
 			foreach ( $journals as $index => $entry ) {
 				if ( $index > 0 ) {
 					$lines[] = '';
@@ -55,11 +56,9 @@ class RunArtifactPrSectionRenderer {
 			}
 		}
 
-		$lines[] = '';
-		$lines[] = '### Completion Evidence';
-		if ( empty( $evidence ) ) {
-			$lines[] = '_No completion evidence artifacts provided._';
-		} else {
+		if ( ! empty( $evidence ) ) {
+			$lines[] = '';
+			$lines[] = '### Completion Evidence';
 			foreach ( $evidence as $label => $status ) {
 				$lines[] = sprintf( '- `%s`: %s', self::markdownInlineCode( (string) $label ), self::plainText( (string) $status ) );
 			}
@@ -122,6 +121,10 @@ class RunArtifactPrSectionRenderer {
 	public static function replaceSection( string $body, array $artifacts ): string {
 		$section = self::render( $artifacts );
 		$pattern = '/' . preg_quote( self::START_MARKER, '/' ) . '.*?' . preg_quote( self::END_MARKER, '/' ) . '/s';
+		if ( '' === $section ) {
+			$body = preg_replace( $pattern, '', $body, 1 ) ?? $body;
+			return rtrim( $body );
+		}
 
 		if ( preg_match( $pattern, $body ) ) {
 			return preg_replace( $pattern, $section, $body, 1 ) ?? $body;

--- a/tests/smoke-run-artifact-pr-section-renderer.php
+++ b/tests/smoke-run-artifact-pr-section-renderer.php
@@ -109,6 +109,21 @@ $assert( 'body-section mode updates existing PR body', str_starts_with( $mode_bo
 $mode_comment = RunArtifactPrSectionRenderer::renderForMode( RunArtifactPrSectionRenderer::MODE_COMMENT, $artifacts, $body );
 $assert( 'comment mode returns only managed comment body', str_starts_with( $mode_comment, RunArtifactPrSectionRenderer::START_MARKER ) && ! str_starts_with( $mode_comment, $body ) );
 
+$empty_section = RunArtifactPrSectionRenderer::render( array() );
+$assert( 'empty artifacts render no managed section', '' === $empty_section );
+$assert( 'empty artifacts omit artifact heading', ! str_contains( $empty_section, '## Agent Run Artifacts' ) );
+$assert( 'empty artifacts omit journal placeholder', ! str_contains( $empty_section, '_No agent journal artifacts provided._' ) );
+$assert( 'empty artifacts omit completion placeholder', ! str_contains( $empty_section, '_No completion evidence artifacts provided._' ) );
+
+$removed_section = RunArtifactPrSectionRenderer::replaceSection( $updated, array() );
+$assert( 'empty replacement removes stale managed section', str_starts_with( $removed_section, $body ) && ! str_contains( $removed_section, RunArtifactPrSectionRenderer::START_MARKER ) );
+
+$empty_mode_body = RunArtifactPrSectionRenderer::renderForMode( RunArtifactPrSectionRenderer::MODE_BODY_SECTION, array(), $updated );
+$assert( 'body-section mode removes stale section for empty artifacts', str_starts_with( $empty_mode_body, $body ) && ! str_contains( $empty_mode_body, RunArtifactPrSectionRenderer::START_MARKER ) );
+
+$empty_mode_comment = RunArtifactPrSectionRenderer::renderForMode( RunArtifactPrSectionRenderer::MODE_COMMENT, array(), $body );
+$assert( 'comment mode renders nothing for empty artifacts', '' === $empty_mode_comment );
+
 if ( ! empty( $failures ) ) {
 	echo "\nFAIL: " . count( $failures ) . " assertion(s)\n";
 	foreach ( $failures as $failure ) {


### PR DESCRIPTION
## Summary
- Avoid rendering the managed Agent Run Artifacts section when there is no journal, completion evidence, or transcript content to show.
- Remove stale managed artifact sections when a later render has no displayable artifacts.
- Extend the renderer smoke test to cover empty artifacts, stale-section removal, and comment-mode no-op behavior.

## Testing
- `php -l inc/Support/RunArtifactPrSectionRenderer.php`
- `php tests/smoke-run-artifact-pr-section-renderer.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the renderer/test changes and ran focused validation; Chris remains responsible for review and merge.