### PR TITLE
Batch dirty path classification

### DIFF
--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -6950,8 +6950,9 @@ class Workspace {
 		$evidence['path_inspection_truncated'] = count( $paths ) > count( $inspect_paths );
 
 		$classification_started = microtime( true );
+		$classifications = $this->classify_dirty_paths_against_default( $primary_path, $wt_path, $default_ref, $inspect_paths );
 		foreach ( $inspect_paths as $path ) {
-			$classification = $this->classify_dirty_path_against_default( $primary_path, $wt_path, $default_ref, $path );
+			$classification = $classifications[ $path ] ?? $this->classify_dirty_path_against_default( $primary_path, $wt_path, $default_ref, $path );
 			$bucket = $classification['bucket'];
 			if ( isset( $evidence['dirty_paths'][ $bucket ] ) ) {
 				++$evidence['dirty_paths'][ $bucket ];
@@ -6973,6 +6974,52 @@ class Workspace {
 		$evidence['effective_status'] = $this->classify_dirty_unpushed_effective_status( $evidence );
 
 		return $evidence;
+	}
+
+	/**
+	 * Classify dirty paths against the remote default branch with batched git probes.
+	 *
+	 * @param string            $primary_path Primary checkout path.
+	 * @param string            $wt_path      Worktree path.
+	 * @param string            $default_ref  Remote default ref.
+	 * @param array<int,string> $paths        Repository-relative paths.
+	 * @return array<string,array<string,string>> Classifications keyed by path.
+	 */
+	private function classify_dirty_paths_against_default( string $primary_path, string $wt_path, string $default_ref, array $paths ): array {
+		$paths = array_values( array_unique( array_filter( array_map( 'strval', $paths ), fn( $path ) => '' !== $path ) ) );
+		if ( array() === $paths ) {
+			return array();
+		}
+
+		$path_args = implode( ' ', array_map( 'escapeshellarg', $paths ) );
+		$existing = $this->run_git( $primary_path, sprintf( 'ls-tree -r --name-only %s -- %s', escapeshellarg( $default_ref ), $path_args ), self::CLEANUP_GIT_PROBE_TIMEOUT );
+		$changed  = $this->run_git( $wt_path, sprintf( 'diff --name-only %s -- %s', escapeshellarg( $default_ref ), $path_args ), self::CLEANUP_GIT_PROBE_TIMEOUT );
+		if ( is_wp_error( $existing ) || is_wp_error( $changed ) || $this->is_git_timeout_error( $existing ) || $this->is_git_timeout_error( $changed ) ) {
+			return array();
+		}
+
+		$existing_set = array_fill_keys( array_values( array_filter( array_map( 'trim', explode( "\n", (string) ( $existing['output'] ?? '' ) ) ) ) ), true );
+		$changed_set  = array_fill_keys( array_values( array_filter( array_map( 'trim', explode( "\n", (string) ( $changed['output'] ?? '' ) ) ) ) ), true );
+		$out          = array();
+		foreach ( $paths as $path ) {
+			$kind = $this->is_generated_or_artifact_path( $path ) ? 'generated_or_artifact' : 'source_like';
+			if ( ! isset( $existing_set[ $path ] ) ) {
+				$out[ $path ] = array(
+					'path'   => $path,
+					'bucket' => 'absent_on_default',
+					'kind'   => $kind,
+				);
+				continue;
+			}
+
+			$out[ $path ] = array(
+				'path'   => $path,
+				'bucket' => isset( $changed_set[ $path ] ) ? 'different_from_default' : 'identical_to_default',
+				'kind'   => $kind,
+			);
+		}
+
+		return $out;
 	}
 
 	/**

--- a/tests/smoke-worktree-metadata-reconcile.php
+++ b/tests/smoke-worktree-metadata-reconcile.php
@@ -526,6 +526,7 @@ namespace {
 	$assert( true, isset( $active_rows['demo@dirty-active']['probe_timings_ms']['upstream_equivalence'] ), 'active/no-signal rows include upstream equivalence probe timing' );
 	$assert( true, isset( $active_rows['demo@dirty-active']['upstream_equivalence']['probe_timings_ms']['git_cherry'] ), 'upstream equivalence includes git cherry probe timing' );
 	$assert( true, isset( $active_rows['demo@dirty-active']['upstream_equivalence']['probe_timings_ms']['dirty_path_classification'] ), 'upstream equivalence includes dirty path classification timing' );
+	$assert( true, (int) ( $active_rows['demo@dirty-active']['upstream_equivalence']['dirty_paths']['inspected'] ?? 0 ) >= 1, 'batched dirty path classification preserves inspected path count' );
 	$budgeted_active_report = $ws->worktree_active_no_signal_report( array( 'limit' => 20, 'offset' => 0, 'internal_budget_label' => '1s', 'internal_budget_seconds' => 1, 'internal_budget_started' => microtime( true ) - 1 ) );
 	$assert( true, ! is_wp_error( $budgeted_active_report ) && ( $budgeted_active_report['success'] ?? false ), 'budgeted active/no-signal report succeeds' );
 	$assert( true, (bool) ( $budgeted_active_report['pagination']['partial'] ?? false ), 'budgeted active/no-signal report returns partial pagination' );


### PR DESCRIPTION
## Summary
- Batch dirty-path comparison against the default ref with one `ls-tree` and one `diff --name-only` call per inspected path set.
- Preserve existing per-path classifier as fallback when batched probes fail or time out.
- Keep existing buckets and generated/source-like classification unchanged.

Closes #377.

## Testing
- `php -l inc/Workspace/Workspace.php && php -l tests/smoke-worktree-metadata-reconcile.php && git diff --check`
- `php tests/smoke-worktree-metadata-reconcile.php`
- `php tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-worktree-cleanup-chunks.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the batched dirty path classifier, smoke coverage, and verification commands for Chris to review.