### PR TITLE
Fetch GitHub Actions artifact items

### DIFF
--- a/inc/Handlers/GitHub/GitHub.php
+++ b/inc/Handlers/GitHub/GitHub.php
@@ -96,6 +96,10 @@ class GitHub extends FetchHandler {
 			return $this->fetchHomeboyCiResults( $config, $context, $repo );
 		}
 
+		if ( 'actions_artifact_items' === $data_source ) {
+			return $this->fetchActionsArtifactItems( $config, $context, $repo );
+		}
+
 		if ( 'files' === $data_source ) {
 			return $this->fetchFiles( $config, $context, $repo );
 		}
@@ -352,6 +356,125 @@ class GitHub extends FetchHandler {
 
 		$context->log( 'info', sprintf( 'GitHub: Prepared Homeboy CI results for %s@%s.', $repo, $sha ) );
 		return array( 'items' => array( $packet ) );
+	}
+
+	/**
+	 * Fetch a JSON file from a GitHub Actions artifact and emit one item per array entry.
+	 */
+	private function fetchActionsArtifactItems( array $config, ExecutionContext $context, string $repo ): array {
+		$artifact_name = (string) ( $config['artifact_name'] ?? '' );
+		$json_file     = (string) ( $config['json_file'] ?? $config['artifact_json_file'] ?? '' );
+
+		if ( '' === $artifact_name ) {
+			$context->log( 'error', 'GitHub: artifact_name is required for actions_artifact_items.' );
+			return array();
+		}
+
+		$result = GitHubAbilities::getActionsArtifact( array(
+			'repo'               => $repo,
+			'pull_number'        => (int) ( $config['pull_number'] ?? $config['pr_number'] ?? 0 ),
+			'head_sha'           => $config['head_sha'] ?? $config['sha'] ?? '',
+			'artifact_name'      => $artifact_name,
+			'max_artifact_bytes' => $config['max_artifact_bytes'] ?? 2000000,
+			'include_json'       => true,
+		) );
+
+		if ( is_wp_error( $result ) ) {
+			$context->log( 'error', 'GitHub: Actions artifact error — ' . $result->get_error_message() );
+			return array();
+		}
+
+		$json_files = is_array( $result['json_files'] ?? null ) ? $result['json_files'] : array();
+		if ( '' === $json_file ) {
+			$json_file = 1 === count( $json_files ) ? (string) array_key_first( $json_files ) : '';
+		}
+
+		if ( '' === $json_file || ! isset( $json_files[ $json_file ] ) || ! is_array( $json_files[ $json_file ] ) ) {
+			$context->log( 'error', sprintf( 'GitHub: Artifact JSON file not found or not an array: %s.', $json_file ) );
+			return array();
+		}
+
+		$payload = $json_files[ $json_file ];
+		$items_payload = $this->selectArtifactItems( $payload, (string) ( $config['items_path'] ?? '' ) );
+		if ( empty( $items_payload ) ) {
+			$context->log( 'info', sprintf( 'GitHub: Artifact JSON file %s contained no items.', $json_file ) );
+			return array();
+		}
+
+		$head_sha = (string) ( $result['head_sha'] ?? $config['head_sha'] ?? '' );
+		$items    = array();
+		foreach ( $items_payload as $index => $item ) {
+			if ( ! is_array( $item ) ) {
+				continue;
+			}
+
+			$item_identifier = sprintf(
+				'github_actions_artifact:%s:%s:%s:%s:%s',
+				$repo,
+				$head_sha,
+				$artifact_name,
+				$json_file,
+				hash( 'sha256', wp_json_encode( $item, JSON_UNESCAPED_SLASHES ) ?: (string) $index )
+			);
+
+			$title = (string) ( $item['title'] ?? $item['selector'] ?? $item['kind'] ?? '' );
+			if ( '' === $title ) {
+				$title = sprintf( '%s item %d', $json_file, (int) $index + 1 );
+			}
+
+			$items[] = array(
+				'title'    => $title,
+				'content'  => wp_json_encode( $item, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ),
+				'metadata' => array(
+					'source_type'      => 'github_actions_artifact',
+					'item_identifier'  => $item_identifier,
+					'original_id'      => $item_identifier,
+					'dedup_key'        => $item_identifier,
+					'original_title'   => $title,
+					'github_repo'      => $repo,
+					'github_type'      => 'actions_artifact_items',
+					'github_head_sha'  => $head_sha,
+					'artifact_name'    => $artifact_name,
+					'artifact_json_file' => $json_file,
+					'artifact_item_index' => (int) $index,
+					'artifact_item'    => $item,
+				),
+			);
+		}
+
+		$context->log( 'info', sprintf( 'GitHub: Prepared %d artifact item packets from %s/%s.', count( $items ), $artifact_name, $json_file ) );
+		return array( 'items' => $items );
+	}
+
+	private function selectArtifactItems( array $payload, string $items_path ): array {
+		$value = $payload;
+		if ( '' !== $items_path ) {
+			foreach ( explode( '.', $items_path ) as $part ) {
+				if ( '' === $part ) {
+					continue;
+				}
+				if ( ! is_array( $value ) || ! array_key_exists( $part, $value ) ) {
+					return array();
+				}
+				$value = $value[ $part ];
+			}
+		}
+
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		if ( array_is_list( $value ) ) {
+			return $value;
+		}
+
+		foreach ( array( 'items', 'packets', 'findings' ) as $key ) {
+			if ( isset( $value[ $key ] ) && is_array( $value[ $key ] ) ) {
+				return $value[ $key ];
+			}
+		}
+
+		return array();
 	}
 
 	private function resolveShaFromConfig( array $config ): string {

--- a/inc/Handlers/GitHub/GitHubSettings.php
+++ b/inc/Handlers/GitHub/GitHubSettings.php
@@ -46,6 +46,7 @@ class GitHubSettings extends FetchHandlerSettings {
 					'check_runs'                     => __( 'Check Runs', 'data-machine-code' ),
 					'commit_statuses'                => __( 'Commit Statuses', 'data-machine-code' ),
 					'homeboy_ci_results'             => __( 'Homeboy CI Results', 'data-machine-code' ),
+					'actions_artifact_items'         => __( 'GitHub Actions Artifact Items', 'data-machine-code' ),
 					'files'                          => __( 'Source Files', 'data-machine-code' ),
 				),
 			),
