### PR TITLE
Add time-budgeted metadata reconciliation drain

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -1250,7 +1250,7 @@ class WorkspaceAbilities {
 								'type'        => 'boolean',
 								'description' => 'Forward force=true to cleanup tasks that support it.',
 							),
-							'dry_run'    => array(
+							'dry_run'      => array(
 								'type'        => 'boolean',
 								'description' => 'Rejected for background cleanup scheduling; use review abilities for dry-runs.',
 							),
@@ -1548,9 +1548,25 @@ class WorkspaceAbilities {
 								'type'        => 'boolean',
 								'description' => 'If true, return a review plan without writing metadata.',
 							),
-							'apply_plan' => array(
+							'apply_plan'   => array(
 								'type'        => 'object',
 								'description' => 'Decoded dry-run plan to apply after exact handle/path/repo/branch revalidation.',
+							),
+							'apply'        => array(
+								'type'        => 'boolean',
+								'description' => 'If true, build and apply bounded DMC-owned reconciliation pages directly.',
+							),
+							'limit'        => array(
+								'type'        => 'integer',
+								'description' => 'Maximum worktrees to scan in each reconciliation page.',
+							),
+							'offset'       => array(
+								'type'        => 'integer',
+								'description' => 'Pagination offset into the worktree inventory ordering.',
+							),
+							'until_budget' => array(
+								'type'        => 'string',
+								'description' => 'Compact time budget for direct apply drain mode, such as 60s or 10m.',
 							),
 						),
 					),
