### PR TITLE
Budget cleanup preflight probes

### DIFF
--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -2499,7 +2499,14 @@ class Workspace {
 			);
 		}
 
-		$listing = $this->worktree_list();
+		$listing = $this->worktree_list(
+			null,
+			null,
+			array(
+				'include_status' => false,
+				'include_disk'   => false,
+			)
+		);
 		if ( $listing instanceof \WP_Error ) {
 			return $listing;
 		}
@@ -2517,7 +2524,8 @@ class Workspace {
 
 		$this->emit_worktree_cleanup_progress( $progress, 'start', '', $checked, $total_worktrees, $candidates, $skipped, $removed_count, $started_at );
 
-		// Fetch + prune each primary once up-front so upstream-gone signals are fresh.
+		// Fetch + prune each primary once per repo, but keep status/disk probes inside
+		// the row loop so budgeted dry-runs can return partial evidence promptly.
 		$fetched = array();
 		$fetch_timeouts = array();
 
@@ -2553,8 +2561,6 @@ class Workspace {
 				), $disk_fields );
 				continue;
 			}
-
-			$dirty_count = (int) ( $wt['dirty'] ?? 0 );
 
 			++$checked;
 			$this->emit_worktree_cleanup_progress( $progress, 'checking', (string) $handle, $checked, $total_worktrees, $candidates, $skipped, $removed_count, $started_at );
@@ -2600,6 +2606,13 @@ class Workspace {
 				), $disk_fields );
 				continue;
 			}
+
+			$dirty_probe = $this->probe_worktree_dirty_count( $wt_path, self::CLEANUP_GIT_PROBE_TIMEOUT );
+			if ( is_wp_error( $dirty_probe ) ) {
+				$skipped[] = $this->build_worktree_probe_timeout_skip( $handle, $repo, $branch, $wt_path, $created_at, $metadata, $disk_fields, $dirty_probe );
+				continue;
+			}
+			$dirty_count = (int) $dirty_probe;
 
 			if ( $dirty_count > 0 && ! $force ) {
 				// Before falling through to the generic dirty_worktree skip, try to


### PR DESCRIPTION
## Summary
- Moves full cleanup dry-run status/disk discovery out of the up-front worktree listing.
- Runs dirty probes inside the budgeted row loop so `--until-budget` can return partial cleanup evidence instead of timing out before the loop starts.
- Keeps cleanup safety intact by still probing dirty state before merge-signal deletion decisions.

Follow-up for #384 after live validation showed the first budget path still blocked in pre-loop listing probes.

## Testing
- `php -l inc/Workspace/Workspace.php`
- `php tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-worktree-metadata-reconcile.php`
- `php tests/smoke-worktree-cleanup-chunks.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine-code@fix-full-cleanup-budget-probes --extension wordpress --changed-since origin/main --errors-only --force-hot --summary`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the remaining pre-loop timeout, implemented the follow-up probe placement fix, and ran local smoke/lint validation; Chris remains responsible for review and merge.