@@ -182,9 +183,21 @@ class GitHubSettings extends FetchHandlerSettings {
 			'max_artifact_bytes'      => array(
 				'type'        => 'number',
 				'label'       => __( 'Max Artifact Bytes', 'data-machine-code' ),
-				'description' => __( 'Maximum Homeboy CI artifact ZIP bytes to download.', 'data-machine-code' ),
+				'description' => __( 'Maximum GitHub Actions artifact ZIP bytes to download.', 'data-machine-code' ),
 				'required'    => false,
 				'default'     => 2000000,
+			),
+			'json_file'               => array(
+				'type'        => 'text',
+				'label'       => __( 'Artifact JSON File', 'data-machine-code' ),
+				'description' => __( 'JSON filename inside the artifact ZIP for actions_artifact_items. If omitted and the artifact has exactly one JSON file, that file is used.', 'data-machine-code' ),
+				'required'    => false,
+			),
+			'items_path'              => array(
+				'type'        => 'text',
+				'label'       => __( 'Artifact Items Path', 'data-machine-code' ),
+				'description' => __( 'Optional dot path to the item array inside the selected JSON file. Leave empty when the file root is the array.', 'data-machine-code' ),
+				'required'    => false,
 			),
 			'state'                   => array(
 				'type'        => 'select',

--- a/tests/smoke-github-actions-artifact-fetch-handler.php
+++ b/tests/smoke-github-actions-artifact-fetch-handler.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Smoke assertions for GitHub Actions artifact item fetch support.
+ *
+ * Run with: php tests/smoke-github-actions-artifact-fetch-handler.php
+ */
+
+$root     = dirname( __DIR__ );
+$handler  = file_get_contents( $root . '/inc/Handlers/GitHub/GitHub.php' );
+$settings = file_get_contents( $root . '/inc/Handlers/GitHub/GitHubSettings.php' );
+
+$assert = static function ( string $message, bool $condition ): void {
+	if ( ! $condition ) {
+		fwrite( STDERR, "FAIL: {$message}\n" );
+		exit( 1 );
+	}
+};
+
+$assert(
+	'github fetch handler routes actions_artifact_items data source',
+	false !== strpos( $handler, "'actions_artifact_items' === \$data_source" )
+);
+
+$assert(
+	'artifact fetch delegates to generic GitHub Actions artifact ability',
+	false !== strpos( $handler, 'GitHubAbilities::getActionsArtifact' )
+);
+
+$assert(
+	'artifact item packets include dedupe item identifiers',
+	false !== strpos( $handler, "'item_identifier'" ) && false !== strpos( $handler, 'github_actions_artifact:' )
+);
+
+$assert(
+	'artifact item packets preserve the original item payload in metadata',
+	false !== strpos( $handler, "'artifact_item'" )
+);
+
+$assert(
+	'settings expose actions_artifact_items as a GitHub data source',
+	false !== strpos( $settings, "'actions_artifact_items'" )
+);
+
+$assert(
+	'settings expose json_file and items_path controls',
+	false !== strpos( $settings, "'json_file'" ) && false !== strpos( $settings, "'items_path'" )
+);
+
+echo "OK: GitHub Actions artifact fetch handler smoke assertions passed.\n";


### PR DESCRIPTION
## Summary
- Add a GitHub fetch data source that downloads a matching Actions artifact and emits one DataPacket item per JSON array entry.
- Expose artifact JSON file and item path settings so Data Machine pipelines can fan out artifact-produced work natively.
- Add smoke coverage for the handler wiring and packet metadata contract.

## Testing
- `php -l inc/Handlers/GitHub/GitHub.php`
- `php -l inc/Handlers/GitHub/GitHubSettings.php`
- `php tests/smoke-github-actions-artifact-fetch-handler.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the fetch handler implementation, smoke assertions, and validation commands for Chris to review.