@@ -2528,6 +2544,9 @@ class WorkspaceAbilities {
 		}
 		if ( array_key_exists( 'offset', $input ) ) {
 			$opts['offset'] = (int) $input['offset'];
+		}
+		if ( isset( $input['until_budget'] ) && '' !== trim( (string) $input['until_budget'] ) ) {
+			$opts['until_budget'] = trim( (string) $input['until_budget'] );
 		}
 
 		return $workspace->worktree_reconcile_metadata( $opts );

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1998,15 +1998,20 @@ class WorkspaceCommand extends BaseCommand {
 	 *   unpushed_commits, missing_metadata, external_worktree, age_filter, unknown_age.
 	 *
 	 * [--limit=<count>]
-	 * : For `cleanup-artifacts --dry-run` and `reconcile-metadata --dry-run`,
+	 * : For `cleanup-artifacts --dry-run` and `reconcile-metadata`,
 	 *   maximum worktrees to scan in this page. Artifact cleanup defaults to
 	 *   100; metadata reconciliation uses this only when pagination is requested.
 	 *   Use 0 plus `--exhaustive` for a full artifact audit.
 	 *
 	 * [--offset=<count>]
-	 * : For `cleanup-artifacts --dry-run` and `reconcile-metadata --dry-run`,
+	 * : For `cleanup-artifacts --dry-run` and `reconcile-metadata`,
 	 *   pagination offset (0-indexed) into the inventory ordering. Walk pages by
 	 *   passing the previous response's `pagination.next_offset`.
+	 *
+	 * [--until-budget=<duration>]
+	 * : For `reconcile-metadata --apply`, drain bounded direct-apply pages until
+	 *   the compact time budget is nearly exhausted (e.g. 60s, 10m). Returns
+	 *   continuation evidence and a next command when more pages remain.
 	 *
 	 * [--exhaustive]
 	 * : For `cleanup-artifacts --dry-run`, scan every worktree AND run per-worktree
@@ -2101,6 +2106,7 @@ class WorkspaceCommand extends BaseCommand {
 	 *     wp datamachine-code workspace worktree reconcile-metadata --dry-run --format=json
 	 *     wp datamachine-code workspace worktree reconcile-metadata --dry-run --limit=25 --offset=0 --format=json
 	 *     wp datamachine-code workspace worktree reconcile-metadata --apply --limit=25 --offset=0 --format=json
+	 *     wp datamachine-code workspace worktree reconcile-metadata --apply --limit=50 --until-budget=60s --format=json
 	 *
 	 *     # Ignore dirty working-tree safety (caution)
 	 *     wp datamachine-code workspace worktree cleanup --force
@@ -2294,6 +2300,9 @@ class WorkspaceCommand extends BaseCommand {
 				}
 				if ( isset( $assoc_args['offset'] ) ) {
 					$input['offset'] = (int) $assoc_args['offset'];
+				}
+				if ( isset( $assoc_args['until-budget'] ) && '' !== trim( (string) $assoc_args['until-budget'] ) ) {
+					$input['until_budget'] = trim( (string) $assoc_args['until-budget'] );
 				}
 				if ( ! empty( $assoc_args['apply-plan'] ) ) {
 					$input['apply_plan'] = $this->read_worktree_json_plan( (string) $assoc_args['apply-plan'], 'metadata reconciliation' );
@@ -3202,11 +3211,15 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 		if ( isset( $result['pagination']['next_offset'] ) ) {
-			WP_CLI::log( sprintf(
-				'Next page: wp datamachine-code workspace worktree reconcile-metadata --apply --limit=%d --offset=%d --format=json',
-				(int) ( $result['pagination']['limit'] ?? 0 ),
-				(int) $result['pagination']['next_offset']
-			) );
+			if ( ! empty( $result['pagination']['next_command'] ) ) {
+				WP_CLI::log( 'Next page: ' . (string) $result['pagination']['next_command'] );
+			} else {
+				WP_CLI::log( sprintf(
+					'Next page: wp datamachine-code workspace worktree reconcile-metadata --apply --limit=%d --offset=%d --format=json',
+					(int) ( $result['pagination']['limit'] ?? 0 ),
+					(int) $result['pagination']['next_offset']
+				) );
+			}
 		}
 		WP_CLI::success( sprintf( 'Wrote metadata for %d worktree(s); %d skipped.', count( $written ), count( $skipped ) ) );
 	}

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -3808,16 +3808,17 @@ class Workspace {
 	 * only that page; omitting both preserves the historical full scan.
 	 * Applying a plan revalidates handle/path/repo/branch before writing metadata.
 	 *
-	 * @param array $opts Options: dry_run bool, apply_plan array, limit int, offset int.
+	 * @param array $opts Options: dry_run bool, apply_plan array, limit int, offset int, until_budget string.
 	 * @return array<string,mixed>|\WP_Error
 	 */
 	public function worktree_reconcile_metadata( array $opts = array() ): array|\WP_Error {
-		$dry_run    = ! empty( $opts['dry_run'] );
-		$apply      = ! empty( $opts['apply'] );
-		$apply_plan = isset( $opts['apply_plan'] ) && is_array( $opts['apply_plan'] ) ? $opts['apply_plan'] : null;
-		$paged      = array_key_exists( 'limit', $opts ) || array_key_exists( 'offset', $opts );
-		$limit      = $paged ? ( array_key_exists( 'limit', $opts ) ? (int) $opts['limit'] : self::METADATA_RECONCILE_DEFAULT_LIMIT ) : 0;
-		$offset     = $paged ? max( 0, (int) ( $opts['offset'] ?? 0 ) ) : 0;
+		$dry_run      = ! empty( $opts['dry_run'] );
+		$apply        = ! empty( $opts['apply'] );
+		$apply_plan   = isset( $opts['apply_plan'] ) && is_array( $opts['apply_plan'] ) ? $opts['apply_plan'] : null;
+		$until_budget = isset( $opts['until_budget'] ) ? trim( (string) $opts['until_budget'] ) : '';
+		$paged        = array_key_exists( 'limit', $opts ) || array_key_exists( 'offset', $opts ) || '' !== $until_budget;
+		$limit        = $paged ? ( array_key_exists( 'limit', $opts ) ? (int) $opts['limit'] : self::METADATA_RECONCILE_DEFAULT_LIMIT ) : 0;
+		$offset       = $paged ? max( 0, (int) ( $opts['offset'] ?? 0 ) ) : 0;
 
 		if ( null !== $apply_plan ) {
 			return $this->apply_worktree_metadata_reconciliation_plan( $apply_plan );
@@ -3828,6 +3829,18 @@ class Workspace {
 		}
 		if ( $paged && $limit <= 0 ) {
 			return new \WP_Error( 'invalid_metadata_reconcile_limit', 'Metadata reconciliation --limit must be greater than 0.', array( 'status' => 400 ) );
+		}
+		if ( '' !== $until_budget ) {
+			if ( ! $apply || $dry_run ) {
+				return new \WP_Error( 'metadata_reconcile_budget_requires_apply', 'Metadata reconciliation --until-budget is only supported with direct --apply.', array( 'status' => 400 ) );
+			}
+
+			$budget_seconds = $this->parse_worktree_metadata_reconciliation_budget( $until_budget );
+			if ( is_wp_error( $budget_seconds ) ) {
+				return $budget_seconds;
+			}
+
+			return $this->drain_worktree_metadata_reconciliation_budget( $limit, $offset, $until_budget, $budget_seconds );
 		}
 
 		$listing = $this->worktree_list(
@@ -3894,6 +3907,140 @@ class Workspace {
 		}
 
 		return $plan;
+	}
+
+	/**
+	 * Drain paged direct metadata reconciliation until the time budget is nearly exhausted.
+	 *
+	 * @param int    $limit          Page size.
+	 * @param int    $offset         Starting offset.
+	 * @param string $budget_label   Original compact budget label.
+	 * @param int    $budget_seconds Parsed budget in seconds.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private function drain_worktree_metadata_reconciliation_budget( int $limit, int $offset, string $budget_label, int $budget_seconds ): array|\WP_Error {
+		$started_at      = microtime( true );
+		$reserve_seconds = min( 5.0, max( 1.0, $budget_seconds * 0.1 ) );
+		$pages           = array();
+		$proposals       = array();
+		$written         = array();
+		$skipped         = array();
+		$scanned         = 0;
+		$next_offset     = $offset;
+		$last_pagination = null;
+
+		do {
+			$page = $this->worktree_reconcile_metadata(
+				array(
+					'apply'  => true,
+					'limit'  => $limit,
+					'offset' => $next_offset,
+				)
+			);
+			if ( is_wp_error( $page ) ) {
+				return $page;
+			}
+
+			$page_pagination = (array) ( $page['pagination'] ?? array() );
+			$page_scanned    = (int) ( $page_pagination['scanned'] ?? 0 );
+			$last_pagination = $page_pagination;
+			$scanned        += $page_scanned;
+			$proposals       = array_merge( $proposals, (array) ( $page['proposals'] ?? array() ) );
+			$written         = array_merge( $written, (array) ( $page['written'] ?? array() ) );
+			$skipped         = array_merge( $skipped, (array) ( $page['skipped'] ?? array() ) );
+			$pages[]         = array(
+				'offset'   => (int) ( $page_pagination['offset'] ?? $next_offset ),
+				'limit'    => (int) ( $page_pagination['limit'] ?? $limit ),
+				'scanned'  => $page_scanned,
+				'written'  => count( (array) ( $page['written'] ?? array() ) ),
+				'skipped'  => count( (array) ( $page['skipped'] ?? array() ) ),
+				'complete' => (bool) ( $page_pagination['complete'] ?? false ),
+			);
+
+			if ( ! empty( $page_pagination['complete'] ) || null === ( $page_pagination['next_offset'] ?? null ) || $page_scanned <= 0 ) {
+				break;
+			}
+
+			$next_offset = (int) $page_pagination['next_offset'];
+		} while ( ( $budget_seconds - ( microtime( true ) - $started_at ) ) > $reserve_seconds );
+
+		$elapsed      = microtime( true ) - $started_at;
+		$complete     = ! empty( $last_pagination['complete'] );
+		$partial      = ! $complete;
+		$next_command = $partial ? sprintf(
+			'studio wp datamachine-code workspace worktree reconcile-metadata --apply --limit=%d --offset=%d --until-budget=%s --format=json',
+			$limit,
+			(int) ( $last_pagination['next_offset'] ?? $next_offset ),
+			$budget_label
+		) : null;
+
+		$classified_skips = $this->classify_worktree_metadata_reconciliation_skips( $skipped );
+		$pagination       = array(
+			'total'       => (int) ( $last_pagination['total'] ?? 0 ),
+			'offset'      => $offset,
+			'limit'       => $limit,
+			'scanned'     => $scanned,
+			'partial'     => $partial,
+			'complete'    => $complete,
+			'next_offset' => $partial ? (int) ( $last_pagination['next_offset'] ?? $next_offset ) : null,
+		);
+		if ( null !== $next_command ) {
+			$pagination['next_command'] = $next_command;
+		}
+
+		return array(
+			'success'        => true,
+			'dry_run'        => false,
+			'applied'        => true,
+			'direct_apply'   => true,
+			'generated_at'   => gmdate( 'c' ),
+			'workspace_path' => $this->workspace_path,
+			'proposals'      => $proposals,
+			'written'        => $written,
+			'skipped'        => $skipped,
+			'still_unsafe'      => $classified_skips['still_unsafe'],
+			'external_worktrees' => $classified_skips['external_worktrees'],
+			'summary'        => $this->build_worktree_metadata_reconciliation_summary( $scanned, $proposals, $written, $skipped ),
+			'pagination'     => $pagination,
+			'evidence'       => array_filter(
+				array(
+					'scope'                  => 'time-budgeted metadata reconciliation direct apply',
+					'apply_source'           => 'direct_apply',
+					'budget'                 => $budget_label,
+					'budget_seconds'         => $budget_seconds,
+					'reserve_seconds'        => $reserve_seconds,
+					'elapsed_seconds'        => round( $elapsed, 3 ),
+					'budget_nearly_exhausted' => $partial,
+					'pages'                  => $pages,
+					'next_command'           => $next_command,
+				)
+			),
+		);
+	}
+
+	/**
+	 * Parse a compact metadata reconciliation time budget.
+	 *
+	 * @param string $duration Duration like 60s, 10m, or 1h.
+	 * @return int|\WP_Error Seconds on success.
+	 */
+	private function parse_worktree_metadata_reconciliation_budget( string $duration ): int|\WP_Error {
+		if ( ! preg_match( '/^(\d+)([smh])$/', trim( $duration ), $matches ) ) {
+			return new \WP_Error( 'invalid_metadata_reconcile_budget', 'Invalid --until-budget duration. Use a compact value like 60s, 10m, or 1h.', array( 'status' => 400 ) );
+		}
+
+		$value = (int) $matches[1];
+		if ( $value <= 0 ) {
+			return new \WP_Error( 'invalid_metadata_reconcile_budget', 'Invalid --until-budget duration. Duration must be greater than zero.', array( 'status' => 400 ) );
+		}
+
+		$unit_seconds = array(
+			's' => 1,
+			'm' => 60,
+			'h' => 3600,
+		);
+
+		return $value * $unit_seconds[ $matches[2] ];
 	}
 
 	/**

--- a/tests/smoke-worktree-metadata-reconcile.php
+++ b/tests/smoke-worktree-metadata-reconcile.php
@@ -425,6 +425,26 @@ namespace {
 	$assert( 'unsafe_cleanup_eligible_state', $unsafe_skips[0]['reason_code'] ?? '', 'dirty worktree cannot become cleanup_eligible through reconciliation plan' );
 	$assert( 1, count( $unsafe_apply['still_unsafe'] ?? array() ), 'apply exposes still-unsafe rows distinctly' );
 
+	\DataMachineCode\Workspace\WorktreeContextInjector::forget_metadata( 'demo@unmanaged-missing' );
+	$budget_offset = 0;
+	$budget_listing = $ws->worktree_list( null, null, array( 'include_status' => false, 'include_disk' => false ) );
+	foreach ( array_values( array_filter( (array) ( $budget_listing['worktrees'] ?? array() ), fn( $wt ) => empty( $wt['is_primary'] ) ) ) as $index => $wt ) {
+		if ( 'demo@unmanaged-missing' === ( $wt['handle'] ?? '' ) ) {
+			$budget_offset = (int) $index;
+			break;
+		}
+	}
+	$budgeted_apply = $ws->worktree_reconcile_metadata( array( 'apply' => true, 'limit' => 1, 'offset' => $budget_offset, 'until_budget' => '1s' ) );
+	$assert( true, ! is_wp_error( $budgeted_apply ) && ( $budgeted_apply['success'] ?? false ), 'time-budgeted direct apply succeeds' );
+	$assert( true, (bool) ( $budgeted_apply['direct_apply'] ?? false ), 'time-budgeted drain uses direct apply path' );
+	$assert( 1, (int) ( $budgeted_apply['pagination']['limit'] ?? 0 ), 'time-budgeted drain preserves page limit' );
+	$assert( 1, (int) ( $budgeted_apply['pagination']['scanned'] ?? 0 ), 'time-budgeted drain scans one page before honoring reserve' );
+	$assert( true, (bool) ( $budgeted_apply['pagination']['partial'] ?? false ), 'time-budgeted drain reports continuation' );
+	$assert( $budget_offset + 1, (int) ( $budgeted_apply['pagination']['next_offset'] ?? 0 ), 'time-budgeted drain reports next offset' );
+	$assert( 1, (int) ( $budgeted_apply['summary']['written'] ?? 0 ), 'time-budgeted drain writes first page metadata' );
+	$assert( 'time-budgeted metadata reconciliation direct apply', $budgeted_apply['evidence']['scope'] ?? '', 'time-budgeted drain exposes evidence scope' );
+	$assert( true, str_contains( $budgeted_apply['pagination']['next_command'] ?? '', '--until-budget=1s' ), 'time-budgeted drain exposes next command' );
+
 	if ( $failures > 0 ) {
 		echo "\n{$failures} / {$total} assertions failed.\n";
 		exit( 1 );


### PR DESCRIPTION
## Summary
- Adds `--until-budget=<duration>` support for `reconcile-metadata --apply` so DMC can drain bounded pages until a time budget is nearly exhausted.
- Returns continuation evidence including next offset and next command for safe resume.
- Uses the direct bounded apply path from #345 and does not require shell-managed plan files.

Closes #341.

## Stacking
- Stacked on #345 (`fix/343-direct-reconcile-apply`) because the drain uses direct bounded apply output.

## Testing
- `php tests/smoke-worktree-metadata-reconcile.php`
- `php -l` on changed PHP files
- `homeboy lint --path . --changed-only --errors-only --force-hot`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and implemented the time-budgeted reconciliation drain and smoke coverage; Chris retains review and merge responsibility.