### PR TITLE
Skip submodule worktrees during cleanup apply

### DIFF
--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -2367,6 +2367,11 @@ class Workspace {
 			);
 		}
 
+		$submodule_skip = $this->build_submodule_worktree_cleanup_skip( $candidate, $real_path );
+		if ( null !== $submodule_skip ) {
+			return array( 'skipped' => $submodule_skip );
+		}
+
 		// Dirty gate: cheap porcelain call, bounded by the cleanup git timeout.
 		$dirty = $this->run_git( $real_path, 'status --porcelain --untracked-files=normal', self::CLEANUP_GIT_PROBE_TIMEOUT );
 		if ( $this->is_git_timeout_error( $dirty ) ) {
@@ -2651,6 +2656,54 @@ class Workspace {
 	}
 
 	/**
+	 * Build a conservative skip row for worktrees that declare submodules.
+	 *
+	 * @param array<string,mixed> $row       Candidate row.
+	 * @param string              $real_path Optional resolved worktree path.
+	 * @return array<string,mixed>|null
+	 */
+	private function build_submodule_worktree_cleanup_skip( array $row, string $real_path = '' ): ?array {
+		$path = '' !== $real_path ? $real_path : (string) ( $row['path'] ?? '' );
+		if ( ! $this->worktree_declares_submodules( $path ) ) {
+			return null;
+		}
+
+		$handle       = (string) ( $row['handle'] ?? '' );
+		$review       = sprintf( 'git -C %s submodule status --recursive', escapeshellarg( $path ) );
+		$remediate    = '' !== $handle
+			? sprintf(
+				'git -C %s submodule deinit --all --force && studio wp datamachine-code workspace worktree remove %s --force',
+				escapeshellarg( $path ),
+				escapeshellarg( $handle )
+			)
+			: '';
+
+		return array_merge( $row, array(
+			'path'                => $path,
+			'reason_code'         => 'submodule_worktree',
+			'reason'              => 'worktree declares submodules; bounded cleanup leaves it in place because git cannot remove submodule-containing worktrees through the normal cleanup path',
+			'hint'                => '' !== $remediate ? 'Review submodules first, then deinitialize them if appropriate and run the remediation command.' : 'Review submodules before attempting manual worktree removal.',
+			'review_command'      => $review,
+			'remediation_command' => $remediate,
+		) );
+	}
+
+	/**
+	 * Detect submodule declarations without mutating the worktree.
+	 *
+	 * @param string $path Worktree path.
+	 * @return bool
+	 */
+	private function worktree_declares_submodules( string $path ): bool {
+		if ( '' === $path || ! is_dir( $path ) ) {
+			return false;
+		}
+
+		$gitmodules = rtrim( $path, '/' ) . '/.gitmodules';
+		return is_file( $gitmodules ) && filesize( $gitmodules ) > 0;
+	}
+
+	/**
 	 * Build stable high-level cleanup buckets for plan/report consumers.
 	 *
 	 * @param int               $candidate_count      Candidate row count.
@@ -2669,6 +2722,7 @@ class Workspace {
 			+ (int) ( $skipped_by_reason['github_unknown'] ?? 0 )
 			+ (int) ( $skipped_by_reason['external_worktree'] ?? 0 )
 			+ (int) ( $skipped_by_reason['protected_branch'] ?? 0 )
+			+ (int) ( $skipped_by_reason['submodule_worktree'] ?? 0 )
 			+ (int) ( $skipped_by_reason['probe_timeout'] ?? 0 )
 			+ (int) ( $skipped_by_reason['unknown_age'] ?? 0 );
 		$blocked_by_dirty_or_unpushed = (int) ( $skipped_by_reason['dirty_worktree'] ?? 0 )
@@ -2721,6 +2775,13 @@ class Workspace {
 				'command'     => 'studio wp datamachine-code workspace worktree cleanup --dry-run --skip-github --format=json',
 				'alternative' => 'No automatic cleanup action is safe from active inventory metadata alone.',
 				'why'         => 'Active rows without stale liveness or PR/task context are not cleanup candidates from inventory alone.',
+				'destructive' => false,
+			),
+			'submodule_worktree' => array(
+				'label'       => 'Review submodules before removing the worktree',
+				'command'     => 'git -C <worktree-path> submodule status --recursive',
+				'alternative' => 'After review, deinitialize submodules and rerun the DMC cleanup apply, or remove the worktree with an explicit git worktree remove command.',
+				'why'         => 'Git refuses to remove worktrees containing submodules through the normal cleanup path; DMC leaves them in place until submodule state is explicitly reviewed.',
 				'destructive' => false,
 			),
 			'repaired_metadata'           => array(

--- a/inc/Workspace/WorkspaceWorktreeInventoryCleanup.php
+++ b/inc/Workspace/WorkspaceWorktreeInventoryCleanup.php
@@ -132,6 +132,12 @@ trait WorkspaceWorktreeInventoryCleanup {
 				continue;
 			}
 
+			$submodule_skip = $this->build_submodule_worktree_cleanup_skip( $base_row );
+			if ( null !== $submodule_skip ) {
+				$skipped[] = $submodule_skip;
+				continue;
+			}
+
 			if ( null !== $age_filter ) {
 				$created_ts = is_string( $created_at ) && '' !== $created_at ? strtotime( $created_at ) : false;
 				if ( false === $created_ts ) {

--- a/tests/smoke-worktree-bounded-cleanup-eligible-apply.php
+++ b/tests/smoke-worktree-bounded-cleanup-eligible-apply.php
@@ -213,13 +213,34 @@ namespace {
 
 	// Real worktree-backed branches that simulate the canonical states the
 	// bounded cleanup-eligible apply must handle.
-	foreach ( array( 'eligible-clean', 'eligible-dirty', 'eligible-unpushed', 'eligible-bounded-extra-1', 'eligible-bounded-extra-2', 'eligible-bounded-extra-3', 'repaired-metadata-clean', 'repaired-metadata-dirty', 'repaired-metadata-recent' ) as $b ) {
+	foreach (
+		array(
+			'eligible-clean',
+			'eligible-dirty',
+			'eligible-unpushed',
+			'eligible-submodule',
+			'eligible-bounded-extra-1',
+			'eligible-bounded-extra-2',
+			'eligible-bounded-extra-3',
+			'repaired-metadata-clean',
+			'repaired-metadata-dirty',
+			'repaired-metadata-recent',
+		) as $b
+	) {
 		$make_branch( $b );
 	}
+	$run( 'git checkout eligible-submodule', $primary );
+	file_put_contents(
+		$primary . '/.gitmodules',
+		"[submodule \"fixture\"]\n\tpath = fixture\n\turl = https://example.com/fixture.git\n"
+	);
+	$run( 'git add .gitmodules && git commit -m "add submodule declaration" && git push', $primary );
+	$run( 'git checkout main', $primary );
 
 	$run( sprintf( 'git worktree add %s eligible-clean', escapeshellarg( $tmp . '/demo@eligible-clean' ) ), $primary );
 	$run( sprintf( 'git worktree add %s eligible-dirty', escapeshellarg( $tmp . '/demo@eligible-dirty' ) ), $primary );
 	$run( sprintf( 'git worktree add %s eligible-unpushed', escapeshellarg( $tmp . '/demo@eligible-unpushed' ) ), $primary );
+	$run( sprintf( 'git worktree add %s eligible-submodule', escapeshellarg( $tmp . '/demo@eligible-submodule' ) ), $primary );
 	$run( sprintf( 'git worktree add %s eligible-bounded-extra-1', escapeshellarg( $tmp . '/demo@eligible-bounded-extra-1' ) ), $primary );
 	$run( sprintf( 'git worktree add %s eligible-bounded-extra-2', escapeshellarg( $tmp . '/demo@eligible-bounded-extra-2' ) ), $primary );
 	$run( sprintf( 'git worktree add %s eligible-bounded-extra-3', escapeshellarg( $tmp . '/demo@eligible-bounded-extra-3' ) ), $primary );
@@ -234,6 +255,7 @@ namespace {
 			'demo@eligible-clean',
 			'demo@eligible-dirty',
 			'demo@eligible-unpushed',
+			'demo@eligible-submodule',
 			'demo@eligible-bounded-extra-1',
 			'demo@eligible-bounded-extra-2',
 			'demo@eligible-bounded-extra-3',
@@ -312,6 +334,7 @@ namespace {
 	$remaining = (int) ( $dry['continuation']['remaining_total'] ?? 0 );
 	$assert( true, $remaining >= 4, 'continuation reports remaining cleanup-eligible candidates' );
 	$assert_skipped( $dry['skipped'] ?? array(), 'demo@repaired-metadata-clean', 'active_no_signal', 'repaired metadata rows require explicit include flag' );
+	$assert_skipped( $dry['skipped'] ?? array(), 'demo@eligible-submodule', 'submodule_worktree', 'submodule worktree is skipped before planning removal' );
 
 	$repaired_dry = $ws->worktree_bounded_cleanup_eligible_apply( array( 'dry_run' => true, 'limit' => 20, 'include_repaired_metadata' => true, 'older_than' => '24h' ) );
 	$assert( true, ! is_wp_error( $repaired_dry ) && ( $repaired_dry['success'] ?? false ), 'repaired-metadata dry-run returns success' );
@@ -347,6 +370,7 @@ namespace {
 
 	$assert_skipped( $apply['skipped'] ?? array(), 'demo@eligible-dirty', 'dirty_worktree', 'dirty worktree skipped on revalidation' );
 	$assert_skipped( $apply['skipped'] ?? array(), 'demo@eligible-unpushed', 'unpushed_commits', 'unpushed worktree skipped on revalidation' );
+	$assert_skipped( $apply['skipped'] ?? array(), 'demo@eligible-submodule', 'submodule_worktree', 'submodule worktree skipped with stable reason on apply' );
 	$assert_skipped( $apply['skipped'] ?? array(), 'demo@no-metadata', 'needs_metadata_reconcile', 'missing-metadata row skipped via inventory gate' );
 	$assert_skipped( $apply['skipped'] ?? array(), 'demo@active-row', 'active_no_signal', 'active row skipped via inventory gate' );
 	$assert_skipped( $apply['skipped'] ?? array(), 'demo@repaired-metadata-clean', 'active_no_signal', 'repaired metadata row skipped without explicit flag on apply' );
@@ -355,6 +379,7 @@ namespace {
 	$assert( false, is_dir( $tmp . '/demo@eligible-clean' ), 'clean cleanup-eligible directory removed from disk' );
 	$assert( true, is_dir( $tmp . '/demo@eligible-dirty' ), 'dirty cleanup-eligible directory survives bounded cleanup-eligible apply' );
 	$assert( true, is_dir( $tmp . '/demo@eligible-unpushed' ), 'unpushed cleanup-eligible directory survives bounded cleanup-eligible apply' );
+	$assert( true, is_dir( $tmp . '/demo@eligible-submodule' ), 'submodule cleanup-eligible directory survives bounded cleanup-eligible apply' );
 
 	$summary = (array) ( $apply['summary'] ?? array() );
 	$assert( true, (int) ( $summary['removed'] ?? 0 ) >= 4, 'summary records removed count' );


### PR DESCRIPTION
## Summary
- Classifies submodule-containing worktrees with a stable `submodule_worktree` cleanup reason before removal.
- Keeps reviewed cleanup conservative and provides remediation/review commands instead of repeatedly surfacing ordinary safe removal rows.

Fixes #396.

## Testing
- `php tests/smoke-worktree-bounded-cleanup-eligible-apply.php`
- `php -l inc/Workspace/Workspace.php`
- `php -l inc/Workspace/WorkspaceWorktreeInventoryCleanup.php`
- `php -l tests/smoke-worktree-bounded-cleanup-eligible-apply.php`
- `homeboy test --path /Users/chubes/Developer/data-machine-code@fix-submodule-worktree-cleanup-skip --extension wordpress`

Note: `homeboy lint --path /Users/chubes/Developer/data-machine-code@fix-submodule-worktree-cleanup-skip --extension wordpress` still reports existing repo-wide PHPCS findings outside this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented and tested the cleanup classification change under Chris's review.