### PR TITLE
Enrich GitHub context metadata

### DIFF
--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -1312,9 +1312,10 @@ class GitHubAbilities {
 		$normalized = array_map( array( self::class, 'normalizeIssue' ), $issues );
 
 		return array(
-			'success' => true,
-			'issues'  => $normalized,
-			'count'   => count( $normalized ),
+			'success'      => true,
+			'issues'       => $normalized,
+			'count'        => count( $normalized ),
+			'generated_at' => gmdate( 'c' ),
 		);
 	}
 
@@ -1338,9 +1339,24 @@ class GitHubAbilities {
 			return $response;
 		}
 
+		$issue = self::normalizeIssue( $response['data'] );
+		if ( $issue['comment_count'] > 0 ) {
+			$latest_comment = self::getLatestIssueComment( $repo, $issue_number, $issue['comment_count'], $pat );
+			if ( is_wp_error( $latest_comment ) ) {
+				return $latest_comment;
+			}
+
+			if ( ! empty( $latest_comment ) ) {
+				$issue['latest_comment']        = $latest_comment;
+				$issue['latest_comment_at']     = $latest_comment['created_at'];
+				$issue['latest_comment_author'] = $latest_comment['user'];
+			}
+		}
+
 		return array(
-			'success' => true,
-			'issue'   => self::normalizeIssue( $response['data'] ),
+			'success'      => true,
+			'issue'        => $issue,
+			'generated_at' => gmdate( 'c' ),
 		);
 	}
 
@@ -2426,9 +2442,10 @@ class GitHubAbilities {
 		$normalized = array_map( array( self::class, 'normalizePull' ), $response['data'] );
 
 		return array(
-			'success' => true,
-			'pulls'   => $normalized,
-			'count'   => count( $normalized ),
+			'success'      => true,
+			'pulls'        => $normalized,
+			'count'        => count( $normalized ),
+			'generated_at' => gmdate( 'c' ),
 		);
 	}
 
@@ -3426,9 +3443,36 @@ class GitHubAbilities {
 		}
 
 		return array(
-			'success' => true,
-			'pull'    => self::normalizePull( $response['data'] ),
+			'success'      => true,
+			'pull'         => self::normalizePull( $response['data'] ),
+			'generated_at' => gmdate( 'c' ),
 		);
