### PR TITLE
Report active worktree cleanup evidence

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -1593,6 +1593,41 @@ class WorkspaceAbilities {
 			);
 
 			wp_register_ability(
+				'datamachine/workspace-worktree-active-no-signal-report',
+				array(
+					'label'               => 'Report Active Worktrees Without Cleanup Signal',
+					'description'         => 'Build a bounded, review-only evidence report for active_no_signal worktrees. Gathers PR, dirty, unpushed, remote tracking, and default-branch evidence without deleting worktrees or branches.',
+					'category'            => 'datamachine-code-workspace',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'limit'  => array(
+								'type'        => 'integer',
+								'description' => 'Maximum active_no_signal rows to inspect in this page. Defaults to 25.',
+							),
+							'offset' => array(
+								'type'        => 'integer',
+								'description' => 'Pagination offset into the active_no_signal inventory ordering.',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'    => array( 'type' => 'boolean' ),
+							'review_only' => array( 'type' => 'boolean' ),
+							'rows'       => array( 'type' => 'array' ),
+							'summary'    => array( 'type' => 'object' ),
+							'pagination' => array( 'type' => 'object' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'worktreeActiveNoSignalReport' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
 				'datamachine/workspace-worktree-cleanup-artifacts',
 				array(
 					'label'               => 'Cleanup Worktree Artifacts',
@@ -2562,6 +2597,25 @@ class WorkspaceAbilities {
 		}
 
 		return $workspace->worktree_reconcile_metadata( $opts );
+	}
+
+	/**
+	 * Build a bounded active/no-signal worktree evidence report.
+	 *
+	 * @param array $input Input parameters (limit, offset).
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public static function worktreeActiveNoSignalReport( array $input ): array|\WP_Error {
+		$workspace = new Workspace();
+		$opts      = array();
+		if ( array_key_exists( 'limit', $input ) ) {
+			$opts['limit'] = (int) $input['limit'];
+		}
+		if ( array_key_exists( 'offset', $input ) ) {
+			$opts['offset'] = (int) $input['offset'];
+		}
+
+		return $workspace->worktree_active_no_signal_report( $opts );
 	}
 
 	/**

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1853,7 +1853,7 @@ class WorkspaceCommand extends BaseCommand {
 	 * <operation>
 	 * : Worktree operation: add, list, remove, prune, cleanup, cleanup-artifacts,
 	 *   bounded-cleanup-eligible-apply, emergency-cleanup, reconcile-metadata,
-	 *   refresh-context, finalize, mark-cleanup-eligible.
+	 *   active-no-signal-report, refresh-context, finalize, mark-cleanup-eligible.
 	 *
 	 * [<repo>]
 	 * : Primary repo name (required for add and remove). For refresh-context, finalize,
@@ -2007,13 +2007,15 @@ class WorkspaceCommand extends BaseCommand {
 	 *   unpushed_commits, missing_metadata, external_worktree, age_filter, unknown_age.
 	 *
 	 * [--limit=<count>]
-	 * : For `cleanup-artifacts --dry-run` and `reconcile-metadata`,
+	 * : For `cleanup-artifacts --dry-run`, `reconcile-metadata`, and
+	 *   `active-no-signal-report`,
 	 *   maximum worktrees to scan in this page. Artifact cleanup defaults to
 	 *   100; metadata reconciliation uses this only when pagination is requested.
 	 *   Use 0 plus `--exhaustive` for a full artifact audit.
 	 *
 	 * [--offset=<count>]
-	 * : For `cleanup-artifacts --dry-run` and `reconcile-metadata`,
+	 * : For `cleanup-artifacts --dry-run`, `reconcile-metadata`, and
+	 *   `active-no-signal-report`,
 	 *   pagination offset (0-indexed) into the inventory ordering. Walk pages by
 	 *   passing the previous response's `pagination.next_offset`.
 	 *
@@ -2116,6 +2118,7 @@ class WorkspaceCommand extends BaseCommand {
 	 *     wp datamachine-code workspace worktree reconcile-metadata --dry-run --limit=25 --offset=0 --format=json
 	 *     wp datamachine-code workspace worktree reconcile-metadata --apply --limit=25 --offset=0 --format=json
 	 *     wp datamachine-code workspace worktree reconcile-metadata --apply --limit=50 --until-budget=60s --format=json
+	 *     wp datamachine-code workspace worktree active-no-signal-report --limit=25 --offset=0 --format=json
 	 *
 	 *     # Ignore dirty working-tree safety (caution)
 	 *     wp datamachine-code workspace worktree cleanup --force
@@ -2148,7 +2151,7 @@ class WorkspaceCommand extends BaseCommand {
 		$operation = $args[0] ?? '';
 
 		if ( '' === $operation ) {
-			WP_CLI::error( 'Usage: wp datamachine-code workspace worktree <add|list|remove|prune|cleanup|cleanup-artifacts|bounded-cleanup-eligible-apply|emergency-cleanup|reconcile-metadata|refresh-context|finalize|mark-cleanup-eligible> [<repo>] [<branch>] [--flags]' );
+			WP_CLI::error( 'Usage: wp datamachine-code workspace worktree <add|list|remove|prune|cleanup|cleanup-artifacts|bounded-cleanup-eligible-apply|emergency-cleanup|reconcile-metadata|active-no-signal-report|refresh-context|finalize|mark-cleanup-eligible> [<repo>] [<branch>] [--flags]' );
 			return;
 		}
 
@@ -2162,6 +2165,7 @@ class WorkspaceCommand extends BaseCommand {
 			'bounded-cleanup-eligible-apply' => 'datamachine/workspace-worktree-bounded-cleanup-eligible-apply',
 			'emergency-cleanup'              => 'datamachine/workspace-worktree-emergency-cleanup',
 			'reconcile-metadata'             => 'datamachine/workspace-worktree-reconcile-metadata',
+			'active-no-signal-report'        => 'datamachine/workspace-worktree-active-no-signal-report',
 			'refresh-context'                => 'datamachine/workspace-worktree-refresh-context',
 			'finalize'                       => 'datamachine/workspace-worktree-finalize',
 			'mark-cleanup-eligible'          => 'datamachine/workspace-worktree-finalize',
@@ -2317,6 +2321,15 @@ class WorkspaceCommand extends BaseCommand {
 				}
 				if ( ! empty( $assoc_args['apply-plan'] ) ) {
 					$input['apply_plan'] = $this->read_worktree_json_plan( (string) $assoc_args['apply-plan'], 'metadata reconciliation' );
+				}
+				break;
+
+			case 'active-no-signal-report':
+				if ( isset( $assoc_args['limit'] ) ) {
+					$input['limit'] = (int) $assoc_args['limit'];
+				}
+				if ( isset( $assoc_args['offset'] ) ) {
+					$input['offset'] = (int) $assoc_args['offset'];
 				}
 				break;
 
@@ -2480,6 +2493,10 @@ class WorkspaceCommand extends BaseCommand {
 				return;
 			case 'reconcile-metadata':
 				$this->render_worktree_metadata_reconciliation_result( $result, $assoc_args );
+				return;
+
+			case 'active-no-signal-report':
+				$this->render_worktree_active_no_signal_report_result( $result, $assoc_args );
 				return;
 
 			case 'cleanup-artifacts':
@@ -3237,6 +3254,81 @@ class WorkspaceCommand extends BaseCommand {
 			}
 		}
 		WP_CLI::success( sprintf( 'Wrote metadata for %d worktree(s); %d skipped.', count( $written ), count( $skipped ) ) );
+	}
+
+	/**
+	 * Render active/no-signal evidence report output.
+	 *
+	 * @param array $result     Report result.
+	 * @param array $assoc_args CLI assoc args.
+	 * @return void
+	 */
+	private function render_worktree_active_no_signal_report_result( array $result, array $assoc_args ): void {
+		$format = isset( $assoc_args['format'] ) ? (string) $assoc_args['format'] : 'table';
+		if ( 'json' === $format ) {
+			$json = wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+			WP_CLI::log( false === $json ? '{}' : $json );
+			return;
+		}
+
+		$summary    = (array) ( $result['summary'] ?? array() );
+		$pagination = (array) ( $result['pagination'] ?? array() );
+		$rows       = (array) ( $result['rows'] ?? array() );
+
+		WP_CLI::log( 'Summary:' );
+		$summary_rows = array(
+			array( 'metric' => 'total_active_no_signal', 'count' => (int) ( $summary['total_active_no_signal'] ?? 0 ) ),
+			array( 'metric' => 'inspected', 'count' => (int) ( $summary['inspected'] ?? 0 ) ),
+			array( 'metric' => 'with_pr', 'count' => (int) ( $summary['with_pr'] ?? 0 ) ),
+			array( 'metric' => 'without_pr', 'count' => (int) ( $summary['without_pr'] ?? 0 ) ),
+			array( 'metric' => 'dirty_or_unpushed', 'count' => (int) ( $summary['dirty_or_unpushed'] ?? 0 ) ),
+		);
+		foreach ( (array) ( $summary['by_suggested_action'] ?? array() ) as $action => $count ) {
+			$summary_rows[] = array( 'metric' => 'action:' . $action, 'count' => (int) $count );
+		}
+		$this->format_items( $summary_rows, array( 'metric', 'count' ), array( 'format' => 'table' ), 'metric' );
+
+		if ( ! empty( $pagination ) ) {
+			WP_CLI::log( sprintf(
+				'Page: offset=%d limit=%d scanned=%d total=%d next_offset=%s complete=%s',
+				(int) ( $pagination['offset'] ?? 0 ),
+				(int) ( $pagination['limit'] ?? 0 ),
+				(int) ( $pagination['scanned'] ?? 0 ),
+				(int) ( $pagination['total'] ?? 0 ),
+				null === ( $pagination['next_offset'] ?? null ) ? '-' : (string) $pagination['next_offset'],
+				! empty( $pagination['complete'] ) ? 'yes' : 'no'
+			) );
+		}
+
+		if ( ! empty( $rows ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( 'Evidence:' );
+			$items = array_map(
+				fn( $row ) => array(
+					'handle'          => $row['handle'] ?? '',
+					'branch'          => $row['branch'] ?? '',
+					'action'          => $row['suggested_action'] ?? '',
+					'dirty'           => null === ( $row['dirty'] ?? null ) ? '-' : (int) $row['dirty'],
+					'unpushed'        => null === ( $row['unpushed'] ?? null ) ? '-' : (int) $row['unpushed'],
+					'pr'              => is_array( $row['pr'] ?? null ) ? (string) ( $row['pr']['html_url'] ?? $row['pr']['number'] ?? '' ) : '',
+					'outside_default' => null === ( $row['commits_outside_default'] ?? null ) ? '-' : (int) $row['commits_outside_default'],
+					'remote_tracking' => null === ( $row['remote_tracking'] ?? null ) ? '-' : ( ! empty( $row['remote_tracking'] ) ? 'yes' : 'no' ),
+				),
+				$rows
+			);
+			$this->format_items( $items, array( 'handle', 'branch', 'action', 'dirty', 'unpushed', 'pr', 'outside_default', 'remote_tracking' ), array( 'format' => 'table' ), 'handle' );
+		}
+
+		if ( null !== ( $pagination['next_offset'] ?? null ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( sprintf(
+				'Next page: wp datamachine-code workspace worktree active-no-signal-report --limit=%d --offset=%d --format=json',
+				(int) ( $pagination['limit'] ?? 0 ),
+				(int) $pagination['next_offset']
+			) );
+		}
+
+		WP_CLI::success( sprintf( 'Inspected %d active/no-signal worktree(s). Review-only; no cleanup was applied.', count( $rows ) ) );
 	}
 
 	/**

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -6317,6 +6317,222 @@ class Workspace {
 	}
 
 	/**
+	 * Build a bounded evidence report for active/no-signal worktrees.
+	 *
+	 * This is review-only. It never deletes worktrees or branches; it gathers the
+	 * facts needed to separate live work from abandoned branches before a later,
+	 * explicit cleanup action.
+	 *
+	 * @param array<string,mixed> $opts Report options.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function worktree_active_no_signal_report( array $opts = array() ): array|\WP_Error {
+		$limit  = array_key_exists( 'limit', $opts ) ? max( 1, (int) $opts['limit'] ) : 25;
+		$offset = array_key_exists( 'offset', $opts ) ? max( 0, (int) $opts['offset'] ) : 0;
+
+		$inventory = $this->worktree_cleanup_inventory_only( '', '', false );
+		if ( is_wp_error( $inventory ) ) {
+			return $inventory;
+		}
+
+		$active = array_values(
+			array_filter(
+				(array) ( $inventory['skipped'] ?? array() ),
+				fn( $row ) => is_array( $row ) && in_array( (string) ( $row['reason_code'] ?? '' ), array( 'active_no_signal', 'no_inventory_cleanup_signal' ), true )
+			)
+		);
+		$total  = count( $active );
+		$page   = array_slice( $active, $offset, $limit );
+
+		$github_cache = array();
+		$rows         = array();
+		$summary      = array(
+			'total_active_no_signal' => $total,
+			'inspected'              => 0,
+			'by_suggested_action'    => array(),
+			'dirty_or_unpushed'      => 0,
+			'with_pr'                => 0,
+			'without_pr'             => 0,
+		);
+
+		foreach ( $page as $row ) {
+			$evidence = $this->build_active_no_signal_evidence_row( $row, $github_cache );
+			$rows[]   = $evidence;
+			++$summary['inspected'];
+
+			$action = (string) ( $evidence['suggested_action'] ?? 'insufficient_signal' );
+			$summary['by_suggested_action'][ $action ] = (int) ( $summary['by_suggested_action'][ $action ] ?? 0 ) + 1;
+			if ( (int) ( $evidence['dirty'] ?? 0 ) > 0 || (int) ( $evidence['unpushed'] ?? 0 ) > 0 ) {
+				++$summary['dirty_or_unpushed'];
+			}
+			if ( ! empty( $evidence['pr']['number'] ) ) {
+				++$summary['with_pr'];
+			} else {
+				++$summary['without_pr'];
+			}
+		}
+
+		$next_offset = ( $offset + count( $page ) ) < $total ? $offset + count( $page ) : null;
+
+		return array(
+			'success'    => true,
+			'mode'       => 'active_no_signal_report',
+			'review_only' => true,
+			'generated_at' => gmdate( 'c' ),
+			'rows'       => $rows,
+			'summary'    => $summary,
+			'pagination' => array(
+				'total'        => $total,
+				'offset'       => $offset,
+				'limit'        => $limit,
+				'scanned'      => count( $page ),
+				'partial'      => null !== $next_offset,
+				'complete'     => null === $next_offset,
+				'next_offset'  => $next_offset,
+				'next_command' => null === $next_offset ? null : sprintf( 'studio wp datamachine-code workspace worktree active-no-signal-report --limit=%d --offset=%d --format=json', $limit, $next_offset ),
+			),
+			'evidence'   => array(
+				'scope' => 'review-only active_no_signal worktree lifecycle evidence',
+				'safety' => 'No worktrees or remote branches are deleted. Dirty and unpushed probes are evidence only.',
+			),
+		);
+	}
+
+	/**
+	 * Build one active/no-signal evidence row.
+	 *
+	 * @param array<string,mixed> $row          Inventory skip row.
+	 * @param array<string,mixed> $github_cache Run-local GitHub cache.
+	 * @return array<string,mixed>
+	 */
+	private function build_active_no_signal_evidence_row( array $row, array &$github_cache ): array {
+		$handle       = (string) ( $row['handle'] ?? '' );
+		$repo         = (string) ( $row['repo'] ?? '' );
+		$branch       = (string) ( $row['branch'] ?? '' );
+		$path         = (string) ( $row['path'] ?? '' );
+		$primary_path = '' !== $repo ? $this->get_primary_path( $repo ) : '';
+		$metadata     = is_array( $row['metadata'] ?? null ) ? $row['metadata'] : array();
+
+		$out = array(
+			'handle'           => $handle,
+			'repo'             => $repo,
+			'branch'           => $branch,
+			'path'             => $path,
+			'created_at'       => $row['created_at'] ?? null,
+			'lifecycle_state'  => $metadata['lifecycle_state'] ?? null,
+			'last_seen_at'     => $metadata['last_seen_at'] ?? ( $metadata['observed_at'] ?? null ),
+			'dirty'            => null,
+			'unpushed'         => null,
+			'pr'               => null,
+			'remote_tracking'  => null,
+			'default_ref'      => null,
+			'commits_outside_default' => null,
+			'suggested_action' => 'insufficient_signal',
+			'reason'           => 'not enough evidence gathered',
+		);
+
+		if ( '' === $repo || '' === $branch || '' === $path || ! is_dir( $path ) || ! is_dir( $primary_path . '/.git' ) ) {
+			$out['suggested_action'] = 'insufficient_signal';
+			$out['reason']           = 'missing repo, branch, path, worktree, or primary checkout';
+			return $out;
+		}
+
+		$dirty = $this->probe_worktree_dirty_count( $path, self::CLEANUP_GIT_PROBE_TIMEOUT );
+		if ( is_wp_error( $dirty ) ) {
+			$out['dirty_error'] = $dirty->get_error_message();
+		} else {
+			$out['dirty'] = (int) $dirty;
+		}
+
+		$unpushed = $this->count_unpushed_commits( $path, self::CLEANUP_GIT_PROBE_TIMEOUT );
+		if ( is_wp_error( $unpushed ) ) {
+			$out['unpushed_error'] = $unpushed->get_error_message();
+		} else {
+			$out['unpushed'] = (int) $unpushed;
+		}
+
+		$remote_ref = 'refs/remotes/origin/' . $branch;
+		$remote     = $this->run_git( $primary_path, sprintf( 'rev-parse --verify --quiet %s', escapeshellarg( $remote_ref ) ), self::CLEANUP_GIT_PROBE_TIMEOUT );
+		$out['remote_tracking'] = ! is_wp_error( $remote ) && ! $this->is_git_timeout_error( $remote );
+
+		$default_ref = $this->resolve_remote_default_ref( $primary_path, self::CLEANUP_GIT_PROBE_TIMEOUT );
+		if ( is_string( $default_ref ) && '' !== $default_ref ) {
+			$out['default_ref'] = $default_ref;
+			$outside = $this->run_git(
+				$primary_path,
+				sprintf( 'rev-list --count %s..%s', escapeshellarg( $default_ref ), escapeshellarg( 'refs/heads/' . $branch ) ),
+				self::CLEANUP_GIT_PROBE_TIMEOUT
+			);
+			if ( ! is_wp_error( $outside ) && ! $this->is_git_timeout_error( $outside ) ) {
+				$out['commits_outside_default'] = (int) trim( (string) ( $outside['output'] ?? '' ) );
+			}
+		}
+
+		$slug = $this->resolve_github_slug( $primary_path );
+		if ( null !== $slug ) {
+			$pr = $this->find_pr_for_branch_direct( $slug, $branch, $github_cache, false );
+			if ( is_wp_error( $pr ) ) {
+				$out['pr_error'] = $pr->get_error_message();
+			} elseif ( is_array( $pr ) ) {
+				$out['pr'] = $pr;
+			}
+		}
+
+		$out['suggested_action'] = $this->suggest_active_no_signal_action( $out );
+		$out['reason']           = $this->describe_active_no_signal_action( $out );
+
+		return $out;
+	}
+
+	/**
+	 * Suggest a review action from active/no-signal evidence.
+	 *
+	 * @param array<string,mixed> $row Evidence row.
+	 * @return string
+	 */
+	private function suggest_active_no_signal_action( array $row ): string {
+		if ( (int) ( $row['dirty'] ?? 0 ) > 0 || (int) ( $row['unpushed'] ?? 0 ) > 0 ) {
+			return 'unsafe_dirty_or_unpushed';
+		}
+
+		$pr = is_array( $row['pr'] ?? null ) ? $row['pr'] : array();
+		if ( ! empty( $pr ) ) {
+			if ( 'closed' === (string) ( $pr['state'] ?? '' ) ) {
+				return ! empty( $pr['merged_at'] ) ? 'finalized_pr_reconcile' : 'closed_pr_reconcile';
+			}
+			return 'active_open_pr';
+		}
+
+		if ( 0 === (int) ( $row['commits_outside_default'] ?? -1 ) ) {
+			return 'merged_to_default';
+		}
+
+		if ( null === ( $row['pr'] ?? null ) && empty( $row['pr_error'] ) ) {
+			return 'no_pr_branch_review';
+		}
+
+		return 'insufficient_signal';
+	}
+
+	/**
+	 * Human-readable explanation for active/no-signal action suggestions.
+	 *
+	 * @param array<string,mixed> $row Evidence row.
+	 * @return string
+	 */
+	private function describe_active_no_signal_action( array $row ): string {
+		return match ( (string) ( $row['suggested_action'] ?? '' ) ) {
+			'unsafe_dirty_or_unpushed' => 'dirty files or unpushed commits require manual handling before cleanup',
+			'finalized_pr_reconcile'   => 'exact branch-head PR lookup found a merged PR; metadata reconciliation should be able to mark cleanup_eligible',
+			'closed_pr_reconcile'      => 'exact branch-head PR lookup found a closed PR; review before marking cleanup_eligible',
+			'active_open_pr'           => 'exact branch-head PR lookup found an open PR',
+			'merged_to_default'        => 'local branch has no commits outside the remote default ref',
+			'no_pr_branch_review'      => 'no exact branch-head PR was found; review age/task context before cleanup',
+			default                    => 'not enough evidence gathered',
+		};
+	}
+
+	/**
 	 * Re-run the bounded cleanup-eligible apply safety gates against the current state.
 	 *
 	 * Returns an enriched candidate row when the worktree is still safe to
@@ -8197,23 +8413,24 @@ class Workspace {
 			return $lookup[ $branch ];
 		}
 
-		return $this->find_finalized_pr_for_branch_direct( $slug, $branch, $github_cache );
+		return $this->find_pr_for_branch_direct( $slug, $branch, $github_cache, true );
 	}
 
 	/**
-	 * Look up a finalized PR for one branch directly via GitHub's head filter.
+	 * Look up a PR for one branch directly via GitHub's head filter.
 	 *
 	 * The repo-level closed-PR snapshot is intentionally bounded for cleanup runs,
 	 * so older PRs can be missed. This precise fallback keeps PR lifecycle as the
 	 * source of truth without treating remote branch existence as liveness.
 	 *
-	 * @param string $slug         owner/repo.
-	 * @param string $branch       Branch name.
-	 * @param array  $github_cache Run-local cache keyed by owner/repo and branch.
-	 * @return array|null|\WP_Error PR data, null when no finalized PR matched, or lookup failure.
+	 * @param string $slug           owner/repo.
+	 * @param string $branch         Branch name.
+	 * @param array  $github_cache   Run-local cache keyed by owner/repo and branch.
+	 * @param bool   $finalized_only If true, ignore open PRs.
+	 * @return array|null|\WP_Error PR data, null when no matching PR exists, or lookup failure.
 	 */
-	private function find_finalized_pr_for_branch_direct( string $slug, string $branch, array &$github_cache = array() ): array|\WP_Error|null {
-		$cache_key = $slug . '#head:' . $branch;
+	private function find_pr_for_branch_direct( string $slug, string $branch, array &$github_cache = array(), bool $finalized_only = true ): array|\WP_Error|null {
+		$cache_key = $slug . '#head:' . ( $finalized_only ? 'finalized:' : 'any:' ) . $branch;
 		if ( array_key_exists( $cache_key, $github_cache ) ) {
 			return $github_cache[ $cache_key ];
 		}
@@ -8268,7 +8485,10 @@ class Workspace {
 			$head_repo = is_array( $head['repo'] ?? null ) ? (string) ( $head['repo']['full_name'] ?? '' ) : '';
 			$head_ref  = (string) ( $head['ref'] ?? '' );
 			$state     = (string) ( $pr['state'] ?? '' );
-			if ( $head_repo !== $slug || $head_ref !== $branch || 'closed' !== $state ) {
+			if ( $head_repo !== $slug || $head_ref !== $branch ) {
+				continue;
+			}
+			if ( $finalized_only && 'closed' !== $state ) {
 				continue;
 			}
 

--- a/tests/smoke-worktree-metadata-reconcile.php
+++ b/tests/smoke-worktree-metadata-reconcile.php
@@ -60,6 +60,70 @@ namespace DataMachineCode\Abilities {
 						),
 					);
 				}
+				if ( str_ends_with( $url, '/pulls' ) && 'acme:pr-merged' === ( $params['head'] ?? '' ) ) {
+					return array(
+						'data' => array(
+							array(
+								'number'    => 101,
+								'state'     => 'closed',
+								'merged_at' => '2026-04-03T00:00:00Z',
+								'html_url'  => 'https://github.com/acme/demo/pull/101',
+								'head'      => array(
+									'ref'  => 'pr-merged',
+									'repo' => array( 'full_name' => 'acme/demo' ),
+								),
+							),
+						),
+					);
+				}
+				if ( str_ends_with( $url, '/pulls' ) && 'acme:head-merged' === ( $params['head'] ?? '' ) ) {
+					return array(
+						'data' => array(
+							array(
+								'number'    => 106,
+								'state'     => 'closed',
+								'merged_at' => '2026-04-05T00:00:00Z',
+								'html_url'  => 'https://github.com/acme/demo/pull/106',
+								'head'      => array(
+									'ref'  => 'head-merged',
+									'repo' => array( 'full_name' => 'acme/demo' ),
+								),
+							),
+						),
+					);
+				}
+				if ( str_ends_with( $url, '/pulls' ) && 'acme:pr-closed' === ( $params['head'] ?? '' ) ) {
+					return array(
+						'data' => array(
+							array(
+								'number'    => 102,
+								'state'     => 'closed',
+								'merged_at' => '',
+								'html_url'  => 'https://github.com/acme/demo/pull/102',
+								'head'      => array(
+									'ref'  => 'pr-closed',
+									'repo' => array( 'full_name' => 'acme/demo' ),
+								),
+							),
+						),
+					);
+				}
+				if ( str_ends_with( $url, '/pulls' ) && 'acme:already-current' === ( $params['head'] ?? '' ) ) {
+					return array(
+						'data' => array(
+							array(
+								'number'    => 105,
+								'state'     => 'open',
+								'merged_at' => '',
+								'html_url'  => 'https://github.com/acme/demo/pull/105',
+								'head'      => array(
+									'ref'  => 'already-current',
+									'repo' => array( 'full_name' => 'acme/demo' ),
+								),
+							),
+						),
+					);
+				}
 				if ( str_ends_with( $url, '/pulls' ) && 'acme:open-branch' === ( $params['head'] ?? '' ) ) {
 					return array(
 						'data' => array(
@@ -274,6 +338,7 @@ namespace {
 	$make_branch( 'unmanaged-dirty' );
 	$make_branch( 'unmanaged-invalid' );
 	$make_branch( 'already-current' );
+	$make_branch( 'head-merged' );
 	$make_branch( 'pr-merged' );
 	$make_branch( 'pr-closed' );
 	$make_branch( 'upstream-gone' );
@@ -286,6 +351,7 @@ namespace {
 	$run( sprintf( 'git worktree add %s unmanaged-dirty', escapeshellarg( $tmp . '/demo@unmanaged-dirty' ) ), $primary );
 	$run( sprintf( 'git worktree add %s unmanaged-invalid', escapeshellarg( $tmp . '/demo@unmanaged-invalid' ) ), $primary );
 	$run( sprintf( 'git worktree add %s already-current', escapeshellarg( $tmp . '/demo@already-current' ) ), $primary );
+	$run( sprintf( 'git worktree add %s head-merged', escapeshellarg( $tmp . '/demo@head-merged' ) ), $primary );
 	$run( sprintf( 'git worktree add %s pr-merged', escapeshellarg( $tmp . '/demo@pr-merged' ) ), $primary );
 	$run( sprintf( 'git worktree add %s pr-closed', escapeshellarg( $tmp . '/demo@pr-closed' ) ), $primary );
 	$run( sprintf( 'git worktree add %s upstream-gone', escapeshellarg( $tmp . '/demo@upstream-gone' ) ), $primary );
@@ -328,6 +394,18 @@ namespace {
 			'repo'            => 'demo',
 			'branch'          => 'already-current',
 			'path'            => $tmp . '/demo@already-current',
+			'created_at'      => '2026-04-01T00:00:00+00:00',
+			'observed_at'     => '2026-04-01T00:00:00+00:00',
+			'lifecycle_state' => \DataMachineCode\Workspace\WorktreeContextInjector::STATE_ACTIVE,
+		)
+	);
+	\DataMachineCode\Workspace\WorktreeContextInjector::store_lifecycle_metadata(
+		'demo@head-merged',
+		array(
+			'handle'          => 'demo@head-merged',
+			'repo'            => 'demo',
+			'branch'          => 'head-merged',
+			'path'            => $tmp . '/demo@head-merged',
 			'created_at'      => '2026-04-01T00:00:00+00:00',
 			'observed_at'     => '2026-04-01T00:00:00+00:00',
 			'lifecycle_state' => \DataMachineCode\Workspace\WorktreeContextInjector::STATE_ACTIVE,
@@ -385,6 +463,20 @@ namespace {
 	$open_pr      = $lookup_reflection->invokeArgs( $ws, array( 'acme/demo', 'open-branch', &$lookup_cache ) );
 	$assert( 103, (int) ( $old_pr['number'] ?? 0 ), 'direct branch PR lookup finds older merged PRs outside the bounded repo snapshot' );
 	$assert( null, $open_pr, 'direct branch PR lookup does not finalize open PR branches' );
+
+	$run( 'git remote set-url origin https://github.com/acme/demo.git', $primary );
+	$active_report = $ws->worktree_active_no_signal_report( array( 'limit' => 20, 'offset' => 0 ) );
+	$run( sprintf( 'git remote set-url origin %s', escapeshellarg( $remote ) ), $primary );
+	$assert( true, ! is_wp_error( $active_report ) && ( $active_report['success'] ?? false ), 'active/no-signal report succeeds' );
+	$assert( true, (bool) ( $active_report['review_only'] ?? false ), 'active/no-signal report is review-only' );
+	$assert( true, (int) ( $active_report['summary']['inspected'] ?? 0 ) > 0, 'active/no-signal report inspects rows' );
+	$active_rows = array();
+	foreach ( (array) ( $active_report['rows'] ?? array() ) as $row ) {
+		$active_rows[ $row['handle'] ?? '' ] = $row;
+	}
+	$assert( 'finalized_pr_reconcile', $active_rows['demo@head-merged']['suggested_action'] ?? '', 'active/no-signal report finds merged PRs by branch head' );
+	$assert( 'active_open_pr', $active_rows['demo@already-current']['suggested_action'] ?? '', 'active/no-signal report preserves open PRs as active' );
+	$assert( 106, (int) ( $active_rows['demo@head-merged']['pr']['number'] ?? 0 ), 'active/no-signal report includes PR evidence' );
 
 	echo "\nDry-run reconciliation\n";
 	$plan = $ws->worktree_reconcile_metadata( array( 'dry_run' => true ) );
@@ -497,7 +589,7 @@ namespace {
 
 	$inventory_after = $ws->worktree_cleanup_merged( array( 'dry_run' => true, 'inventory_only' => true, 'skip_github' => true ) );
 	$assert( 1, (int) ( $inventory_after['summary']['skipped_by_reason']['needs_metadata_reconcile'] ?? 0 ), 'inventory cleanup requires fewer metadata reconciliation passes after apply' );
-	$assert( 5, (int) ( $inventory_after['summary']['skipped_by_reason']['active_no_signal'] ?? 0 ), 'inventory cleanup treats reconciled active metadata like current active metadata' );
+	$assert( 6, (int) ( $inventory_after['summary']['skipped_by_reason']['active_no_signal'] ?? 0 ), 'inventory cleanup treats reconciled active metadata like current active metadata' );
 	$assert( false, isset( $inventory_after['summary']['repair_status'] ), 'inventory cleanup no longer exposes migration status' );
 
 	echo "\nSafety gates\n";


### PR DESCRIPTION
## Summary
- Add a bounded, review-only `active-no-signal-report` worktree command and ability.
- Gather per-worktree evidence for dirty state, unpushed commits, exact branch-head PR state, remote tracking refs, and commits outside the remote default branch.
- Classify each row with suggested review actions like `active_open_pr`, `finalized_pr_reconcile`, `merged_to_default`, `no_pr_branch_review`, or `unsafe_dirty_or_unpushed`.

Closes #358

## Testing
- `php -l inc/Workspace/Workspace.php && php -l inc/Cli/Commands/WorkspaceCommand.php && php -l inc/Abilities/WorkspaceAbilities.php && php -l tests/smoke-worktree-metadata-reconcile.php`
- `php tests/smoke-worktree-metadata-reconcile.php`
- `php tests/smoke-worktree-cleanup-cli.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the bounded evidence report implementation, CLI/ability plumbing, and smoke coverage; Chris directed the cleanup model and will review/test before merge.