### PR TITLE
Support scoped workspace aliases

### DIFF
--- a/inc/Tools/WorkspaceDiffTools.php
+++ b/inc/Tools/WorkspaceDiffTools.php
@@ -134,10 +134,23 @@ class WorkspaceDiffTools extends BaseTool {
 		}
 
 		if ( is_string( $input['name'] ) && WorkspaceAliasResolver::has_alias( $input['name'] ) ) {
-			$alias                    = $input['name'];
-			$input['name']            = WorkspaceAliasResolver::resolve( $alias );
-			$input['_workspace_alias'] = $alias;
-			$input['_workspace_handle'] = $input['name'];
+			$alias = $input['name'];
+			$spec  = WorkspaceAliasResolver::spec( $alias );
+			if ( null !== $spec ) {
+				$input['name']              = $spec['target'];
+				$input['_workspace_alias']  = $alias;
+				$input['_workspace_handle'] = $input['name'];
+				$input['_workspace_root']   = $spec['root'];
+
+				if ( '' !== $spec['root'] ) {
+					$scoped_path = WorkspaceAliasResolver::scope_path( (string) ( $input['path'] ?? '' ), $spec['root'] );
+					if ( false === $scoped_path ) {
+						$input['_workspace_alias_error'] = 'Path is outside the scoped workspace.';
+					} else {
+						$input['path'] = $scoped_path;
+					}
+				}
+			}
 		}
 
 		return $input;
@@ -151,6 +164,9 @@ class WorkspaceDiffTools extends BaseTool {
 		}
 
 		$input  = $this->normalizeInput( $parameters );
