### PR TITLE
Declare agent tool runtime metadata

### DIFF
--- a/inc/Tools/GitHubIssueTool.php
+++ b/inc/Tools/GitHubIssueTool.php
@@ -125,6 +125,9 @@ class GitHubIssueTool extends BaseTool {
 			'class'       => __CLASS__,
 			'method'      => 'handle_tool_call',
 			'description' => $description,
+			'runtime'     => array(
+				'completion_signal' => 'progress',
+			),
 			'parameters'  => array(
 				'type'       => 'object',
 				'properties' => array(

--- a/inc/Tools/GitHubPullRequestTool.php
+++ b/inc/Tools/GitHubPullRequestTool.php
@@ -107,6 +107,9 @@ class GitHubPullRequestTool extends BaseTool {
 			'class'       => __CLASS__,
 			'method'      => 'handle_tool_call',
 			'description' => $description,
+			'runtime'     => array(
+				'completion_signal' => 'progress',
+			),
 			'parameters'  => array(
 				'type'       => 'object',
 				'properties' => array(

--- a/inc/Tools/GitHubTools.php
+++ b/inc/Tools/GitHubTools.php
@@ -199,7 +199,7 @@ class GitHubTools extends BaseTool {
 	 * @return array
 	 */
 	public function getListIssuesDefinition(): array {
-		return array(
+		return $this->repeatableDefinition( array(
 			'class'       => __CLASS__,
 			'method'      => 'handleListIssues',
 			'description' => 'List issues from a GitHub repository. Returns issue numbers, titles, states, labels, assignees, comment counts, timestamps, and a generated_at timestamp. Use to review open issues, track progress, or find specific issues by label.',
@@ -225,7 +225,7 @@ class GitHubTools extends BaseTool {
 				),
 				'required'   => array( 'repo' ),
 			),
-		);
+		) );
 	}
 
 	// -------------------------------------------------------------------------
@@ -259,7 +259,7 @@ class GitHubTools extends BaseTool {
 	 * @return array
 	 */
 	public function getGetIssueDefinition(): array {
-		return array(
+		return $this->repeatableDefinition( array(
 			'class'       => __CLASS__,
 			'method'      => 'handleGetIssue',
 			'description' => 'Get a single GitHub issue with full details including body, labels, assignees, comment count, timestamps, generated_at, and latest comment metadata when comments exist.',
@@ -277,7 +277,7 @@ class GitHubTools extends BaseTool {
 				),
 				'required'   => array( 'repo', 'issue_number' ),
 			),
-		);
+		) );
 	}
 
 	// -------------------------------------------------------------------------
@@ -323,7 +323,7 @@ class GitHubTools extends BaseTool {
 	 * @return array
 	 */
 	public function getManageIssueDefinition(): array {
-		return array(
+		return $this->progressDefinition( array(
 			'class'       => __CLASS__,
 			'method'      => 'handleManageIssue',
 			'description' => 'Update, close, or comment on a GitHub issue. Use action "update" to change title/body or replace the full labels set, "close" to close the issue, or "comment" to add a comment. For surgical label edits that preserve other labels, use add_label_to_issue or remove_label_from_issue instead - action=update replaces the full label set.',
@@ -362,7 +362,7 @@ class GitHubTools extends BaseTool {
 				),
 				'required'   => array( 'repo', 'issue_number', 'action' ),
 			),
-		);
+		) );
 	}
 
 	// -------------------------------------------------------------------------
@@ -508,7 +508,7 @@ class GitHubTools extends BaseTool {
 	 * @return array
 	 */
 	public function getCommentPullRequestDefinition(): array {
-		return array(
+		return $this->progressDefinition( array(
 			'class'       => __CLASS__,
 			'method'      => 'handleCommentPullRequest',
 			'description' => 'Comment on a GitHub pull request without granting broader issue update or close capabilities.',
@@ -534,7 +534,7 @@ class GitHubTools extends BaseTool {
 				),
 				'required'   => array( 'repo', 'pull_number', 'body' ),
 			),
-		);
+		) );
 	}
 
 	/**
@@ -666,7 +666,7 @@ class GitHubTools extends BaseTool {
 	 * @return array
 	 */
 	public function getListPullsDefinition(): array {
-		return array(
+		return $this->repeatableDefinition( array(
 			'class'       => __CLASS__,
 			'method'      => 'handleListPulls',
 			'description' => 'List pull requests from a GitHub repository. Returns PR numbers, titles, states, branches, merge status, comment counts, change counts, timestamps, and generated_at.',
@@ -684,7 +684,7 @@ class GitHubTools extends BaseTool {
 				),
 				'required'   => array( 'repo' ),
 			),
-		);
+		) );
 	}
 
 	// -------------------------------------------------------------------------
@@ -737,7 +737,7 @@ class GitHubTools extends BaseTool {
 	 * @return array
 	 */
 	public function getGetPullDefinition(): array {
-		return array(
+		return $this->repeatableDefinition( array(
 			'class'       => __CLASS__,
 			'method'      => 'handleGetPull',
 			'description' => 'Get one GitHub pull request with normalized title, body, branch, SHA, labels, merge metadata, comment counts, change counts, timestamps, and generated_at.',
@@ -755,7 +755,7 @@ class GitHubTools extends BaseTool {
 				),
 				'required'   => array( 'repo', 'pull_number' ),
 			),
-		);
+		) );
 	}
 
 	/**
@@ -774,7 +774,7 @@ class GitHubTools extends BaseTool {
 	 * @return array
 	 */
 	public function getPullFilesDefinition(): array {
-		return array(
+		return $this->repeatableDefinition( array(
 			'class'       => __CLASS__,
 			'method'      => 'handlePullFiles',
 			'description' => 'List files changed by a GitHub pull request, including filename, status, additions, deletions, and patch when available.',
@@ -800,7 +800,7 @@ class GitHubTools extends BaseTool {
 				),
 				'required'   => array( 'repo', 'pull_number' ),
 			),
-		);
+		) );
 	}
 
 	/**
@@ -1017,7 +1017,7 @@ class GitHubTools extends BaseTool {
 	 * @return array
 	 */
 	public function getPullReviewContextDefinition(): array {
-		return array(
+		return $this->repeatableDefinition( array(
 			'class'       => __CLASS__,
 			'method'      => 'handlePullReviewContext',
 			'description' => 'Build a review-ready context packet for a GitHub pull request, including normalized PR metadata and changed-file patches.',
@@ -1092,7 +1092,7 @@ class GitHubTools extends BaseTool {
 				),
 				'required'   => array( 'repo', 'pull_number' ),
 			),
-		);
+		) );
 	}
 
 	/**
@@ -1249,7 +1249,7 @@ class GitHubTools extends BaseTool {
 	 * @return array
 	 */
 	public function getListTreeDefinition(): array {
-		return array(
+		return $this->repeatableDefinition( array(
 			'class'       => __CLASS__,
 			'method'      => 'handleListTree',
 			'description' => 'List files in a GitHub repository tree at a branch, tag, or commit SHA. Optionally filter to a path prefix.',
@@ -1271,7 +1271,7 @@ class GitHubTools extends BaseTool {
 				),
 				'required'   => array( 'repo' ),
 			),
-		);
+		) );
 	}
 
 	/**
@@ -1290,7 +1290,7 @@ class GitHubTools extends BaseTool {
 	 * @return array
 	 */
 	public function getGetFileDefinition(): array {
-		return array(
+		return $this->repeatableDefinition( array(
 			'class'       => __CLASS__,
 			'method'      => 'handleGetFile',
 			'description' => 'Get decoded content for one or more files from a GitHub repository. Accepts path for one file or paths for one-or-many; always returns files[].',
@@ -1321,7 +1321,7 @@ class GitHubTools extends BaseTool {
 				),
 				'required'   => array( 'repo' ),
 			),
-		);
+		) );
 	}
 
 	/**
@@ -1340,7 +1340,7 @@ class GitHubTools extends BaseTool {
 	 * @return array
 	 */
 	public function getCreateOrUpdateFileDefinition(): array {
-		return array(
+		return $this->progressDefinition( array(
 			'class'       => __CLASS__,
 			'method'      => 'handleCreateOrUpdateFile',
 			'description' => 'Create or update a file in a GitHub repository using the Contents API. If branch is provided and does not exist, it is created from the repository default branch before committing.',
@@ -1375,7 +1375,7 @@ class GitHubTools extends BaseTool {
 				),
 				'required'   => array( 'repo', 'file_path', 'content', 'commit_message' ),
 			),
-		);
+		) );
 	}
 
 	// -------------------------------------------------------------------------