+	}
+
+	/**
+	 * Fetch the newest issue comment using GitHub's ascending issue comment order.
+	 *
+	 * @return array|\WP_Error|null Normalized latest comment, null when none exists, or error.
+	 */
+	private static function getLatestIssueComment( string $repo, int $issue_number, int $comment_count, string $pat ): array|\WP_Error|null {
+		$page = max( 1, $comment_count );
+		$url  = sprintf( '%s/repos/%s/issues/%d/comments', self::API_BASE, $repo, $issue_number );
+
+		$response = self::apiGet( $url, array(
+			'per_page' => 1,
+			'page'     => $page,
+		), $pat );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$comments = is_array( $response['data'] ?? null ) ? $response['data'] : array();
+		if ( empty( $comments ) || ! is_array( $comments[0] ?? null ) ) {
+			return null;
+		}
+
+		return self::normalizeIssueComment( $comments[0] );
 	}
 
 	/**
@@ -4580,43 +4624,69 @@ class GitHubAbilities {
 	// -------------------------------------------------------------------------
 
 	public static function normalizeIssue( array $issue ): array {
+		$comment_count = (int) ( $issue['comments'] ?? 0 );
+
 		return array(
-			'number'     => $issue['number'] ?? 0,
-			'title'      => $issue['title'] ?? '',
-			'state'      => $issue['state'] ?? '',
-			'body'       => $issue['body'] ?? '',
-			'html_url'   => $issue['html_url'] ?? '',
-			'user'       => $issue['user']['login'] ?? '',
-			'labels'     => array_map( fn( $label ) => $label['name'] ?? '', $issue['labels'] ?? array() ),
-			'assignees'  => array_map( fn( $a ) => $a['login'] ?? '', $issue['assignees'] ?? array() ),
-			'comments'   => $issue['comments'] ?? 0,
-			'created_at' => $issue['created_at'] ?? '',
-			'updated_at' => $issue['updated_at'] ?? '',
-			'closed_at'  => $issue['closed_at'] ?? '',
+			'number'        => (int) ( $issue['number'] ?? 0 ),
+			'title'         => $issue['title'] ?? '',
+			'state'         => $issue['state'] ?? '',
+			'body'          => $issue['body'] ?? '',
+			'html_url'      => $issue['html_url'] ?? '',
+			'user'          => $issue['user']['login'] ?? '',
+			'labels'        => array_map( fn( $label ) => $label['name'] ?? '', $issue['labels'] ?? array() ),
+			'assignees'     => array_map( fn( $a ) => $a['login'] ?? '', $issue['assignees'] ?? array() ),
+			'comments'      => $comment_count,
+			'comment_count' => $comment_count,
+			'created_at'    => $issue['created_at'] ?? '',
+			'updated_at'    => $issue['updated_at'] ?? '',
+			'closed_at'     => $issue['closed_at'] ?? '',
+		);
+	}
+
+	public static function normalizeIssueComment( array $comment ): array {
+		return array(
+			'id'         => (int) ( $comment['id'] ?? 0 ),
+			'body'       => $comment['body'] ?? '',
+			'html_url'   => $comment['html_url'] ?? '',
+			'user'       => $comment['user']['login'] ?? '',
+			'created_at' => $comment['created_at'] ?? '',
+			'updated_at' => $comment['updated_at'] ?? '',
 		);
 	}
 
 	public static function normalizePull( array $pr ): array {
+		$comment_count        = (int) ( $pr['comments'] ?? 0 );
+		$review_comment_count = (int) ( $pr['review_comments'] ?? 0 );
+
 		return array(
-			'number'     => $pr['number'] ?? 0,
-			'title'      => $pr['title'] ?? '',
-			'state'      => $pr['state'] ?? '',
-			'body'       => $pr['body'] ?? '',
-			'html_url'   => $pr['html_url'] ?? '',
-			'user'       => $pr['user']['login'] ?? '',
-			'head'       => $pr['head']['ref'] ?? '',
-			'head_ref'   => $pr['head']['ref'] ?? '',
-			'head_sha'   => $pr['head']['sha'] ?? '',
-			'base'       => $pr['base']['ref'] ?? '',
-			'base_ref'   => $pr['base']['ref'] ?? '',
-			'base_sha'   => $pr['base']['sha'] ?? '',
-			'draft'      => $pr['draft'] ?? false,
-			'merged'     => ! empty( $pr['merged_at'] ),
-			'labels'     => array_map( fn( $label ) => $label['name'] ?? '', $pr['labels'] ?? array() ),
-			'created_at' => $pr['created_at'] ?? '',
-			'updated_at' => $pr['updated_at'] ?? '',
-			'closed_at'  => $pr['closed_at'] ?? '',
-			'merged_at'  => $pr['merged_at'] ?? '',
+			'number'               => (int) ( $pr['number'] ?? 0 ),
+			'title'                => $pr['title'] ?? '',
+			'state'                => $pr['state'] ?? '',
+			'body'                 => $pr['body'] ?? '',
+			'html_url'             => $pr['html_url'] ?? '',
+			'user'                 => $pr['user']['login'] ?? '',
+			'head'                 => $pr['head']['ref'] ?? '',
+			'head_ref'             => $pr['head']['ref'] ?? '',
+			'head_sha'             => $pr['head']['sha'] ?? '',
+			'base'                 => $pr['base']['ref'] ?? '',
+			'base_ref'             => $pr['base']['ref'] ?? '',
+			'base_sha'             => $pr['base']['sha'] ?? '',
+			'draft'                => $pr['draft'] ?? false,
+			'merged'               => ! empty( $pr['merged_at'] ),
+			'labels'               => array_map( fn( $label ) => $label['name'] ?? '', $pr['labels'] ?? array() ),
+			'comments'             => $comment_count,
+			'comment_count'        => $comment_count,
+			'issue_comment_count'  => $comment_count,
+			'review_comments'      => $review_comment_count,
+			'review_comment_count' => $review_comment_count,
+			'commits'              => (int) ( $pr['commits'] ?? 0 ),
+			'additions'            => (int) ( $pr['additions'] ?? 0 ),
+			'deletions'            => (int) ( $pr['deletions'] ?? 0 ),
+			'changed_files'        => (int) ( $pr['changed_files'] ?? 0 ),
+			'created_at'           => $pr['created_at'] ?? '',
+			'updated_at'           => $pr['updated_at'] ?? '',
+			'closed_at'            => $pr['closed_at'] ?? '',
+			'merged_at'            => $pr['merged_at'] ?? '',
 		);
 	}
 

--- a/inc/Tools/GitHubTools.php
+++ b/inc/Tools/GitHubTools.php
@@ -202,7 +202,7 @@ class GitHubTools extends BaseTool {
 		return array(
 			'class'       => __CLASS__,
 			'method'      => 'handleListIssues',
-			'description' => 'List issues from a GitHub repository. Returns issue numbers, titles, states, labels, and assignees. Use to review open issues, track progress, or find specific issues by label.',
+			'description' => 'List issues from a GitHub repository. Returns issue numbers, titles, states, labels, assignees, comment counts, timestamps, and a generated_at timestamp. Use to review open issues, track progress, or find specific issues by label.',
 			'parameters'  => array(
 				'type'       => 'object',
 				'properties' => array(
@@ -262,7 +262,7 @@ class GitHubTools extends BaseTool {
 		return array(
 			'class'       => __CLASS__,
 			'method'      => 'handleGetIssue',
-			'description' => 'Get a single GitHub issue with full details including body, labels, assignees, and comment count.',
+			'description' => 'Get a single GitHub issue with full details including body, labels, assignees, comment count, timestamps, generated_at, and latest comment metadata when comments exist.',
 			'parameters'  => array(
 				'type'       => 'object',
 				'properties' => array(
@@ -669,7 +669,7 @@ class GitHubTools extends BaseTool {
 		return array(
 			'class'       => __CLASS__,
 			'method'      => 'handleListPulls',
-			'description' => 'List pull requests from a GitHub repository. Returns PR numbers, titles, states, branches, and merge status.',
+			'description' => 'List pull requests from a GitHub repository. Returns PR numbers, titles, states, branches, merge status, comment counts, change counts, timestamps, and generated_at.',
 			'parameters'  => array(
 				'type'       => 'object',
 				'properties' => array(
@@ -740,7 +740,7 @@ class GitHubTools extends BaseTool {
 		return array(
 			'class'       => __CLASS__,
 			'method'      => 'handleGetPull',
-			'description' => 'Get one GitHub pull request with normalized title, body, branch, SHA, labels, and merge metadata.',
+			'description' => 'Get one GitHub pull request with normalized title, body, branch, SHA, labels, merge metadata, comment counts, change counts, timestamps, and generated_at.',
 			'parameters'  => array(
 				'type'       => 'object',
 				'properties' => array(

--- a/tests/smoke-github-create-abilities.php
+++ b/tests/smoke-github-create-abilities.php
@@ -645,6 +645,59 @@ namespace {
 	$assert( 'createOrUpdateFile existing branch only checks ref, contents, and PUTs', 3 === count( $GLOBALS['dmc_http_calls'] ) );
 	$assert( 'createOrUpdateFile existing branch does not create git ref', ! str_ends_with( (string) ( $GLOBALS['dmc_http_calls'][1]['url'] ?? '' ), '/git/refs' ) && ! str_ends_with( (string) ( $GLOBALS['dmc_http_calls'][2]['url'] ?? '' ), '/git/refs' ) );
 
+	// ---- getIssue: metadata includes comment counts and the latest issue comment.
+	$reset_http();
+	$queue_response( 200, array(
+		'number'     => 123,
+		'title'      => 'Fresh context',
+		'body'       => 'Issue body',
+		'user'       => array( 'login' => 'reporter' ),
+		'labels'     => array( array( 'name' => 'context' ) ),
+		'assignees'  => array(),
+		'comments'   => 2,
+		'created_at' => '2026-05-10T00:00:00Z',
+		'updated_at' => '2026-05-10T02:00:00Z',
+	) );
+	$queue_response( 200, array(
+		array(
+			'id'         => 987,
+			'body'       => 'Latest external input',
+			'html_url'   => 'https://github.com/owner/repo/issues/123#issuecomment-987',
+			'user'       => array( 'login' => 'reviewer' ),
+			'created_at' => '2026-05-10T01:00:00Z',
+			'updated_at' => '2026-05-10T01:05:00Z',
+		),
+	) );
+	$result = GitHubAbilities::getIssue( array( 'repo' => 'owner/repo', 'issue_number' => 123 ) );
+	$issue  = is_array( $result ) ? ( $result['issue'] ?? array() ) : array();
+	$assert( 'getIssue returns generated_at', is_array( $result ) && ! empty( $result['generated_at'] ) );
+	$assert( 'getIssue preserves comments count', 2 === ( $issue['comments'] ?? null ) && 2 === ( $issue['comment_count'] ?? null ) );
+	$assert( 'getIssue fetches latest issue comment page', is_string( $GLOBALS['dmc_http_calls'][1]['url'] ?? null ) && str_contains( $GLOBALS['dmc_http_calls'][1]['url'], '/repos/owner/repo/issues/123/comments' ) && str_contains( $GLOBALS['dmc_http_calls'][1]['url'], 'per_page=1' ) && str_contains( $GLOBALS['dmc_http_calls'][1]['url'], 'page=2' ) );
+	$assert( 'getIssue includes latest comment metadata', 'reviewer' === ( $issue['latest_comment_author'] ?? '' ) && 'Latest external input' === ( $issue['latest_comment']['body'] ?? '' ) );
+
+	// ---- getPull: metadata includes PR comments, review comments, and change counts.
+	$reset_http();
+	$queue_response( 200, array(
+		'number'          => 55,
+		'title'           => 'Review context',
+		'body'            => 'PR body',
+		'user'            => array( 'login' => 'author' ),
+		'head'            => array( 'ref' => 'feature/context', 'sha' => 'head-sha' ),
+		'base'            => array( 'ref' => 'main', 'sha' => 'base-sha' ),
+		'comments'        => 3,
+		'review_comments' => 4,
+		'commits'         => 5,
+		'additions'       => 6,
+		'deletions'       => 7,
+		'changed_files'   => 8,
+	) );
+	$result = GitHubAbilities::getPull( array( 'repo' => 'owner/repo', 'pull_number' => 55 ) );
+	$pull   = is_array( $result ) ? ( $result['pull'] ?? array() ) : array();
+	$assert( 'getPull returns generated_at', is_array( $result ) && ! empty( $result['generated_at'] ) );
+	$assert( 'getPull includes issue comment counts', 3 === ( $pull['comments'] ?? null ) && 3 === ( $pull['comment_count'] ?? null ) && 3 === ( $pull['issue_comment_count'] ?? null ) );
+	$assert( 'getPull includes review comment counts', 4 === ( $pull['review_comments'] ?? null ) && 4 === ( $pull['review_comment_count'] ?? null ) );
+	$assert( 'getPull includes change counts', 5 === ( $pull['commits'] ?? null ) && 6 === ( $pull['additions'] ?? null ) && 7 === ( $pull['deletions'] ?? null ) && 8 === ( $pull['changed_files'] ?? null ) );
+
 	if ( ! empty( $failures ) ) {
 		echo "\nFAIL: " . count( $failures ) . " assertion(s)\n";
 		foreach ( $failures as $failure ) {


### PR DESCRIPTION
## Summary
- Add generated timestamps to GitHub issue and pull list/get ability responses so agents know when context was fetched.
- Add clearer issue/PR comment-count aliases plus PR review/change counts for better review freshness checks.
- Include latest issue comment metadata on `get_github_issue` when comments exist.

## Testing
- `php -l inc/Abilities/GitHubAbilities.php`
- `php -l inc/Tools/GitHubTools.php`
- `php -l tests/smoke-github-create-abilities.php`
- `php tests/smoke-github-create-abilities.php`
- `php tests/smoke-github-readonly-tools.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the metadata enrichment patch, smoke coverage, and validation commands for Chris to review.