+		if ( isset( $input['_workspace_alias_error'] ) ) {
+			return $this->buildErrorResponse( (string) $input['_workspace_alias_error'], $tool_name );
+		}
 		$result = $ability->execute( $input );
 		if ( is_wp_error( $result ) ) {
 			return $this->buildErrorResponse( $result->get_error_message(), $tool_name );
@@ -158,8 +174,9 @@ class WorkspaceDiffTools extends BaseTool {
 
 		$alias  = isset( $input['_workspace_alias'] ) ? (string) $input['_workspace_alias'] : '';
 		$handle = isset( $input['_workspace_handle'] ) ? (string) $input['_workspace_handle'] : '';
+		$root   = isset( $input['_workspace_root'] ) ? (string) $input['_workspace_root'] : '';
 		if ( '' !== $alias && '' !== $handle ) {
-			$result = WorkspaceAliasResolver::sanitize_result( $result, $alias, $handle );
+			$result = WorkspaceAliasResolver::sanitize_result( $result, $alias, $handle, $root );
 		}
 
 		return array(

--- a/inc/Tools/WorkspaceTools.php
+++ b/inc/Tools/WorkspaceTools.php
@@ -241,6 +241,9 @@ class WorkspaceTools extends BaseTool {
 			),
 			array( 'repo' )
 		);
+		if ( isset( $input['_workspace_alias_error'] ) ) {
+			return $this->buildErrorResponse( (string) $input['_workspace_alias_error'], 'workspace_ls' );
+		}
 		$result = $ability->execute( $input );
 
 		if ( is_wp_error( $result ) ) {
@@ -272,6 +275,9 @@ class WorkspaceTools extends BaseTool {
 			'path' => $parameters['path'] ?? '',
 		);
 		$input = $this->resolveWorkspaceInputAliases( $input, array( 'repo' ) );
+		if ( isset( $input['_workspace_alias_error'] ) ) {
+			return $this->buildErrorResponse( (string) $input['_workspace_alias_error'], 'workspace_read' );
+		}
 
 		if ( isset( $parameters['max_size'] ) ) {
 			$input['max_size'] = (int) $parameters['max_size'];
@@ -315,12 +321,15 @@ class WorkspaceTools extends BaseTool {
 			'repo'    => $parameters['repo'] ?? '',
 			'pattern' => $parameters['pattern'] ?? '',
 		);
-		$input = $this->resolveWorkspaceInputAliases( $input, array( 'repo' ) );
 
 		foreach ( array( 'path', 'include' ) as $key ) {
 			if ( isset( $parameters[ $key ] ) ) {
 				$input[ $key ] = $parameters[ $key ];
 			}
+		}
+		$input = $this->resolveWorkspaceInputAliases( $input, array( 'repo' ) );
+		if ( isset( $input['_workspace_alias_error'] ) ) {
+			return $this->buildErrorResponse( (string) $input['_workspace_alias_error'], 'workspace_grep' );
 		}
 
 		foreach ( array( 'max_results', 'context_lines' ) as $key ) {
@@ -510,6 +519,9 @@ class WorkspaceTools extends BaseTool {
 		}
 
 		$input = $this->resolveWorkspaceInputAliases( $input, $handle_keys );
+		if ( isset( $input['_workspace_alias_error'] ) ) {
+			return $this->buildErrorResponse( (string) $input['_workspace_alias_error'], $tool_name );
+		}
 
 		$result = $ability->execute( $input );
 		if ( is_wp_error( $result ) ) {
@@ -531,14 +543,24 @@ class WorkspaceTools extends BaseTool {
 			}
 
 			$alias = $input[ $key ];
-			$real  = WorkspaceAliasResolver::resolve( $alias );
-			if ( $real === $alias ) {
+			$spec  = WorkspaceAliasResolver::spec( $alias );
+			if ( null === $spec ) {
 				continue;
 			}
 
+			$real                      = $spec['target'];
+			$root                      = $spec['root'];
 			$input[ $key ]             = $real;
 			$input['_workspace_alias'] = $alias;
 			$input['_workspace_handle'] = $real;
+			$input['_workspace_root']   = $root;
+
+			$scoped = $this->scopeWorkspacePaths( $input, $root );
+			if ( is_string( $scoped ) ) {
+				$input['_workspace_alias_error'] = $scoped;
+			} else {
+				$input = $scoped;
+			}
 		}
 
 		return $input;
@@ -548,11 +570,81 @@ class WorkspaceTools extends BaseTool {
 	private function sanitizeWorkspaceResult( mixed $result, array $input ): mixed {
 		$alias  = isset( $input['_workspace_alias'] ) ? (string) $input['_workspace_alias'] : '';
 		$handle = isset( $input['_workspace_handle'] ) ? (string) $input['_workspace_handle'] : '';
+		$root   = isset( $input['_workspace_root'] ) ? (string) $input['_workspace_root'] : '';
 		if ( '' === $alias || '' === $handle ) {
 			return $result;
 		}
 
-		return WorkspaceAliasResolver::sanitize_result( $result, $alias, $handle );
+		return WorkspaceAliasResolver::sanitize_result( $result, $alias, $handle, $root );
+	}
+
+	/** @param array<string,mixed> $input Resolved ability input. @return array<string,mixed>|string */
+	private function scopeWorkspacePaths( array $input, string $root ): array|string {
+		if ( '' === $root ) {
+			return $input;
+		}
+
+		if ( array_key_exists( 'pattern', $input ) && ! array_key_exists( 'path', $input ) ) {
+			$input['path'] = '';
+		}
+
+		foreach ( array( 'path' ) as $key ) {
+			if ( array_key_exists( $key, $input ) ) {
+				$scoped = WorkspaceAliasResolver::scope_path( (string) $input[ $key ], $root );
+				if ( false === $scoped ) {
+					return 'Path is outside the scoped workspace.';
+				}
+				$input[ $key ] = $scoped;
+			}
+		}
+
+		if ( array_key_exists( 'paths', $input ) && is_array( $input['paths'] ) ) {
+			$paths = array();
+			foreach ( $input['paths'] as $path ) {
+				$scoped = WorkspaceAliasResolver::scope_path( (string) $path, $root );
+				if ( false === $scoped ) {
+					return 'Path is outside the scoped workspace.';
+				}
+				$paths[] = $scoped;
+			}
+			$input['paths'] = $paths;
+		}
+
+		if ( isset( $input['patch'] ) && is_string( $input['patch'] ) ) {
+			$patch = $this->scopeWorkspacePatch( $input['patch'], $root );
+			if ( false === $patch ) {
+				return 'Patch contains a path outside the scoped workspace.';
+			}
+			$input['patch'] = $patch;
+		}
+
+		return $input;
+	}
+
+	private function scopeWorkspacePatch( string $patch, string $root ): string|false {
+		$lines = explode( "\n", $patch );
+		foreach ( $lines as &$line ) {
+			if ( preg_match( '/^(diff --git) a\/(.+) b\/(.+)$/', $line, $matches ) ) {
+				$from = WorkspaceAliasResolver::scope_path( $matches[2], $root );
+				$to   = WorkspaceAliasResolver::scope_path( $matches[3], $root );
+				if ( false === $from || false === $to ) {
+					return false;
+				}
+				$line = $matches[1] . ' a/' . $from . ' b/' . $to;
+				continue;
+			}
+
+			if ( preg_match( '/^(---|\+\+\+) ([ab])\/(.+)$/', $line, $matches ) ) {
+				$path = WorkspaceAliasResolver::scope_path( $matches[3], $root );
+				if ( false === $path ) {
+					return false;
+				}
+				$line = $matches[1] . ' ' . $matches[2] . '/' . $path;
+			}
+		}
+		unset( $line );
+
+		return implode( "\n", $lines );
 	}
 
 	/**

--- a/inc/Workspace/WorkspaceAliasResolver.php
+++ b/inc/Workspace/WorkspaceAliasResolver.php
@@ -14,12 +14,12 @@ class WorkspaceAliasResolver {
 	private const OPTION = 'datamachine_code_workspace_aliases';
 
 	/**
-	 * Return alias => canonical workspace handle mappings.
+	 * Return normalized alias specs keyed by agent-facing alias.
 	 *
 	 * Runners can persist aliases in the option, or inject them just-in-time via
 	 * the filter when a single conversation should see an opaque project name.
 	 *
-	 * @return array<string,string>
+	 * @return array<string,array{target:string,root:string}>
 	 */
 	public static function aliases(): array {
 		$aliases = function_exists( 'get_option' ) ? get_option( self::OPTION, array() ) : array();
@@ -32,13 +32,23 @@ class WorkspaceAliasResolver {
 		}
 
 		$normalized = array();
-		foreach ( $aliases as $alias => $handle ) {
-			$alias  = trim( (string) $alias );
-			$handle = trim( (string) $handle );
+		foreach ( $aliases as $alias => $spec ) {
+			$alias = trim( (string) $alias );
+			if ( is_array( $spec ) ) {
+				$handle = trim( (string) ( $spec['target'] ?? $spec['handle'] ?? $spec['name'] ?? '' ) );
+				$root   = self::normalize_root( (string) ( $spec['root'] ?? $spec['agent_root'] ?? $spec['path_prefix'] ?? '' ) );
+			} else {
+				$handle = trim( (string) $spec );
+				$root   = '';
+			}
+
 			if ( '' === $alias || '' === $handle ) {
 				continue;
 			}
-			$normalized[ $alias ] = $handle;
+			$normalized[ $alias ] = array(
+				'target' => $handle,
+				'root'   => $root,
+			);
 		}
 
 		return $normalized;
@@ -46,12 +56,21 @@ class WorkspaceAliasResolver {
 
 	public static function resolve( string $handle ): string {
 		$aliases = self::aliases();
-		return $aliases[ $handle ] ?? $handle;
+		return $aliases[ $handle ]['target'] ?? $handle;
+	}
+
+	/**
+	 * Return the normalized alias spec for an agent-facing handle.
+	 *
+	 * @return array{target:string,root:string}|null
+	 */
+	public static function spec( string $handle ): ?array {
+		return self::aliases()[ $handle ] ?? null;
 	}
 
 	public static function alias_for( string $handle ): ?string {
-		foreach ( self::aliases() as $alias => $target ) {
-			if ( $target === $handle ) {
+		foreach ( self::aliases() as $alias => $spec ) {
+			if ( $spec['target'] === $handle ) {
 				return $alias;
 			}
 		}
@@ -63,6 +82,56 @@ class WorkspaceAliasResolver {
 		return isset( self::aliases()[ $handle ] );
 	}
 
+	public static function root_for( string $handle ): string {
+		return self::aliases()[ $handle ]['root'] ?? '';
+	}
+
+	public static function scope_path( string $path, string $root ): string|false {
+		$root = self::normalize_root( $root );
+		if ( '' === $root ) {
+			return $path;
+		}
+
+		$virtual = str_replace( '\\', '/', $path );
+		if ( str_starts_with( $virtual, '/' ) || preg_match( '#^[a-zA-Z][a-zA-Z0-9+.-]*://#', $virtual ) ) {
+			return false;
+		}
+
+		$segments = array();
+		foreach ( explode( '/', $virtual ) as $segment ) {
+			if ( '' === $segment || '.' === $segment ) {
+				continue;
+			}
+
+			if ( '..' === $segment || str_contains( $segment, "\0" ) ) {
+				return false;
+			}
+
+			$segments[] = $segment;
+		}
+
+		return empty( $segments ) ? $root : $root . '/' . implode( '/', $segments );
+	}
+
+	public static function unscope_path( string $path, string $root ): string {
+		$root = self::normalize_root( $root );
+		if ( '' === $root ) {
+			return $path;
+		}
+
+		$normalized = str_replace( '\\', '/', $path );
+		if ( $normalized === $root ) {
+			return '';
+		}
+
+		$prefix = $root . '/';
+		if ( str_starts_with( $normalized, $prefix ) ) {
+			return substr( $normalized, strlen( $prefix ) );
+		}
+
+		return $path;
+	}
+
 	/**
 	 * Sanitize model-facing workspace metadata while leaving content/diff fields intact.
 	 *
@@ -71,15 +140,15 @@ class WorkspaceAliasResolver {
 	 * @param string $handle Canonical workspace handle.
 	 * @return mixed
 	 */
-	public static function sanitize_result( mixed $value, string $alias, string $handle ): mixed {
+	public static function sanitize_result( mixed $value, string $alias, string $handle, string $root = '' ): mixed {
 		if ( is_array( $value ) ) {
 			$sanitized = array();
 			foreach ( $value as $key => $item ) {
-				if ( in_array( $key, array( 'content', 'diff', 'patch' ), true ) ) {
+				if ( in_array( $key, array( 'content', 'patch' ), true ) ) {
 					$sanitized[ $key ] = $item;
 					continue;
 				}
-				$sanitized[ $key ] = self::sanitize_result( $item, $alias, $handle );
+				$sanitized[ $key ] = self::sanitize_result( $item, $alias, $handle, $root );
 			}
 			return $sanitized;
 		}
@@ -88,12 +157,38 @@ class WorkspaceAliasResolver {
 			return $value;
 		}
 
-		$sanitized = str_replace( $handle, $alias, $value );
+		$sanitized = self::sanitize_scoped_string( $value, $root );
+		$sanitized = str_replace( $handle, $alias, $sanitized );
 		if ( str_contains( $handle, '@' ) ) {
 			list( $repo, $slug ) = explode( '@', $handle, 2 );
 			$sanitized = str_replace( array( $repo, $slug ), array( $alias, $alias ), $sanitized );
 		}
 
 		return $sanitized;
+	}
+
+	private static function normalize_root( string $root ): string {
+		$root = trim( str_replace( '\\', '/', $root ), '/' );
+		$segments = array();
+		foreach ( explode( '/', $root ) as $segment ) {
+			if ( '' === $segment || '.' === $segment || '..' === $segment ) {
+				continue;
+			}
+			$segments[] = $segment;
+		}
+
+		return implode( '/', $segments );
+	}
+
+	private static function sanitize_scoped_string( string $value, string $root ): string {
+		$root = self::normalize_root( $root );
+		if ( '' === $root ) {
+			return $value;
+		}
+
+		$sanitized = str_replace( array( 'a/' . $root . '/', 'b/' . $root . '/' ), array( 'a/', 'b/' ), $value );
+		$sanitized = str_replace( $root . '/', '', $sanitized );
+
+		return self::unscope_path( $sanitized, $root );
 	}
 }

--- a/tests/smoke-workspace-alias-tools.php
+++ b/tests/smoke-workspace-alias-tools.php
@@ -74,11 +74,13 @@ namespace {
 				'success'            => true,
 				'name'               => 'wp-rl@agent-runs-modern-api-openai-gpt-5-5',
 				'repo'               => 'wp-rl',
-				'path'               => '/Users/example/wp-rl@agent-runs-modern-api-openai-gpt-5-5/plugins/demo.php',
+				'path'               => '.agent-workspace/current-project/plugins/demo.php',
+				'files'              => array( '.agent-workspace/current-project/plugins/demo.php' ),
+				'diff'               => "diff --git a/.agent-workspace/current-project/plugins/demo.php b/.agent-workspace/current-project/plugins/demo.php\n--- a/.agent-workspace/current-project/plugins/demo.php\n+++ b/.agent-workspace/current-project/plugins/demo.php\n",
 				'branch'             => 'agent-runs-modern-api-openai-gpt-5-5',
 				'conversation_state' => 'incomplete',
 				'next_required_args' => array( 'name' => 'wp-rl@agent-runs-modern-api-openai-gpt-5-5' ),
-				'content'            => 'The real handle wp-rl@agent-runs-modern-api-openai-gpt-5-5 may appear in file content and must not be rewritten.',
+				'content'            => 'The real handle wp-rl@agent-runs-modern-api-openai-gpt-5-5 and .agent-workspace/current-project may appear in file content and must not be rewritten.',
 			);
 		}
 	}
@@ -102,7 +104,12 @@ namespace {
 		'datamachine_code_workspace_aliases',
 		fn( array $aliases ): array => array_merge(
 			$aliases,
-			array( 'current-project' => 'wp-rl@agent-runs-modern-api-openai-gpt-5-5' )
+			array(
+				'current-project' => array(
+					'target' => 'wp-rl@agent-runs-modern-api-openai-gpt-5-5',
+					'root'   => '.agent-workspace/current-project',
+				),
+			)
 		)
 	);
 
@@ -115,14 +122,40 @@ namespace {
 	$assert( 'alias resolves before ability execution', 'wp-rl@agent-runs-modern-api-openai-gpt-5-5' === ( $ability->last_input['name'] ?? '' ) );
 	$assert( 'agent-facing name is sanitized', 'current-project' === ( $data['name'] ?? '' ) );
 	$assert( 'agent-facing repo is sanitized', 'current-project' === ( $data['repo'] ?? '' ) );
-	$assert( 'agent-facing paths are sanitized', is_string( $data['path'] ?? null ) && ! str_contains( $data['path'], 'wp-rl@agent-runs' ) );
+	$assert( 'agent-facing paths are sanitized', 'plugins/demo.php' === ( $data['path'] ?? '' ) );
+	$assert( 'agent-facing file lists strip scoped root', array( 'plugins/demo.php' ) === ( $data['files'] ?? array() ) );
+	$assert( 'agent-facing diffs strip scoped root', is_string( $data['diff'] ?? null ) && str_contains( $data['diff'], 'a/plugins/demo.php' ) && ! str_contains( $data['diff'], '.agent-workspace' ) );
 	$assert( 'nested required args are sanitized', 'current-project' === ( $data['next_required_args']['name'] ?? '' ) );
-	$assert( 'file content is not rewritten', is_string( $data['content'] ?? null ) && str_contains( $data['content'], 'wp-rl@agent-runs-modern-api-openai-gpt-5-5' ) );
+	$assert( 'file content is not rewritten', is_string( $data['content'] ?? null ) && str_contains( $data['content'], 'wp-rl@agent-runs-modern-api-openai-gpt-5-5' ) && str_contains( $data['content'], '.agent-workspace/current-project' ) );
 
 	$diff_tools = new \DataMachineCode\Tools\WorkspaceDiffTools();
 	$diff       = $diff_tools->handleDiffSummary( array( 'name' => 'current-project' ) );
 	$assert( 'diff tools resolve aliases before ability execution', 'wp-rl@agent-runs-modern-api-openai-gpt-5-5' === ( $ability->last_input['name'] ?? '' ) );
+	$assert( 'diff tools scope empty path to alias root', '.agent-workspace/current-project' === ( $ability->last_input['path'] ?? '' ) );
 	$assert( 'diff tool result is sanitized', 'current-project' === ( $diff['data']['name'] ?? '' ) );
+
+	add_filter(
+		'datamachine_code_workspace_aliases',
+		fn( array $aliases ): array => array_merge(
+			$aliases,
+			array(
+				'scoped-project' => array(
+					'target' => 'wp-rl@agent-runs-modern-api-openai-gpt-5-5',
+					'root'   => '.agent-workspace/current-project',
+				),
+			)
+		)
+	);
+
+	$write = $tools->handleWrite( array( 'repo' => 'scoped-project', 'path' => 'plugins/demo.php', 'content' => '<?php' ) );
+	$assert( 'scoped write succeeds', true === ( $write['success'] ?? false ) );
+	$assert( 'scoped write prefixes virtual path before ability execution', '.agent-workspace/current-project/plugins/demo.php' === ( $ability->last_input['path'] ?? '' ) );
+
+	$grep = $tools->handleGrep( array( 'repo' => 'scoped-project', 'pattern' => 'Plugin Name' ) );
+	$assert( 'scoped grep defaults to alias root', '.agent-workspace/current-project' === ( $ability->last_input['path'] ?? '' ) );
+
+	$escape = $tools->handleRead( array( 'repo' => 'scoped-project', 'path' => '../README.md' ) );
+	$assert( 'scoped read rejects path escape', false === ( $escape['success'] ?? true ) );
 
 	if ( $failures ) {
 		echo "\nFAIL: " . count( $failures ) . " assertion(s) failed\n";


### PR DESCRIPTION
## Summary
- Extend workspace aliases from simple handle mappings to normalized specs with optional scoped roots.
- Prefix tool paths into scoped roots before ability execution and strip scoped prefixes from model-facing paths/diffs.
- Add smoke coverage for scoped writes, greps, diff sanitization, and path escape rejection.

## Tests
- `php tests/smoke-workspace-alias-tools.php`
- `php tests/smoke-workspace-policy-tools.php`
- `php tests/smoke-tool-schemas.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the scoped alias implementation and smoke coverage; Chris remains responsible for review and validation.