@@ -1409,7 +1409,7 @@ class GitHubTools extends BaseTool {
 	 * @return array
 	 */
 	public function getListReposDefinition(): array {
-		return array(
+		return $this->repeatableDefinition( array(
 			'class'       => __CLASS__,
 			'method'      => 'handleListRepos',
 			'description' => 'List GitHub repositories for a user or organization. Shows repo names, languages, stars, open issues, and last push date.',
@@ -1427,6 +1427,22 @@ class GitHubTools extends BaseTool {
 				),
 				'required'   => array( 'owner' ),
 			),
-		);
+		) );
+	}
+
+	/** @param array<string,mixed> $definition Tool definition. @return array<string,mixed> */
+	private function repeatableDefinition( array $definition ): array {
+		return $this->withRuntime( $definition, array( 'duplicate_policy' => 'repeatable' ) );
+	}
+
+	/** @param array<string,mixed> $definition Tool definition. @return array<string,mixed> */
+	private function progressDefinition( array $definition ): array {
+		return $this->withRuntime( $definition, array( 'completion_signal' => 'progress' ) );
+	}
+
+	/** @param array<string,mixed> $definition Tool definition. @param array<string,mixed> $runtime Runtime metadata. @return array<string,mixed> */
+	private function withRuntime( array $definition, array $runtime ): array {
+		$definition['runtime'] = array_merge( is_array( $definition['runtime'] ?? null ) ? $definition['runtime'] : array(), $runtime );
+		return $definition;
 	}
 }

