### PR TITLE
Add opaque workspace aliases

### DIFF
--- a/inc/Tools/WorkspaceDiffTools.php
+++ b/inc/Tools/WorkspaceDiffTools.php
@@ -8,6 +8,7 @@
 namespace DataMachineCode\Tools;
 
 use DataMachine\Engine\AI\Tools\BaseTool;
+use DataMachineCode\Workspace\WorkspaceAliasResolver;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -132,6 +133,13 @@ class WorkspaceDiffTools extends BaseTool {
 			}
 		}
 
+		if ( is_string( $input['name'] ) && WorkspaceAliasResolver::has_alias( $input['name'] ) ) {
+			$alias                    = $input['name'];
+			$input['name']            = WorkspaceAliasResolver::resolve( $alias );
+			$input['_workspace_alias'] = $alias;
+			$input['_workspace_handle'] = $input['name'];
+		}
+
 		return $input;
 	}
 
@@ -142,9 +150,16 @@ class WorkspaceDiffTools extends BaseTool {
 			return $this->buildErrorResponse( "{$tool_name} ability not available.", $tool_name );
 		}
 
-		$result = $ability->execute( $this->normalizeInput( $parameters ) );
+		$input  = $this->normalizeInput( $parameters );
+		$result = $ability->execute( $input );
 		if ( is_wp_error( $result ) ) {
 			return $this->buildErrorResponse( $result->get_error_message(), $tool_name );
+		}
+
+		$alias  = isset( $input['_workspace_alias'] ) ? (string) $input['_workspace_alias'] : '';
+		$handle = isset( $input['_workspace_handle'] ) ? (string) $input['_workspace_handle'] : '';
+		if ( '' !== $alias && '' !== $handle ) {
+			$result = WorkspaceAliasResolver::sanitize_result( $result, $alias, $handle );
 		}
 
 		return array(

--- a/inc/Tools/WorkspaceTools.php
+++ b/inc/Tools/WorkspaceTools.php
@@ -12,6 +12,7 @@
 namespace DataMachineCode\Tools;
 
 use DataMachine\Engine\AI\Tools\BaseTool;
+use DataMachineCode\Workspace\WorkspaceAliasResolver;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -205,11 +206,9 @@ class WorkspaceTools extends BaseTool {
 			return $this->buildErrorResponse( 'Workspace show ability not available.', 'workspace_show' );
 		}
 
-		$result = $ability->execute(
-			array(
-				'name' => $parameters['name'] ?? '',
-			)
-		);
+		$input = array( 'name' => $parameters['name'] ?? '' );
+		$input = $this->resolveWorkspaceInputAliases( $input, array( 'name' ) );
+		$result = $ability->execute( $input );
 
 		if ( is_wp_error( $result ) ) {
 			return $this->buildErrorResponse( $result->get_error_message(), 'workspace_show' );
@@ -217,7 +216,7 @@ class WorkspaceTools extends BaseTool {
 
 		return array(
 			'success'   => true,
-			'data'      => $result,
+			'data'      => $this->sanitizeWorkspaceResult( $result, $input ),
 			'tool_name' => 'workspace_show',
 		);
 	}
@@ -235,12 +234,14 @@ class WorkspaceTools extends BaseTool {
 			return $this->buildErrorResponse( 'Workspace ls ability not available.', 'workspace_ls' );
 		}
 
-		$result = $ability->execute(
+		$input = $this->resolveWorkspaceInputAliases(
 			array(
 				'repo' => $parameters['repo'] ?? '',
 				'path' => $parameters['path'] ?? '',
-			)
+			),
+			array( 'repo' )
 		);
+		$result = $ability->execute( $input );
 
 		if ( is_wp_error( $result ) ) {
 			return $this->buildErrorResponse( $result->get_error_message(), 'workspace_ls' );
@@ -248,7 +249,7 @@ class WorkspaceTools extends BaseTool {
 
 		return array(
 			'success'   => true,
-			'data'      => $result,
+			'data'      => $this->sanitizeWorkspaceResult( $result, $input ),
 			'tool_name' => 'workspace_ls',
 		);
 	}
@@ -270,6 +271,7 @@ class WorkspaceTools extends BaseTool {
 			'repo' => $parameters['repo'] ?? '',
 			'path' => $parameters['path'] ?? '',
 		);
+		$input = $this->resolveWorkspaceInputAliases( $input, array( 'repo' ) );
 
 		if ( isset( $parameters['max_size'] ) ) {
 			$input['max_size'] = (int) $parameters['max_size'];
@@ -291,7 +293,7 @@ class WorkspaceTools extends BaseTool {
 
 		return array(
 			'success'   => true,
-			'data'      => $result,
+			'data'      => $this->sanitizeWorkspaceResult( $result, $input ),
 			'tool_name' => 'workspace_read',
 		);
 	}
@@ -313,6 +315,7 @@ class WorkspaceTools extends BaseTool {
 			'repo'    => $parameters['repo'] ?? '',
 			'pattern' => $parameters['pattern'] ?? '',
 		);
+		$input = $this->resolveWorkspaceInputAliases( $input, array( 'repo' ) );
 
 		foreach ( array( 'path', 'include' ) as $key ) {
 			if ( isset( $parameters[ $key ] ) ) {
@@ -334,7 +337,7 @@ class WorkspaceTools extends BaseTool {
 
 		return array(
 			'success'   => true,
-			'data'      => $result,
+			'data'      => $this->sanitizeWorkspaceResult( $result, $input ),
 			'tool_name' => 'workspace_grep',
 		);
 	}
@@ -345,7 +348,7 @@ class WorkspaceTools extends BaseTool {
 			'repo'    => $parameters['repo'] ?? '',
 			'path'    => $parameters['path'] ?? '',
 			'content' => $parameters['content'] ?? '',
-		) );
+		), array( 'repo' ) );
 	}
 
 	/** @param array<string,mixed> $parameters Tool parameters. @return array<string,mixed> */
@@ -361,7 +364,7 @@ class WorkspaceTools extends BaseTool {
 			$input['replace_all'] = (bool) $parameters['replace_all'];
 		}
 
-		return $this->executeAbility( 'datamachine/workspace-edit', 'workspace_edit', $input );
+		return $this->executeAbility( 'datamachine/workspace-edit', 'workspace_edit', $input, array( 'repo' ) );
 	}
 
 	/** @param array<string,mixed> $parameters Tool parameters. @return array<string,mixed> */
@@ -375,7 +378,7 @@ class WorkspaceTools extends BaseTool {
 			$input['allow_primary_mutation'] = (bool) $parameters['allow_primary_mutation'];
 		}
 
-		return $this->executeAbility( 'datamachine/workspace-apply-patch', 'workspace_apply_patch', $input );
+		return $this->executeAbility( 'datamachine/workspace-apply-patch', 'workspace_apply_patch', $input, array( 'repo' ) );
 	}
 
 	/** @param array<string,mixed> $parameters Tool parameters. @return array<string,mixed> */
