### PR TITLE
Require opt-in for pipeline workspace tools

### DIFF
--- a/inc/Tools/WorkspaceTools.php
+++ b/inc/Tools/WorkspaceTools.php
@@ -69,7 +69,8 @@ class WorkspaceTools extends BaseTool {
 	 */
 	public function __construct() {
 		$contexts        = array( 'chat', 'pipeline' );
-		$policy_contexts = array( 'chat', 'pipeline_policy' );
+		$policy_contexts = array( 'chat', 'pipeline' );
+		$policy_meta     = array( 'requires_opt_in' => true );
 		$this->registerTool( 'workspace_path', array( $this, 'getPathDefinition' ), $contexts, array( 'ability' => 'datamachine/workspace-path' ) );
 		$this->registerTool( 'workspace_capabilities', array( $this, 'getCapabilitiesDefinition' ), $contexts, array( 'ability' => 'datamachine/workspace-capabilities' ) );
 		$this->registerTool( 'workspace_list', array( $this, 'getListDefinition' ), $contexts, array( 'ability' => 'datamachine/workspace-list' ) );
@@ -77,18 +78,18 @@ class WorkspaceTools extends BaseTool {
 		$this->registerTool( 'workspace_ls', array( $this, 'getLsDefinition' ), $contexts, array( 'ability' => 'datamachine/workspace-ls' ) );
 		$this->registerTool( 'workspace_read', array( $this, 'getReadDefinition' ), $contexts, array( 'ability' => 'datamachine/workspace-read' ) );
 		$this->registerTool( 'workspace_grep', array( $this, 'getGrepDefinition' ), $contexts, array( 'ability' => 'datamachine/workspace-grep' ) );
-		$this->registerTool( 'workspace_write', array( $this, 'getWriteDefinition' ), $policy_contexts, array( 'ability' => 'datamachine/workspace-write' ) );
-		$this->registerTool( 'workspace_edit', array( $this, 'getEditDefinition' ), $policy_contexts, array( 'ability' => 'datamachine/workspace-edit' ) );
-		$this->registerTool( 'workspace_apply_patch', array( $this, 'getApplyPatchDefinition' ), $policy_contexts, array( 'ability' => 'datamachine/workspace-apply-patch' ) );
-		$this->registerTool( 'workspace_delete', array( $this, 'getDeleteDefinition' ), $policy_contexts, array( 'ability' => 'datamachine/workspace-delete' ) );
-		$this->registerTool( 'workspace_git_status', array( $this, 'getGitStatusDefinition' ), $policy_contexts, array( 'ability' => 'datamachine/workspace-git-status' ) );
-		$this->registerTool( 'workspace_git_log', array( $this, 'getGitLogDefinition' ), $policy_contexts, array( 'ability' => 'datamachine/workspace-git-log' ) );
-		$this->registerTool( 'workspace_git_diff', array( $this, 'getGitDiffDefinition' ), $policy_contexts, array( 'ability' => 'datamachine/workspace-git-diff' ) );
-		$this->registerTool( 'workspace_git_pull', array( $this, 'getGitPullDefinition' ), $policy_contexts, array( 'ability' => 'datamachine/workspace-git-pull' ) );
-		$this->registerTool( 'workspace_worktree_add', array( $this, 'getWorktreeAddDefinition' ), $policy_contexts, array( 'ability' => 'datamachine/workspace-worktree-add' ) );
-		$this->registerTool( 'workspace_git_add', array( $this, 'getGitAddDefinition' ), $policy_contexts, array( 'ability' => 'datamachine/workspace-git-add' ) );
-		$this->registerTool( 'workspace_git_commit', array( $this, 'getGitCommitDefinition' ), $policy_contexts, array( 'ability' => 'datamachine/workspace-git-commit' ) );
-		$this->registerTool( 'workspace_git_push', array( $this, 'getGitPushDefinition' ), $policy_contexts, array( 'ability' => 'datamachine/workspace-git-push' ) );
+		$this->registerTool( 'workspace_write', array( $this, 'getWriteDefinition' ), $policy_contexts, $policy_meta + array( 'ability' => 'datamachine/workspace-write' ) );
+		$this->registerTool( 'workspace_edit', array( $this, 'getEditDefinition' ), $policy_contexts, $policy_meta + array( 'ability' => 'datamachine/workspace-edit' ) );
+		$this->registerTool( 'workspace_apply_patch', array( $this, 'getApplyPatchDefinition' ), $policy_contexts, $policy_meta + array( 'ability' => 'datamachine/workspace-apply-patch' ) );
+		$this->registerTool( 'workspace_delete', array( $this, 'getDeleteDefinition' ), $policy_contexts, $policy_meta + array( 'ability' => 'datamachine/workspace-delete' ) );
+		$this->registerTool( 'workspace_git_status', array( $this, 'getGitStatusDefinition' ), $policy_contexts, $policy_meta + array( 'ability' => 'datamachine/workspace-git-status' ) );
+		$this->registerTool( 'workspace_git_log', array( $this, 'getGitLogDefinition' ), $policy_contexts, $policy_meta + array( 'ability' => 'datamachine/workspace-git-log' ) );
+		$this->registerTool( 'workspace_git_diff', array( $this, 'getGitDiffDefinition' ), $policy_contexts, $policy_meta + array( 'ability' => 'datamachine/workspace-git-diff' ) );
+		$this->registerTool( 'workspace_git_pull', array( $this, 'getGitPullDefinition' ), $policy_contexts, $policy_meta + array( 'ability' => 'datamachine/workspace-git-pull' ) );
+		$this->registerTool( 'workspace_worktree_add', array( $this, 'getWorktreeAddDefinition' ), $policy_contexts, $policy_meta + array( 'ability' => 'datamachine/workspace-worktree-add' ) );
+		$this->registerTool( 'workspace_git_add', array( $this, 'getGitAddDefinition' ), $policy_contexts, $policy_meta + array( 'ability' => 'datamachine/workspace-git-add' ) );
+		$this->registerTool( 'workspace_git_commit', array( $this, 'getGitCommitDefinition' ), $policy_contexts, $policy_meta + array( 'ability' => 'datamachine/workspace-git-commit' ) );
+		$this->registerTool( 'workspace_git_push', array( $this, 'getGitPushDefinition' ), $policy_contexts, $policy_meta + array( 'ability' => 'datamachine/workspace-git-push' ) );
 	}
 
 	/**

--- a/tests/smoke-workspace-policy-tools.php
+++ b/tests/smoke-workspace-policy-tools.php
@@ -104,7 +104,8 @@ namespace {
 	);
 
 	foreach ( $policy_tools as $tool ) {
-		$assert( "{$tool} is policy-gated for pipeline use", array( 'chat', 'pipeline_policy' ) === ( $tools[ $tool ]['modes'] ?? null ) );
+		$assert( "{$tool} is available in real chat and pipeline modes", array( 'chat', 'pipeline' ) === ( $tools[ $tool ]['modes'] ?? null ) );
+		$assert( "{$tool} requires explicit opt-in for pipeline use", true === ( $tools[ $tool ]['requires_opt_in'] ?? null ) );
 	}
 
 	if ( $failures ) {


### PR DESCRIPTION
## Summary
- Move workspace policy tools off the synthetic `pipeline_policy` mode and onto real `chat`/`pipeline` modes.
- Mark write/git/worktree workspace tools with `requires_opt_in` so pipeline access remains explicit through allow-only policy.
- Update the workspace policy smoke to assert both real mode membership and opt-in metadata.

## Related
- Depends on Extra-Chill/data-machine#2022.
- Part of Extra-Chill/data-machine#2020.
- Follow-up World of WordPress PR will switch the world pipeline to additive `agent_modes`.

## Validation
- `php tests/smoke-workspace-policy-tools.php` — OK, 31 assertions
- `homeboy test data-machine-code` — activation/install passed; PHPUnit discovery found zero tests

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the workspace tool registration update and smoke assertions, then ran validation; Chris remains responsible for review and merge.