--- a/inc/Tools/WordPressRuntimeTools.php
+++ b/inc/Tools/WordPressRuntimeTools.php
@@ -82,7 +82,7 @@ class WordPressRuntimeTools extends BaseTool {
 
 	/** @return array<string,mixed> */
 	public function getInventoryDefinition(): array {
-		return array(
+		return $this->repeatableDefinition( array(
 			'class'       => __CLASS__,
 			'method'      => 'handleInventory',
 			'description' => 'Inspect the live WordPress runtime inventory: WP/PHP versions, active theme, installed plugins/themes, mu-plugins, drop-ins, and safe source-root policy metadata.',
@@ -91,12 +91,12 @@ class WordPressRuntimeTools extends BaseTool {
 				'properties' => array(),
 				'required'   => array(),
 			),
-		);
+		) );
 	}
 
 	/** @return array<string,mixed> */
 	public function getLsDefinition(): array {
-		return array(
+		return $this->repeatableDefinition( array(
 			'class'       => __CLASS__,
 			'method'      => 'handleLs',
 			'description' => 'List files/directories under allowlisted WordPress runtime source roots only. Default path is wp-content/plugins.',
@@ -114,12 +114,12 @@ class WordPressRuntimeTools extends BaseTool {
 				),
 				'required'   => array(),
 			),
-		);
+		) );
 	}
 
 	/** @return array<string,mixed> */
 	public function getReadDefinition(): array {
-		return array(
+		return $this->repeatableDefinition( array(
 			'class'       => __CLASS__,
 			'method'      => 'handleRead',
 			'description' => 'Read a bounded text file under allowlisted WordPress runtime source roots only. Denies sensitive paths, traversal, oversized files, and binary files.',
@@ -145,7 +145,13 @@ class WordPressRuntimeTools extends BaseTool {
 				),
 				'required'   => array( 'path' ),
 			),
-		);
+		) );
+	}
+
+	/** @param array<string,mixed> $definition Tool definition. @return array<string,mixed> */
+	private function repeatableDefinition( array $definition ): array {
+		$definition['runtime'] = array_merge( is_array( $definition['runtime'] ?? null ) ? $definition['runtime'] : array(), array( 'duplicate_policy' => 'repeatable' ) );
+		return $definition;
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed> */

--- a/inc/Tools/WorkspaceDiffTools.php
+++ b/inc/Tools/WorkspaceDiffTools.php
@@ -59,7 +59,7 @@ class WorkspaceDiffTools extends BaseTool {
 
 	/** @return array<string,mixed> */
 	public function getDiffSummaryDefinition(): array {
-		return array(
+		return $this->repeatableDefinition( array(
 			'class'       => __CLASS__,
 			'method'      => 'handleDiffSummary',
 			'description' => 'Summarize changed files, additions/deletions, test-touch status, and compact git diff metadata for a workspace handle.',
@@ -74,12 +74,12 @@ class WorkspaceDiffTools extends BaseTool {
 				),
 				'required'   => array( 'name' ),
 			),
-		);
+		) );
 	}
 
 	/** @return array<string,mixed> */
 	public function getDiffValidateDefinition(): array {
-		return array(
+		return $this->repeatableDefinition( array(
 			'class'       => __CLASS__,
 			'method'      => 'handleDiffValidate',
 			'description' => 'Validate workspace diff shape using allowed/denied path patterns and optional test-change requirements.',
@@ -109,7 +109,13 @@ class WorkspaceDiffTools extends BaseTool {
 				),
 				'required'   => array( 'name' ),
 			),
-		);
+		) );
+	}
+
+	/** @param array<string,mixed> $definition Tool definition. @return array<string,mixed> */
+	private function repeatableDefinition( array $definition ): array {
+		$definition['runtime'] = array_merge( is_array( $definition['runtime'] ?? null ) ? $definition['runtime'] : array(), array( 'duplicate_policy' => 'repeatable' ) );
+		return $definition;
 	}
 
 	/** @param array<string,mixed> $parameters Tool parameters. @return array<string,mixed> */

