### PR TITLE
Skip PR lookup for unsafe active rows

### DIFF
--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -5647,13 +5647,17 @@ class Workspace {
 			}
 		}
 
-		$slug = $this->time_worktree_probe( $out['probe_timings_ms'], 'github_slug', fn() => $this->resolve_github_slug( $primary_path ) );
-		if ( null !== $slug ) {
-			$pr = $this->time_worktree_probe( $out['probe_timings_ms'], 'github_pr_lookup', fn() => $this->find_pr_for_branch_direct( $slug, $branch, $github_cache, false ) );
-			if ( is_wp_error( $pr ) ) {
-				$out['pr_error'] = $pr->get_error_message();
-			} elseif ( is_array( $pr ) ) {
-				$out['pr'] = $pr;
+		if ( (int) ( $out['dirty'] ?? 0 ) > 0 || (int) ( $out['unpushed'] ?? 0 ) > 0 ) {
+			$out['pr_lookup_skipped'] = 'dirty_or_unpushed_rows_are_always_manual_review';
+		} else {
+			$slug = $this->time_worktree_probe( $out['probe_timings_ms'], 'github_slug', fn() => $this->resolve_github_slug( $primary_path ) );
+			if ( null !== $slug ) {
+				$pr = $this->time_worktree_probe( $out['probe_timings_ms'], 'github_pr_lookup', fn() => $this->find_pr_for_branch_direct( $slug, $branch, $github_cache, false ) );
+				if ( is_wp_error( $pr ) ) {
+					$out['pr_error'] = $pr->get_error_message();
+				} elseif ( is_array( $pr ) ) {
+					$out['pr'] = $pr;
+				}
 			}
 		}
 

--- a/tests/smoke-worktree-metadata-reconcile.php
+++ b/tests/smoke-worktree-metadata-reconcile.php
@@ -524,6 +524,8 @@ namespace {
 	$assert( true, isset( $active_report['summary']['slow_rows'][0]['elapsed_ms'] ), 'active/no-signal summary includes slow row timing samples' );
 	$assert( true, isset( $active_rows['demo@dirty-active']['probe_timings_ms']['dirty_count'] ), 'active/no-signal rows include dirty probe timing' );
 	$assert( true, isset( $active_rows['demo@dirty-active']['probe_timings_ms']['upstream_equivalence'] ), 'active/no-signal rows include upstream equivalence probe timing' );
+	$assert( 'dirty_or_unpushed_rows_are_always_manual_review', $active_rows['demo@dirty-active']['pr_lookup_skipped'] ?? '', 'dirty active/no-signal rows skip GitHub PR lookup' );
+	$assert( false, isset( $active_rows['demo@dirty-active']['probe_timings_ms']['github_pr_lookup'] ), 'dirty active/no-signal rows do not spend time on GitHub PR lookup' );
 	$assert( true, isset( $active_rows['demo@dirty-active']['upstream_equivalence']['probe_timings_ms']['git_cherry'] ), 'upstream equivalence includes git cherry probe timing' );
 	$assert( true, isset( $active_rows['demo@dirty-active']['upstream_equivalence']['probe_timings_ms']['dirty_path_classification'] ), 'upstream equivalence includes dirty path classification timing' );
 	$assert( true, (int) ( $active_rows['demo@dirty-active']['upstream_equivalence']['dirty_paths']['inspected'] ?? 0 ) >= 1, 'batched dirty path classification preserves inspected path count' );


### PR DESCRIPTION
## Summary
- Skip exact GitHub PR lookup for active/no-signal rows that are already dirty or unpushed.
- Record `pr_lookup_skipped=dirty_or_unpushed_rows_are_always_manual_review` so the missing PR probe is explicit in diagnostics.
- Preserve exact branch-head PR lookup for clean rows where PR lifecycle affects the suggested action.

Closes #380.

## Testing
- `php -l inc/Workspace/Workspace.php && php -l tests/smoke-worktree-metadata-reconcile.php && git diff --check`
- `php tests/smoke-worktree-metadata-reconcile.php`
- `php tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-worktree-cleanup-chunks.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the PR lookup skip, smoke assertions, and verification commands for Chris to review.