### PR TITLE
Reconcile active worktrees with GitHub branch signals

### DIFF
--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -4498,7 +4498,7 @@ class Workspace {
 			return $pr_signal;
 		}
 
-		$signal = $this->detect_merge_signal( $primary_path, $repo, $branch, true, $github_cache );
+		$signal = $this->detect_merge_signal( $primary_path, $repo, $branch, false, $github_cache );
 		if ( null === $signal ) {
 			return null;
 		}
@@ -8077,16 +8077,18 @@ class Workspace {
 
 		if ( ! empty( $pr['merged_at'] ) ) {
 			return array(
-				'signal' => 'pr-merged',
-				'reason' => sprintf( 'PR #%d merged (%s)', $pr['number'], $pr['state'] ),
-				'pr_url' => $pr['html_url'] ?? null,
+				'signal'          => 'pr-merged',
+				'reason'          => sprintf( 'PR #%d merged (%s)', $pr['number'], $pr['state'] ),
+				'finalized_state' => WorktreeContextInjector::STATE_MERGED,
+				'pr_url'          => $pr['html_url'] ?? null,
 			);
 		}
 
 		return array(
-			'signal' => 'pr-closed',
-			'reason' => sprintf( 'PR #%d closed without merge', $pr['number'] ),
-			'pr_url' => $pr['html_url'] ?? null,
+			'signal'          => 'pr-closed',
+			'reason'          => sprintf( 'PR #%d closed without merge', $pr['number'] ),
+			'finalized_state' => WorktreeContextInjector::STATE_CLOSED,
+			'pr_url'          => $pr['html_url'] ?? null,
 		);
 	}
 

--- a/tests/smoke-worktree-metadata-reconcile.php
+++ b/tests/smoke-worktree-metadata-reconcile.php
@@ -343,7 +343,6 @@ namespace {
 			'pr_repo'         => 'acme/demo',
 		)
 	);
-
 	$ws = new \DataMachineCode\Workspace\Workspace();
 
 	echo "\nDry-run reconciliation\n";


### PR DESCRIPTION
## Summary
- Enables metadata reconciliation to use cached GitHub branch/PR discovery for active worktrees without stored PR metadata.
- Persists explicit finalized state evidence for PR signals discovered through branch lookup.
- Keeps dirty/unpushed safety gates before promoting cleanup eligibility.

Closes #353.

## Testing
- `php tests/smoke-worktree-metadata-reconcile.php`
- `php -l inc/Workspace/Workspace.php`
- `php -l tests/smoke-worktree-metadata-reconcile.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and implemented the active worktree lifecycle reconciliation change; Chris retains review and merge responsibility.