--- a/inc/Tools/WorkspaceTools.php
+++ b/inc/Tools/WorkspaceTools.php
@@ -528,7 +528,7 @@ class WorkspaceTools extends BaseTool {
 	 * @return array
 	 */
 	public function getPathDefinition(): array {
-		return array(
+		return $this->repeatableDefinition( array(
 			'class'       => __CLASS__,
 			'method'      => 'handlePath',
 			'description' => 'Get the Data Machine workspace path. Optionally ensure it exists.',
@@ -542,7 +542,7 @@ class WorkspaceTools extends BaseTool {
 				),
 				'required'   => array(),
 			),
-		);
+		) );
 	}
 
 	/**
@@ -551,7 +551,7 @@ class WorkspaceTools extends BaseTool {
 	 * @return array Tool definition.
 	 */
 	public function getCapabilitiesDefinition(): array {
-		return array(
+		return $this->repeatableDefinition( array(
 			'class'       => self::class,
 			'method'      => 'handleCapabilities',
 			'description' => 'Inspect whether the current Data Machine Code workspace backend can run local git operations in this runtime.',
@@ -565,7 +565,7 @@ class WorkspaceTools extends BaseTool {
 				),
 				'required'   => array(),
 			),
-		);
+		) );
 	}
 
 	/**
@@ -574,7 +574,7 @@ class WorkspaceTools extends BaseTool {
 	 * @return array
 	 */
 	public function getListDefinition(): array {
-		return array(
+		return $this->repeatableDefinition( array(
 			'class'       => __CLASS__,
 			'method'      => 'handleList',
 			'description' => 'List repositories currently present in the Data Machine workspace.',
@@ -583,7 +583,7 @@ class WorkspaceTools extends BaseTool {
 				'properties' => array(),
 				'required'   => array(),
 			),
-		);
+		) );
 	}
 
 	/**
@@ -592,7 +592,7 @@ class WorkspaceTools extends BaseTool {
 	 * @return array
 	 */
 	public function getShowDefinition(): array {
-		return array(
+		return $this->repeatableDefinition( array(
 			'class'       => __CLASS__,
 			'method'      => 'handleShow',
 			'description' => 'Show detailed information about a workspace repository (branch, remote, latest commit, dirty count).',
@@ -606,7 +606,7 @@ class WorkspaceTools extends BaseTool {
 				),
 				'required'   => array( 'name' ),
 			),
-		);
+		) );
 	}
 
 	/**
@@ -615,7 +615,7 @@ class WorkspaceTools extends BaseTool {
 	 * @return array
 	 */
 	public function getLsDefinition(): array {
-		return array(
+		return $this->repeatableDefinition( array(
 			'class'       => __CLASS__,
 			'method'      => 'handleLs',
 			'description' => 'List directory contents within a workspace repository.',
@@ -633,7 +633,7 @@ class WorkspaceTools extends BaseTool {
 				),
 				'required'   => array( 'repo' ),
 			),
-		);
+		) );
 	}
 
 	/**
@@ -642,7 +642,7 @@ class WorkspaceTools extends BaseTool {
 	 * @return array
 	 */
 	public function getReadDefinition(): array {
-		return array(
+		return $this->repeatableDefinition( array(
 			'class'       => __CLASS__,
 			'method'      => 'handleRead',
 			'description' => 'Read a text file from a workspace repository. Supports optional max_size, offset, and limit for large files.',
@@ -672,7 +672,7 @@ class WorkspaceTools extends BaseTool {
 				),
 				'required'   => array( 'repo', 'path' ),
 			),
-		);
+		) );
 	}
 
 	/**
@@ -681,7 +681,7 @@ class WorkspaceTools extends BaseTool {
 	 * @return array
 	 */
 	public function getGrepDefinition(): array {
-		return array(
+		return $this->repeatableDefinition( array(
 			'class'       => __CLASS__,
 			'method'      => 'handleGrep',
 			'description' => 'Search text files in a workspace repository using a regular expression pattern.',
@@ -715,12 +715,12 @@ class WorkspaceTools extends BaseTool {
 				),
 				'required'   => array( 'repo', 'pattern' ),
 			),
-		);
+		) );
 	}
 
 	/** @return array<string,mixed> */
 	public function getWriteDefinition(): array {
-		return array(
+		return $this->progressDefinition( array(
 			'class'       => __CLASS__,
 			'method'      => 'handleWrite',
 			'description' => 'Create or overwrite a file in a workspace repository. Policy-gated for pipeline use.',
@@ -733,12 +733,12 @@ class WorkspaceTools extends BaseTool {
 				),
 				'required'   => array( 'repo', 'path', 'content' ),
 			),
-		);
+		) );
 	}
 
 	/** @return array<string,mixed> */
 	public function getEditDefinition(): array {
-		return array(
+		return $this->progressDefinition( array(
 			'class'       => __CLASS__,
 			'method'      => 'handleEdit',
 			'description' => 'Find-and-replace exact text in a workspace repository file. Policy-gated for pipeline use.',
@@ -753,12 +753,12 @@ class WorkspaceTools extends BaseTool {
 				),
 				'required'   => array( 'repo', 'path', 'old_string', 'new_string' ),
 			),
-		);
+		) );
 	}
 
 	/** @return array<string,mixed> */
 	public function getApplyPatchDefinition(): array {
-		return array(
+		return $this->progressDefinition( array(
 			'class'       => __CLASS__,
 			'method'      => 'handleApplyPatch',
 			'description' => 'Apply a unified diff to a workspace repository using git apply checks. Policy-gated for pipeline use.',
@@ -771,12 +771,12 @@ class WorkspaceTools extends BaseTool {
 				),
 				'required'   => array( 'repo', 'patch' ),
 			),
-		);
+		) );
 	}
 
 	/** @return array<string,mixed> */
 	public function getDeleteDefinition(): array {
-		return array(
+		return $this->progressDefinition( array(
 			'class'       => __CLASS__,
 			'method'      => 'handleDelete',
 			'description' => 'Delete a tracked or untracked path from a workspace repository. Policy-gated for pipeline use.',
@@ -790,19 +790,19 @@ class WorkspaceTools extends BaseTool {
 				),
 				'required'   => array( 'repo', 'path' ),
 			),
-		);
+		) );
 	}
 
 	/** @return array<string,mixed> */
 	public function getGitStatusDefinition(): array {
-		return $this->simpleGitDefinition( 'handleGitStatus', 'Get git status information for a workspace handle.', array() );
+		return $this->simpleGitDefinition( 'handleGitStatus', 'Get git status information for a workspace handle.', array(), array( 'name' ), array( 'duplicate_policy' => 'repeatable' ) );
 	}
 
 	/** @return array<string,mixed> */
 	public function getGitLogDefinition(): array {
 		return $this->simpleGitDefinition( 'handleGitLog', 'Read git log entries for a workspace handle.', array(
 			'limit' => array( 'type' => 'integer', 'description' => 'Maximum log entries to return.' ),
-		) );
+		), array( 'name' ), array( 'duplicate_policy' => 'repeatable' ) );
 	}
 
 	/** @return array<string,mixed> */