@@ -391,12 +394,12 @@ class WorkspaceTools extends BaseTool {
 			}
 		}
 
-		return $this->executeAbility( 'datamachine/workspace-delete', 'workspace_delete', $input );
+		return $this->executeAbility( 'datamachine/workspace-delete', 'workspace_delete', $input, array( 'repo' ) );
 	}
 
 	/** @param array<string,mixed> $parameters Tool parameters. @return array<string,mixed> */
 	public function handleGitStatus( array $parameters ): array {
-		return $this->executeAbility( 'datamachine/workspace-git-status', 'workspace_git_status', array( 'name' => $parameters['name'] ?? $parameters['repo'] ?? '' ) );
+		return $this->executeAbility( 'datamachine/workspace-git-status', 'workspace_git_status', array( 'name' => $parameters['name'] ?? $parameters['repo'] ?? '' ), array( 'name' ) );
 	}
 
 	/** @param array<string,mixed> $parameters Tool parameters. @return array<string,mixed> */
@@ -406,7 +409,7 @@ class WorkspaceTools extends BaseTool {
 			$input['limit'] = (int) $parameters['limit'];
 		}
 
-		return $this->executeAbility( 'datamachine/workspace-git-log', 'workspace_git_log', $input );
+		return $this->executeAbility( 'datamachine/workspace-git-log', 'workspace_git_log', $input, array( 'name' ) );
 	}
 
 	/** @param array<string,mixed> $parameters Tool parameters. @return array<string,mixed> */
