### PR TITLE
Expose reconciliation apply CLI flags

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1944,6 +1944,15 @@ class WorkspaceCommand extends BaseCommand {
 	 *   exact current matches. For reconcile-metadata, applies a reviewed
 	 *   non-destructive metadata plan.
 	 *
+	 * [--apply]
+	 * : For `reconcile-metadata`, apply DMC-owned bounded metadata reconciliation
+	 *   directly without a JSON plan file. For cleanup subcommands, use the
+	 *   operation-specific apply path instead.
+	 *
+	 * [--via-jobs]
+	 * : For `reconcile-metadata --apply`, schedule bounded metadata
+	 *   reconciliation pages as jobs instead of applying synchronously.
+	 *
 	 * [--skip-github]
 	 * : Skip the GitHub API lookup and rely only on the local `upstream-gone`
 	 *   signal (cleanup only). Faster, but misses merged branches where the

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -616,6 +616,8 @@ namespace {
 	echo "\n[0a] WP-CLI synopsis exposes cleanup flags\n";
 	datamachine_code_cleanup_assert( str_contains( $doc_comment, "\n\t * [--inventory-only]" ), 'worktree synopsis declares --inventory-only at top level' );
 	datamachine_code_cleanup_assert( str_contains( $doc_comment, "\n\t * [--include-repaired-metadata]" ), 'worktree synopsis declares --include-repaired-metadata at top level' );
+	datamachine_code_cleanup_assert( str_contains( $doc_comment, "\n\t * [--apply]" ), 'worktree synopsis declares --apply at top level' );
+	datamachine_code_cleanup_assert( str_contains( $doc_comment, "\n\t * [--via-jobs]" ), 'worktree synopsis declares --via-jobs at top level' );
 	datamachine_code_cleanup_assert( ! str_contains( $doc_comment, "\n\t\t * [--apply-plan=<file>]" ), 'cleanup flags are not hidden behind nested docblock indentation' );
 	datamachine_code_cleanup_assert( str_contains( $cleanup_doc_comment, 'Control task-backed workspace cleanup runs.' ), 'workspace cleanup command documents task-backed controller surface' );
 	datamachine_code_cleanup_assert( str_contains( $cleanup_doc_comment, '<plan|apply|run|status|resume|cancel|evidence>' ), 'workspace cleanup synopsis exposes DB-backed and task-backed cleanup operations' );


### PR DESCRIPTION
## Summary
- Adds `--apply` and `--via-jobs` to the `workspace worktree` WP-CLI synopsis so reconcile-metadata apply modes dispatch instead of failing parameter validation.
- Extends CLI smoke coverage to assert the flags are exposed at top level.

Closes #349.

## Testing
- `php tests/smoke-worktree-cleanup-cli.php`
- `php -l inc/Cli/Commands/WorkspaceCommand.php`
- `php -l tests/smoke-worktree-cleanup-cli.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and implemented the CLI synopsis fix and smoke coverage; Chris retains review and merge responsibility.