@@ -812,7 +812,7 @@ class WorkspaceTools extends BaseTool {
 			'to'     => array( 'type' => 'string', 'description' => 'Optional to git ref.' ),
 			'staged' => array( 'type' => 'boolean', 'description' => 'Read staged diff instead of working tree diff.' ),
 			'path'   => array( 'type' => 'string', 'description' => 'Optional relative path filter.' ),
-		) );
+		), array( 'name' ), array( 'duplicate_policy' => 'repeatable' ) );
 	}
 
 	/** @return array<string,mixed> */
@@ -820,12 +820,12 @@ class WorkspaceTools extends BaseTool {
 		return $this->simpleGitDefinition( 'handleGitPull', 'Run git pull --ff-only for a workspace handle. Policy-gated for pipeline use.', array(
 			'allow_dirty'            => array( 'type' => 'boolean', 'description' => 'Allow pull when working tree is dirty. Default false.' ),
 			'allow_primary_mutation' => array( 'type' => 'boolean', 'description' => 'Permit mutation on a primary checkout. Default false.' ),
-		) );
+		), array( 'name' ), array( 'completion_signal' => 'progress' ) );
 	}
 
 	/** @return array<string,mixed> */
 	public function getWorktreeAddDefinition(): array {
-		return array(
+		return $this->progressDefinition( array(
 			'class'       => __CLASS__,
 			'method'      => 'handleWorktreeAdd',
 			'description' => 'Create a git worktree for a workspace repository branch. Policy-gated for pipeline use.',
@@ -845,7 +845,7 @@ class WorkspaceTools extends BaseTool {
 				),
 				'required'   => array( 'repo', 'branch' ),
 			),
-		);
+		) );
 	}
 
 	/** @return array<string,mixed> */