@@ -421,7 +424,7 @@ class WorkspaceTools extends BaseTool {
 			$input['staged'] = (bool) $parameters['staged'];
 		}
 
-		return $this->executeAbility( 'datamachine/workspace-git-diff', 'workspace_git_diff', $input );
+		return $this->executeAbility( 'datamachine/workspace-git-diff', 'workspace_git_diff', $input, array( 'name' ) );
 	}
 
 	/** @param array<string,mixed> $parameters Tool parameters. @return array<string,mixed> */
@@ -433,7 +436,7 @@ class WorkspaceTools extends BaseTool {
 			}
 		}
 
-		return $this->executeAbility( 'datamachine/workspace-git-pull', 'workspace_git_pull', $input );
+		return $this->executeAbility( 'datamachine/workspace-git-pull', 'workspace_git_pull', $input, array( 'name' ) );
 	}
 
 	/** @param array<string,mixed> $parameters Tool parameters. @return array<string,mixed> */
@@ -455,7 +458,7 @@ class WorkspaceTools extends BaseTool {
 			}
 		}
 
-		return $this->executeAbility( 'datamachine/workspace-worktree-add', 'workspace_worktree_add', $input );
+		return $this->executeAbility( 'datamachine/workspace-worktree-add', 'workspace_worktree_add', $input, array( 'repo' ) );
 	}
 
 	/** @param array<string,mixed> $parameters Tool parameters. @return array<string,mixed> */
@@ -468,7 +471,7 @@ class WorkspaceTools extends BaseTool {
 			$input['allow_primary_mutation'] = (bool) $parameters['allow_primary_mutation'];
 		}
 
-		return $this->executeAbility( 'datamachine/workspace-git-add', 'workspace_git_add', $input );
+		return $this->executeAbility( 'datamachine/workspace-git-add', 'workspace_git_add', $input, array( 'name' ) );
 	}
 
 	/** @param array<string,mixed> $parameters Tool parameters. @return array<string,mixed> */
@@ -481,7 +484,7 @@ class WorkspaceTools extends BaseTool {
 			$input['allow_primary_mutation'] = (bool) $parameters['allow_primary_mutation'];
 		}
 
-		return $this->executeAbility( 'datamachine/workspace-git-commit', 'workspace_git_commit', $input );
+		return $this->executeAbility( 'datamachine/workspace-git-commit', 'workspace_git_commit', $input, array( 'name' ) );
 	}
 
 	/** @param array<string,mixed> $parameters Tool parameters. @return array<string,mixed> */
@@ -496,15 +499,17 @@ class WorkspaceTools extends BaseTool {
 			$input['allow_primary_mutation'] = (bool) $parameters['allow_primary_mutation'];
 		}
 
