### PR TITLE
Add GitHub PR merge cleanup commands

### DIFF
--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -509,6 +509,10 @@ class GitHubAbilities {
 								'enum'        => array( 'merge', 'squash', 'rebase' ),
 								'description' => 'GitHub merge method. Default: squash.',
 							),
+							'delete_branch'     => array(
+								'type'        => 'boolean',
+								'description' => 'Delete the pull request head branch through the GitHub API after a successful merge when the branch is in the same repository.',
+							),
 						),
 					),
 					'output_schema'       => array(
@@ -525,6 +529,50 @@ class GitHubAbilities {
 						),
 					),
 					'execute_callback'    => array( self::class, 'mergePullRequest' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/cleanup-github-pull-request',
+				array(
+					'label'               => 'Cleanup GitHub Pull Request',
+					'description'         => 'Delete a merged pull request head branch through the GitHub API without checking out local branches',
+					'category'            => 'datamachine-code-github',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'repo', 'pull_number' ),
+						'properties' => array(
+							'repo'        => array(
+								'type'        => 'string',
+								'description' => 'Repository in owner/repo format.',
+							),
+							'pull_number' => array(
+								'type'        => 'integer',
+								'description' => 'Pull request number.',
+							),
+							'dry_run'     => array(
+								'type'        => 'boolean',
+								'description' => 'Preview the cleanup decision without deleting the branch.',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'                => array( 'type' => 'boolean' ),
+							'repo'                   => array( 'type' => 'string' ),
+							'pull_number'            => array( 'type' => 'integer' ),
+							'head_branch'            => array( 'type' => 'string' ),
+							'branch_deleted'         => array( 'type' => 'boolean' ),
+							'branch_already_deleted' => array( 'type' => 'boolean' ),
+							'dry_run'                => array( 'type' => 'boolean' ),
+							'message'                => array( 'type' => 'string' ),
+							'error'                  => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'cleanupPullRequest' ),
 					'permission_callback' => fn() => PermissionHelper::can_manage(),
 					'meta'                => array( 'show_in_rest' => false ),
 				)
@@ -2157,7 +2205,7 @@ class GitHubAbilities {
 	 * Calls `GET /repos/{owner}/{repo}/pulls/{pull_number}` immediately before
 	 * `PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge`.
 	 *
-	 * @param array         $input       Required: repo, pull_number, expected_head_sha. Optional: merge_method.
+	 * @param array         $input       Required: repo, pull_number, expected_head_sha. Optional: merge_method, delete_branch.
 	 * @param callable|null $api_get     Optional test seam: fn(string $url, array $query, string $pat): array|WP_Error.
 	 * @param callable|null $api_request Optional test seam: fn(string $method, string $url, array $body, string $pat): array|WP_Error.
 	 * @return array|\WP_Error Success payload or error.
@@ -2167,6 +2215,7 @@ class GitHubAbilities {
 		$pull_number       = (int) ( $input['pull_number'] ?? 0 );
 		$expected_head_sha = sanitize_text_field( $input['expected_head_sha'] ?? '' );
 		$merge_method      = sanitize_text_field( $input['merge_method'] ?? 'squash' );
+		$delete_branch     = ! empty( $input['delete_branch'] );
 
 		if ( empty( $repo ) || $pull_number <= 0 || '' === $expected_head_sha ) {
 			return new \WP_Error( 'missing_params', 'Repository, pull_number, and expected_head_sha are required.', array( 'status' => 400 ) );
@@ -2208,7 +2257,7 @@ class GitHubAbilities {
 
 		$data = is_array( $response['data'] ?? null ) ? $response['data'] : array();
 
-		return array(
+		$result = array(
 			'success'          => true,
 			'repo'             => $repo,
 			'pull_number'      => $pull_number,
@@ -2219,6 +2268,111 @@ class GitHubAbilities {
 			'pull_request_url' => (string) ( $pull['html_url'] ?? '' ),
 			'merge_method'     => $merge_method,
 		);
+
+		if ( $delete_branch && ! empty( $result['merged'] ) ) {
+			$result['cleanup'] = self::cleanupPullRequest(
+				array(
+					'repo'        => $repo,
+					'pull_number' => $pull_number,
+				),
+				static fn( string $url, array $query, string $credential ): array|\WP_Error => $api_get( $url, $query, $credential ),
+				static fn( string $method, string $url, ?array $body, string $credential ): array|\WP_Error => $api_request( $method, $url, $body, $credential )
+			);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Delete a merged pull request head branch through the GitHub API.
+	 *
+	 * This intentionally does not use local git or `gh`, so it is safe to call
+	 * from a linked worktree where the base branch is already checked out in the
+	 * primary checkout.
+	 *
+	 * @param array         $input       Required: repo, pull_number. Optional: dry_run.
+	 * @param callable|null $api_get     Optional test seam: fn(string $url, array $query, string $pat): array|WP_Error.
+	 * @param callable|null $api_request Optional test seam: fn(string $method, string $url, ?array $body, string $pat): array|WP_Error.
+	 * @return array|\WP_Error Success payload or error.
+	 */
+	public static function cleanupPullRequest( array $input, ?callable $api_get = null, ?callable $api_request = null ): array|\WP_Error {
+		$repo        = sanitize_text_field( $input['repo'] ?? '' );
+		$pull_number = (int) ( $input['pull_number'] ?? 0 );
+		$dry_run     = ! empty( $input['dry_run'] );
+
+		if ( empty( $repo ) || $pull_number <= 0 ) {
+			return new \WP_Error( 'missing_params', 'Repository and pull_number are required.', array( 'status' => 400 ) );
+		}
+
+		$pat = self::getPatForRepo( $repo );
+		if ( empty( $pat ) ) {
+			return self::patError();
+		}
+
+		$api_get     = $api_get ?? array( self::class, 'apiGet' );
+		$api_request = $api_request ?? array( self::class, 'apiRequest' );
+		$pull_url    = sprintf( '%s/repos/%s/pulls/%d', self::API_BASE, $repo, $pull_number );
+
+		$pull_response = $api_get( $pull_url, array(), $pat );
+		if ( is_wp_error( $pull_response ) ) {
+			return $pull_response;
+		}
+
+		$pull        = is_array( $pull_response['data'] ?? null ) ? $pull_response['data'] : array();
+		$head_branch = sanitize_text_field( $pull['head']['ref'] ?? '' );
+		$head_repo   = sanitize_text_field( $pull['head']['repo']['full_name'] ?? '' );
+		$merged      = ! empty( $pull['merged_at'] );
+
+		if ( ! $merged ) {
+			return new \WP_Error( 'pull_request_not_merged', 'Pull request head branch cleanup requires a merged pull request.', array( 'status' => 409 ) );
+		}
+
+		if ( '' === $head_branch ) {
+			return new \WP_Error( 'pull_request_head_branch_missing', 'GitHub did not return a pull request head branch.', array( 'status' => 500 ) );
+		}
+
+		if ( '' !== $head_repo && $head_repo !== $repo ) {
+			return new \WP_Error( 'pull_request_head_repo_mismatch', 'Refusing to delete a pull request branch from a different repository.', array( 'status' => 409 ) );
+		}
+
+		if ( in_array( $head_branch, array( 'main', 'master', 'trunk', 'develop', 'HEAD' ), true ) ) {
+			return new \WP_Error( 'protected_head_branch', sprintf( 'Refusing to delete protected branch %s.', $head_branch ), array( 'status' => 409 ) );
+		}
+
+		$result = array(
+			'success'                => true,
+			'repo'                   => $repo,
+			'pull_number'            => $pull_number,
+			'head_branch'            => $head_branch,
+			'head_repo'              => '' !== $head_repo ? $head_repo : $repo,
+			'branch_deleted'         => false,
+			'branch_already_deleted' => false,
+			'dry_run'                => $dry_run,
+			'pull_request_url'       => (string) ( $pull['html_url'] ?? '' ),
+		);
+
+		if ( $dry_run ) {
+			$result['message'] = sprintf( 'Would delete branch %s from %s.', $head_branch, $repo );
+			return $result;
+		}
+
+		$encoded_head_branch = implode( '/', array_map( 'rawurlencode', explode( '/', $head_branch ) ) );
+		$delete_url          = sprintf( '%s/repos/%s/git/refs/heads/%s', self::API_BASE, $repo, $encoded_head_branch );
+		$deleted    = $api_request( 'DELETE', $delete_url, null, $pat );
+		if ( is_wp_error( $deleted ) ) {
+			$status = is_array( $deleted->get_error_data() ) ? (int) ( $deleted->get_error_data()['status'] ?? 0 ) : 0;
+			if ( 404 !== $status ) {
+				return $deleted;
+			}
+
+			$result['branch_already_deleted'] = true;
+			$result['message']                = sprintf( 'Branch %s was already deleted from %s.', $head_branch, $repo );
+			return $result;
+		}
+
+		$result['branch_deleted'] = true;
+		$result['message']        = sprintf( 'Deleted branch %s from %s.', $head_branch, $repo );
+		return $result;
 	}
 
 	/**

--- a/inc/Cli/Commands/GitHubCommand.php
+++ b/inc/Cli/Commands/GitHubCommand.php
@@ -376,6 +376,124 @@ class GitHubCommand extends BaseCommand {
 	}
 
 	/**
+	 * Merge a GitHub pull request through the GitHub API.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <pull_number>
+	 * : Pull request number to merge.
+	 *
+	 * [--repo=<repo>]
+	 * : Repository in owner/repo format.
+	 *
+	 * --expected-head-sha=<sha>
+	 * : Exact pull request head SHA expected immediately before merge.
+	 *
+	 * [--method=<method>]
+	 * : GitHub merge method.
+	 * ---
+	 * default: squash
+	 * options:
+	 *   - merge
+	 *   - squash
+	 *   - rebase
+	 * ---
+	 *
+	 * [--delete-branch]
+	 * : Delete the pull request head branch through the GitHub API after merge.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-code github merge 383 --repo=Extra-Chill/data-machine-code --expected-head-sha=abc123 --delete-branch
+	 *
+	 * @subcommand merge
+	 */
+	public function merge_pull( array $args, array $assoc_args ): void {
+		$this->requireConfig();
+
+		$pull_number = \absint( $args[0] ?? 0 );
+		if ( $pull_number <= 0 ) {
+			WP_CLI::error( 'Please provide a valid pull request number.' );
+			return;
+		}
+
+		$expected_head_sha = trim( (string) ( $assoc_args['expected-head-sha'] ?? '' ) );
+		if ( '' === $expected_head_sha ) {
+			WP_CLI::error( 'Required: --expected-head-sha=<sha>' );
+			return;
+		}
+
+		$input = $this->resolveRepo( array(
+			'repo'              => $assoc_args['repo'] ?? '',
+			'pull_number'       => $pull_number,
+			'expected_head_sha' => $expected_head_sha,
+			'merge_method'      => $assoc_args['method'] ?? 'squash',
+			'delete_branch'     => ! empty( $assoc_args['delete-branch'] ),
+		) );
+
+		$result = GitHubAbilities::mergePullRequest( $input );
+		$this->render_pull_mutation_result( $result, $assoc_args, 'Pull request merged.' );
+	}
+
+	/**
+	 * Cleanup a merged GitHub pull request through the GitHub API.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <pull_number>
+	 * : Pull request number to cleanup.
+	 *
+	 * [--repo=<repo>]
+	 * : Repository in owner/repo format.
+	 *
+	 * [--dry-run]
+	 * : Preview the cleanup decision without deleting the branch.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-code github cleanup-pr 383 --repo=Extra-Chill/data-machine-code --dry-run
+	 *     wp datamachine-code github cleanup-pr 383 --repo=Extra-Chill/data-machine-code
+	 *
+	 * @subcommand cleanup-pr
+	 */
+	public function cleanup_pull( array $args, array $assoc_args ): void {
+		$this->requireConfig();
+
+		$pull_number = \absint( $args[0] ?? 0 );
+		if ( $pull_number <= 0 ) {
+			WP_CLI::error( 'Please provide a valid pull request number.' );
+			return;
+		}
+
+		$input = $this->resolveRepo( array(
+			'repo'        => $assoc_args['repo'] ?? '',
+			'pull_number' => $pull_number,
+			'dry_run'     => ! empty( $assoc_args['dry-run'] ),
+		) );
+
+		$result = GitHubAbilities::cleanupPullRequest( $input );
+		$this->render_pull_mutation_result( $result, $assoc_args, 'Pull request cleanup complete.' );
+	}
+
+	/**
 	 * List repositories for a user or organization.
 	 *
 	 * ## OPTIONS
@@ -741,6 +859,36 @@ class GitHubCommand extends BaseCommand {
 			}
 		}
 		return $input;
+	}
+
+	/**
+	 * Render a PR mutation result.
+	 */
+	private function render_pull_mutation_result( array|\WP_Error $result, array $assoc_args, string $fallback_message ): void {
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
+
+		if ( 'json' === ( $assoc_args['format'] ?? 'table' ) ) {
+			WP_CLI::line( \wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		$items = array();
+		foreach ( $result as $key => $value ) {
+			if ( is_array( $value ) || is_object( $value ) ) {
+				continue;
+			}
+
+			$items[] = array(
+				'field' => (string) $key,
+				'value' => is_bool( $value ) ? ( $value ? 'yes' : 'no' ) : (string) $value,
+			);
+		}
+
+		$this->format_items( $items, array( 'field', 'value' ), $assoc_args );
+		WP_CLI::success( (string) ( $result['message'] ?? $fallback_message ) );
 	}
 
 	/**

--- a/inc/Tools/GitHubTools.php
+++ b/inc/Tools/GitHubTools.php
@@ -38,6 +38,10 @@ class GitHubTools extends BaseTool {
 			'access_level' => 'editor',
 			'ability'      => 'datamachine/merge-github-pull-request',
 		) );
+		$this->registerTool( 'cleanup_github_pull_request', array( $this, 'getCleanupPullRequestDefinition' ), $contexts, array(
+			'access_level' => 'editor',
+			'ability'      => 'datamachine/cleanup-github-pull-request',
+		) );
 		$this->registerTool( 'list_github_pulls', array( $this, 'getListPullsDefinition' ), $contexts, array( 'access_level' => 'editor' ) );
 		$this->registerTool( 'get_github_pull', array( $this, 'getGetPullDefinition' ), $contexts, array(
 			'access_level' => 'editor',
@@ -126,6 +130,7 @@ class GitHubTools extends BaseTool {
 			'comment_github_pull_request',
 			'upsert_github_pull_review_comment',
 			'merge_github_pull_request',
+			'cleanup_github_pull_request',
 			'list_github_pulls',
 			'get_github_pull',
 			'get_github_pull_files',
@@ -601,6 +606,16 @@ class GitHubTools extends BaseTool {
 	}
 
 	/**
+	 * Handle cleanup_github_pull_request tool call.
+	 *
+	 * @param array $parameters Tool parameters.
+	 * @return array
+	 */
+	public function handleCleanupPullRequest( array $parameters ): array {
+		return $this->executeGitHubAbility( 'datamachine/cleanup-github-pull-request', 'cleanup_github_pull_request', $parameters );
+	}
+
+	/**
 	 * Get tool definition for merge_github_pull_request.
 	 *
 	 * @return array
@@ -629,8 +644,43 @@ class GitHubTools extends BaseTool {
 						'type'        => 'string',
 						'description' => 'GitHub merge method: merge, squash, or rebase. Default: squash.',
 					),
+					'delete_branch'     => array(
+						'type'        => 'boolean',
+						'description' => 'Delete the pull request head branch through the GitHub API after merge when the branch is in the same repository.',
+					),
 				),
 				'required'   => array( 'repo', 'pull_number', 'expected_head_sha' ),
+			),
+		);
+	}
+
+	/**
+	 * Get tool definition for cleanup_github_pull_request.
+	 *
+	 * @return array
+	 */
+	public function getCleanupPullRequestDefinition(): array {
+		return array(
+			'class'       => __CLASS__,
+			'method'      => 'handleCleanupPullRequest',
+			'description' => 'Delete a merged pull request head branch through the GitHub API without checking out or switching local branches. Supports dry_run previews.',
+			'parameters'  => array(
+				'type'       => 'object',
+				'properties' => array(
+					'repo'        => array(
+						'type'        => 'string',
+						'description' => 'Repository in owner/repo format.',
+					),
+					'pull_number' => array(
+						'type'        => 'integer',
+						'description' => 'Pull request number.',
+					),
+					'dry_run'     => array(
+						'type'        => 'boolean',
+						'description' => 'Preview the cleanup decision without deleting the branch.',
+					),
+				),
+				'required'   => array( 'repo', 'pull_number' ),
 			),
 		);
 	}

--- a/tests/smoke-github-merge-pull-request.php
+++ b/tests/smoke-github-merge-pull-request.php
@@ -158,7 +158,7 @@ namespace {
 	}
 
 	function wp_get_ability( string $name ): ?DMC_Test_Ability {
-		if ( 'datamachine/merge-github-pull-request' === $name ) {
+		if ( in_array( $name, array( 'datamachine/merge-github-pull-request', 'datamachine/cleanup-github-pull-request' ), true ) ) {
 			return new DMC_Test_Ability( $name );
 		}
 
@@ -191,7 +191,27 @@ namespace {
 				'number'   => 42,
 				'state'    => 'open',
 				'html_url' => 'https://github.com/owner/repo/pull/42',
-				'head'     => array( 'sha' => $sha ),
+				'head'     => array(
+					'ref'  => 'feature/test',
+					'sha'  => $sha,
+					'repo' => array( 'full_name' => 'owner/repo' ),
+				),
+			),
+		);
+	};
+
+	$merged_pull = static function ( string $head_repo = 'owner/repo', string $head_ref = 'feature/test' ): array {
+		return array(
+			'success' => true,
+			'data'    => array(
+				'number'    => 42,
+				'state'     => 'closed',
+				'merged_at' => '2026-05-12T15:14:37Z',
+				'html_url'  => 'https://github.com/owner/repo/pull/42',
+				'head'      => array(
+					'ref'  => $head_ref,
+					'repo' => array( 'full_name' => $head_repo ),
+				),
 			),
 		);
 	};
@@ -213,6 +233,10 @@ namespace {
 	$assert( 'merge ability uses mergePullRequest execute_callback', array( GitHubAbilities::class, 'mergePullRequest' ) === ( $ability['execute_callback'] ?? null ) );
 	$assert( 'merge ability requires repo, pull_number, expected_head_sha', array( 'repo', 'pull_number', 'expected_head_sha' ) === ( $ability['input_schema']['required'] ?? array() ) );
 	$assert( 'merge ability limits merge_method enum', array( 'merge', 'squash', 'rebase' ) === ( $ability['input_schema']['properties']['merge_method']['enum'] ?? array() ) );
+	$assert( 'merge ability exposes delete_branch', isset( $ability['input_schema']['properties']['delete_branch'] ) );
+	$cleanup_ability = $GLOBALS['dmc_registered_abilities']['datamachine/cleanup-github-pull-request'] ?? null;
+	$assert( 'cleanup ability is registered', null !== $cleanup_ability );
+	$assert( 'cleanup ability uses cleanupPullRequest execute_callback', array( GitHubAbilities::class, 'cleanupPullRequest' ) === ( $cleanup_ability['execute_callback'] ?? null ) );
 
 	$permission = $ability['permission_callback'] ?? null;
 	PermissionHelper::$can_manage_result = false;
@@ -297,12 +321,71 @@ namespace {
 	$assert( 'mergePullRequest rejects head SHA mismatch', $result instanceof WP_Error && 'pull_request_head_sha_mismatch' === $result->get_error_code() );
 	$assert( 'mergePullRequest does not merge after SHA mismatch', false === $merge_called );
 
+	$calls = array();
+	$result = GitHubAbilities::cleanupPullRequest(
+		array(
+			'repo'        => 'owner/repo',
+			'pull_number' => 42,
+			'dry_run'     => true,
+		),
+		static function ( string $url, array $query, string $pat ) use ( &$calls, $merged_pull ): array {
+			$calls[] = array( 'method' => 'GET', 'url' => $url, 'query' => $query, 'pat' => $pat );
+			return $merged_pull();
+		},
+		static function ( string $method, string $url, ?array $body, string $pat ) use ( &$calls ): array {
+			$calls[] = compact( 'method', 'url', 'body', 'pat' );
+			return array( 'success' => true, 'data' => null );
+		}
+	);
+	$assert( 'cleanupPullRequest dry-run succeeds', is_array( $result ) && true === ( $result['dry_run'] ?? false ) );
+	$assert( 'cleanupPullRequest dry-run does not delete branch', 1 === count( $calls ) );
+
+	$calls = array();
+	$result = GitHubAbilities::cleanupPullRequest(
+		array(
+			'repo'        => 'owner/repo',
+			'pull_number' => 42,
+		),
+		static function ( string $url, array $query, string $pat ) use ( &$calls, $merged_pull ): array {
+			$calls[] = array( 'method' => 'GET', 'url' => $url, 'query' => $query, 'pat' => $pat );
+			return $merged_pull();
+		},
+		static function ( string $method, string $url, ?array $body, string $pat ) use ( &$calls ): array {
+			$calls[] = compact( 'method', 'url', 'body', 'pat' );
+			return array( 'success' => true, 'data' => null );
+		}
+	);
+	$assert( 'cleanupPullRequest deletes merged same-repo branch', is_array( $result ) && true === ( $result['branch_deleted'] ?? false ) );
+	$assert( 'cleanupPullRequest calls GitHub refs delete endpoint', 'DELETE' === ( $calls[1]['method'] ?? '' ) && str_contains( $calls[1]['url'] ?? '', '/repos/owner/repo/git/refs/heads/' ) );
+
+	$result = GitHubAbilities::cleanupPullRequest(
+		array(
+			'repo'        => 'owner/repo',
+			'pull_number' => 42,
+		),
+		static fn(): array => $open_pull(),
+		static fn(): array => array( 'success' => true, 'data' => null )
+	);
+	$assert( 'cleanupPullRequest rejects unmerged PR', $result instanceof WP_Error && 'pull_request_not_merged' === $result->get_error_code() );
+
+	$result = GitHubAbilities::cleanupPullRequest(
+		array(
+			'repo'        => 'owner/repo',
+			'pull_number' => 42,
+		),
+		static fn(): array => $merged_pull( 'fork/repo' ),
+		static fn(): array => array( 'success' => true, 'data' => null )
+	);
+	$assert( 'cleanupPullRequest rejects fork head repo', $result instanceof WP_Error && 'pull_request_head_repo_mismatch' === $result->get_error_code() );
+
 	$tools = new GitHubTools();
 	$assert( 'merge_github_pull_request tool is registered', isset( $tools->registered['merge_github_pull_request'] ) );
+	$assert( 'cleanup_github_pull_request tool is registered', isset( $tools->registered['cleanup_github_pull_request'] ) );
 	$assert( 'merge tool links to merge ability', 'datamachine/merge-github-pull-request' === ( $tools->registered['merge_github_pull_request']['options']['ability'] ?? '' ) );
+	$assert( 'cleanup tool links to cleanup ability', 'datamachine/cleanup-github-pull-request' === ( $tools->registered['cleanup_github_pull_request']['options']['ability'] ?? '' ) );
 	$definition = $tools->getMergePullRequestDefinition();
 	$params     = $definition['parameters'] ?? array();
-	$assert( 'merge tool requires expected_head_sha', true === ( $params['expected_head_sha']['required'] ?? false ) );
+	$assert( 'merge tool requires expected_head_sha', in_array( 'expected_head_sha', $params['required'] ?? array(), true ) );
 	$tool_result = $tools->handle_tool_call(
 		array(
 			'repo'              => 'owner/repo',
@@ -315,6 +398,17 @@ namespace {
 	$assert( 'merge tool response names tool', 'merge_github_pull_request' === ( $tool_result['tool_name'] ?? '' ) );
 	$tool_call = $GLOBALS['dmc_tool_ability_calls'][0] ?? array();
 	$assert( 'merge tool calls merge ability', 'datamachine/merge-github-pull-request' === ( $tool_call['name'] ?? '' ) );
+	$cleanup_definition = $tools->getCleanupPullRequestDefinition();
+	$cleanup_result     = $tools->handle_tool_call(
+		array(
+			'repo'        => 'owner/repo',
+			'pull_number' => 42,
+			'dry_run'     => true,
+		),
+		$cleanup_definition
+	);
+	$assert( 'cleanup tool returns direct ability success', true === ( $cleanup_result['success'] ?? false ) );
+	$assert( 'cleanup tool response names tool', 'cleanup_github_pull_request' === ( $cleanup_result['tool_name'] ?? '' ) );
 
 	$scaffold_source = file_get_contents( __DIR__ . '/../inc/GitHub/PrReviewFlowScaffold.php' );
 	$assert( 'PR review scaffold does not enable merge tool', ! str_contains( $scaffold_source, 'merge_github_pull_request' ) );


### PR DESCRIPTION
## Summary
- Add `wp datamachine-code github merge <pr>` for SHA-guarded server-side PR merges through the GitHub API.
- Add `wp datamachine-code github cleanup-pr <pr>` to delete merged same-repo PR head branches via API without checking out local branches.
- Expose matching cleanup ability/tool support and extend the existing merge ability/tool with optional `delete_branch` cleanup.

## Verification
- `php -l inc/Abilities/GitHubAbilities.php`
- `php -l inc/Cli/Commands/GitHubCommand.php`
- `php -l inc/Tools/GitHubTools.php`
- `php -l tests/smoke-github-merge-pull-request.php`
- `php tests/smoke-github-merge-pull-request.php`
- `git diff --check origin/main...HEAD`

## Notes
- `homeboy lint --path /Users/chubes/Developer/data-machine-code@add-pr-merge-cleanup-commands` remains red on existing baseline PHPCS findings unrelated to this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the GitHub API-backed merge/cleanup CLI, ability, and tool plumbing plus focused smoke coverage; Chris requested the direction and remains responsible for review and merge.