### PR TITLE
Filter workspace list by repo

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -86,7 +86,12 @@ class WorkspaceAbilities {
 					'category'            => 'datamachine-code-workspace',
 					'input_schema'        => array(
 						'type'       => 'object',
-						'properties' => array(),
+						'properties' => array(
+							'repo' => array(
+								'type'        => 'string',
+								'description' => 'Optional primary repository name to filter by. Includes the primary checkout and its worktrees.',
+							),
+						),
 					),
 					'output_schema'       => array(
 						'type'       => 'object',
@@ -2004,9 +2009,10 @@ class WorkspaceAbilities {
 	 * @param array $input Input parameters.
 	 * @return array Result.
 	 */
-	public static function listRepos( array $input ): array|\WP_Error { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+	public static function listRepos( array $input ): array|\WP_Error {
 		$workspace = new Workspace();
-		return $workspace->list_repos();
+		$repo      = isset( $input['repo'] ) ? (string) $input['repo'] : null;
+		return $workspace->list_repos( $repo );
 	}
 
 	/**

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -87,6 +87,9 @@ class WorkspaceCommand extends BaseCommand {
 	 *
 	 * ## OPTIONS
 	 *
+	 * [--repo=<repo>]
+	 * : Filter by primary repository name. Includes the primary checkout and its worktrees.
+	 *
 	 * [--format=<format>]
 	 * : Output format.
 	 * ---
@@ -106,6 +109,9 @@ class WorkspaceCommand extends BaseCommand {
 	 *     # List as JSON
 	 *     wp datamachine-code workspace list --format=json
 	 *
+	 *     # List one primary checkout and its worktrees
+	 *     wp datamachine-code workspace list --repo=homeboy
+	 *
 	 * @subcommand list
 	 */
 	public function list_repos( array $args, array $assoc_args ): void {
@@ -115,7 +121,12 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 
-		$result = $ability->execute( array() );
+		$input = array();
+		if ( isset( $assoc_args['repo'] ) ) {
+			$input['repo'] = (string) $assoc_args['repo'];
+		}
+
+		$result = $ability->execute( $input );
 
 		if ( is_wp_error( $result ) ) {
 			WP_CLI::error( $result->get_error_message() );
@@ -123,6 +134,11 @@ class WorkspaceCommand extends BaseCommand {
 		}
 
 		if ( empty( $result['repos'] ) ) {
+			if ( isset( $assoc_args['repo'] ) ) {
+				WP_CLI::log( sprintf( 'No repos matching "%s" in workspace (%s).', (string) $assoc_args['repo'], $result['path'] ?? '' ) );
+				return;
+			}
+
 			WP_CLI::log( sprintf( 'No repos in workspace (%s).', $result['path'] ?? '' ) );
 			WP_CLI::log( 'Clone one with: wp datamachine-code workspace clone <url>' );
 			return;

--- a/inc/Tools/WorkspaceTools.php
+++ b/inc/Tools/WorkspaceTools.php
@@ -167,14 +167,19 @@ class WorkspaceTools extends BaseTool {
 	 *
 	 * @return array
 	 */
-	public function handleList(): array {
+	public function handleList( array $parameters = array() ): array {
 		$ability = wp_get_ability( 'datamachine/workspace-list' );
 
 		if ( ! $ability ) {
 			return $this->buildErrorResponse( 'Workspace list ability not available.', 'workspace_list' );
 		}
 
-		$result = $ability->execute( array() );
+		$input = array();
+		if ( isset( $parameters['repo'] ) ) {
+			$input['repo'] = (string) $parameters['repo'];
+		}
+
+		$result = $ability->execute( $input );
 
 		if ( is_wp_error( $result ) ) {
 			return $this->buildErrorResponse( $result->get_error_message(), 'workspace_list' );
@@ -580,7 +585,12 @@ class WorkspaceTools extends BaseTool {
 			'description' => 'List repositories currently present in the Data Machine workspace.',
 			'parameters'  => array(
 				'type'       => 'object',
-				'properties' => array(),
+				'properties' => array(
+					'repo' => array(
+						'type'        => 'string',
+						'description' => 'Optional primary repository name to filter by. Includes the primary checkout and its worktrees.',
+					),
+				),
 				'required'   => array(),
 			),
 		) );

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -408,14 +408,17 @@ class Workspace {
 	/**
 	 * List repositories in the workspace.
 	 *
+	 * @param string|null $repo Optional primary repository name to include.
 	 * @return array{success: bool, repos: array, path: string}|\WP_Error
 	 */
-	public function list_repos(): array|\WP_Error {
+	public function list_repos( ?string $repo = null ): array|\WP_Error {
 		$path    = $this->workspace_path;
 		$visible = $this->require_workspace_visible();
 		if ( null !== $visible ) {
 			return $visible;
 		}
+
+		$repo_filter = null !== $repo && '' !== trim( $repo ) ? $this->parse_handle( $repo )['repo'] : null;
 
 		if ( ! is_dir( $path ) ) {
 			return array(
@@ -442,6 +445,10 @@ class Workspace {
 			$is_git   = is_dir( $git_path ) || is_file( $git_path );
 			$is_wt    = is_file( $git_path );
 			$parsed   = $this->parse_handle( $entry );
+
+			if ( null !== $repo_filter && $parsed['repo'] !== $repo_filter ) {
+				continue;
+			}
 
 			$repo_info = array(
 				'name'        => $entry,

--- a/tests/smoke-workspace-list-repo-filter.php
+++ b/tests/smoke-workspace-list-repo-filter.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Pure-PHP smoke test for workspace repo list filtering.
+ *
+ * Run: php tests/smoke-workspace-list-repo-filter.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Core\FilesRepository {
+	class FilesystemHelper {
+		public static function get() {
+			return null;
+		}
+	}
+}
+
+namespace {
+	$workspace_path = rtrim( sys_get_temp_dir(), '/' ) . '/datamachine-code-list-filter-' . getmypid();
+	$remove_tree    = static function ( string $path ) use ( &$remove_tree ): void {
+		if ( ! is_dir( $path ) ) {
+			return;
+		}
+
+		foreach ( scandir( $path ) ?: array() as $entry ) {
+			if ( '.' === $entry || '..' === $entry ) {
+				continue;
+			}
+
+			$child = $path . '/' . $entry;
+			is_dir( $child ) ? $remove_tree( $child ) : unlink( $child );
+		}
+
+		rmdir( $path );
+	};
+	register_shutdown_function( $remove_tree, $workspace_path );
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/fixtures/web-root/' );
+	}
+
+	if ( ! defined( 'DATAMACHINE_WORKSPACE_PATH' ) ) {
+		define( 'DATAMACHINE_WORKSPACE_PATH', $workspace_path );
+	}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			private string $code;
+			private string $message;
+			private $data;
+
+			public function __construct( string $code = '', string $message = '', $data = array() ) {
+				$this->code    = $code;
+				$this->message = $message;
+				$this->data    = $data;
+			}
+
+			public function get_error_code(): string {
+				return $this->code;
+			}
+
+			public function get_error_message(): string {
+				return $this->message;
+			}
+
+			public function get_error_data() {
+				return $this->data;
+			}
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $thing ): bool {
+			return $thing instanceof \WP_Error;
+		}
+	}
+
+	require __DIR__ . '/../inc/Workspace/Workspace.php';
+
+	$failures = 0;
+	$total    = 0;
+
+	$assert_same = function ( $expected, $actual, string $message ) use ( &$failures, &$total ): void {
+		$total++;
+		if ( $expected === $actual ) {
+			echo "  [PASS] {$message}\n";
+			return;
+		}
+
+		$failures++;
+		echo "  [FAIL] {$message}\n";
+		echo '    expected: ' . var_export( $expected, true ) . "\n";
+		echo '    actual:   ' . var_export( $actual, true ) . "\n";
+	};
+
+	$repo_names = static function ( array $result ): array {
+		return array_values( array_map( static fn( array $repo ): string => $repo['name'], $result['repos'] ?? array() ) );
+	};
+
+	echo "=== smoke-workspace-list-repo-filter ===\n";
+
+	mkdir( $workspace_path . '/homeboy', 0755, true );
+	mkdir( $workspace_path . '/homeboy@feature-one', 0755, true );
+	mkdir( $workspace_path . '/data-machine-code', 0755, true );
+
+	$workspace = new \DataMachineCode\Workspace\Workspace();
+
+	echo "\n[1] Unfiltered list includes every workspace directory\n";
+	$all = $workspace->list_repos();
+	$assert_same( array( 'data-machine-code', 'homeboy', 'homeboy@feature-one' ), $repo_names( $all ), 'unfiltered list includes all repos' );
+
+	echo "\n[2] Repo filter includes primary checkout and worktrees\n";
+	$filtered = $workspace->list_repos( 'homeboy' );
+	$assert_same( array( 'homeboy', 'homeboy@feature-one' ), $repo_names( $filtered ), 'repo filter includes matching primary and worktree handles' );
+
+	echo "\n[3] Missing repo filter returns an empty list\n";
+	$missing = $workspace->list_repos( 'missing' );
+	$assert_same( array(), $repo_names( $missing ), 'missing repo filter returns no repos' );
+
+	echo "\nResult: " . ( $total - $failures ) . "/{$total} passed\n";
+	exit( $failures > 0 ? 1 : 0 );
+}


### PR DESCRIPTION
## Summary
- Add an optional `--repo=<repo>` filter to `wp datamachine-code workspace list`.
- Apply the same repo filter through the workspace list ability and agent tool so primary checkouts and related worktrees can be listed together.
- Cover the filtering behavior with a focused smoke test.

## Verification
- `php -l inc/Workspace/Workspace.php`
- `php -l inc/Abilities/WorkspaceAbilities.php`
- `php -l inc/Cli/Commands/WorkspaceCommand.php`
- `php -l inc/Tools/WorkspaceTools.php`
- `php -l tests/smoke-workspace-list-repo-filter.php`
- `php tests/smoke-workspace-list-repo-filter.php`
- `git diff --check origin/main...HEAD`

## Notes
- `homeboy lint --path /Users/chubes/Developer/data-machine-code@add-workspace-list-repo-filter` remains red on existing baseline PHPCS findings unrelated to this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the CLI/ability/tool filter plumbing and smoke test; Chris requested the change and remains responsible for review and merge.