### PR TITLE
Diagnose dirty worktree upstream equivalence

### DIFF
--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -6631,6 +6631,7 @@ class Workspace {
 			'remote_tracking'  => null,
 			'default_ref'      => null,
 			'commits_outside_default' => null,
+			'upstream_equivalence' => null,
 			'suggested_action' => 'insufficient_signal',
 			'reason'           => 'not enough evidence gathered',
 		);
@@ -6670,6 +6671,10 @@ class Workspace {
 			if ( ! is_wp_error( $outside ) && ! $this->is_git_timeout_error( $outside ) ) {
 				$out['commits_outside_default'] = (int) trim( (string) ( $outside['output'] ?? '' ) );
 			}
+
+			if ( (int) ( $out['dirty'] ?? 0 ) > 0 || (int) ( $out['unpushed'] ?? 0 ) > 0 ) {
+				$out['upstream_equivalence'] = $this->build_dirty_unpushed_upstream_equivalence_evidence( $primary_path, $path, $default_ref );
+			}
 		}
 
 		$slug = $this->resolve_github_slug( $primary_path );
@@ -6686,6 +6691,135 @@ class Workspace {
 		$out['reason']           = $this->describe_active_no_signal_action( $out );
 
 		return $out;
+	}
+
+	/**
+	 * Build diagnostic evidence for dirty/unpushed worktrees against remote default.
+	 *
+	 * This is intentionally evidence-only. Cleanup still treats dirty files and
+	 * unpushed commits as hard blockers until a separate reviewed apply path proves
+	 * a safe subset.
+	 *
+	 * @param string $primary_path Primary checkout path.
+	 * @param string $wt_path      Worktree path.
+	 * @param string $default_ref  Remote default ref.
+	 * @return array<string,mixed>
+	 */
+	private function build_dirty_unpushed_upstream_equivalence_evidence( string $primary_path, string $wt_path, string $default_ref ): array {
+		$evidence = array(
+			'default_ref' => $default_ref,
+			'unpushed_patch_equivalent' => null,
+			'unpushed_cherry' => array(
+				'equivalent' => 0,
+				'unmatched'  => 0,
+				'unknown'    => 0,
+			),
+			'dirty_paths' => array(
+				'total'                => 0,
+				'identical_to_default' => 0,
+				'different_from_default' => 0,
+				'absent_on_default'    => 0,
+				'untracked'            => 0,
+				'unknown'              => 0,
+				'samples'              => array(),
+			),
+		);
+
+		$cherry = $this->run_git( $wt_path, sprintf( 'cherry %s HEAD', escapeshellarg( $default_ref ) ), self::CLEANUP_GIT_PROBE_TIMEOUT );
+		if ( ! is_wp_error( $cherry ) && ! $this->is_git_timeout_error( $cherry ) ) {
+			$lines = array_values( array_filter( array_map( 'trim', explode( "\n", (string) ( $cherry['output'] ?? '' ) ) ) ) );
+			foreach ( $lines as $line ) {
+				if ( str_starts_with( $line, '-' ) ) {
+					++$evidence['unpushed_cherry']['equivalent'];
+				} elseif ( str_starts_with( $line, '+' ) ) {
+					++$evidence['unpushed_cherry']['unmatched'];
+				} else {
+					++$evidence['unpushed_cherry']['unknown'];
+				}
+			}
+			if ( count( $lines ) > 0 ) {
+				$evidence['unpushed_patch_equivalent'] = 0 === (int) $evidence['unpushed_cherry']['unmatched'] && 0 === (int) $evidence['unpushed_cherry']['unknown'];
+			}
+		}
+
+		$tracked = $this->run_git( $wt_path, 'diff --name-only HEAD', self::CLEANUP_GIT_PROBE_TIMEOUT );
+		$paths   = array();
+		if ( ! is_wp_error( $tracked ) && ! $this->is_git_timeout_error( $tracked ) ) {
+			$paths = array_merge( $paths, array_values( array_filter( array_map( 'trim', explode( "\n", (string) ( $tracked['output'] ?? '' ) ) ) ) ) );
+		}
+
+		$untracked = $this->run_git( $wt_path, 'ls-files --others --exclude-standard', self::CLEANUP_GIT_PROBE_TIMEOUT );
+		if ( ! is_wp_error( $untracked ) && ! $this->is_git_timeout_error( $untracked ) ) {
+			foreach ( array_values( array_filter( array_map( 'trim', explode( "\n", (string) ( $untracked['output'] ?? '' ) ) ) ) ) as $path ) {
+				$paths[] = $path;
+				++$evidence['dirty_paths']['untracked'];
+			}
+		}
+
+		$paths = array_values( array_unique( array_filter( $paths, fn( $path ) => '' !== (string) $path ) ) );
+		$evidence['dirty_paths']['total'] = count( $paths );
+
+		foreach ( $paths as $path ) {
+			$classification = $this->classify_dirty_path_against_default( $primary_path, $wt_path, $default_ref, $path );
+			$bucket = $classification['bucket'];
+			if ( isset( $evidence['dirty_paths'][ $bucket ] ) ) {
+				++$evidence['dirty_paths'][ $bucket ];
+			} else {
+				++$evidence['dirty_paths']['unknown'];
+			}
+			if ( count( $evidence['dirty_paths']['samples'] ) < 10 ) {
+				$evidence['dirty_paths']['samples'][] = $classification;
+			}
+		}
+
+		return $evidence;
+	}
+
+	/**
+	 * Classify one dirty path against the remote default branch.
+	 *
+	 * @param string $primary_path Primary checkout path.
+	 * @param string $wt_path      Worktree path.
+	 * @param string $default_ref  Remote default ref.
+	 * @param string $path         Repository-relative path.
+	 * @return array<string,string>
+	 */
+	private function classify_dirty_path_against_default( string $primary_path, string $wt_path, string $default_ref, string $path ): array {
+		$exists = $this->run_git( $primary_path, sprintf( 'cat-file -e %s', escapeshellarg( $default_ref . ':' . $path ) ), self::CLEANUP_GIT_PROBE_TIMEOUT );
+		if ( $this->is_git_timeout_error( $exists ) ) {
+			return array(
+				'path'   => $path,
+				'bucket' => 'unknown',
+				'reason' => $exists->get_error_message(),
+			);
+		}
+		if ( is_wp_error( $exists ) ) {
+			return array(
+				'path'   => $path,
+				'bucket' => 'absent_on_default',
+			);
+		}
+
+		$diff = $this->run_git( $wt_path, sprintf( 'diff --name-only %s -- %s', escapeshellarg( $default_ref ), escapeshellarg( $path ) ), self::CLEANUP_GIT_PROBE_TIMEOUT );
+		if ( $this->is_git_timeout_error( $diff ) ) {
+			return array(
+				'path'   => $path,
+				'bucket' => 'unknown',
+				'reason' => $diff->get_error_message(),
+			);
+		}
+		if ( is_wp_error( $diff ) ) {
+			return array(
+				'path'   => $path,
+				'bucket' => 'unknown',
+				'reason' => $diff->get_error_message(),
+			);
+		}
+
+		return array(
+			'path'   => $path,
+			'bucket' => '' === trim( (string) ( $diff['output'] ?? '' ) ) ? 'identical_to_default' : 'different_from_default',
+		);
 	}
 
 	/**

--- a/tests/smoke-worktree-metadata-reconcile.php
+++ b/tests/smoke-worktree-metadata-reconcile.php
@@ -325,6 +325,7 @@ namespace {
 	$run( 'git add README.md && git commit -m init', $primary );
 	$run( 'git branch -M main', $primary );
 	$run( 'git push -u origin main', $primary );
+	$run( 'git remote set-head origin main', $primary );
 
 	$make_branch = function ( string $branch ) use ( $primary, $run ): void {
 		$run( sprintf( 'git checkout -b %s', escapeshellarg( $branch ) ), $primary );
@@ -338,6 +339,7 @@ namespace {
 	$make_branch( 'unmanaged-dirty' );
 	$make_branch( 'unmanaged-invalid' );
 	$make_branch( 'already-current' );
+	$make_branch( 'dirty-active' );
 	$make_branch( 'head-merged' );
 	$make_branch( 'pr-merged' );
 	$make_branch( 'pr-closed' );
@@ -351,6 +353,7 @@ namespace {
 	$run( sprintf( 'git worktree add %s unmanaged-dirty', escapeshellarg( $tmp . '/demo@unmanaged-dirty' ) ), $primary );
 	$run( sprintf( 'git worktree add %s unmanaged-invalid', escapeshellarg( $tmp . '/demo@unmanaged-invalid' ) ), $primary );
 	$run( sprintf( 'git worktree add %s already-current', escapeshellarg( $tmp . '/demo@already-current' ) ), $primary );
+	$run( sprintf( 'git worktree add %s dirty-active', escapeshellarg( $tmp . '/demo@dirty-active' ) ), $primary );
 	$run( sprintf( 'git worktree add %s head-merged', escapeshellarg( $tmp . '/demo@head-merged' ) ), $primary );
 	$run( sprintf( 'git worktree add %s pr-merged', escapeshellarg( $tmp . '/demo@pr-merged' ) ), $primary );
 	$run( sprintf( 'git worktree add %s pr-closed', escapeshellarg( $tmp . '/demo@pr-closed' ) ), $primary );
@@ -360,6 +363,7 @@ namespace {
 	mkdir( $tmp . '-external', 0755, true );
 	$run( sprintf( 'git worktree add %s external-branch', escapeshellarg( $tmp . '-external/demo-external' ) ), $primary );
 	file_put_contents( $tmp . '/demo@unmanaged-dirty/scratch.txt', 'dirty' );
+	file_put_contents( $tmp . '/demo@dirty-active/scratch.txt', 'dirty' );
 	file_put_contents( $tmp . '/demo@dirty-merged/scratch.txt', 'dirty' );
 	file_put_contents( $tmp . '/demo@unpushed-merged/local.txt', 'local' );
 	$run( 'git add local.txt && git commit -m local-unpushed', $tmp . '/demo@unpushed-merged' );
@@ -394,6 +398,18 @@ namespace {
 			'repo'            => 'demo',
 			'branch'          => 'already-current',
 			'path'            => $tmp . '/demo@already-current',
+			'created_at'      => '2026-04-01T00:00:00+00:00',
+			'observed_at'     => '2026-04-01T00:00:00+00:00',
+			'lifecycle_state' => \DataMachineCode\Workspace\WorktreeContextInjector::STATE_ACTIVE,
+		)
+	);
+	\DataMachineCode\Workspace\WorktreeContextInjector::store_lifecycle_metadata(
+		'demo@dirty-active',
+		array(
+			'handle'          => 'demo@dirty-active',
+			'repo'            => 'demo',
+			'branch'          => 'dirty-active',
+			'path'            => $tmp . '/demo@dirty-active',
 			'created_at'      => '2026-04-01T00:00:00+00:00',
 			'observed_at'     => '2026-04-01T00:00:00+00:00',
 			'lifecycle_state' => \DataMachineCode\Workspace\WorktreeContextInjector::STATE_ACTIVE,
@@ -477,6 +493,9 @@ namespace {
 	$assert( 'finalized_pr_reconcile', $active_rows['demo@head-merged']['suggested_action'] ?? '', 'active/no-signal report finds merged PRs by branch head' );
 	$assert( 'active_open_pr', $active_rows['demo@already-current']['suggested_action'] ?? '', 'active/no-signal report preserves open PRs as active' );
 	$assert( 106, (int) ( $active_rows['demo@head-merged']['pr']['number'] ?? 0 ), 'active/no-signal report includes PR evidence' );
+	$assert( 'unsafe_dirty_or_unpushed', $active_rows['demo@dirty-active']['suggested_action'] ?? '', 'active/no-signal report keeps dirty rows unsafe' );
+	$assert( true, is_array( $active_rows['demo@dirty-active']['upstream_equivalence'] ?? null ), 'active/no-signal report includes upstream equivalence diagnostics for dirty rows' );
+	$assert( true, (int) ( $active_rows['demo@dirty-active']['upstream_equivalence']['dirty_paths']['absent_on_default'] ?? 0 ) >= 1, 'dirty diagnostics classify paths absent on default' );
 	$run( 'git remote set-url origin https://github.com/acme/demo.git', $primary );
 	$finalized_dry_run = $ws->worktree_active_no_signal_finalized_apply( array( 'dry_run' => true, 'limit' => 20, 'offset' => 0 ) );
 	$run( sprintf( 'git remote set-url origin %s', escapeshellarg( $remote ) ), $primary );
@@ -596,7 +615,7 @@ namespace {
 
 	$inventory_after = $ws->worktree_cleanup_merged( array( 'dry_run' => true, 'inventory_only' => true, 'skip_github' => true ) );
 	$assert( 1, (int) ( $inventory_after['summary']['skipped_by_reason']['needs_metadata_reconcile'] ?? 0 ), 'inventory cleanup requires fewer metadata reconciliation passes after apply' );
-	$assert( 6, (int) ( $inventory_after['summary']['skipped_by_reason']['active_no_signal'] ?? 0 ), 'inventory cleanup treats reconciled active metadata like current active metadata' );
+	$assert( 7, (int) ( $inventory_after['summary']['skipped_by_reason']['active_no_signal'] ?? 0 ), 'inventory cleanup treats reconciled active metadata like current active metadata' );
 	$assert( false, isset( $inventory_after['summary']['repair_status'] ), 'inventory cleanup no longer exposes migration status' );
 
 	$run( 'git remote set-url origin https://github.com/acme/demo.git', $primary );


### PR DESCRIPTION
## Summary
- Add upstream-equivalence diagnostics to active/no-signal report rows that are dirty or unpushed.
- Report `git cherry` patch-equivalence counts for unpushed commits against the remote default branch.
- Classify dirty paths as identical to default, different from default, absent on default, untracked, or unknown with samples.

Closes #364

## Testing
- `php -l inc/Workspace/Workspace.php && php -l tests/smoke-worktree-metadata-reconcile.php`
- `php tests/smoke-worktree-metadata-reconcile.php`
- `php tests/smoke-worktree-cleanup-cli.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the diagnostic evidence path and smoke coverage; cleanup semantics remain conservative and Chris identified the false-positive dirty/unpushed problem.