### PR TITLE
Budget full worktree cleanup dry-runs

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -1513,13 +1513,25 @@ class WorkspaceAbilities {
 								'type'        => 'string',
 								'description' => 'Optional candidate age filter such as 7d, 24h, 30m, or 60s. Uses lifecycle created_at metadata only.',
 							),
-							'sort'        => array(
+							'sort'                      => array(
 								'type'        => 'string',
 								'description' => 'Optional cleanup candidate sort: size or age.',
 							),
 							'include_repaired_metadata' => array(
 								'type'        => 'boolean',
 								'description' => 'If true, include repaired metadata rows as operator-approved removal candidates after full safety revalidation.',
+							),
+							'limit'                     => array(
+								'type'        => 'integer',
+								'description' => 'For dry-run cleanup, maximum worktrees to inspect in this page.',
+							),
+							'offset'                    => array(
+								'type'        => 'integer',
+								'description' => 'For dry-run cleanup, pagination offset into the worktree inventory.',
+							),
+							'until_budget'              => array(
+								'type'        => 'string',
+								'description' => 'For dry-run cleanup, compact wall-clock budget such as 60s or 10m. Returns continuation evidence when more rows remain.',
 							),
 						),
 					),
@@ -2635,10 +2647,10 @@ class WorkspaceAbilities {
 	public static function worktreeCleanup( array $input ): array|\WP_Error {
 		$workspace = new Workspace();
 		$opts      = array(
-			'dry_run'                 => ! empty( $input['dry_run'] ),
-			'force'                   => ! empty( $input['force'] ),
-			'skip_github'             => ! empty( $input['skip_github'] ),
-			'inventory_only'          => ! empty( $input['inventory_only'] ),
+			'dry_run'                   => ! empty( $input['dry_run'] ),
+			'force'                     => ! empty( $input['force'] ),
+			'skip_github'               => ! empty( $input['skip_github'] ),
+			'inventory_only'            => ! empty( $input['inventory_only'] ),
 			'include_repaired_metadata' => ! empty( $input['include_repaired_metadata'] ),
 		);
 		if ( isset( $input['apply_plan'] ) && is_array( $input['apply_plan'] ) ) {
@@ -2649,6 +2661,15 @@ class WorkspaceAbilities {
 		}
 		if ( isset( $input['sort'] ) && '' !== trim( (string) $input['sort'] ) ) {
 			$opts['sort'] = trim( (string) $input['sort'] );
+		}
+		if ( array_key_exists( 'limit', $input ) ) {
+			$opts['limit'] = (int) $input['limit'];
+		}
+		if ( array_key_exists( 'offset', $input ) ) {
+			$opts['offset'] = (int) $input['offset'];
+		}
+		if ( isset( $input['until_budget'] ) && '' !== trim( (string) $input['until_budget'] ) ) {
+			$opts['until_budget'] = trim( (string) $input['until_budget'] );
 		}
 		if ( isset( $input['progress_callback'] ) && is_callable( $input['progress_callback'] ) ) {
 			$opts['progress_callback'] = $input['progress_callback'];

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -2025,23 +2025,23 @@ class WorkspaceCommand extends BaseCommand {
 	 *   unpushed_commits, missing_metadata, external_worktree, age_filter, unknown_age.
 	 *
 	 * [--limit=<count>]
-	 * : For `cleanup-artifacts --dry-run`, `reconcile-metadata`, and
-	 *   `active-no-signal-report`,
+	 * : For `cleanup --dry-run`, `cleanup-artifacts --dry-run`,
+	 *   `reconcile-metadata`, and `active-no-signal-report`,
 	 *   maximum worktrees to scan in this page. Artifact cleanup defaults to
 	 *   100; metadata reconciliation uses this only when pagination is requested.
 	 *   Use 0 plus `--exhaustive` for a full artifact audit.
 	 *
 	 * [--offset=<count>]
-	 * : For `cleanup-artifacts --dry-run`, `reconcile-metadata`, and
-	 *   `active-no-signal-report`,
+	 * : For `cleanup --dry-run`, `cleanup-artifacts --dry-run`,
+	 *   `reconcile-metadata`, and `active-no-signal-report`,
 	 *   pagination offset (0-indexed) into the inventory ordering. Walk pages by
 	 *   passing the previous response's `pagination.next_offset`.
 	 *
 	 * [--until-budget=<duration>]
-	 * : For `reconcile-metadata`, enforce a compact wall-clock budget for dry-run
-	 *   pages or direct-apply drains (e.g. 60s, 10m). Also supported by
-	 *   `active-no-signal-report`. Returns continuation evidence and a next command
-	 *   when more rows remain.
+	 * : For `cleanup --dry-run` and `reconcile-metadata`, enforce a compact
+	 *   wall-clock budget for dry-run pages or direct-apply drains (e.g. 60s,
+	 *   10m). Also supported by `active-no-signal-report`. Returns continuation
+	 *   evidence and a next command when more rows remain.
 	 *
 	 * [--exhaustive]
 	 * : For `cleanup-artifacts --dry-run`, scan every worktree AND run per-worktree
@@ -2311,6 +2311,15 @@ class WorkspaceCommand extends BaseCommand {
 				$input['skip_github']    = ! empty( $assoc_args['skip-github'] );
 				$input['inventory_only'] = ! empty( $assoc_args['inventory-only'] );
 				$input['include_repaired_metadata'] = ! empty( $assoc_args['include-repaired-metadata'] );
+				if ( isset( $assoc_args['limit'] ) ) {
+					$input['limit'] = (int) $assoc_args['limit'];
+				}
+				if ( isset( $assoc_args['offset'] ) ) {
+					$input['offset'] = (int) $assoc_args['offset'];
+				}
+				if ( isset( $assoc_args['until-budget'] ) && '' !== trim( (string) $assoc_args['until-budget'] ) ) {
+					$input['until_budget'] = trim( (string) $assoc_args['until-budget'] );
+				}
 				if ( ! in_array( (string) ( $assoc_args['format'] ?? '' ), array( 'json', 'yaml' ), true ) ) {
 					$input['progress_callback'] = function ( array $event ): void {
 						$this->render_worktree_cleanup_progress( $event );
@@ -3318,14 +3327,32 @@ class WorkspaceCommand extends BaseCommand {
 
 		WP_CLI::log( 'Summary:' );
 		$summary_rows = array(
-			array( 'metric' => 'total_active_no_signal', 'count' => (int) ( $summary['total_active_no_signal'] ?? 0 ) ),
-			array( 'metric' => 'inspected', 'count' => (int) ( $summary['inspected'] ?? 0 ) ),
-			array( 'metric' => 'with_pr', 'count' => (int) ( $summary['with_pr'] ?? 0 ) ),
-			array( 'metric' => 'without_pr', 'count' => (int) ( $summary['without_pr'] ?? 0 ) ),
-			array( 'metric' => 'dirty_or_unpushed', 'count' => (int) ( $summary['dirty_or_unpushed'] ?? 0 ) ),
+			array(
+				'metric' => 'total_active_no_signal',
+				'count'  => (int) ( $summary['total_active_no_signal'] ?? 0 ),
+			),
+			array(
+				'metric' => 'inspected',
+				'count'  => (int) ( $summary['inspected'] ?? 0 ),
+			),
+			array(
+				'metric' => 'with_pr',
+				'count'  => (int) ( $summary['with_pr'] ?? 0 ),
+			),
+			array(
+				'metric' => 'without_pr',
+				'count'  => (int) ( $summary['without_pr'] ?? 0 ),
+			),
+			array(
+				'metric' => 'dirty_or_unpushed',
+				'count'  => (int) ( $summary['dirty_or_unpushed'] ?? 0 ),
+			),
 		);
 		foreach ( (array) ( $summary['by_suggested_action'] ?? array() ) as $action => $count ) {
-			$summary_rows[] = array( 'metric' => 'action:' . $action, 'count' => (int) $count );
+			$summary_rows[] = array(
+				'metric' => 'action:' . $action,
+				'count'  => (int) $count,
+			);
 		}
 		$this->format_items( $summary_rows, array( 'metric', 'count' ), array( 'format' => 'table' ), 'metric' );
 
@@ -3395,13 +3422,28 @@ class WorkspaceCommand extends BaseCommand {
 
 		WP_CLI::log( 'Finalized active/no-signal apply summary:' );
 		$summary_rows = array(
-			array( 'metric' => 'inspected', 'count' => (int) ( $summary['inspected'] ?? 0 ) ),
-			array( 'metric' => 'planned', 'count' => (int) ( $summary['planned'] ?? count( $planned ) ) ),
-			array( 'metric' => 'written', 'count' => (int) ( $summary['written'] ?? count( $written ) ) ),
-			array( 'metric' => 'skipped', 'count' => (int) ( $summary['skipped'] ?? count( $skipped ) ) ),
+			array(
+				'metric' => 'inspected',
+				'count'  => (int) ( $summary['inspected'] ?? 0 ),
+			),
+			array(
+				'metric' => 'planned',
+				'count'  => (int) ( $summary['planned'] ?? count( $planned ) ),
+			),
+			array(
+				'metric' => 'written',
+				'count'  => (int) ( $summary['written'] ?? count( $written ) ),
+			),
+			array(
+				'metric' => 'skipped',
+				'count'  => (int) ( $summary['skipped'] ?? count( $skipped ) ),
+			),
 		);
 		foreach ( (array) ( $summary['skipped_by_reason'] ?? array() ) as $reason => $count ) {
-			$summary_rows[] = array( 'metric' => 'skipped:' . $reason, 'count' => (int) $count );
+			$summary_rows[] = array(
+				'metric' => 'skipped:' . $reason,
+				'count'  => (int) $count,
+			);
 		}
 		$this->format_items( $summary_rows, array( 'metric', 'count' ), array( 'format' => 'table' ), 'metric' );
 
@@ -3475,13 +3517,28 @@ class WorkspaceCommand extends BaseCommand {
 
 		WP_CLI::log( 'Equivalent-clean active/no-signal apply summary:' );
 		$summary_rows = array(
-			array( 'metric' => 'inspected', 'count' => (int) ( $summary['inspected'] ?? 0 ) ),
-			array( 'metric' => 'planned', 'count' => (int) ( $summary['planned'] ?? count( $planned ) ) ),
-			array( 'metric' => 'written', 'count' => (int) ( $summary['written'] ?? count( $written ) ) ),
-			array( 'metric' => 'skipped', 'count' => (int) ( $summary['skipped'] ?? count( $skipped ) ) ),
+			array(
+				'metric' => 'inspected',
+				'count'  => (int) ( $summary['inspected'] ?? 0 ),
+			),
+			array(
+				'metric' => 'planned',
+				'count'  => (int) ( $summary['planned'] ?? count( $planned ) ),
+			),
+			array(
+				'metric' => 'written',
+				'count'  => (int) ( $summary['written'] ?? count( $written ) ),
+			),
+			array(
+				'metric' => 'skipped',
+				'count'  => (int) ( $summary['skipped'] ?? count( $skipped ) ),
+			),
 		);
 		foreach ( (array) ( $summary['skipped_by_reason'] ?? array() ) as $reason => $count ) {
-			$summary_rows[] = array( 'metric' => 'skipped:' . $reason, 'count' => (int) $count );
+			$summary_rows[] = array(
+				'metric' => 'skipped:' . $reason,
+				'count'  => (int) $count,
+			);
 		}
 		$this->format_items( $summary_rows, array( 'metric', 'count' ), array( 'format' => 'table' ), 'metric' );
 

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -2432,6 +2432,26 @@ class Workspace {
 		$sort           = isset( $opts['sort'] ) ? trim( (string) $opts['sort'] ) : '';
 		$progress       = isset( $opts['progress_callback'] ) && is_callable( $opts['progress_callback'] ) ? $opts['progress_callback'] : null;
 		$started_at     = microtime( true );
+		$limit          = array_key_exists( 'limit', $opts ) ? max( 1, (int) $opts['limit'] ) : null;
+		$offset         = array_key_exists( 'offset', $opts ) ? max( 0, (int) $opts['offset'] ) : 0;
+		$budget_context = null;
+		$budget_stopped = false;
+
+		if ( isset( $opts['until_budget'] ) && '' !== trim( (string) $opts['until_budget'] ) ) {
+			if ( ! $dry_run ) {
+				return new \WP_Error( 'cleanup_budget_requires_dry_run', 'Budgeted cleanup is review-only. Use --dry-run with --until-budget, then apply a reviewed cleanup path.', array( 'status' => 400 ) );
+			}
+
+			$budget_seconds = $this->parse_worktree_metadata_reconciliation_budget( trim( (string) $opts['until_budget'] ) );
+			if ( is_wp_error( $budget_seconds ) ) {
+				return $budget_seconds;
+			}
+			$budget_context = $this->build_worktree_loop_budget_context( $opts, $started_at );
+		}
+
+		if ( ( null !== $limit || $offset > 0 ) && ! $dry_run ) {
+			return new \WP_Error( 'cleanup_pagination_requires_dry_run', 'Paginated cleanup is review-only. Use --dry-run with --limit/--offset, then apply a reviewed cleanup path.', array( 'status' => 400 ) );
+		}
 
 		if ( '' !== $sort && ! in_array( $sort, array( 'size', 'age' ), true ) ) {
 			return new \WP_Error( 'invalid_cleanup_sort', 'Invalid cleanup sort. Use size or age.', array( 'status' => 400 ) );
@@ -2488,17 +2508,26 @@ class Workspace {
 		$candidates         = array();
 		$skipped            = array();
 		$github_cache       = array();
-		$worktrees          = array_values( array_filter( (array) $listing['worktrees'], fn( $wt ) => empty( $wt['is_primary'] ) ) );
+		$all_worktrees      = array_values( array_filter( (array) $listing['worktrees'], fn( $wt ) => empty( $wt['is_primary'] ) ) );
+		$total_worktrees    = count( $all_worktrees );
+		$worktrees          = array_slice( $all_worktrees, $offset, $limit );
 		$checked            = 0;
+		$processed          = 0;
 		$removed_count      = 0;
 
-		$this->emit_worktree_cleanup_progress( $progress, 'start', '', $checked, count( $worktrees ), $candidates, $skipped, $removed_count, $started_at );
+		$this->emit_worktree_cleanup_progress( $progress, 'start', '', $checked, $total_worktrees, $candidates, $skipped, $removed_count, $started_at );
 
 		// Fetch + prune each primary once up-front so upstream-gone signals are fresh.
 		$fetched = array();
 		$fetch_timeouts = array();
 
 		foreach ( $worktrees as $wt ) {
+			if ( null !== $budget_context && $this->is_worktree_loop_budget_exhausted( $budget_context ) ) {
+				$budget_stopped = true;
+				break;
+			}
+
+			++$processed;
 			$handle       = $wt['handle'] ?? '?';
 			$repo         = $wt['repo'] ?? '';
 			$branch       = $wt['branch'] ?? '';
@@ -2528,7 +2557,7 @@ class Workspace {
 			$dirty_count = (int) ( $wt['dirty'] ?? 0 );
 
 			++$checked;
-			$this->emit_worktree_cleanup_progress( $progress, 'checking', (string) $handle, $checked, count( $worktrees ), $candidates, $skipped, $removed_count, $started_at );
+			$this->emit_worktree_cleanup_progress( $progress, 'checking', (string) $handle, $checked, $total_worktrees, $candidates, $skipped, $removed_count, $started_at );
 
 			if ( '' === $repo || '' === $branch || '' === $wt_path ) {
 				$missing_fields = array();
@@ -2822,11 +2851,15 @@ class Workspace {
 		}
 
 		$summary = $this->build_worktree_cleanup_summary( $candidates, array(), $skipped, $age_filter );
+		$pagination = $this->build_worktree_cleanup_pagination( $offset, $limit, $processed, $total_worktrees, $budget_stopped, $budget_context );
+		if ( null !== $pagination ) {
+			$summary['pagination'] = $pagination;
+		}
 
 		if ( $dry_run ) {
-			$this->emit_worktree_cleanup_progress( $progress, 'done', '', $checked, count( $worktrees ), $candidates, $skipped, $removed_count, $started_at );
+			$this->emit_worktree_cleanup_progress( $progress, 'done', '', $checked, $total_worktrees, $candidates, $skipped, $removed_count, $started_at );
 
-			return array(
+			$result = array(
 				'success'    => true,
 				'dry_run'    => true,
 				'candidates' => $candidates,
@@ -2834,6 +2867,17 @@ class Workspace {
 				'skipped'    => $skipped,
 				'summary'    => $summary,
 			);
+			if ( null !== $pagination ) {
+				$result['pagination'] = $pagination;
+			}
+			if ( null !== $budget_context ) {
+				$result['evidence'] = array(
+					'elapsed_ms' => (int) round( ( microtime( true ) - $started_at ) * 1000 ),
+					'budget'     => $this->summarize_worktree_loop_budget_context( $budget_context, $budget_stopped ),
+				);
+			}
+
+			return $result;
 		}
 
 		$removed = array();
@@ -2877,7 +2921,7 @@ class Workspace {
 		// Final sweep to drop any remaining registry entries.
 		$this->worktree_prune();
 
-		$this->emit_worktree_cleanup_progress( $progress, 'done', '', $checked, count( $worktrees ), $candidates, $skipped, $removed_count, $started_at );
+		$this->emit_worktree_cleanup_progress( $progress, 'done', '', $checked, $total_worktrees, $candidates, $skipped, $removed_count, $started_at );
 
 		return array(
 			'success'    => true,
@@ -2886,6 +2930,48 @@ class Workspace {
 			'removed'    => $removed,
 			'skipped'    => $skipped,
 			'summary'    => $this->build_worktree_cleanup_summary( $candidates, $removed, $skipped, $age_filter ),
+		);
+	}
+
+	/**
+	 * Build pagination evidence for bounded full cleanup dry-runs.
+	 *
+	 * @param int        $offset         Inventory offset for this page.
+	 * @param int|null   $limit          Optional page size.
+	 * @param int        $processed      Rows consumed from this page.
+	 * @param int        $total          Total non-primary worktrees.
+	 * @param bool       $budget_stopped Whether the budget stopped the scan early.
+	 * @param array|null $budget_context Optional budget context.
+	 * @return array<string,mixed>|null
+	 */
+	private function build_worktree_cleanup_pagination( int $offset, ?int $limit, int $processed, int $total, bool $budget_stopped, ?array $budget_context ): ?array {
+		if ( 0 === $offset && null === $limit && null === $budget_context ) {
+			return null;
+		}
+
+		$next_offset = ( $offset + $processed ) < $total ? $offset + $processed : null;
+		$command     = null;
+		if ( null !== $next_offset ) {
+			$parts = array(
+				'studio wp datamachine-code workspace worktree cleanup --dry-run',
+				null === $limit ? null : '--limit=' . $limit,
+				'--offset=' . $next_offset,
+				null === $budget_context ? null : '--until-budget=' . (string) ( $budget_context['label'] ?? '' ),
+				'--format=json',
+			);
+			$command = implode( ' ', array_values( array_filter( $parts, fn( $part ) => null !== $part && '' !== $part ) ) );
+		}
+
+		return array(
+			'total'          => $total,
+			'offset'         => $offset,
+			'limit'          => $limit,
+			'scanned'        => $processed,
+			'partial'        => null !== $next_offset,
+			'complete'       => null === $next_offset,
+			'next_offset'    => $next_offset,
+			'next_command'   => $command,
+			'budget_stopped' => $budget_stopped,
 		);
 	}
 
@@ -4135,7 +4221,14 @@ class Workspace {
 		$path   = (string) ( $row['path'] ?? '' );
 		$pr     = is_array( $row['pr'] ?? null ) ? $row['pr'] : array();
 
-		foreach ( array( 'handle' => $handle, 'repo' => $repo, 'branch' => $branch, 'path' => $path ) as $field => $value ) {
+		foreach (
+			array(
+				'handle' => $handle,
+				'repo'   => $repo,
+				'branch' => $branch,
+				'path'   => $path,
+			) as $field => $value
+		) {
 			if ( '' === $value ) {
 				return new \WP_Error( 'missing_identity', 'missing required identity field: ' . $field );
 			}
@@ -4225,7 +4318,14 @@ class Workspace {
 		$branch = (string) ( $row['branch'] ?? '' );
 		$path   = (string) ( $row['path'] ?? '' );
 
-		foreach ( array( 'handle' => $handle, 'repo' => $repo, 'branch' => $branch, 'path' => $path ) as $field => $value ) {
+		foreach (
+			array(
+				'handle' => $handle,
+				'repo'   => $repo,
+				'branch' => $branch,
+				'path'   => $path,
+			) as $field => $value
+		) {
 			if ( '' === $value ) {
 				return new \WP_Error( 'missing_identity', 'missing required identity field: ' . $field );
 			}
@@ -4609,10 +4709,10 @@ class Workspace {
 			return 'equivalent_clean';
 		}
 		$meaningful = (int) ( $dirty['different_from_default'] ?? 0 ) + (int) ( $dirty['absent_on_default'] ?? 0 ) + (int) ( $dirty['untracked'] ?? 0 );
-		if ( $meaningful > 0 && $meaningful === (int) ( $dirty['generated_or_artifact'] ?? 0 ) ) {
+		if ( 0 < $meaningful && (int) ( $dirty['generated_or_artifact'] ?? 0 ) === $meaningful ) {
 			return 'equivalent_generated_dirty';
 		}
-		if ( $meaningful > 0 && $meaningful === (int) ( $dirty['absent_on_default'] ?? 0 ) ) {
+		if ( 0 < $meaningful && (int) ( $dirty['absent_on_default'] ?? 0 ) === $meaningful ) {
 			return 'equivalent_obsolete_dirty';
 		}
 

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -732,6 +732,13 @@ namespace {
 	datamachine_code_cleanup_assert( str_contains( $decoded['summary']['skipped_next_commands'][1]['command'] ?? '', 'reconcile-metadata --dry-run --format=json' ), 'JSON metadata command is metadata reconciliation' );
 	datamachine_code_cleanup_assert( str_contains( $decoded['summary']['skipped_next_commands'][2]['alternative'] ?? '', 'No automatic cleanup action is safe' ), 'JSON active/no-signal command explains no automatic cleanup action' );
 
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->worktree( array( 'cleanup' ), array( 'dry-run' => true, 'limit' => 5, 'offset' => 10, 'until-budget' => '30s', 'format' => 'json' ) );
+	datamachine_code_cleanup_assert( 5 === (int) ( $ability->last_input['limit'] ?? 0 ), 'cleanup forwards dry-run limit' );
+	datamachine_code_cleanup_assert( 10 === (int) ( $ability->last_input['offset'] ?? 0 ), 'cleanup forwards dry-run offset' );
+	datamachine_code_cleanup_assert( '30s' === ( $ability->last_input['until_budget'] ?? '' ), 'cleanup forwards dry-run time budget' );
+
 	echo "\n[1b] --apply-plan decodes JSON and forbids force\n";
 	$plan_file = sys_get_temp_dir() . '/dmc-cleanup-plan-' . bin2hex( random_bytes( 3 ) ) . '.json';
 	file_put_contents( $plan_file, wp_json_encode( datamachine_code_cleanup_report() ) );


### PR DESCRIPTION
## Summary
- Adds `--limit`, `--offset`, and `--until-budget` support to full `workspace worktree cleanup --dry-run` scans.
- Returns pagination and budget evidence with a resumable next command when a dry-run stops early.
- Keeps paginated/budgeted cleanup review-only so destructive cleanup still goes through reviewed apply paths.

Closes #384.

## Testing
- `php -l inc/Workspace/Workspace.php`
- `php -l inc/Cli/Commands/WorkspaceCommand.php`
- `php -l inc/Abilities/WorkspaceAbilities.php`
- `php tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-worktree-metadata-reconcile.php`
- `php tests/smoke-worktree-cleanup-chunks.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine-code@fix-full-cleanup-budget --extension wordpress --changed-since origin/main --errors-only --force-hot --summary`
- `homeboy test --path /Users/chubes/Developer/data-machine-code@fix-full-cleanup-budget --extension wordpress --force-hot --summary`
- `git diff --check origin/main...HEAD`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the cleanup timeout, implemented the budgeted dry-run path, and ran local smoke/lint validation; Chris remains responsible for review and merge.