### PR TITLE
Clean up merged PR worktrees before branch deletion

### DIFF
--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -22,6 +22,7 @@ use DataMachineCode\GitHub\PrReviewEscalationPolicy;
 use DataMachineCode\Support\GitHubCredentialResolver;
 use DataMachineCode\Support\RunArtifactBundleFileWriter;
 use DataMachineCode\Support\RunArtifactPrSectionRenderer;
+use DataMachineCode\Workspace\Workspace;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -43,6 +44,10 @@ if ( ! class_exists( RunArtifactBundleFileWriter::class ) ) {
 
 if ( ! class_exists( RunArtifactPrSectionRenderer::class ) ) {
 	require_once dirname( __DIR__ ) . '/Support/RunArtifactPrSectionRenderer.php';
+}
+
+if ( ! class_exists( Workspace::class ) ) {
+	require_once dirname( __DIR__ ) . '/Workspace/Workspace.php';
 }
 
 class GitHubAbilities {
@@ -525,6 +530,7 @@ class GitHubAbilities {
 							'sha'         => array( 'type' => 'string' ),
 							'message'     => array( 'type' => 'string' ),
 							'html_url'    => array( 'type' => 'string' ),
+							'local_worktree_cleanup' => array( 'type' => 'object' ),
 							'error'       => array( 'type' => 'string' ),
 						),
 					),
@@ -569,6 +575,7 @@ class GitHubAbilities {
 							'branch_already_deleted' => array( 'type' => 'boolean' ),
 							'dry_run'                => array( 'type' => 'boolean' ),
 							'message'                => array( 'type' => 'string' ),
+							'local_worktree_cleanup' => array( 'type' => 'object' ),
 							'error'                  => array( 'type' => 'string' ),
 						),
 					),
@@ -2356,6 +2363,17 @@ class GitHubAbilities {
 			return $result;
 		}
 
+		$local_cleanup = self::cleanupMergedPullRequestWorktree( $repo, $head_branch, (string) ( $pull['html_url'] ?? '' ) );
+		if ( $local_cleanup instanceof \WP_Error ) {
+			$result['local_worktree_cleanup'] = array(
+				'success' => false,
+				'code'    => $local_cleanup->get_error_code(),
+				'message' => $local_cleanup->get_error_message(),
+			);
+		} else {
+			$result['local_worktree_cleanup'] = $local_cleanup;
+		}
+
 		$encoded_head_branch = implode( '/', array_map( 'rawurlencode', explode( '/', $head_branch ) ) );
 		$delete_url          = sprintf( '%s/repos/%s/git/refs/heads/%s', self::API_BASE, $repo, $encoded_head_branch );
 		$deleted    = $api_request( 'DELETE', $delete_url, null, $pat );
