### PR TITLE
Promote finalized worktree report evidence

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -1628,6 +1628,46 @@ class WorkspaceAbilities {
 			);
 
 			wp_register_ability(
+				'datamachine/workspace-worktree-active-no-signal-finalized-apply',
+				array(
+					'label'               => 'Promote Finalized Active Worktrees',
+					'description'         => 'Promote active_no_signal rows with merged PR evidence into explicit cleanup_eligible metadata. Reviewable and bounded; never deletes worktrees.',
+					'category'            => 'datamachine-code-workspace',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'dry_run' => array(
+								'type'        => 'boolean',
+								'description' => 'If true, preview metadata promotions without writing.',
+							),
+							'limit'   => array(
+								'type'        => 'integer',
+								'description' => 'Maximum active_no_signal rows to inspect in this page. Defaults to 25.',
+							),
+							'offset'  => array(
+								'type'        => 'integer',
+								'description' => 'Pagination offset into the active_no_signal inventory ordering.',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'dry_run' => array( 'type' => 'boolean' ),
+							'planned' => array( 'type' => 'array' ),
+							'written' => array( 'type' => 'array' ),
+							'skipped' => array( 'type' => 'array' ),
+							'summary' => array( 'type' => 'object' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'worktreeActiveNoSignalFinalizedApply' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
 				'datamachine/workspace-worktree-cleanup-artifacts',
 				array(
 					'label'               => 'Cleanup Worktree Artifacts',
@@ -2616,6 +2656,27 @@ class WorkspaceAbilities {
 		}
 
 		return $workspace->worktree_active_no_signal_report( $opts );
+	}
+
+	/**
+	 * Promote finalized active/no-signal evidence into cleanup metadata.
+	 *
+	 * @param array $input Input parameters (dry_run, limit, offset).
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public static function worktreeActiveNoSignalFinalizedApply( array $input ): array|\WP_Error {
+		$workspace = new Workspace();
+		$opts      = array(
+			'dry_run' => ! empty( $input['dry_run'] ),
+		);
+		if ( array_key_exists( 'limit', $input ) ) {
+			$opts['limit'] = (int) $input['limit'];
+		}
+		if ( array_key_exists( 'offset', $input ) ) {
+			$opts['offset'] = (int) $input['offset'];
+		}
+
+		return $workspace->worktree_active_no_signal_finalized_apply( $opts );
 	}
 
 	/**

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1853,7 +1853,8 @@ class WorkspaceCommand extends BaseCommand {
 	 * <operation>
 	 * : Worktree operation: add, list, remove, prune, cleanup, cleanup-artifacts,
 	 *   bounded-cleanup-eligible-apply, emergency-cleanup, reconcile-metadata,
-	 *   active-no-signal-report, refresh-context, finalize, mark-cleanup-eligible.
+	 *   active-no-signal-report, active-no-signal-finalized-apply,
+	 *   refresh-context, finalize, mark-cleanup-eligible.
 	 *
 	 * [<repo>]
 	 * : Primary repo name (required for add and remove). For refresh-context, finalize,
@@ -2119,6 +2120,8 @@ class WorkspaceCommand extends BaseCommand {
 	 *     wp datamachine-code workspace worktree reconcile-metadata --apply --limit=25 --offset=0 --format=json
 	 *     wp datamachine-code workspace worktree reconcile-metadata --apply --limit=50 --until-budget=60s --format=json
 	 *     wp datamachine-code workspace worktree active-no-signal-report --limit=25 --offset=0 --format=json
+	 *     wp datamachine-code workspace worktree active-no-signal-finalized-apply --dry-run --limit=25 --offset=0 --format=json
+	 *     wp datamachine-code workspace worktree active-no-signal-finalized-apply --limit=25 --offset=0 --format=json
 	 *
 	 *     # Ignore dirty working-tree safety (caution)
 	 *     wp datamachine-code workspace worktree cleanup --force
@@ -2151,7 +2154,7 @@ class WorkspaceCommand extends BaseCommand {
 		$operation = $args[0] ?? '';
 
 		if ( '' === $operation ) {
-			WP_CLI::error( 'Usage: wp datamachine-code workspace worktree <add|list|remove|prune|cleanup|cleanup-artifacts|bounded-cleanup-eligible-apply|emergency-cleanup|reconcile-metadata|active-no-signal-report|refresh-context|finalize|mark-cleanup-eligible> [<repo>] [<branch>] [--flags]' );
+			WP_CLI::error( 'Usage: wp datamachine-code workspace worktree <add|list|remove|prune|cleanup|cleanup-artifacts|bounded-cleanup-eligible-apply|emergency-cleanup|reconcile-metadata|active-no-signal-report|active-no-signal-finalized-apply|refresh-context|finalize|mark-cleanup-eligible> [<repo>] [<branch>] [--flags]' );
 			return;
 		}
 
@@ -2166,6 +2169,7 @@ class WorkspaceCommand extends BaseCommand {
 			'emergency-cleanup'              => 'datamachine/workspace-worktree-emergency-cleanup',
 			'reconcile-metadata'             => 'datamachine/workspace-worktree-reconcile-metadata',
 			'active-no-signal-report'        => 'datamachine/workspace-worktree-active-no-signal-report',
+			'active-no-signal-finalized-apply' => 'datamachine/workspace-worktree-active-no-signal-finalized-apply',
 			'refresh-context'                => 'datamachine/workspace-worktree-refresh-context',
 			'finalize'                       => 'datamachine/workspace-worktree-finalize',
 			'mark-cleanup-eligible'          => 'datamachine/workspace-worktree-finalize',
@@ -2325,6 +2329,10 @@ class WorkspaceCommand extends BaseCommand {
 				break;
 
 			case 'active-no-signal-report':
+			case 'active-no-signal-finalized-apply':
+				if ( 'active-no-signal-finalized-apply' === $operation ) {
+					$input['dry_run'] = ! empty( $assoc_args['dry-run'] );
+				}
 				if ( isset( $assoc_args['limit'] ) ) {
 					$input['limit'] = (int) $assoc_args['limit'];
 				}
@@ -2497,6 +2505,10 @@ class WorkspaceCommand extends BaseCommand {
 
 			case 'active-no-signal-report':
 				$this->render_worktree_active_no_signal_report_result( $result, $assoc_args );
+				return;
+
+			case 'active-no-signal-finalized-apply':
+				$this->render_worktree_active_no_signal_finalized_apply_result( $result, $assoc_args );
 				return;
 
 			case 'cleanup-artifacts':
@@ -3329,6 +3341,86 @@ class WorkspaceCommand extends BaseCommand {
 		}
 
 		WP_CLI::success( sprintf( 'Inspected %d active/no-signal worktree(s). Review-only; no cleanup was applied.', count( $rows ) ) );
+	}
+
+	/**
+	 * Render finalized active/no-signal metadata apply output.
+	 *
+	 * @param array $result     Apply result.
+	 * @param array $assoc_args CLI assoc args.
+	 * @return void
+	 */
+	private function render_worktree_active_no_signal_finalized_apply_result( array $result, array $assoc_args ): void {
+		$format = isset( $assoc_args['format'] ) ? (string) $assoc_args['format'] : 'table';
+		if ( 'json' === $format ) {
+			$json = wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+			WP_CLI::log( false === $json ? '{}' : $json );
+			return;
+		}
+
+		$summary = (array) ( $result['summary'] ?? array() );
+		$planned = (array) ( $result['planned'] ?? array() );
+		$written = (array) ( $result['written'] ?? array() );
+		$skipped = (array) ( $result['skipped'] ?? array() );
+		$dry_run = ! empty( $result['dry_run'] );
+
+		WP_CLI::log( 'Finalized active/no-signal apply summary:' );
+		$summary_rows = array(
+			array( 'metric' => 'inspected', 'count' => (int) ( $summary['inspected'] ?? 0 ) ),
+			array( 'metric' => 'planned', 'count' => (int) ( $summary['planned'] ?? count( $planned ) ) ),
+			array( 'metric' => 'written', 'count' => (int) ( $summary['written'] ?? count( $written ) ) ),
+			array( 'metric' => 'skipped', 'count' => (int) ( $summary['skipped'] ?? count( $skipped ) ) ),
+		);
+		foreach ( (array) ( $summary['skipped_by_reason'] ?? array() ) as $reason => $count ) {
+			$summary_rows[] = array( 'metric' => 'skipped:' . $reason, 'count' => (int) $count );
+		}
+		$this->format_items( $summary_rows, array( 'metric', 'count' ), array( 'format' => 'table' ), 'metric' );
+
+		$rows = $dry_run ? $planned : $written;
+		if ( ! empty( $rows ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( $dry_run ? 'Would promote:' : 'Promoted:' );
+			$items = array_map(
+				fn( $row ) => array(
+					'handle' => $row['handle'] ?? '',
+					'branch' => $row['branch'] ?? '',
+					'pr'     => is_array( $row['pr'] ?? null ) ? (string) ( $row['pr']['html_url'] ?? $row['pr']['number'] ?? '' ) : (string) ( $row['metadata']['pr_url'] ?? '' ),
+					'state'  => $row['metadata']['lifecycle_state'] ?? '',
+				),
+				$rows
+			);
+			$this->format_items( $items, array( 'handle', 'branch', 'pr', 'state' ), array( 'format' => 'table' ), 'handle' );
+		}
+
+		if ( ! empty( $skipped ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( 'Skipped:' );
+			$items = array_map(
+				fn( $row ) => array(
+					'handle'      => $row['handle'] ?? '',
+					'action'      => $row['action'] ?? '',
+					'reason_code' => $row['reason_code'] ?? '',
+					'reason'      => $row['reason'] ?? '',
+				),
+				array_slice( $skipped, 0, 10 )
+			);
+			$this->format_items( $items, array( 'handle', 'action', 'reason_code', 'reason' ), array( 'format' => 'table' ), 'handle' );
+		}
+
+		if ( isset( $result['pagination']['next_offset'] ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( sprintf(
+				'Next page: wp datamachine-code workspace worktree active-no-signal-finalized-apply --limit=%d --offset=%d --format=json',
+				(int) ( $result['pagination']['limit'] ?? 0 ),
+				(int) $result['pagination']['next_offset']
+			) );
+		}
+
+		if ( $dry_run ) {
+			WP_CLI::success( sprintf( '%d finalized worktree(s) would be promoted to cleanup_eligible metadata.', count( $planned ) ) );
+			return;
+		}
+		WP_CLI::success( sprintf( 'Promoted %d finalized worktree(s) to cleanup_eligible metadata.', count( $written ) ) );
 	}
 
 	/**

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -6399,6 +6399,209 @@ class Workspace {
 	}
 
 	/**
+	 * Promote finalized PR evidence from the active/no-signal report into cleanup metadata.
+	 *
+	 * This writes lifecycle metadata only. It never removes worktrees; callers use
+	 * bounded cleanup-eligible apply after reviewing the written rows.
+	 *
+	 * @param array<string,mixed> $opts Apply options.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function worktree_active_no_signal_finalized_apply( array $opts = array() ): array|\WP_Error {
+		$dry_run = ! empty( $opts['dry_run'] );
+		$report  = $this->worktree_active_no_signal_report( $opts );
+		if ( is_wp_error( $report ) ) {
+			return $report;
+		}
+
+		$written = array();
+		$skipped = array();
+		$planned = array();
+
+		foreach ( (array) ( $report['rows'] ?? array() ) as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+
+			if ( 'finalized_pr_reconcile' !== (string) ( $row['suggested_action'] ?? '' ) ) {
+				$skipped[] = $this->build_active_no_signal_finalized_apply_skip( $row, 'not_finalized_pr', 'row is not a finalized merged PR candidate' );
+				continue;
+			}
+
+			$metadata = $this->build_active_no_signal_finalized_metadata( $row );
+			if ( is_wp_error( $metadata ) ) {
+				$skipped[] = $this->build_active_no_signal_finalized_apply_skip( $row, $metadata->get_error_code(), $metadata->get_error_message() );
+				continue;
+			}
+
+			$planned[] = array(
+				'handle'   => (string) ( $row['handle'] ?? '' ),
+				'repo'     => (string) ( $row['repo'] ?? '' ),
+				'branch'   => (string) ( $row['branch'] ?? '' ),
+				'path'     => (string) ( $row['path'] ?? '' ),
+				'pr'       => $row['pr'] ?? null,
+				'metadata' => $metadata,
+			);
+
+			if ( $dry_run ) {
+				continue;
+			}
+
+			$handle = (string) ( $row['handle'] ?? '' );
+			WorktreeContextInjector::store_lifecycle_metadata( $handle, $metadata );
+			$written[] = array(
+				'handle'   => $handle,
+				'repo'     => (string) ( $row['repo'] ?? '' ),
+				'branch'   => (string) ( $row['branch'] ?? '' ),
+				'path'     => (string) ( $row['path'] ?? '' ),
+				'metadata' => WorktreeContextInjector::get_metadata( $handle ),
+			);
+		}
+
+		$summary = array(
+			'inspected'           => (int) ( $report['summary']['inspected'] ?? 0 ),
+			'planned'             => count( $planned ),
+			'written'             => count( $written ),
+			'skipped'             => count( $skipped ),
+			'skipped_by_reason'   => array(),
+			'report_action_counts' => $report['summary']['by_suggested_action'] ?? array(),
+		);
+		foreach ( $skipped as $skip ) {
+			$reason = (string) ( $skip['reason_code'] ?? 'unknown' );
+			$summary['skipped_by_reason'][ $reason ] = (int) ( $summary['skipped_by_reason'][ $reason ] ?? 0 ) + 1;
+		}
+
+		return array(
+			'success'      => true,
+			'mode'         => 'active_no_signal_finalized_apply',
+			'dry_run'      => $dry_run,
+			'applied'      => ! $dry_run,
+			'destructive'  => false,
+			'generated_at' => gmdate( 'c' ),
+			'planned'      => $planned,
+			'written'      => $written,
+			'skipped'      => $skipped,
+			'summary'      => $summary,
+			'pagination'   => $report['pagination'] ?? array(),
+			'evidence'     => array(
+				'scope' => 'promote finalized active_no_signal PR evidence into cleanup_eligible metadata',
+				'safety' => 'Revalidates dirty, unpushed, identity, and closed+merged PR evidence before writing metadata. Does not delete worktrees.',
+			),
+		);
+	}
+
+	/**
+	 * Build cleanup metadata from one finalized active/no-signal evidence row.
+	 *
+	 * @param array<string,mixed> $row Evidence row.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private function build_active_no_signal_finalized_metadata( array $row ): array|\WP_Error {
+		$handle = (string) ( $row['handle'] ?? '' );
+		$repo   = (string) ( $row['repo'] ?? '' );
+		$branch = (string) ( $row['branch'] ?? '' );
+		$path   = (string) ( $row['path'] ?? '' );
+		$pr     = is_array( $row['pr'] ?? null ) ? $row['pr'] : array();
+
+		foreach ( array( 'handle' => $handle, 'repo' => $repo, 'branch' => $branch, 'path' => $path ) as $field => $value ) {
+			if ( '' === $value ) {
+				return new \WP_Error( 'missing_identity', 'missing required identity field: ' . $field );
+			}
+		}
+		if ( ! is_dir( $path ) ) {
+			return new \WP_Error( 'missing_worktree', 'worktree path no longer exists' );
+		}
+
+		$primary_path = $this->get_primary_path( $repo );
+		if ( ! is_dir( $primary_path . '/.git' ) ) {
+			return new \WP_Error( 'missing_primary', 'primary checkout missing' );
+		}
+
+		$dirty = $this->probe_worktree_dirty_count( $path, self::CLEANUP_GIT_PROBE_TIMEOUT );
+		if ( is_wp_error( $dirty ) ) {
+			return $dirty;
+		}
+		$unpushed = $this->count_unpushed_commits( $path, self::CLEANUP_GIT_PROBE_TIMEOUT );
+		if ( is_wp_error( $unpushed ) ) {
+			return $unpushed;
+		}
+		if ( (int) $dirty > 0 || (int) $unpushed > 0 ) {
+			return new \WP_Error( 'unsafe_dirty_or_unpushed', 'refusing to mark dirty or unpushed worktree cleanup_eligible from active/no-signal evidence' );
+		}
+
+		$slug = $this->resolve_github_slug( $primary_path );
+		if ( null === $slug ) {
+			return new \WP_Error( 'missing_github_repo', 'primary checkout does not resolve to a GitHub repository' );
+		}
+
+		$github_cache = array();
+		$current_pr   = $this->find_pr_for_branch_direct( $slug, $branch, $github_cache, true );
+		if ( is_wp_error( $current_pr ) ) {
+			return $current_pr;
+		}
+		if ( ! is_array( $current_pr ) || empty( $current_pr['merged_at'] ) ) {
+			return new \WP_Error( 'missing_finalized_pr', 'exact branch-head PR is not currently closed and merged' );
+		}
+
+		$pr_url = (string) ( $current_pr['html_url'] ?? ( $pr['html_url'] ?? '' ) );
+		if ( '' === $pr_url ) {
+			return new \WP_Error( 'missing_pr_url', 'merged PR evidence is missing html_url' );
+		}
+
+		$base_metadata = is_array( $row['metadata'] ?? null ) ? $row['metadata'] : array();
+		$metadata      = array_merge(
+			$base_metadata,
+			array(
+				'handle'       => $handle,
+				'repo'         => $repo,
+				'branch'       => $branch,
+				'path'         => $path,
+				'observed_at'  => gmdate( 'c' ),
+				'last_seen_at' => gmdate( 'c' ),
+			),
+			WorktreeContextInjector::build_finalizer_metadata( WorktreeContextInjector::STATE_MERGED, $pr_url )
+		);
+		$metadata['auto_finalized_by']            = 'active_no_signal_finalized_apply';
+		$metadata['auto_finalized_signal']        = 'pr-merged';
+		$metadata['auto_finalized_reason']        = sprintf( 'active/no-signal report found merged PR #%d', (int) ( $current_pr['number'] ?? 0 ) );
+		$metadata['cleanup_eligibility_evidence'] = array_filter(
+			array(
+				'signal'          => 'pr-merged',
+				'finalized_state' => WorktreeContextInjector::STATE_MERGED,
+				'reason'          => 'exact branch-head PR is closed and merged',
+				'detected_at'     => gmdate( 'c' ),
+				'dirty'           => (int) $dirty,
+				'unpushed'        => (int) $unpushed,
+				'pr_url'          => $pr_url,
+				'pr_number'       => (int) ( $current_pr['number'] ?? 0 ),
+			),
+			fn( $value ) => null !== $value && '' !== $value
+		);
+
+		return $metadata;
+	}
+
+	/**
+	 * Build a skip row for finalized active/no-signal apply.
+	 *
+	 * @param array<string,mixed> $row         Evidence row.
+	 * @param string              $reason_code Stable reason code.
+	 * @param string              $reason      Human-readable reason.
+	 * @return array<string,mixed>
+	 */
+	private function build_active_no_signal_finalized_apply_skip( array $row, string $reason_code, string $reason ): array {
+		return array(
+			'handle'      => (string) ( $row['handle'] ?? '' ),
+			'repo'        => (string) ( $row['repo'] ?? '' ),
+			'branch'      => (string) ( $row['branch'] ?? '' ),
+			'path'        => (string) ( $row['path'] ?? '' ),
+			'reason_code' => $reason_code,
+			'reason'      => $reason,
+			'action'      => (string) ( $row['suggested_action'] ?? '' ),
+		);
+	}
+
+	/**
 	 * Build one active/no-signal evidence row.
 	 *
 	 * @param array<string,mixed> $row          Inventory skip row.
@@ -6420,6 +6623,7 @@ class Workspace {
 			'path'             => $path,
 			'created_at'       => $row['created_at'] ?? null,
 			'lifecycle_state'  => $metadata['lifecycle_state'] ?? null,
+			'metadata'         => $metadata,
 			'last_seen_at'     => $metadata['last_seen_at'] ?? ( $metadata['observed_at'] ?? null ),
 			'dirty'            => null,
 			'unpushed'         => null,

--- a/tests/smoke-worktree-metadata-reconcile.php
+++ b/tests/smoke-worktree-metadata-reconcile.php
@@ -477,6 +477,13 @@ namespace {
 	$assert( 'finalized_pr_reconcile', $active_rows['demo@head-merged']['suggested_action'] ?? '', 'active/no-signal report finds merged PRs by branch head' );
 	$assert( 'active_open_pr', $active_rows['demo@already-current']['suggested_action'] ?? '', 'active/no-signal report preserves open PRs as active' );
 	$assert( 106, (int) ( $active_rows['demo@head-merged']['pr']['number'] ?? 0 ), 'active/no-signal report includes PR evidence' );
+	$run( 'git remote set-url origin https://github.com/acme/demo.git', $primary );
+	$finalized_dry_run = $ws->worktree_active_no_signal_finalized_apply( array( 'dry_run' => true, 'limit' => 20, 'offset' => 0 ) );
+	$run( sprintf( 'git remote set-url origin %s', escapeshellarg( $remote ) ), $primary );
+	$assert( true, ! is_wp_error( $finalized_dry_run ) && ( $finalized_dry_run['success'] ?? false ), 'finalized active/no-signal dry-run succeeds' );
+	$assert( true, (bool) ( $finalized_dry_run['dry_run'] ?? false ), 'finalized active/no-signal dry-run does not write' );
+	$assert( 1, (int) ( $finalized_dry_run['summary']['planned'] ?? 0 ), 'finalized active/no-signal dry-run plans merged PR rows only' );
+	$assert( '', \DataMachineCode\Workspace\WorktreeContextInjector::get_metadata( 'demo@head-merged' )['cleanup_eligible_at'] ?? '', 'finalized active/no-signal dry-run leaves metadata unchanged' );
 
 	echo "\nDry-run reconciliation\n";
 	$plan = $ws->worktree_reconcile_metadata( array( 'dry_run' => true ) );
@@ -591,6 +598,15 @@ namespace {
 	$assert( 1, (int) ( $inventory_after['summary']['skipped_by_reason']['needs_metadata_reconcile'] ?? 0 ), 'inventory cleanup requires fewer metadata reconciliation passes after apply' );
 	$assert( 6, (int) ( $inventory_after['summary']['skipped_by_reason']['active_no_signal'] ?? 0 ), 'inventory cleanup treats reconciled active metadata like current active metadata' );
 	$assert( false, isset( $inventory_after['summary']['repair_status'] ), 'inventory cleanup no longer exposes migration status' );
+
+	$run( 'git remote set-url origin https://github.com/acme/demo.git', $primary );
+	$finalized_apply = $ws->worktree_active_no_signal_finalized_apply( array( 'limit' => 20, 'offset' => 0 ) );
+	$run( sprintf( 'git remote set-url origin %s', escapeshellarg( $remote ) ), $primary );
+	$assert( true, ! is_wp_error( $finalized_apply ) && ( $finalized_apply['success'] ?? false ), 'finalized active/no-signal apply succeeds' );
+	$assert( 1, (int) ( $finalized_apply['summary']['written'] ?? 0 ), 'finalized active/no-signal apply writes merged PR metadata' );
+	$stored_head_merged = \DataMachineCode\Workspace\WorktreeContextInjector::get_metadata( 'demo@head-merged' );
+	$assert( 'cleanup_eligible', $stored_head_merged['lifecycle_state'] ?? '', 'finalized active/no-signal apply stores cleanup_eligible state' );
+	$assert( 'pr-merged', $stored_head_merged['cleanup_eligibility_evidence']['signal'] ?? '', 'finalized active/no-signal apply stores PR merge evidence' );
 
 	echo "\nSafety gates\n";
 	$stale_plan['proposals'][0]['branch'] = 'wrong-branch';


### PR DESCRIPTION
## Summary
- Add `active-no-signal-finalized-apply` to promote report rows with merged PR evidence into explicit `cleanup_eligible` metadata.
- Revalidate identity, dirty state, unpushed commits, and exact branch-head closed+merged PR evidence immediately before writing metadata.
- Keep deletion separate: this apply path only writes lifecycle metadata, then existing bounded cleanup handles removal.

Closes #362

## Testing
- `php -l inc/Workspace/Workspace.php`
- `php -l inc/Cli/Commands/WorkspaceCommand.php`
- `php -l inc/Abilities/WorkspaceAbilities.php`
- `php -l tests/smoke-worktree-metadata-reconcile.php`
- `php tests/smoke-worktree-metadata-reconcile.php`
- `php tests/smoke-worktree-cleanup-cli.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the finalized evidence promotion path, CLI/ability plumbing, and smoke coverage; Chris directed the cleanup model and will review/test before merge.