### PR TITLE
Expose slow worktree row timing

### DIFF
--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -3887,10 +3887,14 @@ class Workspace {
 				$page_worktrees = array_slice( $page_worktrees, 0, $index );
 				break;
 			}
+			$row_started = microtime( true );
 			$proposal = $this->build_worktree_metadata_reconciliation_row( $wt, $github_cache, $fetched );
+			$elapsed_ms = (int) round( ( microtime( true ) - $row_started ) * 1000 );
 			if ( isset( $proposal['proposal'] ) ) {
+				$proposal['proposal']['elapsed_ms'] = $elapsed_ms;
 				$proposals[] = $proposal['proposal'];
 			} elseif ( isset( $proposal['skip'] ) ) {
+				$proposal['skip']['elapsed_ms'] = $elapsed_ms;
 				$skipped[] = $proposal['skip'];
 			}
 		}
@@ -4964,6 +4968,33 @@ class Workspace {
 			'skipped'           => count( $skipped ),
 			'skipped_by_reason' => $skipped_by_reason,
 			'proposed_by_state' => $states,
+			'slow_rows'         => $this->summarize_slow_worktree_rows( array_merge( $proposals, $skipped ) ),
+		);
+	}
+
+	/**
+	 * Summarize the slowest worktree rows from an expensive report page.
+	 *
+	 * @param array<int,array<string,mixed>> $rows Timed rows.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function summarize_slow_worktree_rows( array $rows ): array {
+		$timed = array_values( array_filter( $rows, fn( $row ) => is_array( $row ) && isset( $row['elapsed_ms'] ) ) );
+		usort( $timed, fn( $a, $b ) => (int) ( $b['elapsed_ms'] ?? 0 ) <=> (int) ( $a['elapsed_ms'] ?? 0 ) );
+
+		return array_map(
+			fn( $row ) => array_filter(
+				array(
+					'handle'      => (string) ( $row['handle'] ?? '' ),
+					'repo'        => (string) ( $row['repo'] ?? '' ),
+					'branch'      => (string) ( $row['branch'] ?? '' ),
+					'elapsed_ms'  => (int) ( $row['elapsed_ms'] ?? 0 ),
+					'action'      => (string) ( $row['suggested_action'] ?? '' ),
+					'reason_code' => (string) ( $row['reason_code'] ?? '' ),
+				),
+				fn( $value ) => '' !== $value
+			),
+			array_slice( $timed, 0, 10 )
 		);
 	}
 
@@ -6446,7 +6477,9 @@ class Workspace {
 				$page = array_slice( $page, 0, $index );
 				break;
 			}
+			$row_started = microtime( true );
 			$evidence = $this->build_active_no_signal_evidence_row( $row, $github_cache );
+			$evidence['elapsed_ms'] = (int) round( ( microtime( true ) - $row_started ) * 1000 );
 			$rows[]   = $evidence;
 			++$summary['inspected'];
 
@@ -6484,7 +6517,7 @@ class Workspace {
 			'review_only' => true,
 			'generated_at' => gmdate( 'c' ),
 			'rows'       => $rows,
-			'summary'    => $summary,
+			'summary'    => array_merge( $summary, array( 'slow_rows' => $this->summarize_slow_worktree_rows( $rows ) ) ),
 			'pagination' => $pagination,
 			'evidence'   => array(
 				'scope' => 'review-only active_no_signal worktree lifecycle evidence',

--- a/tests/smoke-worktree-metadata-reconcile.php
+++ b/tests/smoke-worktree-metadata-reconcile.php
@@ -520,6 +520,8 @@ namespace {
 	$assert( 250, (int) ( $active_rows['demo@dirty-active']['upstream_equivalence']['path_inspection_limit'] ?? 0 ), 'dirty diagnostics expose path inspection cap' );
 	$assert( true, isset( $active_rows['demo@dirty-active']['upstream_equivalence']['dirty_paths']['generated_or_artifact'] ), 'dirty diagnostics count generated/artifact paths' );
 	$assert( 'equivalent_clean', $active_rows['demo@equivalent-clean']['upstream_equivalence']['effective_status'] ?? '', 'dirty diagnostics classify patch-equivalent clean rows' );
+	$assert( true, isset( $active_rows['demo@dirty-active']['elapsed_ms'] ), 'active/no-signal rows include elapsed timing' );
+	$assert( true, isset( $active_report['summary']['slow_rows'][0]['elapsed_ms'] ), 'active/no-signal summary includes slow row timing samples' );
 	$budgeted_active_report = $ws->worktree_active_no_signal_report( array( 'limit' => 20, 'offset' => 0, 'internal_budget_label' => '1s', 'internal_budget_seconds' => 1, 'internal_budget_started' => microtime( true ) - 1 ) );
 	$assert( true, ! is_wp_error( $budgeted_active_report ) && ( $budgeted_active_report['success'] ?? false ), 'budgeted active/no-signal report succeeds' );
 	$assert( true, (bool) ( $budgeted_active_report['pagination']['partial'] ?? false ), 'budgeted active/no-signal report returns partial pagination' );
@@ -550,6 +552,8 @@ namespace {
 	$assert( 'filesystem', $by_handle['demo@unmanaged-missing']['source_map']['created_at'] ?? '', 'missing metadata created_at source is filesystem' );
 	$assert( 'reconcile_run', $by_handle['demo@unmanaged-missing']['source_map']['observed_at'] ?? '', 'missing metadata observed_at source is reconcile run' );
 	$assert( 'current_site', $by_handle['demo@unmanaged-missing']['source_map']['origin_site'] ?? '', 'missing metadata origin site is inferred from current site' );
+	$assert( true, isset( $by_handle['demo@unmanaged-missing']['elapsed_ms'] ), 'metadata reconciliation proposal rows include elapsed timing' );
+	$assert( true, isset( $plan['summary']['slow_rows'][0]['elapsed_ms'] ), 'metadata reconciliation summary includes slow row timing samples' );
 	$assert( 'metadata', $by_handle['demo@unmanaged-partial']['source_map']['created_at'] ?? '', 'partial metadata preserves created_at source' );
 	$assert( 'git', $by_handle['demo@unmanaged-partial']['source_map']['branch'] ?? '', 'branch source is git' );
 	$assert( array( 'lifecycle_state' ), $by_handle['demo@unmanaged-invalid']['invalid_fields'] ?? array(), 'invalid lifecycle state is planned for repair' );


### PR DESCRIPTION
## Summary
- Add `elapsed_ms` to metadata reconciliation proposal/skip rows and active/no-signal evidence rows.
- Add `summary.slow_rows` samples sorted by elapsed time for expensive worktree reports.
- Keep cleanup and reconciliation behavior unchanged; this is diagnostic evidence only.

Closes #372.

## Testing
- `php -l inc/Workspace/Workspace.php && php -l tests/smoke-worktree-metadata-reconcile.php && git diff --check`
- `php tests/smoke-worktree-metadata-reconcile.php`
- `php tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-worktree-cleanup-chunks.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted timing diagnostics, smoke assertions, and verification commands for Chris to review.