### PR TITLE
Support show and diff for remote workspaces

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -1921,6 +1921,10 @@ class WorkspaceAbilities {
 	 * @return array Result.
 	 */
 	public static function showRepo( array $input ): array|\WP_Error {
+		if ( RemoteWorkspaceBackend::should_handle() ) {
+			return ( new RemoteWorkspaceBackend() )->show( $input['name'] ?? '' );
+		}
+
 		$workspace = new Workspace();
 		return $workspace->show_repo( $input['name'] ?? '' );
 	}
@@ -2758,6 +2762,16 @@ class WorkspaceAbilities {
 	 * @return array
 	 */
 	public static function gitDiff( array $input ): array|\WP_Error {
+		if ( RemoteWorkspaceBackend::should_handle() ) {
+			return ( new RemoteWorkspaceBackend() )->git_diff(
+				$input['name'] ?? '',
+				$input['from'] ?? null,
+				$input['to'] ?? null,
+				! empty( $input['staged'] ),
+				$input['path'] ?? null
+			);
+		}
+
 		$workspace = new Workspace();
 		return $workspace->git_diff(
 			$input['name'] ?? '',

--- a/inc/Workspace/RemoteWorkspaceBackend.php
+++ b/inc/Workspace/RemoteWorkspaceBackend.php
@@ -386,6 +386,87 @@ class RemoteWorkspaceBackend {
 	}
 
 	/**
+	 * Show remote workspace details.
+	 *
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function show( string $handle ): array|\WP_Error {
+		$context = $this->resolve_handle( $handle );
+		if ( is_wp_error( $context ) ) {
+			return $context;
+		}
+
+		$files = array_values( array_unique( array_values( (array) $context['changed_files'] ) ) );
+
+		return array(
+			'success'     => true,
+			'backend'     => 'github_api',
+			'name'        => $handle,
+			'repo'        => $context['repo_name'],
+			'is_worktree' => isset( $context['branch'] ) && '' !== (string) $context['branch'],
+			'path'        => 'github://' . $context['repo'] . ( '' !== (string) $context['branch']
+				? '#' . $context['branch']
+				: '' ),
+			'branch'      => '' !== (string) $context['branch'] ? (string) $context['branch'] : null,
+			'remote'      => 'https://github.com/' . $context['repo'] . '.git',
+			'commit'      => '' !== $context['last_commit_sha'] ? $context['last_commit_sha'] : null,
+			'dirty'       => count( $files ),
+			'files'       => $files,
+		);
+	}
+
+	/**
+	 * Return a diff of pending remote workspace changes.
+	 *
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function git_diff( string $handle, ?string $from = null, ?string $to = null, bool $staged = false, ?string $path = null ): array|\WP_Error {
+		unset( $staged );
+
+		$context = $this->resolve_handle( $handle );
+		if ( is_wp_error( $context ) ) {
+			return $context;
+		}
+
+		if ( ( null !== $from && '' !== trim( $from ) ) || ( null !== $to && '' !== trim( $to ) ) ) {
+			return new \WP_Error( 'remote_workspace_diff_refs_unsupported', 'Remote workspace diff currently supports pending workspace changes only; omit from/to refs.', array( 'status' => 400 ) );
+		}
+
+		$path_filter = null;
+		if ( null !== $path && '' !== trim( $path ) ) {
+			$normalized = $this->normalize_path( $path );
+			if ( is_wp_error( $normalized ) ) {
+				return $normalized;
+			}
+			$path_filter = $normalized;
+		}
+
+		$diff = '';
+		foreach ( (array) $context['pending_files'] as $changed_path => $new_content ) {
+			$changed_path = (string) $changed_path;
+			if ( null !== $path_filter && $changed_path !== $path_filter ) {
+				continue;
+			}
+
+			$old_content = '';
+			$current     = $this->get_file_contents_with_fallback( $context, $changed_path );
+			if ( ! is_wp_error( $current ) && ! empty( $current['files'][0] ) ) {
+				$old_content = (string) ( $current['files'][0]['content'] ?? '' );
+			}
+
+			$diff .= $this->build_full_file_diff( $changed_path, $old_content, (string) $new_content );
+		}
+
+		return array(
+			'success' => true,
+			'backend' => 'github_api',
+			'name'    => $handle,
+			'repo'    => $context['repo_name'],
+			'diff'    => $diff,
+		);
+	}
+
+	/**
 	 * Return pending remote workspace changes.
 	 *
 	 * @return array<string,mixed>|\WP_Error
@@ -577,6 +658,33 @@ class RemoteWorkspaceBackend {
 		}
 
 		return false;
+	}
+
+	private function build_full_file_diff( string $path, string $old_content, string $new_content ): string {
+		$old_lines = $this->diff_lines( $old_content );
+		$new_lines = $this->diff_lines( $new_content );
+
+		$diff  = 'diff --git a/' . $path . ' b/' . $path . "\n";
+		$diff .= '--- a/' . $path . "\n";
+		$diff .= '+++ b/' . $path . "\n";
+		$diff .= sprintf( '@@ -1,%d +1,%d @@', count( $old_lines ), count( $new_lines ) ) . "\n";
+		foreach ( $old_lines as $line ) {
+			$diff .= '-' . $line . "\n";
+		}
+		foreach ( $new_lines as $line ) {
+			$diff .= '+' . $line . "\n";
+		}
+
+		return $diff;
+	}
+
+	/** @return array<int,string> */
+	private function diff_lines( string $content ): array {
+		if ( '' === $content ) {
+			return array();
+		}
+
+		return explode( "\n", rtrim( $content, "\n" ) );
 	}
 
 	/**

--- a/tests/smoke-remote-workspace-backend.php
+++ b/tests/smoke-remote-workspace-backend.php
@@ -156,6 +156,12 @@ namespace {
 	$edit = $backend->edit_file( 'example@fix-example', 'src/example.php', 'old', 'new' );
 	$assert( 'edit stages pending content', ! is_wp_error( $edit ) && 1 === $edit['replacements'] );
 
+	$show = $backend->show( 'example@fix-example' );
+	$assert( 'show supports remote worktree handles', ! is_wp_error( $show ) && 'github_api' === $show['backend'] && 1 === $show['dirty'] && 'fix/example' === $show['branch'] );
+
+	$diff = $backend->git_diff( 'example@fix-example', path: 'src/example.php' );
+	$assert( 'diff supports remote pending changes', ! is_wp_error( $diff ) && str_contains( $diff['diff'], '-return \'old\';' ) && str_contains( $diff['diff'], '+return \'new\';' ) );
+
 	$worktree_grep = $backend->grep( 'example@fix-example', 'new', null, '*.php' );
 	$assert( 'grep searches pending worktree content', ! is_wp_error( $worktree_grep ) && 1 === $worktree_grep['count'] && str_contains( $worktree_grep['matches'][0]['text'], 'new' ) );
 


### PR DESCRIPTION
## Summary
- Routes `workspace_show` and `workspace_git_diff` through the GitHub-backed remote workspace backend when local git is unavailable.
- Adds remote workspace `show()` metadata and pending-change `git_diff()` output so runner-provided handles work consistently across read, edit, status, diff, commit, and push tools.
- Extends the remote backend smoke test to cover show/diff on a worktree handle after an edit.

## Testing
- `php -l inc/Workspace/RemoteWorkspaceBackend.php`
- `php -l inc/Abilities/WorkspaceAbilities.php`
- `php -l tests/smoke-remote-workspace-backend.php`
- `php tests/smoke-remote-workspace-backend.php`
- `php tests/smoke-tool-result-contracts.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed transcript tool failures from a World Creator run, drafted the remote workspace backend fix, and ran targeted smoke validation.