@@ -853,7 +853,7 @@ class WorkspaceTools extends BaseTool {
 		return $this->simpleGitDefinition( 'handleGitAdd', 'Stage repository paths with git add. Policy-gated for pipeline use.', array(
 			'paths'                  => array( 'type' => 'array', 'items' => array( 'type' => 'string' ), 'description' => 'Relative paths to stage.' ),
 			'allow_primary_mutation' => array( 'type' => 'boolean', 'description' => 'Permit mutation on a primary checkout. Default false.' ),
-		), array( 'name', 'paths' ) );
+		), array( 'name', 'paths' ), array( 'completion_signal' => 'progress' ) );
 	}
 
 	/** @return array<string,mixed> */
@@ -861,7 +861,7 @@ class WorkspaceTools extends BaseTool {
 		return $this->simpleGitDefinition( 'handleGitCommit', 'Commit staged changes in a workspace handle. Policy-gated for pipeline use.', array(
 			'message'                => array( 'type' => 'string', 'description' => 'Commit message.' ),
 			'allow_primary_mutation' => array( 'type' => 'boolean', 'description' => 'Permit mutation on a primary checkout. Default false.' ),
-		), array( 'name', 'message' ) );
+		), array( 'name', 'message' ), array( 'completion_signal' => 'progress' ) );
 	}
 
 	/** @return array<string,mixed> */
