### PR TITLE
Promote equivalent clean worktrees for cleanup

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -1668,6 +1668,46 @@ class WorkspaceAbilities {
 			);
 
 			wp_register_ability(
+				'datamachine/workspace-worktree-active-no-signal-equivalent-clean-apply',
+				array(
+					'label'               => 'Promote Equivalent Clean Active Worktrees',
+					'description'         => 'Promote active_no_signal rows with effective_status=equivalent_clean into explicit cleanup_eligible metadata. Reviewable and bounded; never deletes worktrees.',
+					'category'            => 'datamachine-code-workspace',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'dry_run' => array(
+								'type'        => 'boolean',
+								'description' => 'If true, preview metadata promotions without writing.',
+							),
+							'limit'   => array(
+								'type'        => 'integer',
+								'description' => 'Maximum active_no_signal rows to inspect in this page. Defaults to 25.',
+							),
+							'offset'  => array(
+								'type'        => 'integer',
+								'description' => 'Pagination offset into the active_no_signal inventory ordering.',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'dry_run' => array( 'type' => 'boolean' ),
+							'planned' => array( 'type' => 'array' ),
+							'written' => array( 'type' => 'array' ),
+							'skipped' => array( 'type' => 'array' ),
+							'summary' => array( 'type' => 'object' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'worktreeActiveNoSignalEquivalentCleanApply' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
 				'datamachine/workspace-worktree-cleanup-artifacts',
 				array(
 					'label'               => 'Cleanup Worktree Artifacts',
@@ -2677,6 +2717,27 @@ class WorkspaceAbilities {
 		}
 
 		return $workspace->worktree_active_no_signal_finalized_apply( $opts );
+	}
+
+	/**
+	 * Promote equivalent-clean active/no-signal evidence into cleanup metadata.
+	 *
+	 * @param array $input Input parameters (dry_run, limit, offset).
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public static function worktreeActiveNoSignalEquivalentCleanApply( array $input ): array|\WP_Error {
+		$workspace = new Workspace();
+		$opts      = array(
+			'dry_run' => ! empty( $input['dry_run'] ),
+		);
+		if ( array_key_exists( 'limit', $input ) ) {
+			$opts['limit'] = (int) $input['limit'];
+		}
+		if ( array_key_exists( 'offset', $input ) ) {
+			$opts['offset'] = (int) $input['offset'];
+		}
+
+		return $workspace->worktree_active_no_signal_equivalent_clean_apply( $opts );
 	}
 
 	/**

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1854,6 +1854,7 @@ class WorkspaceCommand extends BaseCommand {
 	 * : Worktree operation: add, list, remove, prune, cleanup, cleanup-artifacts,
 	 *   bounded-cleanup-eligible-apply, emergency-cleanup, reconcile-metadata,
 	 *   active-no-signal-report, active-no-signal-finalized-apply,
+	 *   active-no-signal-equivalent-clean-apply,
 	 *   refresh-context, finalize, mark-cleanup-eligible.
 	 *
 	 * [<repo>]
@@ -2122,6 +2123,8 @@ class WorkspaceCommand extends BaseCommand {
 	 *     wp datamachine-code workspace worktree active-no-signal-report --limit=25 --offset=0 --format=json
 	 *     wp datamachine-code workspace worktree active-no-signal-finalized-apply --dry-run --limit=25 --offset=0 --format=json
 	 *     wp datamachine-code workspace worktree active-no-signal-finalized-apply --limit=25 --offset=0 --format=json
+	 *     wp datamachine-code workspace worktree active-no-signal-equivalent-clean-apply --dry-run --limit=25 --offset=0 --format=json
+	 *     wp datamachine-code workspace worktree active-no-signal-equivalent-clean-apply --limit=25 --offset=0 --format=json
 	 *
 	 *     # Ignore dirty working-tree safety (caution)
 	 *     wp datamachine-code workspace worktree cleanup --force
@@ -2154,7 +2157,7 @@ class WorkspaceCommand extends BaseCommand {
 		$operation = $args[0] ?? '';
 
 		if ( '' === $operation ) {
-			WP_CLI::error( 'Usage: wp datamachine-code workspace worktree <add|list|remove|prune|cleanup|cleanup-artifacts|bounded-cleanup-eligible-apply|emergency-cleanup|reconcile-metadata|active-no-signal-report|active-no-signal-finalized-apply|refresh-context|finalize|mark-cleanup-eligible> [<repo>] [<branch>] [--flags]' );
+			WP_CLI::error( 'Usage: wp datamachine-code workspace worktree <add|list|remove|prune|cleanup|cleanup-artifacts|bounded-cleanup-eligible-apply|emergency-cleanup|reconcile-metadata|active-no-signal-report|active-no-signal-finalized-apply|active-no-signal-equivalent-clean-apply|refresh-context|finalize|mark-cleanup-eligible> [<repo>] [<branch>] [--flags]' );
 			return;
 		}
 
@@ -2170,6 +2173,7 @@ class WorkspaceCommand extends BaseCommand {
 			'reconcile-metadata'             => 'datamachine/workspace-worktree-reconcile-metadata',
 			'active-no-signal-report'        => 'datamachine/workspace-worktree-active-no-signal-report',
 			'active-no-signal-finalized-apply' => 'datamachine/workspace-worktree-active-no-signal-finalized-apply',
+			'active-no-signal-equivalent-clean-apply' => 'datamachine/workspace-worktree-active-no-signal-equivalent-clean-apply',
 			'refresh-context'                => 'datamachine/workspace-worktree-refresh-context',
 			'finalize'                       => 'datamachine/workspace-worktree-finalize',
 			'mark-cleanup-eligible'          => 'datamachine/workspace-worktree-finalize',
@@ -2330,7 +2334,8 @@ class WorkspaceCommand extends BaseCommand {
 
 			case 'active-no-signal-report':
 			case 'active-no-signal-finalized-apply':
-				if ( 'active-no-signal-finalized-apply' === $operation ) {
+			case 'active-no-signal-equivalent-clean-apply':
+				if ( in_array( $operation, array( 'active-no-signal-finalized-apply', 'active-no-signal-equivalent-clean-apply' ), true ) ) {
 					$input['dry_run'] = ! empty( $assoc_args['dry-run'] );
 				}
 				if ( isset( $assoc_args['limit'] ) ) {
@@ -2509,6 +2514,10 @@ class WorkspaceCommand extends BaseCommand {
 
 			case 'active-no-signal-finalized-apply':
 				$this->render_worktree_active_no_signal_finalized_apply_result( $result, $assoc_args );
+				return;
+
+			case 'active-no-signal-equivalent-clean-apply':
+				$this->render_worktree_active_no_signal_equivalent_clean_apply_result( $result, $assoc_args );
 				return;
 
 			case 'cleanup-artifacts':
@@ -3421,6 +3430,86 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 		WP_CLI::success( sprintf( 'Promoted %d finalized worktree(s) to cleanup_eligible metadata.', count( $written ) ) );
+	}
+
+	/**
+	 * Render equivalent-clean active/no-signal metadata apply output.
+	 *
+	 * @param array $result     Apply result.
+	 * @param array $assoc_args CLI assoc args.
+	 * @return void
+	 */
+	private function render_worktree_active_no_signal_equivalent_clean_apply_result( array $result, array $assoc_args ): void {
+		$format = isset( $assoc_args['format'] ) ? (string) $assoc_args['format'] : 'table';
+		if ( 'json' === $format ) {
+			$json = wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+			WP_CLI::log( false === $json ? '{}' : $json );
+			return;
+		}
+
+		$summary = (array) ( $result['summary'] ?? array() );
+		$planned = (array) ( $result['planned'] ?? array() );
+		$written = (array) ( $result['written'] ?? array() );
+		$skipped = (array) ( $result['skipped'] ?? array() );
+		$dry_run = ! empty( $result['dry_run'] );
+
+		WP_CLI::log( 'Equivalent-clean active/no-signal apply summary:' );
+		$summary_rows = array(
+			array( 'metric' => 'inspected', 'count' => (int) ( $summary['inspected'] ?? 0 ) ),
+			array( 'metric' => 'planned', 'count' => (int) ( $summary['planned'] ?? count( $planned ) ) ),
+			array( 'metric' => 'written', 'count' => (int) ( $summary['written'] ?? count( $written ) ) ),
+			array( 'metric' => 'skipped', 'count' => (int) ( $summary['skipped'] ?? count( $skipped ) ) ),
+		);
+		foreach ( (array) ( $summary['skipped_by_reason'] ?? array() ) as $reason => $count ) {
+			$summary_rows[] = array( 'metric' => 'skipped:' . $reason, 'count' => (int) $count );
+		}
+		$this->format_items( $summary_rows, array( 'metric', 'count' ), array( 'format' => 'table' ), 'metric' );
+
+		$rows = $dry_run ? $planned : $written;
+		if ( ! empty( $rows ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( $dry_run ? 'Would promote:' : 'Promoted:' );
+			$items = array_map(
+				fn( $row ) => array(
+					'handle' => $row['handle'] ?? '',
+					'branch' => $row['branch'] ?? '',
+					'signal' => $row['metadata']['cleanup_eligibility_evidence']['signal'] ?? '',
+					'state'  => $row['metadata']['lifecycle_state'] ?? '',
+				),
+				$rows
+			);
+			$this->format_items( $items, array( 'handle', 'branch', 'signal', 'state' ), array( 'format' => 'table' ), 'handle' );
+		}
+
+		if ( ! empty( $skipped ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( 'Skipped:' );
+			$items = array_map(
+				fn( $row ) => array(
+					'handle'      => $row['handle'] ?? '',
+					'action'      => $row['action'] ?? '',
+					'reason_code' => $row['reason_code'] ?? '',
+					'reason'      => $row['reason'] ?? '',
+				),
+				array_slice( $skipped, 0, 10 )
+			);
+			$this->format_items( $items, array( 'handle', 'action', 'reason_code', 'reason' ), array( 'format' => 'table' ), 'handle' );
+		}
+
+		if ( isset( $result['pagination']['next_offset'] ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( sprintf(
+				'Next page: wp datamachine-code workspace worktree active-no-signal-equivalent-clean-apply --limit=%d --offset=%d --format=json',
+				(int) ( $result['pagination']['limit'] ?? 0 ),
+				(int) $result['pagination']['next_offset']
+			) );
+		}
+
+		if ( $dry_run ) {
+			WP_CLI::success( sprintf( '%d equivalent-clean worktree(s) would be promoted to cleanup_eligible metadata.', count( $planned ) ) );
+			return;
+		}
+		WP_CLI::success( sprintf( 'Promoted %d equivalent-clean worktree(s) to cleanup_eligible metadata.', count( $written ) ) );
 	}
 
 	/**

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -6491,6 +6491,99 @@ class Workspace {
 	}
 
 	/**
+	 * Promote effectively clean upstream-equivalent active/no-signal rows into cleanup metadata.
+	 *
+	 * This writes lifecycle metadata only. It never removes worktrees; callers use
+	 * bounded cleanup-eligible apply after reviewing the written rows.
+	 *
+	 * @param array<string,mixed> $opts Apply options.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function worktree_active_no_signal_equivalent_clean_apply( array $opts = array() ): array|\WP_Error {
+		$dry_run = ! empty( $opts['dry_run'] );
+		$report  = $this->worktree_active_no_signal_report( $opts );
+		if ( is_wp_error( $report ) ) {
+			return $report;
+		}
+
+		$written = array();
+		$skipped = array();
+		$planned = array();
+
+		foreach ( (array) ( $report['rows'] ?? array() ) as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+
+			$effective_status = (string) ( $row['upstream_equivalence']['effective_status'] ?? '' );
+			if ( 'equivalent_clean' !== $effective_status ) {
+				$skipped[] = $this->build_active_no_signal_finalized_apply_skip( $row, 'not_equivalent_clean', 'row is not effectively clean upstream-equivalent work' );
+				continue;
+			}
+
+			$metadata = $this->build_active_no_signal_equivalent_clean_metadata( $row );
+			if ( is_wp_error( $metadata ) ) {
+				$skipped[] = $this->build_active_no_signal_finalized_apply_skip( $row, $metadata->get_error_code(), $metadata->get_error_message() );
+				continue;
+			}
+
+			$planned[] = array(
+				'handle'               => (string) ( $row['handle'] ?? '' ),
+				'repo'                 => (string) ( $row['repo'] ?? '' ),
+				'branch'               => (string) ( $row['branch'] ?? '' ),
+				'path'                 => (string) ( $row['path'] ?? '' ),
+				'upstream_equivalence' => $metadata['cleanup_eligibility_evidence']['upstream_equivalence'] ?? null,
+				'metadata'             => $metadata,
+			);
+
+			if ( $dry_run ) {
+				continue;
+			}
+
+			$handle = (string) ( $row['handle'] ?? '' );
+			WorktreeContextInjector::store_lifecycle_metadata( $handle, $metadata );
+			$written[] = array(
+				'handle'   => $handle,
+				'repo'     => (string) ( $row['repo'] ?? '' ),
+				'branch'   => (string) ( $row['branch'] ?? '' ),
+				'path'     => (string) ( $row['path'] ?? '' ),
+				'metadata' => WorktreeContextInjector::get_metadata( $handle ),
+			);
+		}
+
+		$summary = array(
+			'inspected'            => (int) ( $report['summary']['inspected'] ?? 0 ),
+			'planned'              => count( $planned ),
+			'written'              => count( $written ),
+			'skipped'              => count( $skipped ),
+			'skipped_by_reason'    => array(),
+			'report_action_counts' => $report['summary']['by_suggested_action'] ?? array(),
+		);
+		foreach ( $skipped as $skip ) {
+			$reason = (string) ( $skip['reason_code'] ?? 'unknown' );
+			$summary['skipped_by_reason'][ $reason ] = (int) ( $summary['skipped_by_reason'][ $reason ] ?? 0 ) + 1;
+		}
+
+		return array(
+			'success'      => true,
+			'mode'         => 'active_no_signal_equivalent_clean_apply',
+			'dry_run'      => $dry_run,
+			'applied'      => ! $dry_run,
+			'destructive'  => false,
+			'generated_at' => gmdate( 'c' ),
+			'planned'      => $planned,
+			'written'      => $written,
+			'skipped'      => $skipped,
+			'summary'      => $summary,
+			'pagination'   => $report['pagination'] ?? array(),
+			'evidence'     => array(
+				'scope' => 'promote effectively clean upstream-equivalent active_no_signal rows into cleanup_eligible metadata',
+				'safety' => 'Revalidates upstream-equivalence evidence before writing metadata. Does not delete worktrees.',
+			),
+		);
+	}
+
+	/**
 	 * Build cleanup metadata from one finalized active/no-signal evidence row.
 	 *
 	 * @param array<string,mixed> $row Evidence row.
@@ -6579,6 +6672,103 @@ class Workspace {
 		);
 
 		return $metadata;
+	}
+
+	/**
+	 * Build cleanup metadata from one effectively clean upstream-equivalent row.
+	 *
+	 * @param array<string,mixed> $row Evidence row.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private function build_active_no_signal_equivalent_clean_metadata( array $row ): array|\WP_Error {
+		$handle = (string) ( $row['handle'] ?? '' );
+		$repo   = (string) ( $row['repo'] ?? '' );
+		$branch = (string) ( $row['branch'] ?? '' );
+		$path   = (string) ( $row['path'] ?? '' );
+
+		foreach ( array( 'handle' => $handle, 'repo' => $repo, 'branch' => $branch, 'path' => $path ) as $field => $value ) {
+			if ( '' === $value ) {
+				return new \WP_Error( 'missing_identity', 'missing required identity field: ' . $field );
+			}
+		}
+		if ( ! is_dir( $path ) ) {
+			return new \WP_Error( 'missing_worktree', 'worktree path no longer exists' );
+		}
+
+		$equivalence = $this->build_current_effective_clean_cleanup_evidence( $repo, $path );
+		if ( is_wp_error( $equivalence ) ) {
+			return $equivalence;
+		}
+
+		$base_metadata = is_array( $row['metadata'] ?? null ) ? $row['metadata'] : array();
+		$metadata      = array_merge(
+			$base_metadata,
+			array(
+				'handle'       => $handle,
+				'repo'         => $repo,
+				'branch'       => $branch,
+				'path'         => $path,
+				'observed_at'  => gmdate( 'c' ),
+				'last_seen_at' => gmdate( 'c' ),
+			),
+			WorktreeContextInjector::build_finalizer_metadata( WorktreeContextInjector::STATE_CLEANUP_ELIGIBLE )
+		);
+		$metadata['auto_finalized_by']            = 'active_no_signal_equivalent_clean_apply';
+		$metadata['auto_finalized_signal']        = 'upstream-equivalent-clean';
+		$metadata['auto_finalized_reason']        = 'active/no-signal report found patch-equivalent upstream work with no source-like dirty paths';
+		$metadata['cleanup_eligibility_evidence'] = array(
+			'signal'               => 'upstream-equivalent-clean',
+			'finalized_state'      => WorktreeContextInjector::STATE_CLEANUP_ELIGIBLE,
+			'reason'               => 'unpushed commits are patch-equivalent to default and dirty paths are clean against default',
+			'detected_at'          => gmdate( 'c' ),
+			'dirty'                => (int) ( $equivalence['dirty'] ?? 0 ),
+			'unpushed'             => (int) ( $equivalence['unpushed'] ?? 0 ),
+			'upstream_equivalence' => $equivalence['upstream_equivalence'] ?? array(),
+		);
+
+		return $metadata;
+	}
+
+	/**
+	 * Recompute effective-clean evidence for the current worktree state.
+	 *
+	 * @param string $repo    Repository name.
+	 * @param string $wt_path Worktree path.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private function build_current_effective_clean_cleanup_evidence( string $repo, string $wt_path ): array|\WP_Error {
+		$primary_path = $this->get_primary_path( $repo );
+		if ( ! is_dir( $primary_path . '/.git' ) ) {
+			return new \WP_Error( 'missing_primary', 'primary checkout missing' );
+		}
+
+		$dirty = $this->probe_worktree_dirty_count( $wt_path, self::CLEANUP_GIT_PROBE_TIMEOUT );
+		if ( is_wp_error( $dirty ) ) {
+			return $dirty;
+		}
+		$unpushed = $this->count_unpushed_commits( $wt_path, self::CLEANUP_GIT_PROBE_TIMEOUT );
+		if ( is_wp_error( $unpushed ) ) {
+			return $unpushed;
+		}
+		if ( 0 === (int) $dirty && 0 === (int) $unpushed ) {
+			return new \WP_Error( 'no_dirty_or_unpushed_signal', 'worktree no longer has dirty or unpushed evidence requiring upstream-equivalent cleanup handling' );
+		}
+
+		$default_ref = $this->resolve_remote_default_ref( $primary_path, self::CLEANUP_GIT_PROBE_TIMEOUT );
+		if ( ! is_string( $default_ref ) || '' === $default_ref ) {
+			return new \WP_Error( 'missing_default_ref', 'primary checkout default ref could not be resolved' );
+		}
+
+		$upstream_equivalence = $this->build_dirty_unpushed_upstream_equivalence_evidence( $primary_path, $wt_path, $default_ref );
+		if ( 'equivalent_clean' !== (string) ( $upstream_equivalence['effective_status'] ?? '' ) ) {
+			return new \WP_Error( 'not_equivalent_clean', 'current worktree evidence is not effectively clean upstream-equivalent' );
+		}
+
+		return array(
+			'dirty'                => (int) $dirty,
+			'unpushed'             => (int) $unpushed,
+			'upstream_equivalence' => $upstream_equivalence,
+		);
 	}
 
 	/**
@@ -6744,9 +6934,7 @@ class Workspace {
 					++$evidence['unpushed_cherry']['unknown'];
 				}
 			}
-			if ( count( $lines ) > 0 ) {
-				$evidence['unpushed_patch_equivalent'] = 0 === (int) $evidence['unpushed_cherry']['unmatched'] && 0 === (int) $evidence['unpushed_cherry']['unknown'];
-			}
+			$evidence['unpushed_patch_equivalent'] = 0 === (int) $evidence['unpushed_cherry']['unmatched'] && 0 === (int) $evidence['unpushed_cherry']['unknown'];
 		}
 
 		$tracked = $this->run_git( $wt_path, 'diff --name-only HEAD', self::CLEANUP_GIT_PROBE_TIMEOUT );
@@ -7065,6 +7253,20 @@ class Workspace {
 			);
 		}
 
+		$primary_path = $this->get_primary_path( $repo );
+		if ( ! is_dir( $primary_path . '/.git' ) ) {
+			return array(
+				'skipped' => array(
+					'handle'      => $handle,
+					'repo'        => $repo,
+					'branch'      => $branch,
+					'path'        => $wt_path,
+					'reason_code' => 'primary_missing',
+					'reason'      => 'primary checkout missing — bounded cleanup-eligible apply cannot route git worktree remove',
+				),
+			);
+		}
+
 		// Dirty gate: cheap porcelain call, bounded by the cleanup git timeout.
 		$dirty = $this->run_git( $real_path, 'status --porcelain --untracked-files=normal', self::CLEANUP_GIT_PROBE_TIMEOUT );
 		if ( $this->is_git_timeout_error( $dirty ) ) {
@@ -7094,21 +7296,8 @@ class Workspace {
 
 		$dirty_lines = trim( (string) ( $dirty['output'] ?? '' ) );
 		$dirty_count = '' === $dirty_lines ? 0 : substr_count( $dirty_lines, "\n" ) + 1;
-		if ( $dirty_count > 0 && ! $force ) {
-			return array(
-				'skipped' => array(
-					'handle'      => $handle,
-					'repo'        => $repo,
-					'branch'      => $branch,
-					'path'        => $wt_path,
-					'reason_code' => 'dirty_worktree',
-					'reason'      => sprintf( 'working tree dirty (%d entries) — bounded cleanup-eligible apply refuses to override; rerun with force=true after review', $dirty_count ),
-					'dirty'       => $dirty_count,
-				),
-			);
-		}
-
-		// Unpushed gate: hard stop even with force=true (data loss > dirty loss).
+		// Unpushed gate: hard stop unless metadata was promoted by the reviewed
+		// upstream-equivalent apply path and the same evidence still holds now.
 		$unpushed = $this->count_unpushed_commits( $real_path, self::CLEANUP_GIT_PROBE_TIMEOUT );
 		if ( $unpushed instanceof \WP_Error ) {
 			return array(
@@ -7122,7 +7311,30 @@ class Workspace {
 				),
 			);
 		}
-		if ( $unpushed > 0 ) {
+
+		$metadata         = is_array( $candidate['metadata'] ?? null ) ? $candidate['metadata'] : array();
+		$cleanup_evidence = is_array( $metadata['cleanup_eligibility_evidence'] ?? null ) ? $metadata['cleanup_eligibility_evidence'] : array();
+		$allow_effective_clean_removal = false;
+		if ( ( $dirty_count > 0 || $unpushed > 0 ) && 'upstream-equivalent-clean' === (string) ( $cleanup_evidence['signal'] ?? '' ) ) {
+			$current_equivalence = $this->build_current_effective_clean_cleanup_evidence( $repo, $real_path );
+			$allow_effective_clean_removal = ! is_wp_error( $current_equivalence );
+		}
+
+		if ( $dirty_count > 0 && ! $force && ! $allow_effective_clean_removal ) {
+			return array(
+				'skipped' => array(
+					'handle'      => $handle,
+					'repo'        => $repo,
+					'branch'      => $branch,
+					'path'        => $wt_path,
+					'reason_code' => 'dirty_worktree',
+					'reason'      => sprintf( 'working tree dirty (%d entries) — bounded cleanup-eligible apply refuses to override; rerun with force=true after review', $dirty_count ),
+					'dirty'       => $dirty_count,
+				),
+			);
+		}
+
+		if ( $unpushed > 0 && ! $allow_effective_clean_removal ) {
 			return array(
 				'skipped' => array(
 					'handle'      => $handle,
@@ -7132,21 +7344,6 @@ class Workspace {
 					'reason_code' => 'unpushed_commits',
 					'reason'      => sprintf( '%d unpushed commit(s) — bounded cleanup-eligible apply refuses to remove even with force=true', $unpushed ),
 					'unpushed'    => $unpushed,
-				),
-			);
-		}
-
-		// Primary must still exist or remove_worktree_by_path will fail noisily.
-		$primary_path = $this->get_primary_path( $repo );
-		if ( ! is_dir( $primary_path . '/.git' ) ) {
-			return array(
-				'skipped' => array(
-					'handle'      => $handle,
-					'repo'        => $repo,
-					'branch'      => $branch,
-					'path'        => $wt_path,
-					'reason_code' => 'primary_missing',
-					'reason'      => 'primary checkout missing — bounded cleanup-eligible apply cannot route git worktree remove',
 				),
 			);
 		}

--- a/tests/smoke-worktree-metadata-reconcile.php
+++ b/tests/smoke-worktree-metadata-reconcile.php
@@ -347,6 +347,9 @@ namespace {
 	$make_branch( 'dirty-merged' );
 	$make_branch( 'unpushed-merged' );
 	$make_branch( 'external-branch' );
+	$run( 'git checkout -b equivalent-clean', $primary );
+	$run( 'git push -u origin equivalent-clean', $primary );
+	$run( 'git checkout main', $primary );
 
 	$run( sprintf( 'git worktree add %s unmanaged-missing', escapeshellarg( $tmp . '/demo@unmanaged-missing' ) ), $primary );
 	$run( sprintf( 'git worktree add %s unmanaged-partial', escapeshellarg( $tmp . '/demo@unmanaged-partial' ) ), $primary );
@@ -360,6 +363,7 @@ namespace {
 	$run( sprintf( 'git worktree add %s upstream-gone', escapeshellarg( $tmp . '/demo@upstream-gone' ) ), $primary );
 	$run( sprintf( 'git worktree add %s dirty-merged', escapeshellarg( $tmp . '/demo@dirty-merged' ) ), $primary );
 	$run( sprintf( 'git worktree add %s unpushed-merged', escapeshellarg( $tmp . '/demo@unpushed-merged' ) ), $primary );
+	$run( sprintf( 'git worktree add %s equivalent-clean', escapeshellarg( $tmp . '/demo@equivalent-clean' ) ), $primary );
 	mkdir( $tmp . '-external', 0755, true );
 	$run( sprintf( 'git worktree add %s external-branch', escapeshellarg( $tmp . '-external/demo-external' ) ), $primary );
 	file_put_contents( $tmp . '/demo@unmanaged-dirty/scratch.txt', 'dirty' );
@@ -367,6 +371,10 @@ namespace {
 	file_put_contents( $tmp . '/demo@dirty-merged/scratch.txt', 'dirty' );
 	file_put_contents( $tmp . '/demo@unpushed-merged/local.txt', 'local' );
 	$run( 'git add local.txt && git commit -m local-unpushed', $tmp . '/demo@unpushed-merged' );
+	file_put_contents( $tmp . '/demo@equivalent-clean/equivalent.txt', 'equivalent' );
+	$run( 'git add equivalent.txt && git commit -m equivalent-local', $tmp . '/demo@equivalent-clean' );
+	file_put_contents( $primary . '/equivalent.txt', 'equivalent' );
+	$run( 'git add equivalent.txt && git commit -m equivalent-local && git push origin main', $primary );
 	$run( sprintf( 'git --git-dir=%s update-ref -d refs/heads/upstream-gone', escapeshellarg( $remote ) ) );
 	$run( sprintf( 'git --git-dir=%s update-ref -d refs/heads/dirty-merged', escapeshellarg( $remote ) ) );
 
@@ -472,6 +480,18 @@ namespace {
 			'pr_repo'         => 'acme/demo',
 		)
 	);
+	\DataMachineCode\Workspace\WorktreeContextInjector::store_lifecycle_metadata(
+		'demo@equivalent-clean',
+		array(
+			'handle'          => 'demo@equivalent-clean',
+			'repo'            => 'demo',
+			'branch'          => 'equivalent-clean',
+			'path'            => $tmp . '/demo@equivalent-clean',
+			'created_at'      => '2026-04-01T00:00:00+00:00',
+			'observed_at'     => '2026-04-01T00:00:00+00:00',
+			'lifecycle_state' => \DataMachineCode\Workspace\WorktreeContextInjector::STATE_ACTIVE,
+		)
+	);
 	$ws = new \DataMachineCode\Workspace\Workspace();
 	$lookup_reflection = new \ReflectionMethod( $ws, 'find_closed_pr_for_branch' );
 	$lookup_cache = array( 'acme/demo' => array() );
@@ -481,7 +501,7 @@ namespace {
 	$assert( null, $open_pr, 'direct branch PR lookup does not finalize open PR branches' );
 
 	$run( 'git remote set-url origin https://github.com/acme/demo.git', $primary );
-	$active_report = $ws->worktree_active_no_signal_report( array( 'limit' => 20, 'offset' => 0 ) );
+	$active_report = $ws->worktree_active_no_signal_report( array( 'limit' => 50, 'offset' => 0 ) );
 	$run( sprintf( 'git remote set-url origin %s', escapeshellarg( $remote ) ), $primary );
 	$assert( true, ! is_wp_error( $active_report ) && ( $active_report['success'] ?? false ), 'active/no-signal report succeeds' );
 	$assert( true, (bool) ( $active_report['review_only'] ?? false ), 'active/no-signal report is review-only' );
@@ -499,8 +519,9 @@ namespace {
 	$assert( true, isset( $active_rows['demo@dirty-active']['upstream_equivalence']['effective_status'] ), 'dirty diagnostics include effective status' );
 	$assert( 250, (int) ( $active_rows['demo@dirty-active']['upstream_equivalence']['path_inspection_limit'] ?? 0 ), 'dirty diagnostics expose path inspection cap' );
 	$assert( true, isset( $active_rows['demo@dirty-active']['upstream_equivalence']['dirty_paths']['generated_or_artifact'] ), 'dirty diagnostics count generated/artifact paths' );
+	$assert( 'equivalent_clean', $active_rows['demo@equivalent-clean']['upstream_equivalence']['effective_status'] ?? '', 'dirty diagnostics classify patch-equivalent clean rows' );
 	$run( 'git remote set-url origin https://github.com/acme/demo.git', $primary );
-	$finalized_dry_run = $ws->worktree_active_no_signal_finalized_apply( array( 'dry_run' => true, 'limit' => 20, 'offset' => 0 ) );
+	$finalized_dry_run = $ws->worktree_active_no_signal_finalized_apply( array( 'dry_run' => true, 'limit' => 50, 'offset' => 0 ) );
 	$run( sprintf( 'git remote set-url origin %s', escapeshellarg( $remote ) ), $primary );
 	$assert( true, ! is_wp_error( $finalized_dry_run ) && ( $finalized_dry_run['success'] ?? false ), 'finalized active/no-signal dry-run succeeds' );
 	$assert( true, (bool) ( $finalized_dry_run['dry_run'] ?? false ), 'finalized active/no-signal dry-run does not write' );
@@ -514,7 +535,7 @@ namespace {
 	$assert( 7, (int) ( $plan['summary']['proposed'] ?? 0 ), 'dry-run proposes unmanaged rows and safe merged lifecycle finalizers' );
 	$assert( 0, (int) ( $plan['summary']['written'] ?? 0 ), 'dry-run writes nothing' );
 	$assert( 1, (int) ( $plan['summary']['skipped_by_reason']['external_worktree'] ?? 0 ), 'dry-run distinguishes external worktrees' );
-	$assert( 2, (int) ( $plan['summary']['skipped_by_reason']['unsafe_cleanup_eligible_state'] ?? 0 ), 'dry-run keeps dirty and unpushed merged worktrees out of auto-finalize proposals' );
+	$assert( 3, (int) ( $plan['summary']['skipped_by_reason']['unsafe_cleanup_eligible_state'] ?? 0 ), 'dry-run keeps dirty and unpushed merged worktrees out of auto-finalize proposals' );
 	$assert( 1, count( $plan['external_worktrees'] ?? array() ), 'dry-run exposes external worktree bucket' );
 
 	$by_handle = array();
@@ -618,17 +639,28 @@ namespace {
 
 	$inventory_after = $ws->worktree_cleanup_merged( array( 'dry_run' => true, 'inventory_only' => true, 'skip_github' => true ) );
 	$assert( 1, (int) ( $inventory_after['summary']['skipped_by_reason']['needs_metadata_reconcile'] ?? 0 ), 'inventory cleanup requires fewer metadata reconciliation passes after apply' );
-	$assert( 7, (int) ( $inventory_after['summary']['skipped_by_reason']['active_no_signal'] ?? 0 ), 'inventory cleanup treats reconciled active metadata like current active metadata' );
+	$assert( 8, (int) ( $inventory_after['summary']['skipped_by_reason']['active_no_signal'] ?? 0 ), 'inventory cleanup treats reconciled active metadata like current active metadata' );
 	$assert( false, isset( $inventory_after['summary']['repair_status'] ), 'inventory cleanup no longer exposes migration status' );
 
 	$run( 'git remote set-url origin https://github.com/acme/demo.git', $primary );
-	$finalized_apply = $ws->worktree_active_no_signal_finalized_apply( array( 'limit' => 20, 'offset' => 0 ) );
+	$finalized_apply = $ws->worktree_active_no_signal_finalized_apply( array( 'limit' => 50, 'offset' => 0 ) );
 	$run( sprintf( 'git remote set-url origin %s', escapeshellarg( $remote ) ), $primary );
 	$assert( true, ! is_wp_error( $finalized_apply ) && ( $finalized_apply['success'] ?? false ), 'finalized active/no-signal apply succeeds' );
 	$assert( 1, (int) ( $finalized_apply['summary']['written'] ?? 0 ), 'finalized active/no-signal apply writes merged PR metadata' );
 	$stored_head_merged = \DataMachineCode\Workspace\WorktreeContextInjector::get_metadata( 'demo@head-merged' );
 	$assert( 'cleanup_eligible', $stored_head_merged['lifecycle_state'] ?? '', 'finalized active/no-signal apply stores cleanup_eligible state' );
 	$assert( 'pr-merged', $stored_head_merged['cleanup_eligibility_evidence']['signal'] ?? '', 'finalized active/no-signal apply stores PR merge evidence' );
+
+	$equivalent_clean_dry_run = $ws->worktree_active_no_signal_equivalent_clean_apply( array( 'dry_run' => true, 'limit' => 50, 'offset' => 0 ) );
+	$assert( true, ! is_wp_error( $equivalent_clean_dry_run ) && ( $equivalent_clean_dry_run['success'] ?? false ), 'equivalent-clean active/no-signal dry-run succeeds' );
+	$assert( 1, (int) ( $equivalent_clean_dry_run['summary']['planned'] ?? 0 ), 'equivalent-clean dry-run plans only equivalent clean rows' );
+	$assert( '', \DataMachineCode\Workspace\WorktreeContextInjector::get_metadata( 'demo@equivalent-clean' )['cleanup_eligible_at'] ?? '', 'equivalent-clean dry-run leaves metadata unchanged' );
+	$equivalent_clean_apply = $ws->worktree_active_no_signal_equivalent_clean_apply( array( 'limit' => 50, 'offset' => 0 ) );
+	$assert( true, ! is_wp_error( $equivalent_clean_apply ) && ( $equivalent_clean_apply['success'] ?? false ), 'equivalent-clean active/no-signal apply succeeds' );
+	$assert( 1, (int) ( $equivalent_clean_apply['summary']['written'] ?? 0 ), 'equivalent-clean active/no-signal apply writes metadata' );
+	$stored_equivalent_clean = \DataMachineCode\Workspace\WorktreeContextInjector::get_metadata( 'demo@equivalent-clean' );
+	$assert( 'cleanup_eligible', $stored_equivalent_clean['lifecycle_state'] ?? '', 'equivalent-clean apply stores cleanup_eligible state' );
+	$assert( 'upstream-equivalent-clean', $stored_equivalent_clean['cleanup_eligibility_evidence']['signal'] ?? '', 'equivalent-clean apply stores upstream equivalence evidence' );
 
 	echo "\nSafety gates\n";
 	$stale_plan['proposals'][0]['branch'] = 'wrong-branch';


### PR DESCRIPTION
## Summary
- Add `active-no-signal-equivalent-clean-apply` to promote only `effective_status=equivalent_clean` rows into `cleanup_eligible` metadata.
- Revalidate upstream-equivalence at apply time and keep generated/obsolete/unknown/not-equivalent dirty rows skipped.
- Allow bounded cleanup revalidation to honor the reviewed `upstream-equivalent-clean` metadata when the evidence still holds.

Closes #368.

## Testing
- `php -l inc/Workspace/Workspace.php && php -l inc/Cli/Commands/WorkspaceCommand.php && php -l inc/Abilities/WorkspaceAbilities.php && php -l tests/smoke-worktree-metadata-reconcile.php`
- `php tests/smoke-worktree-metadata-reconcile.php`
- `php tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-worktree-cleanup-chunks.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, smoke coverage, and verification commands for Chris to review.