### PR TITLE
Schedule metadata reconciliation page jobs

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -1539,7 +1539,7 @@ class WorkspaceAbilities {
 				'datamachine/workspace-worktree-reconcile-metadata',
 				array(
 					'label'               => 'Reconcile Worktree Metadata',
-					'description'         => 'Build or apply a reviewed, non-destructive lifecycle metadata plan for unmanaged workspace worktrees. Never removes worktrees and never infers cleanup eligibility.',
+					'description'         => 'Build, apply, or schedule bounded apply jobs for lifecycle metadata reconciliation. Never removes worktrees; apply paths revalidate identity and cleanup-eligibility safety gates before writing.',
 					'category'            => 'datamachine-code-workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
@@ -1551,6 +1551,22 @@ class WorkspaceAbilities {
 							'apply_plan' => array(
 								'type'        => 'object',
 								'description' => 'Decoded dry-run plan to apply after exact handle/path/repo/branch revalidation.',
+							),
+							'apply'      => array(
+								'type'        => 'boolean',
+								'description' => 'If true, run DMC-owned direct apply without a manual plan.',
+							),
+							'via_jobs'   => array(
+								'type'        => 'boolean',
+								'description' => 'With apply=true, schedule bounded metadata reconciliation page jobs instead of applying synchronously.',
+							),
+							'limit'      => array(
+								'type'        => 'integer',
+								'description' => 'Page size for bounded dry-run, direct apply, or job-backed apply.',
+							),
+							'offset'     => array(
+								'type'        => 'integer',
+								'description' => 'Pagination offset for bounded dry-run or direct apply. Job-backed apply schedules from offset 0 across all pages.',
 							),
 						),
 					),
@@ -2517,8 +2533,9 @@ class WorkspaceAbilities {
 	public static function worktreeReconcileMetadata( array $input ): array|\WP_Error {
 		$workspace = new Workspace();
 		$opts      = array(
-			'dry_run' => ! empty( $input['dry_run'] ),
-			'apply'   => ! empty( $input['apply'] ),
+			'dry_run'  => ! empty( $input['dry_run'] ),
+			'apply'    => ! empty( $input['apply'] ),
+			'via_jobs' => ! empty( $input['via_jobs'] ),
 		);
 		if ( isset( $input['apply_plan'] ) && is_array( $input['apply_plan'] ) ) {
 			$opts['apply_plan'] = $input['apply_plan'];
@@ -2528,6 +2545,9 @@ class WorkspaceAbilities {
 		}
 		if ( array_key_exists( 'offset', $input ) ) {
 			$opts['offset'] = (int) $input['offset'];
+		}
+		if ( isset( $input['source'] ) && '' !== trim( (string) $input['source'] ) ) {
+			$opts['source'] = trim( (string) $input['source'] );
 		}
 
 		return $workspace->worktree_reconcile_metadata( $opts );

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -2289,6 +2289,8 @@ class WorkspaceCommand extends BaseCommand {
 			case 'reconcile-metadata':
 				$input['dry_run'] = ! empty( $assoc_args['dry-run'] );
 				$input['apply']   = ! empty( $assoc_args['apply'] );
+				$input['via_jobs'] = ! empty( $assoc_args['via-jobs'] );
+				$input['source']   = self::CLEANUP_CLI_SOURCE;
 				if ( isset( $assoc_args['limit'] ) ) {
 					$input['limit'] = (int) $assoc_args['limit'];
 				}
@@ -3199,6 +3201,10 @@ class WorkspaceCommand extends BaseCommand {
 				) );
 			}
 			WP_CLI::success( sprintf( '%d metadata reconciliation proposal(s). Review JSON output before applying; --apply-plan remains a low-level escape hatch until DB-backed cleanup runs land.', count( $proposals ) ) );
+			return;
+		}
+		if ( ! empty( $result['job_backed'] ) ) {
+			WP_CLI::success( sprintf( 'Scheduled %d metadata reconciliation page job(s).', (int) ( $summary['scheduled_jobs'] ?? 0 ) ) );
 			return;
 		}
 		if ( isset( $result['pagination']['next_offset'] ) ) {

--- a/inc/Tasks/WorktreeCleanupChunkTask.php
+++ b/inc/Tasks/WorktreeCleanupChunkTask.php
@@ -55,6 +55,11 @@ class WorktreeCleanupChunkTask extends SystemTask {
 			return;
 		}
 
+		if ( 'metadata_reconciliation_page' === $chunk_type ) {
+			$this->execute_metadata_reconciliation_page( $jobId, $params, $started_at );
+			return;
+		}
+
 		if ( '' === $chunk_type || array() === $rows ) {
 			$this->completeJob(
 				$jobId,
@@ -249,6 +254,72 @@ class WorktreeCleanupChunkTask extends SystemTask {
 				$started_at,
 				array(
 					'pagination' => $plan['pagination'] ?? null,
+					'summary'    => $result['summary'] ?? array(),
+					'result'     => $this->compact_evidence_result( $result ),
+				)
+			)
+		);
+	}
+
+	/**
+	 * Apply one bounded metadata reconciliation page.
+	 *
+	 * @param int   $jobId      Job ID.
+	 * @param array $params     Task params.
+	 * @param float $started_at Start timestamp.
+	 * @return void
+	 */
+	private function execute_metadata_reconciliation_page( int $jobId, array $params, float $started_at ): void {
+		$limit     = max( 1, (int) ( $params['limit'] ?? 50 ) );
+		$offset    = max( 0, (int) ( $params['offset'] ?? 0 ) );
+		$workspace = new Workspace();
+
+		$result = $workspace->worktree_reconcile_metadata(
+			array(
+				'apply'  => true,
+				'limit'  => $limit,
+				'offset' => $offset,
+			)
+		);
+
+		if ( $result instanceof \WP_Error ) {
+			$this->completeJob(
+				$jobId,
+				$this->build_chunk_result(
+					'metadata_reconciliation_page',
+					array(),
+					array(),
+					array(),
+					array(
+						array(
+							'handle'      => '',
+							'reason_code' => $result->get_error_code(),
+							'reason'      => $result->get_error_message(),
+						),
+					),
+					0,
+					$started_at,
+					array(
+						'limit'  => $limit,
+						'offset' => $offset,
+					)
+				)
+			);
+			return;
+		}
+
+		$this->completeJob(
+			$jobId,
+			$this->build_chunk_result(
+				'metadata_reconciliation_page',
+				array_values( (array) ( $result['proposals'] ?? array() ) ),
+				array_values( (array) ( $result['written'] ?? array() ) ),
+				array_values( (array) ( $result['skipped'] ?? array() ) ),
+				array(),
+				0,
+				$started_at,
+				array(
+					'pagination' => $result['pagination'] ?? null,
 					'summary'    => $result['summary'] ?? array(),
 					'result'     => $this->compact_evidence_result( $result ),
 				)

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -3812,8 +3812,11 @@ class Workspace {
 	 * @return array<string,mixed>|\WP_Error
 	 */
 	public function worktree_reconcile_metadata( array $opts = array() ): array|\WP_Error {
+		$started_at = microtime( true );
 		$dry_run    = ! empty( $opts['dry_run'] );
 		$apply      = ! empty( $opts['apply'] );
+		$via_jobs   = ! empty( $opts['via_jobs'] );
+		$source     = isset( $opts['source'] ) ? trim( (string) $opts['source'] ) : 'workspace_metadata_reconcile';
 		$apply_plan = isset( $opts['apply_plan'] ) && is_array( $opts['apply_plan'] ) ? $opts['apply_plan'] : null;
 		$paged      = array_key_exists( 'limit', $opts ) || array_key_exists( 'offset', $opts );
 		$limit      = $paged ? ( array_key_exists( 'limit', $opts ) ? (int) $opts['limit'] : self::METADATA_RECONCILE_DEFAULT_LIMIT ) : 0;
@@ -3826,8 +3829,16 @@ class Workspace {
 		if ( ! $dry_run && ! $apply ) {
 			return new \WP_Error( 'metadata_reconcile_requires_review', 'Metadata reconciliation is dry-run-first. Pass --dry-run to review JSON output, or pass apply=true for DMC-owned lifecycle reconciliation.', array( 'status' => 400 ) );
 		}
+		if ( $via_jobs && ( $dry_run || ! $apply || null !== $apply_plan ) ) {
+			return new \WP_Error( 'metadata_reconcile_via_jobs_requires_apply', 'Job-backed metadata reconciliation requires apply=true without dry_run or apply_plan.', array( 'status' => 400 ) );
+		}
 		if ( $paged && $limit <= 0 ) {
 			return new \WP_Error( 'invalid_metadata_reconcile_limit', 'Metadata reconciliation --limit must be greater than 0.', array( 'status' => 400 ) );
+		}
+		if ( $via_jobs && ! $paged ) {
+			$limit  = self::METADATA_RECONCILE_DEFAULT_LIMIT;
+			$offset = 0;
+			$paged  = true;
 		}
 
 		$listing = $this->worktree_list(
@@ -3889,11 +3900,115 @@ class Workspace {
 		}
 
 		if ( $apply ) {
+			if ( $via_jobs ) {
+				return $this->schedule_worktree_metadata_reconciliation_pages( $plan, $limit, $source, $started_at );
+			}
 			$plan['direct_apply'] = true;
 			return $this->apply_worktree_metadata_reconciliation_plan( $plan );
 		}
 
 		return $plan;
+	}
+
+	/**
+	 * Schedule bounded metadata reconciliation apply pages as system jobs.
+	 *
+	 * @param array<string,mixed> $first_page First bounded dry-run page.
+	 * @param int                 $limit      Page size.
+	 * @param string              $source     Caller marker.
+	 * @param float               $started_at Start timestamp.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private function schedule_worktree_metadata_reconciliation_pages( array $first_page, int $limit, string $source, float $started_at ): array|\WP_Error {
+		if ( ! class_exists( '\DataMachine\Engine\Tasks\TaskScheduler' ) ) {
+			return new \WP_Error( 'task_scheduler_unavailable', 'Data Machine TaskScheduler is unavailable; cannot schedule metadata reconciliation jobs.', array( 'status' => 500 ) );
+		}
+
+		$pagination = (array) ( $first_page['pagination'] ?? array() );
+		$total      = max( 0, (int) ( $pagination['total'] ?? $pagination['scanned'] ?? 0 ) );
+		$start      = max( 0, (int) ( $pagination['offset'] ?? 0 ) );
+		$limit      = max( 1, $limit );
+		$items      = array();
+		for ( $offset = $start; $offset < $total; $offset += $limit ) {
+			$items[] = array(
+				'chunk_type'  => 'metadata_reconciliation_page',
+				'chunk_index' => count( $items ),
+				'limit'       => $limit,
+				'offset'      => $offset,
+				'source'      => $source,
+			);
+		}
+
+		if ( array() === $items ) {
+			return array(
+				'success'        => true,
+				'dry_run'        => false,
+				'applied'        => false,
+				'job_backed'     => true,
+				'generated_at'   => gmdate( 'c' ),
+				'workspace_path' => $this->workspace_path,
+				'proposals'      => array(),
+				'written'        => array(),
+				'skipped'        => array(),
+				'still_unsafe'       => array(),
+				'external_worktrees' => array(),
+				'summary'            => array(
+					'inspected'      => 0,
+					'proposed'       => 0,
+					'written'        => 0,
+					'skipped'        => 0,
+					'scheduled_jobs' => 0,
+					'limit'          => $limit,
+				),
+				'pagination'     => $pagination,
+				'evidence'       => array(
+					'elapsed_ms' => (int) round( ( microtime( true ) - $started_at ) * 1000 ),
+					'note'       => 'No metadata reconciliation pages eligible for scheduling.',
+					'source'     => $source,
+				),
+			);
+		}
+
+		$batch_result = \DataMachine\Engine\Tasks\TaskScheduler::scheduleBatch(
+			'worktree_cleanup_chunk',
+			$items,
+			array( 'source' => $source )
+		);
+
+		if ( false === $batch_result ) {
+			return new \WP_Error( 'metadata_reconcile_schedule_failed', 'Failed to schedule metadata reconciliation page jobs.', array( 'status' => 500 ) );
+		}
+
+		return array(
+			'success'        => true,
+			'dry_run'        => false,
+			'applied'        => false,
+			'job_backed'     => true,
+			'generated_at'   => gmdate( 'c' ),
+			'workspace_path' => $this->workspace_path,
+			'proposals'      => array_values( (array) ( $first_page['proposals'] ?? array() ) ),
+			'written'        => array(),
+			'skipped'        => array(),
+			'still_unsafe'       => array_values( (array) ( $first_page['still_unsafe'] ?? array() ) ),
+			'external_worktrees' => array_values( (array) ( $first_page['external_worktrees'] ?? array() ) ),
+			'summary'            => array_merge(
+				(array) ( $first_page['summary'] ?? array() ),
+				array(
+					'written'        => 0,
+					'scheduled_jobs' => count( $items ),
+					'limit'          => $limit,
+				)
+			),
+			'pagination'     => $pagination,
+			'evidence'       => array(
+				'elapsed_ms'      => (int) round( ( microtime( true ) - $started_at ) * 1000 ),
+				'scope'           => 'job-backed metadata reconciliation apply',
+				'page_offsets'    => array_column( $items, 'offset' ),
+				'batch_job_id'    => (int) ( $batch_result['batch_job_id'] ?? 0 ),
+				'direct_job_ids'  => $batch_result['job_ids'] ?? array(),
+				'source'          => $source,
+			),
+		);
 	}
 
 	/**

--- a/tests/smoke-worktree-metadata-reconcile.php
+++ b/tests/smoke-worktree-metadata-reconcile.php
@@ -50,6 +50,42 @@ namespace DataMachineCode\Abilities {
 	}
 }
 
+namespace DataMachine\Engine\AI\System\Tasks {
+	if ( ! class_exists( __NAMESPACE__ . '\\SystemTask' ) ) {
+		abstract class SystemTask {
+			abstract public function executeTask( int $jobId, array $params ): void;
+			abstract public function getTaskType(): string;
+			protected function completeJob( int $jobId, array $data ): void {
+				$GLOBALS['datamachine_code_reconcile_chunk_jobs'][ $jobId ] = $data;
+			}
+			protected function failJob( int $jobId, string $message ): void {
+				$GLOBALS['datamachine_code_reconcile_chunk_jobs'][ $jobId ] = array( 'error' => $message );
+			}
+		}
+	}
+}
+
+namespace DataMachine\Engine\Tasks {
+	if ( ! class_exists( __NAMESPACE__ . '\\TaskScheduler' ) ) {
+		class TaskScheduler {
+			public static array $batches = array();
+
+			public static function scheduleBatch( string $task_type, array $items, array $context = array() ) {
+				self::$batches[] = array(
+					'task_type' => $task_type,
+					'items'     => $items,
+					'context'   => $context,
+				);
+
+				return array(
+					'batch_job_id' => 901,
+					'job_ids'      => range( 1001, 1000 + count( $items ) ),
+				);
+			}
+		}
+	}
+}
+
 namespace {
 	if ( ! defined( 'ABSPATH' ) ) {
 		define( 'ABSPATH', __DIR__ . '/' );
@@ -132,6 +168,7 @@ namespace {
 	require __DIR__ . '/../inc/Workspace/WorktreeDiskBudget.php';
 	require __DIR__ . '/../inc/Workspace/WorktreeContextInjector.php';
 	require __DIR__ . '/../inc/Workspace/Workspace.php';
+	require __DIR__ . '/../inc/Tasks/WorktreeCleanupChunkTask.php';
 
 	exec( 'git --version 2>&1', $_gv, $gv_exit );
 	if ( 0 !== $gv_exit ) {
@@ -155,6 +192,7 @@ namespace {
 	$failures = 0;
 	$total    = 0;
 	$datamachine_code_test_options = array();
+	$GLOBALS['datamachine_code_reconcile_chunk_jobs'] = array();
 
 	$assert = function ( $expected, $actual, string $message ) use ( &$failures, &$total ): void {
 		$total++;
@@ -361,6 +399,20 @@ namespace {
 	$assert( 2, (int) ( $page['summary']['inspected'] ?? 0 ), 'paginated dry-run summary is page-scoped' );
 	$assert( true, isset( $page['evidence']['fields_skipped_by_listing'] ), 'paginated dry-run exposes listing evidence' );
 
+	\DataMachine\Engine\Tasks\TaskScheduler::$batches = array();
+	$job_backed = $ws->worktree_reconcile_metadata( array( 'apply' => true, 'via_jobs' => true, 'limit' => 3 ) );
+	$assert( true, ! is_wp_error( $job_backed ) && ( $job_backed['success'] ?? false ), 'job-backed reconciliation scheduling succeeds' );
+	$assert( true, (bool) ( $job_backed['job_backed'] ?? false ), 'job-backed reconciliation reports job_backed' );
+	$assert( false, (bool) ( $job_backed['applied'] ?? true ), 'job-backed parent does not write metadata synchronously' );
+	$assert( true, (int) ( $job_backed['summary']['scheduled_jobs'] ?? 0 ) >= 4, 'job-backed reconciliation schedules bounded page jobs' );
+	$scheduled_batch = \DataMachine\Engine\Tasks\TaskScheduler::$batches[0] ?? array();
+	$assert( 'worktree_cleanup_chunk', $scheduled_batch['task_type'] ?? '', 'job-backed reconciliation uses cleanup chunk task' );
+	$assert( 'metadata_reconciliation_page', $scheduled_batch['items'][0]['chunk_type'] ?? '', 'scheduled reconciliation job uses metadata page chunk type' );
+	$assert( array( 0, 3, 6, 9 ), array_slice( array_column( (array) ( $scheduled_batch['items'] ?? array() ), 'offset' ), 0, 4 ), 'scheduled reconciliation jobs carry bounded offsets' );
+	$assert( '', \DataMachineCode\Workspace\WorktreeContextInjector::get_metadata( 'demo@unmanaged-missing' )['handle'] ?? '', 'job-backed parent leaves metadata untouched until jobs run' );
+	$bad_job_backed = $ws->worktree_reconcile_metadata( array( 'dry_run' => true, 'via_jobs' => true, 'limit' => 3 ) );
+	$assert( true, is_wp_error( $bad_job_backed ), 'job-backed reconciliation rejects dry-run mode' );
+
 	$inventory_before = $ws->worktree_cleanup_merged( array( 'dry_run' => true, 'inventory_only' => true, 'skip_github' => true ) );
 	$assert( 4, (int) ( $inventory_before['summary']['skipped_by_reason']['needs_metadata_reconcile'] ?? 0 ), 'inventory cleanup sees missing metadata before apply' );
 
@@ -424,6 +476,13 @@ namespace {
 	$unsafe_skips = array_values( array_filter( $unsafe_apply['skipped'] ?? array(), fn( $row ) => 'demo@unmanaged-dirty' === ( $row['handle'] ?? '' ) ) );
 	$assert( 'unsafe_cleanup_eligible_state', $unsafe_skips[0]['reason_code'] ?? '', 'dirty worktree cannot become cleanup_eligible through reconciliation plan' );
 	$assert( 1, count( $unsafe_apply['still_unsafe'] ?? array() ), 'apply exposes still-unsafe rows distinctly' );
+
+	$task = new \DataMachineCode\Tasks\WorktreeCleanupChunkTask();
+	$task->executeTask( 1201, array( 'chunk_type' => 'metadata_reconciliation_page', 'limit' => 2, 'offset' => 0 ) );
+	$job_result = $GLOBALS['datamachine_code_reconcile_chunk_jobs'][1201] ?? array();
+	$assert( true, (bool) ( $job_result['success'] ?? false ), 'metadata reconciliation page job completes successfully' );
+	$assert( 'metadata_reconciliation_page', $job_result['chunk_type'] ?? '', 'metadata reconciliation page job records chunk type' );
+	$assert( true, isset( $job_result['evidence']['summary'] ), 'metadata reconciliation page job records summary evidence' );
 
 	if ( $failures > 0 ) {
 		echo "\n{$failures} / {$total} assertions failed.\n";


### PR DESCRIPTION
## Summary
- Adds `reconcile-metadata --apply --via-jobs --limit=N` support for scheduling bounded metadata reconciliation pages.
- Reuses existing cleanup chunk task plumbing while executing page jobs through the direct apply path.
- Records scheduled offsets, job ids, pagination, summary, and elapsed timing evidence.

Closes #342.

## Stacking
- Stacked on #345 (`fix/343-direct-reconcile-apply`) because page jobs use direct bounded apply.

## Testing
- `php tests/smoke-worktree-metadata-reconcile.php`
- `php tests/smoke-worktree-cleanup-chunks.php`
- `php -l` on changed PHP files
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and implemented job-backed reconciliation scheduling and smoke coverage; Chris retains review and merge responsibility.