@@ -870,12 +870,12 @@ class WorkspaceTools extends BaseTool {
 			'remote'                 => array( 'type' => 'string', 'description' => 'Remote name. Default origin.' ),
 			'branch'                 => array( 'type' => 'string', 'description' => 'Branch override.' ),
 			'allow_primary_mutation' => array( 'type' => 'boolean', 'description' => 'Permit mutation on a primary checkout. Default false.' ),
-		) );
+		), array( 'name' ), array( 'completion_signal' => 'progress' ) );
 	}
 
 	/** @param array<string,mixed> $extra_properties Extra parameters. @param string[] $required Required properties. @return array<string,mixed> */
-	private function simpleGitDefinition( string $method, string $description, array $extra_properties, array $required = array( 'name' ) ): array {
-		return array(
+	private function simpleGitDefinition( string $method, string $description, array $extra_properties, array $required = array( 'name' ), array $runtime = array() ): array {
+		return $this->withRuntime( array(
 			'class'       => __CLASS__,
 			'method'      => $method,
 			'description' => $description,
@@ -890,6 +890,26 @@ class WorkspaceTools extends BaseTool {
 				),
 				'required'   => $required,
 			),
-		);
+		), $runtime );
+	}
+
+	/** @param array<string,mixed> $definition Tool definition. @return array<string,mixed> */
+	private function repeatableDefinition( array $definition ): array {
+		return $this->withRuntime( $definition, array( 'duplicate_policy' => 'repeatable' ) );
+	}
+
+	/** @param array<string,mixed> $definition Tool definition. @return array<string,mixed> */
+	private function progressDefinition( array $definition ): array {
+		return $this->withRuntime( $definition, array( 'completion_signal' => 'progress' ) );
+	}
+
+	/** @param array<string,mixed> $definition Tool definition. @param array<string,mixed> $runtime Runtime metadata. @return array<string,mixed> */
+	private function withRuntime( array $definition, array $runtime ): array {
+		if ( empty( $runtime ) ) {
+			return $definition;
+		}
+
+		$definition['runtime'] = array_merge( is_array( $definition['runtime'] ?? null ) ? $definition['runtime'] : array(), $runtime );
+		return $definition;
 	}
 }


### PR DESCRIPTION
## Summary
- Declares Data Machine agent-loop `runtime` metadata on Data Machine Code tool definitions.
- Marks workspace/GitHub/WordPress inspection tools as repeatable so duplicate-call prevention does not block legitimate re-reads.
- Marks workspace mutations, GitHub writes, PR creation, and issue creation as progress signals for completion assertion nudges.

Depends on Extra-Chill/data-machine#1951.

## Testing
- `php -l inc/Tools/WorkspaceTools.php`
- `php -l inc/Tools/GitHubTools.php`
- `php -l inc/Tools/WordPressRuntimeTools.php`
- `php -l inc/Tools/GitHubPullRequestTool.php`
- `php -l inc/Tools/GitHubIssueTool.php`
- `php -l inc/Tools/WorkspaceDiffTools.php`
- `php tests/smoke-tool-result-contracts.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the tool metadata declarations and validation pass based on the Data Machine runtime metadata contract.