### PR TITLE
Use PR lifecycle to resolve finalized worktrees

### DIFF
--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -8193,11 +8193,97 @@ class Workspace {
 			return $lookup;
 		}
 
-		if ( null === $lookup ) {
+		if ( null !== $lookup && isset( $lookup[ $branch ] ) ) {
+			return $lookup[ $branch ];
+		}
+
+		return $this->find_finalized_pr_for_branch_direct( $slug, $branch, $github_cache );
+	}
+
+	/**
+	 * Look up a finalized PR for one branch directly via GitHub's head filter.
+	 *
+	 * The repo-level closed-PR snapshot is intentionally bounded for cleanup runs,
+	 * so older PRs can be missed. This precise fallback keeps PR lifecycle as the
+	 * source of truth without treating remote branch existence as liveness.
+	 *
+	 * @param string $slug         owner/repo.
+	 * @param string $branch       Branch name.
+	 * @param array  $github_cache Run-local cache keyed by owner/repo and branch.
+	 * @return array|null|\WP_Error PR data, null when no finalized PR matched, or lookup failure.
+	 */
+	private function find_finalized_pr_for_branch_direct( string $slug, string $branch, array &$github_cache = array() ): array|\WP_Error|null {
+		$cache_key = $slug . '#head:' . $branch;
+		if ( array_key_exists( $cache_key, $github_cache ) ) {
+			return $github_cache[ $cache_key ];
+		}
+
+		if ( ! class_exists( '\DataMachineCode\Abilities\GitHubAbilities' ) ) {
+			$github_cache[ $cache_key ] = null;
 			return null;
 		}
 
-		return $lookup[ $branch ] ?? null;
+		$parts = explode( '/', $slug, 2 );
+		$owner = $parts[0] ?? '';
+		if ( '' === $owner || empty( $parts[1] ) ) {
+			$github_cache[ $cache_key ] = null;
+			return null;
+		}
+
+		$pat = \DataMachineCode\Abilities\GitHubAbilities::getPat( array( 'repo' => $slug ) );
+		if ( empty( $pat ) ) {
+			$github_cache[ $cache_key ] = null;
+			return null;
+		}
+
+		$response = \DataMachineCode\Abilities\GitHubAbilities::apiGet(
+			GitHubRemote::apiUrl( $slug, 'pulls' ),
+			array(
+				'head'      => $owner . ':' . $branch,
+				'sort'      => 'updated',
+				'direction' => 'desc',
+				'state'     => 'all',
+				'per_page'  => 5,
+			),
+			$pat,
+			self::CLEANUP_GITHUB_TIMEOUT
+		);
+
+		if ( is_wp_error( $response ) ) {
+			$error = new \WP_Error(
+				'github_cleanup_branch_lookup_failed',
+				sprintf( 'GitHub cleanup branch lookup failed for %s:%s: %s', $slug, $branch, $response->get_error_message() ),
+				$response->get_error_data()
+			);
+			$github_cache[ $cache_key ] = $error;
+			return $error;
+		}
+
+		foreach ( (array) ( $response['data'] ?? array() ) as $pr ) {
+			if ( ! is_array( $pr ) ) {
+				continue;
+			}
+
+			$head      = is_array( $pr['head'] ?? null ) ? $pr['head'] : array();
+			$head_repo = is_array( $head['repo'] ?? null ) ? (string) ( $head['repo']['full_name'] ?? '' ) : '';
+			$head_ref  = (string) ( $head['ref'] ?? '' );
+			$state     = (string) ( $pr['state'] ?? '' );
+			if ( $head_repo !== $slug || $head_ref !== $branch || 'closed' !== $state ) {
+				continue;
+			}
+
+			$github_cache[ $cache_key ] = array(
+				'number'    => (int) ( $pr['number'] ?? 0 ),
+				'state'     => $state,
+				'merged_at' => (string) ( $pr['merged_at'] ?? '' ),
+				'html_url'  => (string) ( $pr['html_url'] ?? '' ),
+			);
+
+			return $github_cache[ $cache_key ];
+		}
+
+		$github_cache[ $cache_key ] = null;
+		return null;
 	}
 
 	/**

--- a/tests/smoke-worktree-metadata-reconcile.php
+++ b/tests/smoke-worktree-metadata-reconcile.php
@@ -23,7 +23,7 @@ namespace DataMachineCode\Abilities {
 			public static function getPat(): string {
 				return 'test-token';
 			}
-			public static function apiGet( string $url, array $params, string $pat ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+			public static function apiGet( string $url, array $params, string $pat, int $timeout = 0 ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 				if ( str_ends_with( $url, '/pulls/101' ) ) {
 					return array(
 						'data' => array(
@@ -41,6 +41,38 @@ namespace DataMachineCode\Abilities {
 							'state'     => 'closed',
 							'merged_at' => '',
 							'html_url'  => 'https://github.com/acme/demo/pull/102',
+						),
+					);
+				}
+				if ( str_ends_with( $url, '/pulls' ) && 'acme:old-merged-branch' === ( $params['head'] ?? '' ) ) {
+					return array(
+						'data' => array(
+							array(
+								'number'    => 103,
+								'state'     => 'closed',
+								'merged_at' => '2026-04-04T00:00:00Z',
+								'html_url'  => 'https://github.com/acme/demo/pull/103',
+								'head'      => array(
+									'ref'  => 'old-merged-branch',
+									'repo' => array( 'full_name' => 'acme/demo' ),
+								),
+							),
+						),
+					);
+				}
+				if ( str_ends_with( $url, '/pulls' ) && 'acme:open-branch' === ( $params['head'] ?? '' ) ) {
+					return array(
+						'data' => array(
+							array(
+								'number'    => 104,
+								'state'     => 'open',
+								'merged_at' => '',
+								'html_url'  => 'https://github.com/acme/demo/pull/104',
+								'head'      => array(
+									'ref'  => 'open-branch',
+									'repo' => array( 'full_name' => 'acme/demo' ),
+								),
+							),
 						),
 					);
 				}
@@ -106,6 +138,9 @@ namespace {
 			}
 			public function get_error_code(): string {
 				return $this->code;
+			}
+			public function get_error_data(): array {
+				return $this->data;
 			}
 		}
 	}
@@ -344,6 +379,12 @@ namespace {
 		)
 	);
 	$ws = new \DataMachineCode\Workspace\Workspace();
+	$lookup_reflection = new \ReflectionMethod( $ws, 'find_closed_pr_for_branch' );
+	$lookup_cache = array( 'acme/demo' => array() );
+	$old_pr       = $lookup_reflection->invokeArgs( $ws, array( 'acme/demo', 'old-merged-branch', &$lookup_cache ) );
+	$open_pr      = $lookup_reflection->invokeArgs( $ws, array( 'acme/demo', 'open-branch', &$lookup_cache ) );
+	$assert( 103, (int) ( $old_pr['number'] ?? 0 ), 'direct branch PR lookup finds older merged PRs outside the bounded repo snapshot' );
+	$assert( null, $open_pr, 'direct branch PR lookup does not finalize open PR branches' );
 
 	echo "\nDry-run reconciliation\n";
 	$plan = $ws->worktree_reconcile_metadata( array( 'dry_run' => true ) );


### PR DESCRIPTION
## Summary
- Add a direct GitHub PR lookup fallback using the branch head when the bounded closed-PR cache misses.
- Keep PR lifecycle as cleanup truth for finalized worktrees while ignoring open PRs and preserving dirty/unpushed safety gates.
- Cover older finalized PRs outside the bounded repo snapshot in the metadata reconciliation smoke test.

Closes #355

## Testing
- `php -l inc/Workspace/Workspace.php`
- `php -l tests/smoke-worktree-metadata-reconcile.php`
- `php tests/smoke-worktree-metadata-reconcile.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the PR lifecycle lookup fallback and smoke-test coverage; Chris directed the lifecycle model and will review/test before merge.