@@ -2373,6 +2391,35 @@ class GitHubAbilities {
 		$result['branch_deleted'] = true;
 		$result['message']        = sprintf( 'Deleted branch %s from %s.', $head_branch, $repo );
 		return $result;
+	}
+
+	/**
+	 * Best-effort local DMC worktree cleanup for a merged pull request branch.
+	 *
+	 * @param string $repo        GitHub repository slug (`owner/repo`).
+	 * @param string $head_branch Pull request head branch.
+	 * @param string $pr_url      Pull request URL.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private static function cleanupMergedPullRequestWorktree( string $repo, string $head_branch, string $pr_url ): array|\WP_Error {
+		if ( ! class_exists( Workspace::class ) ) {
+			return array(
+				'success' => true,
+				'skipped' => true,
+				'reason'  => 'workspace_unavailable',
+			);
+		}
+
+		$workspace = new Workspace();
+		if ( ! method_exists( $workspace, 'cleanup_merged_pr_worktree' ) ) {
+			return array(
+				'success' => true,
+				'skipped' => true,
+				'reason'  => 'workspace_cleanup_unsupported',
+			);
+		}
+
+		return $workspace->cleanup_merged_pr_worktree( $repo, $head_branch, '' !== $pr_url ? $pr_url : null );
 	}
 
 	/**

--- a/inc/Workspace/WorkspaceWorktreeLifecycle.php
+++ b/inc/Workspace/WorkspaceWorktreeLifecycle.php
@@ -416,6 +416,157 @@ trait WorkspaceWorktreeLifecycle {
 	}
 
 	/**
+	 * Finalize and remove the local DMC worktree for a merged PR head branch.
+	 *
+	 * This is the targeted post-merge path used before remote branch deletion.
+	 * It only touches workspace worktrees whose primary origin matches the exact
+	 * GitHub `owner/repo` slug and whose checked-out branch matches the PR head.
+	 *
+	 * @param string      $github_repo GitHub repository slug (`owner/repo`).
+	 * @param string      $branch      Pull request head branch.
+	 * @param string|null $pr_url      Optional pull request URL for lifecycle metadata.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function cleanup_merged_pr_worktree( string $github_repo, string $branch, ?string $pr_url = null ): array|\WP_Error {
+		$github_repo = trim( $github_repo );
+		$branch      = trim( $branch );
+
+		if ( '' === $github_repo || '' === $branch ) {
+			return new \WP_Error( 'missing_pr_worktree_cleanup_params', 'GitHub repo and branch are required for merged PR worktree cleanup.', array( 'status' => 400 ) );
+		}
+
+		if ( in_array( $branch, array( 'main', 'master', 'trunk', 'develop', 'HEAD' ), true ) ) {
+			return new \WP_Error( 'protected_head_branch', sprintf( 'Refusing to clean up protected branch %s.', $branch ), array( 'status' => 409 ) );
+		}
+
+		$listing = $this->worktree_list(
+			null,
+			null,
+			array(
+				'include_status' => false,
+				'include_disk'   => false,
+			)
+		);
+		if ( $listing instanceof \WP_Error ) {
+			return $listing;
+		}
+
+		$matches = array();
+		foreach ( (array) ( $listing['worktrees'] ?? array() ) as $wt ) {
+			if ( ! empty( $wt['is_primary'] ) || ! empty( $wt['external'] ) ) {
+				continue;
+			}
+
+			$repo         = (string) ( $wt['repo'] ?? '' );
+			$primary_path = '' !== $repo ? $this->get_primary_path( $repo ) : '';
+			if ( '' === $primary_path || ! is_dir( $primary_path . '/.git' ) ) {
+				continue;
+			}
+
+			if ( $github_repo !== (string) $this->resolve_github_slug( $primary_path ) ) {
+				continue;
+			}
+
+			if ( $branch !== (string) ( $wt['branch'] ?? '' ) ) {
+				continue;
+			}
+
+			$matches[] = $wt;
+		}
+
+		if ( empty( $matches ) ) {
+			return array(
+				'success' => true,
+				'found'   => false,
+				'repo'    => $github_repo,
+				'branch'  => $branch,
+				'message' => sprintf( 'No DMC worktree found for %s:%s.', $github_repo, $branch ),
+			);
+		}
+
+		if ( count( $matches ) > 1 ) {
+			return new \WP_Error(
+				'ambiguous_pr_worktree_cleanup',
+				sprintf( 'Refusing merged PR worktree cleanup because %d worktrees match %s:%s.', count( $matches ), $github_repo, $branch ),
+				array(
+					'status'  => 409,
+					'matches' => array_map( static fn( array $wt ): string => (string) ( $wt['handle'] ?? '' ), $matches ),
+				)
+			);
+		}
+
+		$wt      = $matches[0];
+		$repo    = (string) ( $wt['repo'] ?? '' );
+		$handle  = (string) ( $wt['handle'] ?? '' );
+		$wt_path = (string) ( $wt['path'] ?? '' );
+
+		if ( '' === $repo || '' === $handle || '' === $wt_path ) {
+			return new \WP_Error( 'invalid_pr_worktree_match', 'Matched worktree is missing repo, handle, or path metadata.', array( 'status' => 500 ) );
+		}
+
+		$dirty = $this->probe_worktree_dirty_count( $wt_path, self::CLEANUP_GIT_PROBE_TIMEOUT );
+		if ( $dirty instanceof \WP_Error ) {
+			return $dirty;
+		}
+		if ( (int) $dirty > 0 ) {
+			return new \WP_Error( 'dirty_worktree', sprintf( 'Refusing merged PR cleanup for %s because the worktree has %d dirty file(s).', $handle, (int) $dirty ), array( 'status' => 409 ) );
+		}
+
+		$unpushed = $this->count_unpushed_commits( $wt_path, self::CLEANUP_GIT_PROBE_TIMEOUT );
+		if ( $unpushed instanceof \WP_Error ) {
+			return $unpushed;
+		}
+		if ( (int) $unpushed > 0 ) {
+			return new \WP_Error( 'unpushed_commits', sprintf( 'Refusing merged PR cleanup for %s because it has %d unpushed commit(s).', $handle, (int) $unpushed ), array( 'status' => 409 ) );
+		}
+
+		$finalized = $this->worktree_finalize( $handle, WorktreeContextInjector::STATE_MERGED, $pr_url );
+		if ( $finalized instanceof \WP_Error ) {
+			return $finalized;
+		}
+
+		$removed = WorkspaceMutationLock::with_repo(
+			$this->workspace_path,
+			$repo,
+			function () use ( $repo, $branch, $wt_path ) {
+				$remove = $this->remove_worktree_by_path( $repo, $branch, $wt_path, false );
+				if ( $remove instanceof \WP_Error ) {
+					return $remove;
+				}
+
+				$primary_path = $this->get_primary_path( $repo );
+				$delete       = $this->run_git( $primary_path, sprintf( 'branch -D %s', escapeshellarg( $branch ) ) );
+				if ( $delete instanceof \WP_Error ) {
+					$remove['local_branch_deleted'] = false;
+					$remove['local_branch_error']   = $delete->get_error_message();
+					return $remove;
+				}
+
+				$remove['local_branch_deleted'] = true;
+				return $remove;
+			}
+		);
+
+		if ( $removed instanceof \WP_Error ) {
+			return $removed;
+		}
+
+		$this->worktree_prune();
+
+		return array(
+			'success'   => true,
+			'found'     => true,
+			'repo'      => $github_repo,
+			'branch'    => $branch,
+			'handle'    => $handle,
+			'path'      => $wt_path,
+			'finalized' => $finalized,
+			'removed'   => $removed,
+			'message'   => sprintf( 'Cleaned up merged PR worktree %s before branch deletion.', $handle ),
+		);
+	}
+
+	/**
 	 * Rewrite a worktree's injected context files from the originating site's
 	 * current memory state.
 	 *

--- a/tests/smoke-github-merge-pull-request.php
+++ b/tests/smoke-github-merge-pull-request.php
@@ -80,6 +80,21 @@ namespace DataMachineCode\Support {
 	}
 }
 
+namespace DataMachineCode\Workspace {
+	class Workspace {
+		public static array $cleanup_calls = array();
+
+		public function cleanup_merged_pr_worktree( string $repo, string $branch, ?string $pr_url = null ): array {
+			self::$cleanup_calls[] = compact( 'repo', 'branch', 'pr_url' );
+			return array(
+				'success' => true,
+				'found'   => true,
+				'handle'  => 'repo@feature-test',
+			);
+		}
+	}
+}
+
 namespace DataMachineCode\GitHub {
 	class PrReviewEscalationPolicy {}
 	class PrHomeboyReviewRunner {}
@@ -172,6 +187,7 @@ namespace {
 	use DataMachineCode\Abilities\GitHubAbilities;
 	use DataMachineCode\Support\GitHubCredentialResolver;
 	use DataMachineCode\Tools\GitHubTools;
+	use DataMachineCode\Workspace\Workspace;
 
 	$failures = array();
 	$assert   = function ( string $label, bool $cond ) use ( &$failures ): void {
@@ -322,6 +338,7 @@ namespace {
 	$assert( 'mergePullRequest does not merge after SHA mismatch', false === $merge_called );
 
 	$calls = array();
+	Workspace::$cleanup_calls = array();
 	$result = GitHubAbilities::cleanupPullRequest(
 		array(
 			'repo'        => 'owner/repo',
@@ -357,6 +374,8 @@ namespace {
 	);
 	$assert( 'cleanupPullRequest deletes merged same-repo branch', is_array( $result ) && true === ( $result['branch_deleted'] ?? false ) );
 	$assert( 'cleanupPullRequest calls GitHub refs delete endpoint', 'DELETE' === ( $calls[1]['method'] ?? '' ) && str_contains( $calls[1]['url'] ?? '', '/repos/owner/repo/git/refs/heads/' ) );
+	$assert( 'cleanupPullRequest removes matching DMC worktree before remote branch delete', array( 'repo' => 'owner/repo', 'branch' => 'feature/test', 'pr_url' => 'https://github.com/owner/repo/pull/42' ) === ( Workspace::$cleanup_calls[0] ?? array() ) );
+	$assert( 'cleanupPullRequest returns local worktree cleanup evidence', true === ( $result['local_worktree_cleanup']['found'] ?? false ) );
 
 	$result = GitHubAbilities::cleanupPullRequest(
 		array(

--- a/tests/smoke-worktree-lifecycle-metadata.php
+++ b/tests/smoke-worktree-lifecycle-metadata.php
@@ -275,6 +275,7 @@ namespace {
 	file_put_contents( $primary . '/README.md', "# Demo\n" );
 	$run( 'git add README.md', $primary );
 	$run( 'git commit -m initial', $primary );
+	$run( 'git remote add origin https://github.com/acme/demo.git', $primary );
 	putenv( 'OPENCODE_RUN_ID=smoke-run-123' );
 	putenv( 'OPENCODE_PID=12345' );
 
@@ -370,6 +371,15 @@ namespace {
 	$feature_skip = array_values( array_filter( $plan['skipped'] ?? array(), fn( $skip ) => ( $skip['handle'] ?? '' ) === 'demo@feature-metadata' ) );
 	$old_skip = array_values( array_filter( $plan['skipped'] ?? array(), fn( $skip ) => ( $skip['handle'] ?? '' ) === 'demo@feature-old-record' ) );
 	$assert( true, is_array( $old_skip[0]['metadata'] ?? null ), 'cleanup dry-run uses DB-backed metadata when option row is absent' );
+
+	$pr_cleanup_worktree = $ws->worktree_add( 'demo', 'feature/pr-cleanup', 'HEAD', false, false, true, false );
+	$assert( true, ! is_wp_error( $pr_cleanup_worktree ) && ( $pr_cleanup_worktree['success'] ?? false ), 'PR cleanup worktree fixture is created' );
+	$pr_cleanup = $ws->cleanup_merged_pr_worktree( 'acme/demo', 'feature/pr-cleanup', 'https://github.com/acme/demo/pull/456' );
+	$assert( true, ! is_wp_error( $pr_cleanup ) && ( $pr_cleanup['success'] ?? false ), 'merged PR worktree cleanup succeeds' );
+	$assert( true, (bool) ( $pr_cleanup['found'] ?? false ), 'merged PR worktree cleanup finds exact GitHub repo and branch match' );
+	$assert( false, is_dir( DATAMACHINE_WORKSPACE_PATH . '/demo@feature-pr-cleanup' ), 'merged PR worktree cleanup removes the attached worktree directory' );
+	$branch_check = trim( $run( 'git branch --list feature/pr-cleanup', $primary ) );
+	$assert( '', $branch_check, 'merged PR worktree cleanup deletes the local checked-out branch after removal' );
 
 	$removed_old = $ws->worktree_remove( 'demo', 'feature/old-record', true );
 	$assert( true, ! is_wp_error( $removed_old ) && ( $removed_old['success'] ?? false ), 'worktree_remove succeeds for old record' );


### PR DESCRIPTION
## Summary
- Finalize and remove matching local DMC worktrees before deleting merged PR head branches through the GitHub cleanup flow.
- Scope local cleanup by exact GitHub repo and PR head branch, with dirty/unpushed/protected/ambiguous safety checks.
- Add smoke coverage for GitHub cleanup routing and real local worktree branch deletion.

## Tests
- php tests/smoke-github-merge-pull-request.php
- php tests/smoke-worktree-lifecycle-metadata.php
- php -l inc/Abilities/GitHubAbilities.php
- php -l inc/Workspace/WorkspaceWorktreeLifecycle.php
- php -l tests/smoke-worktree-lifecycle-metadata.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation and smoke test updates; Chris requested the issue fix and will own final review/merge.

Fixes #399