### PR TITLE
Clarify worktree cleanup reporting

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -2848,6 +2848,18 @@ class WorkspaceCommand extends BaseCommand {
 				'count'  => (int) $count,
 			);
 		}
+		foreach ( (array) ( $summary['stale_reasons'] ?? array() ) as $reason => $count ) {
+			$summary_rows[] = array(
+				'metric' => 'stale:' . $reason,
+				'count'  => (int) $count,
+			);
+		}
+		foreach ( (array) ( $summary['liveness'] ?? array() ) as $state => $count ) {
+			$summary_rows[] = array(
+				'metric' => 'liveness:' . $state,
+				'count'  => (int) $count,
+			);
+		}
 		if ( isset( $summary['age_filter'] ) && is_array( $summary['age_filter'] ) ) {
 			$summary_rows[] = array(
 				'metric' => 'age_filter:excluded',

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -6736,6 +6736,8 @@ class Workspace {
 	private function build_worktree_cleanup_summary( array $candidates, array $removed, array $skipped, ?array $age_filter = null ): array {
 		$skipped_by_reason    = array();
 		$candidates_by_signal = array();
+		$stale_reasons        = array();
+		$liveness             = array();
 		$size_by_repo         = array();
 		$artifact_by_repo     = array();
 		$total_size_bytes     = 0;
@@ -6756,6 +6758,14 @@ class Workspace {
 			$repo           = (string) ( $row['repo'] ?? 'unknown' );
 			$size_bytes     = isset( $row['size_bytes'] ) ? (int) $row['size_bytes'] : 0;
 			$artifact_bytes = isset( $row['artifact_size_bytes'] ) ? (int) $row['artifact_size_bytes'] : 0;
+			$stale_reason   = (string) ( $row['stale_reason'] ?? '' );
+			$liveness_state = (string) ( $row['liveness'] ?? '' );
+			if ( '' !== $stale_reason ) {
+				$stale_reasons[ $stale_reason ] = ( $stale_reasons[ $stale_reason ] ?? 0 ) + 1;
+			}
+			if ( '' !== $liveness_state ) {
+				$liveness[ $liveness_state ] = ( $liveness[ $liveness_state ] ?? 0 ) + 1;
+			}
 			if ( $size_bytes > 0 ) {
 				$size_by_repo[ $repo ] = ( $size_by_repo[ $repo ] ?? 0 ) + $size_bytes;
 				$total_size_bytes     += $size_bytes;
@@ -6768,6 +6778,8 @@ class Workspace {
 
 		ksort( $skipped_by_reason );
 		ksort( $candidates_by_signal );
+		ksort( $stale_reasons );
+		ksort( $liveness );
 		arsort( $size_by_repo );
 		arsort( $artifact_by_repo );
 
@@ -6777,8 +6789,10 @@ class Workspace {
 			'skipped'               => count( $skipped ),
 			'skipped_by_reason'     => $skipped_by_reason,
 			'skipped_next_commands' => $this->worktree_cleanup_skipped_next_commands( $skipped_by_reason ),
-			'cleanup_buckets'       => $this->worktree_cleanup_buckets( $candidates_by_signal, $skipped_by_reason ),
+			'cleanup_buckets'       => $this->worktree_cleanup_buckets( count( $candidates ), $candidates_by_signal, $skipped_by_reason ),
 			'candidates_by_signal'  => $candidates_by_signal,
+			'stale_reasons'         => $stale_reasons,
+			'liveness'              => $liveness,
 			'total_size_bytes'      => $total_size_bytes,
 			'artifact_size_bytes'   => $total_artifact_bytes,
 			'size_by_repo'          => $size_by_repo,
@@ -6798,16 +6812,40 @@ class Workspace {
 	/**
 	 * Build stable high-level cleanup buckets for plan/report consumers.
 	 *
+	 * @param int               $candidate_count      Candidate row count.
 	 * @param array<string,int> $candidates_by_signal Candidate signal counts.
 	 * @param array<string,int> $skipped_by_reason    Skipped reason counts.
 	 * @return array<string,int>
 	 */
-	private function worktree_cleanup_buckets( array $candidates_by_signal, array $skipped_by_reason ): array {
+	private function worktree_cleanup_buckets( int $candidate_count, array $candidates_by_signal, array $skipped_by_reason ): array {
+		$needs_reconciliation = (int) ( $skipped_by_reason['needs_metadata_reconcile'] ?? 0 )
+			+ (int) ( $skipped_by_reason['requires_full_scan'] ?? 0 )
+			+ (int) ( $skipped_by_reason['missing_metadata'] ?? 0 )
+			+ (int) ( $skipped_by_reason['lifecycle_reconciliation_candidate'] ?? 0 );
+		$needs_full_review = (int) ( $skipped_by_reason['active_no_signal'] ?? 0 )
+			+ (int) ( $skipped_by_reason['no_inventory_cleanup_signal'] ?? 0 )
+			+ (int) ( $skipped_by_reason['no_merge_signal'] ?? 0 )
+			+ (int) ( $skipped_by_reason['github_unknown'] ?? 0 )
+			+ (int) ( $skipped_by_reason['external_worktree'] ?? 0 )
+			+ (int) ( $skipped_by_reason['protected_branch'] ?? 0 )
+			+ (int) ( $skipped_by_reason['probe_timeout'] ?? 0 )
+			+ (int) ( $skipped_by_reason['unknown_age'] ?? 0 );
+		$blocked_by_dirty_or_unpushed = (int) ( $skipped_by_reason['dirty_worktree'] ?? 0 )
+			+ (int) ( $skipped_by_reason['merged_pr_with_only_obsolete_dirty_changes'] ?? 0 )
+			+ (int) ( $skipped_by_reason['unpushed_commits'] ?? 0 );
+
 		$buckets = array(
+			'blocked_by_dirty_or_unpushed'       => $blocked_by_dirty_or_unpushed,
+			'needs_full_review'                  => $needs_full_review,
+			'needs_reconciliation'               => $needs_reconciliation,
+			'safe_to_remove_now'                 => $candidate_count,
+
+			// Legacy aliases retained for existing automation while callers migrate
+			// to the explicit safety buckets above.
 			'explicit_cleanup_candidates'         => (int) ( $candidates_by_signal['cleanup_eligible'] ?? 0 ),
 			'lifecycle_reconciliation_candidates' => (int) ( $skipped_by_reason['lifecycle_reconciliation_candidate'] ?? 0 ),
 			'metadata_reconciliation_candidates'  => (int) ( $skipped_by_reason['needs_metadata_reconcile'] ?? 0 ) + (int) ( $skipped_by_reason['requires_full_scan'] ?? 0 ) + (int) ( $skipped_by_reason['missing_metadata'] ?? 0 ),
-			'dirty_unpushed'                      => (int) ( $skipped_by_reason['dirty_worktree'] ?? 0 ) + (int) ( $skipped_by_reason['unpushed_commits'] ?? 0 ),
+			'dirty_unpushed'                      => $blocked_by_dirty_or_unpushed,
 			'active_no_signal'                    => (int) ( $skipped_by_reason['active_no_signal'] ?? 0 ) + (int) ( $skipped_by_reason['no_inventory_cleanup_signal'] ?? 0 ),
 		);
 

--- a/tests/smoke-workspace-hygiene-report.php
+++ b/tests/smoke-workspace-hygiene-report.php
@@ -175,6 +175,9 @@ namespace {
 		datamachine_code_hygiene_report_assert( 1 === (int) ( $with_cleanup['cleanup']['summary']['would_remove'] ?? 0 ), 'inventory cleanup counts explicit cleanup signal' );
 		datamachine_code_hygiene_report_assert( 1 === (int) ( $with_cleanup['cleanup']['summary']['skipped_by_reason']['lifecycle_reconciliation_candidate'] ?? 0 ), 'inventory cleanup surfaces stale PR-backed metadata as lifecycle reconciliation candidate' );
 		datamachine_code_hygiene_report_assert( 1 === (int) ( $with_cleanup['cleanup']['summary']['skipped_by_reason']['needs_metadata_reconcile'] ?? 0 ), 'inventory cleanup skips missing metadata with metadata reconciliation reason' );
+		datamachine_code_hygiene_report_assert( 1 === (int) ( $with_cleanup['cleanup']['summary']['cleanup_buckets']['safe_to_remove_now'] ?? 0 ), 'inventory cleanup buckets count safe-to-remove candidates' );
+		datamachine_code_hygiene_report_assert( 2 === (int) ( $with_cleanup['cleanup']['summary']['cleanup_buckets']['needs_reconciliation'] ?? 0 ), 'inventory cleanup buckets count reconciliation candidates' );
+		datamachine_code_hygiene_report_assert( 0 === (int) ( $with_cleanup['cleanup']['summary']['cleanup_buckets']['needs_full_review'] ?? -1 ), 'inventory cleanup buckets count full-review rows' );
 		datamachine_code_hygiene_report_assert( 1 === (int) ( $with_cleanup['cleanup']['summary']['cleanup_buckets']['metadata_reconciliation_candidates'] ?? 0 ), 'inventory cleanup buckets count metadata reconciliation candidates' );
 
 		echo "\n[2] Full report remains explicitly available\n";

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -164,11 +164,21 @@ namespace {
 					'repaired_metadata'                    => 1,
 				),
 				'cleanup_buckets'       => array(
+					'blocked_by_dirty_or_unpushed'       => 1,
+					'needs_full_review'                  => 11,
+					'needs_reconciliation'               => 3,
+					'safe_to_remove_now'                 => 1,
 					'active_no_signal'                    => 1,
 					'dirty_unpushed'                      => 1,
 					'explicit_cleanup_candidates'         => 0,
 					'lifecycle_reconciliation_candidates' => 1,
 					'metadata_reconciliation_candidates'  => 2,
+				),
+				'stale_reasons'        => array(
+					'dirty' => 1,
+				),
+				'liveness'             => array(
+					'stale' => 1,
 				),
 				'skipped_next_commands' => array(
 					array(
@@ -707,8 +717,14 @@ namespace {
 	datamachine_code_cleanup_assert( 'needs_metadata_reconcile' === ( $decoded['skipped'][11]['reason_code'] ?? '' ), 'JSON missing metadata row uses metadata reconciliation reason' );
 	datamachine_code_cleanup_assert( str_contains( $decoded['skipped'][11]['hint'] ?? '', 'reconcile-metadata --dry-run' ), 'JSON metadata reconciliation row includes remediation hint' );
 	datamachine_code_cleanup_assert( 10 === (int) ( $decoded['summary']['skipped_by_reason']['no_merge_signal'] ?? 0 ), 'JSON summary includes reason counts' );
+	datamachine_code_cleanup_assert( 1 === (int) ( $decoded['summary']['cleanup_buckets']['safe_to_remove_now'] ?? 0 ), 'JSON summary includes safe-to-remove bucket count' );
+	datamachine_code_cleanup_assert( 3 === (int) ( $decoded['summary']['cleanup_buckets']['needs_reconciliation'] ?? 0 ), 'JSON summary includes combined reconciliation bucket count' );
+	datamachine_code_cleanup_assert( 11 === (int) ( $decoded['summary']['cleanup_buckets']['needs_full_review'] ?? 0 ), 'JSON summary includes full-review bucket count' );
+	datamachine_code_cleanup_assert( 1 === (int) ( $decoded['summary']['cleanup_buckets']['blocked_by_dirty_or_unpushed'] ?? 0 ), 'JSON summary includes dirty/unpushed blocker bucket count' );
 	datamachine_code_cleanup_assert( 1 === (int) ( $decoded['summary']['cleanup_buckets']['lifecycle_reconciliation_candidates'] ?? 0 ), 'JSON summary includes lifecycle reconciliation bucket count' );
 	datamachine_code_cleanup_assert( 2 === (int) ( $decoded['summary']['cleanup_buckets']['metadata_reconciliation_candidates'] ?? 0 ), 'JSON summary includes metadata reconciliation bucket count' );
+	datamachine_code_cleanup_assert( 1 === (int) ( $decoded['summary']['stale_reasons']['dirty'] ?? 0 ), 'JSON summary includes stale reason metadata counts' );
+	datamachine_code_cleanup_assert( 1 === (int) ( $decoded['summary']['liveness']['stale'] ?? 0 ), 'JSON summary includes liveness metadata counts' );
 	datamachine_code_cleanup_assert( 4 === count( $decoded['summary']['skipped_next_commands'] ?? array() ), 'JSON summary includes actionable skipped next commands' );
 	datamachine_code_cleanup_assert( str_contains( $decoded['summary']['skipped_next_commands'][0]['command'] ?? '', 'worktree cleanup --dry-run --format=json' ), 'JSON lifecycle command runs DMC-owned cleanup signal detection' );
 	datamachine_code_cleanup_assert( str_contains( $decoded['summary']['skipped_next_commands'][1]['command'] ?? '', 'reconcile-metadata --dry-run --format=json' ), 'JSON metadata command is metadata reconciliation' );
@@ -780,7 +796,7 @@ namespace {
 	$command->worktree( array( 'cleanup' ), array( 'dry-run' => true, 'skip-github' => true, 'older-than' => '7d' ) );
 	datamachine_code_cleanup_assert( '7d' === ( $ability->last_input['older_than'] ?? null ), 'older-than forwards to cleanup ability as older_than' );
 	datamachine_code_cleanup_assert( is_callable( $ability->last_input['progress_callback'] ?? null ), 'human cleanup passes progress callback to ability' );
-	datamachine_code_cleanup_assert( in_array( 'table:18:metric,count', WP_CLI::$logs, true ), 'age filter, cleanup buckets, and disk summary rows are rendered' );
+	datamachine_code_cleanup_assert( in_array( 'table:24:metric,count', WP_CLI::$logs, true ), 'age filter, cleanup buckets, stale/liveness, and disk summary rows are rendered' );
 
 	WP_CLI::$logs      = array();
 	WP_CLI::$successes = array();

--- a/tests/smoke-worktree-cleanup.php
+++ b/tests/smoke-worktree-cleanup.php
@@ -409,6 +409,10 @@ namespace {
 	$inventory_missing = array_values( array_filter( $inventory_plan['skipped'] ?? array(), fn( $s ) => ( $s['handle'] ?? '' ) === 'demo@inventory-missing-metadata' ) )[0] ?? array();
 	$assert( 'needs_metadata_reconcile', $inventory_missing['reason_code'] ?? '', 'inventory-only missing metadata requires metadata reconciliation' );
 	$inventory_buckets = (array) ( $inventory_plan['summary']['cleanup_buckets'] ?? array() );
+	$assert( 2, (int) ( $inventory_buckets['safe_to_remove_now'] ?? 0 ), 'inventory cleanup bucket counts safe-to-remove candidates' );
+	$assert( 5, (int) ( $inventory_buckets['needs_reconciliation'] ?? 0 ), 'inventory cleanup bucket counts reconciliation candidates separately' );
+	$assert( 4, (int) ( $inventory_buckets['needs_full_review'] ?? 0 ), 'inventory cleanup bucket counts full-review rows separately' );
+	$assert( 0, (int) ( $inventory_buckets['blocked_by_dirty_or_unpushed'] ?? -1 ), 'inventory cleanup bucket keeps dirty/unpushed blockers separate' );
 	$assert( 2, (int) ( $inventory_buckets['explicit_cleanup_candidates'] ?? 0 ), 'inventory cleanup bucket counts explicit cleanup candidates' );
 	$assert( 1, (int) ( $inventory_buckets['lifecycle_reconciliation_candidates'] ?? 0 ), 'inventory cleanup bucket counts lifecycle reconciliation candidates' );
 	$assert( 4, (int) ( $inventory_buckets['metadata_reconciliation_candidates'] ?? 0 ), 'inventory cleanup bucket counts metadata reconciliation candidates' );


### PR DESCRIPTION
## Summary
- Adds cleanup summary buckets for `safe_to_remove_now`, `needs_reconciliation`, `needs_full_review`, and `blocked_by_dirty_or_unpushed`.
- Surfaces stale reason and liveness counts in cleanup/hygiene reporting without changing cleanup safety decisions.
- Keeps legacy cleanup bucket aliases for compatibility.

Closes #335.

## Testing
- `php tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-worktree-cleanup.php`
- `php tests/smoke-workspace-hygiene-report.php`
- `php tests/smoke-worktree-metadata-reconcile.php`
- `php tests/smoke-worktree-list-scaling.php`
- `php -l inc/Workspace/Workspace.php`
- `php -l inc/Cli/Commands/WorkspaceCommand.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and implemented cleanup reporting changes and smoke coverage; Chris retains review and merge responsibility.