-		return $this->executeAbility( 'datamachine/workspace-git-push', 'workspace_git_push', $input );
+		return $this->executeAbility( 'datamachine/workspace-git-push', 'workspace_git_push', $input, array( 'name' ) );
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed> */
-	private function executeAbility( string $ability_name, string $tool_name, array $input ): array {
+	private function executeAbility( string $ability_name, string $tool_name, array $input, array $handle_keys = array() ): array {
 		$ability = wp_get_ability( $ability_name );
 		if ( ! $ability ) {
 			return $this->buildErrorResponse( "{$tool_name} ability not available.", $tool_name );
 		}
+
+		$input = $this->resolveWorkspaceInputAliases( $input, $handle_keys );
 
 		$result = $ability->execute( $input );
 		if ( is_wp_error( $result ) ) {
@@ -513,9 +518,41 @@ class WorkspaceTools extends BaseTool {
 
 		return array(
 			'success'   => true,
-			'data'      => $result,
+			'data'      => $this->sanitizeWorkspaceResult( $result, $input ),
 			'tool_name' => $tool_name,
 		);
+	}
+
+	/** @param array<string,mixed> $input Tool input. @param string[] $handle_keys Keys that hold workspace handles. @return array<string,mixed> */
+	private function resolveWorkspaceInputAliases( array $input, array $handle_keys ): array {
+		foreach ( $handle_keys as $key ) {
+			if ( ! isset( $input[ $key ] ) || ! is_string( $input[ $key ] ) ) {
+				continue;
+			}
+
+			$alias = $input[ $key ];
+			$real  = WorkspaceAliasResolver::resolve( $alias );
+			if ( $real === $alias ) {
+				continue;
+			}
+
+			$input[ $key ]             = $real;
+			$input['_workspace_alias'] = $alias;
+			$input['_workspace_handle'] = $real;
+		}
+
+		return $input;
+	}
+
+	/** @param mixed $result Ability result. @param array<string,mixed> $input Resolved ability input. @return mixed */
+	private function sanitizeWorkspaceResult( mixed $result, array $input ): mixed {
+		$alias  = isset( $input['_workspace_alias'] ) ? (string) $input['_workspace_alias'] : '';
+		$handle = isset( $input['_workspace_handle'] ) ? (string) $input['_workspace_handle'] : '';
+		if ( '' === $alias || '' === $handle ) {
+			return $result;
+		}
+
+		return WorkspaceAliasResolver::sanitize_result( $result, $alias, $handle );
 	}
 
 	/**

--- a/inc/Workspace/WorkspaceAliasResolver.php
+++ b/inc/Workspace/WorkspaceAliasResolver.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Workspace alias resolver for agent-facing tool calls.
+ *
+ * @package DataMachineCode\Workspace
+ */
+
+namespace DataMachineCode\Workspace;
+
+defined( 'ABSPATH' ) || exit;
+
+class WorkspaceAliasResolver {
+
+	private const OPTION = 'datamachine_code_workspace_aliases';
+
+	/**
+	 * Return alias => canonical workspace handle mappings.
+	 *
+	 * Runners can persist aliases in the option, or inject them just-in-time via
+	 * the filter when a single conversation should see an opaque project name.
+	 *
+	 * @return array<string,string>
+	 */
+	public static function aliases(): array {
+		$aliases = function_exists( 'get_option' ) ? get_option( self::OPTION, array() ) : array();
+		if ( ! is_array( $aliases ) ) {
+			$aliases = array();
+		}
+
+		if ( function_exists( 'apply_filters' ) ) {
+			$aliases = apply_filters( 'datamachine_code_workspace_aliases', $aliases );
+		}
+
+		$normalized = array();
+		foreach ( $aliases as $alias => $handle ) {
+			$alias  = trim( (string) $alias );
+			$handle = trim( (string) $handle );
+			if ( '' === $alias || '' === $handle ) {
+				continue;
+			}
+			$normalized[ $alias ] = $handle;
+		}
+
+		return $normalized;
+	}
+
+	public static function resolve( string $handle ): string {
+		$aliases = self::aliases();
+		return $aliases[ $handle ] ?? $handle;
+	}
+
+	public static function alias_for( string $handle ): ?string {
+		foreach ( self::aliases() as $alias => $target ) {
+			if ( $target === $handle ) {
+				return $alias;
+			}
+		}
+
+		return null;
+	}
+
+	public static function has_alias( string $handle ): bool {
+		return isset( self::aliases()[ $handle ] );
+	}
+
+	/**
+	 * Sanitize model-facing workspace metadata while leaving content/diff fields intact.
+	 *
+	 * @param mixed  $value  Tool result value.
+	 * @param string $alias  Agent-facing alias.
+	 * @param string $handle Canonical workspace handle.
+	 * @return mixed
+	 */
+	public static function sanitize_result( mixed $value, string $alias, string $handle ): mixed {
+		if ( is_array( $value ) ) {
+			$sanitized = array();
+			foreach ( $value as $key => $item ) {
+				if ( in_array( $key, array( 'content', 'diff', 'patch' ), true ) ) {
+					$sanitized[ $key ] = $item;
+					continue;
+				}
+				$sanitized[ $key ] = self::sanitize_result( $item, $alias, $handle );
+			}
+			return $sanitized;
+		}
+
+		if ( ! is_string( $value ) || '' === $handle ) {
+			return $value;
+		}
+
+		$sanitized = str_replace( $handle, $alias, $value );
+		if ( str_contains( $handle, '@' ) ) {
+			list( $repo, $slug ) = explode( '@', $handle, 2 );
+			$sanitized = str_replace( array( $repo, $slug ), array( $alias, $alias ), $sanitized );
+		}
+
+		return $sanitized;
+	}
+}

--- a/tests/smoke-workspace-alias-tools.php
+++ b/tests/smoke-workspace-alias-tools.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Smoke test for agent-facing workspace aliases.
+ *
+ * Run: php tests/smoke-workspace-alias-tools.php
+ */
+
+declare( strict_types=1 );
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	$GLOBALS['dmc_workspace_alias_filters'] = array();
+	$GLOBALS['dmc_workspace_alias_ability'] = null;
+
+	function add_filter( string $tag, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		$GLOBALS['dmc_workspace_alias_filters'][ $tag ][ $priority ][] = $callback;
+	}
+
+	function apply_filters( string $tag, $value ) {
+		if ( empty( $GLOBALS['dmc_workspace_alias_filters'][ $tag ] ) ) {
+			return $value;
+		}
+
+		ksort( $GLOBALS['dmc_workspace_alias_filters'][ $tag ] );
+		foreach ( $GLOBALS['dmc_workspace_alias_filters'][ $tag ] as $callbacks ) {
+			foreach ( $callbacks as $callback ) {
+				$value = $callback( $value );
+			}
+		}
+
+		return $value;
+	}
+
+	function get_option( string $name, $default = false ) {
+		return $default;
+	}
+
+	function wp_get_ability( string $name ) {
+		return $GLOBALS['dmc_workspace_alias_ability'];
+	}
+
+	function is_wp_error( $value ): bool {
+		return false;
+	}
+}
+
+namespace DataMachine\Engine\AI\Tools {
+	class BaseTool {
+		protected function registerTool( string $tool_id, callable $definition_callback, array $contexts = array(), array $options = array() ): void {}
+		protected function buildErrorResponse( string $message, string $tool_name ): array {
+			return array(
+				'success'   => false,
+				'error'     => $message,
+				'tool_name' => $tool_name,
+			);
+		}
+	}
+}
+
+namespace {
+	require __DIR__ . '/../inc/Workspace/WorkspaceAliasResolver.php';
+	require __DIR__ . '/../inc/Tools/WorkspaceTools.php';
+	require __DIR__ . '/../inc/Tools/WorkspaceDiffTools.php';
+
+	class DataMachineCodeWorkspaceAliasFakeAbility {
+		public array $last_input = array();
+
+		public function execute( array $input ): array {
+			$this->last_input = $input;
+			return array(
+				'success'            => true,
+				'name'               => 'wp-rl@agent-runs-modern-api-openai-gpt-5-5',
+				'repo'               => 'wp-rl',
+				'path'               => '/Users/example/wp-rl@agent-runs-modern-api-openai-gpt-5-5/plugins/demo.php',
+				'branch'             => 'agent-runs-modern-api-openai-gpt-5-5',
+				'conversation_state' => 'incomplete',
+				'next_required_args' => array( 'name' => 'wp-rl@agent-runs-modern-api-openai-gpt-5-5' ),
+				'content'            => 'The real handle wp-rl@agent-runs-modern-api-openai-gpt-5-5 may appear in file content and must not be rewritten.',
+			);
+		}
+	}
+
+	$failures = array();
+	$passes   = 0;
+	$assert   = function ( string $label, bool $condition ) use ( &$failures, &$passes ): void {
+		if ( $condition ) {
+			++$passes;
+			echo "  ok {$label}\n";
+			return;
+		}
+
+		$failures[] = $label;
+		echo "  fail {$label}\n";
+	};
+
+	echo "Workspace alias tools - smoke\n";
+
+	add_filter(
+		'datamachine_code_workspace_aliases',
+		fn( array $aliases ): array => array_merge(
+			$aliases,
+			array( 'current-project' => 'wp-rl@agent-runs-modern-api-openai-gpt-5-5' )
+		)
+	);
+
+	$ability                                  = new DataMachineCodeWorkspaceAliasFakeAbility();
+	$GLOBALS['dmc_workspace_alias_ability'] = $ability;
+	$tools                                    = new \DataMachineCode\Tools\WorkspaceTools();
+	$result                                   = $tools->handleGitStatus( array( 'name' => 'current-project' ) );
+	$data                                     = $result['data'] ?? array();
+
+	$assert( 'alias resolves before ability execution', 'wp-rl@agent-runs-modern-api-openai-gpt-5-5' === ( $ability->last_input['name'] ?? '' ) );
+	$assert( 'agent-facing name is sanitized', 'current-project' === ( $data['name'] ?? '' ) );
+	$assert( 'agent-facing repo is sanitized', 'current-project' === ( $data['repo'] ?? '' ) );
+	$assert( 'agent-facing paths are sanitized', is_string( $data['path'] ?? null ) && ! str_contains( $data['path'], 'wp-rl@agent-runs' ) );
+	$assert( 'nested required args are sanitized', 'current-project' === ( $data['next_required_args']['name'] ?? '' ) );
+	$assert( 'file content is not rewritten', is_string( $data['content'] ?? null ) && str_contains( $data['content'], 'wp-rl@agent-runs-modern-api-openai-gpt-5-5' ) );
+
+	$diff_tools = new \DataMachineCode\Tools\WorkspaceDiffTools();
+	$diff       = $diff_tools->handleDiffSummary( array( 'name' => 'current-project' ) );
+	$assert( 'diff tools resolve aliases before ability execution', 'wp-rl@agent-runs-modern-api-openai-gpt-5-5' === ( $ability->last_input['name'] ?? '' ) );
+	$assert( 'diff tool result is sanitized', 'current-project' === ( $diff['data']['name'] ?? '' ) );
+
+	if ( $failures ) {
+		echo "\nFAIL: " . count( $failures ) . " assertion(s) failed\n";
+		foreach ( $failures as $failure ) {
+			echo "  - {$failure}\n";
+		}
+		exit( 1 );
+	}
+
+	echo "\nOK ({$passes} assertions)\n";
+}


### PR DESCRIPTION
## Summary
- Add workspace alias resolution so agent-facing tools can use opaque names like `current-project` while abilities receive canonical workspace handles.
- Sanitize model-facing workspace metadata for alias-backed calls without rewriting file content, diffs, or patches.
- Cover workspace and workspace-diff alias behavior with a smoke test.

## Testing
- `php tests/smoke-workspace-alias-tools.php`
- `php tests/smoke-workspace-policy-tools.php`
- `php tests/smoke-tool-schemas.php`
- `git diff --check origin/main...HEAD`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the generic alias resolver, tool plumbing, smoke coverage, and local verification; Chris reviewed the direction and requested the PR.

Fixes #391.