### PR TITLE
ci: add Homeboy release workflow and ZIP asset

### DIFF
--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -1,0 +1,75 @@
+name: Homeboy
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+concurrency:
+  group: homeboy-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  homeboy:
+    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@v2
+    with:
+      commands: audit,lint,test
+      expected-commands: audit,lint,test
+      autofix: 'false'
+    secrets: inherit
+
+  build-release-asset:
+    if: needs.homeboy.outputs.released == 'true'
+    needs: [homeboy]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.homeboy.outputs.release-tag }}
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          tools: composer:v2
+
+      - run: composer install --no-dev --optimize-autoloader --prefer-dist --no-interaction
+
+      - name: Build plugin ZIP
+        run: |
+          mkdir -p dist/data-machine-code
+          rsync -a ./ dist/data-machine-code/ \
+            --exclude='.git' \
+            --exclude='.github' \
+            --exclude='.claude' \
+            --exclude='.datamachine' \
+            --exclude='AGENTS.md' \
+            --exclude='dist' \
+            --exclude='docs' \
+            --exclude='node_modules' \
+            --exclude='tests' \
+            --exclude='*.zip' \
+            --exclude='*.tar.gz' \
+            --exclude='*.log' \
+            --exclude='*.tmp' \
+            --exclude='*.temp' \
+            --exclude='*.cache' \
+            --exclude='*.bak' \
+            --exclude='*.backup' \
+            --exclude='phpstan-baseline.neon' \
+            --exclude='phpunit.xml*'
+          cd dist
+          zip -r data-machine-code.zip data-machine-code
+
+      - run: gh release upload "${{ needs.homeboy.outputs.release-tag }}" dist/data-machine-code.zip --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds the standard Homeboy reusable workflow for audit, lint, test, conventional-release automation.
- Adds a `build-release-asset` follow-up job when Homeboy creates a release.
- Builds and uploads `data-machine-code.zip` with Composer production dependencies bundled for clean plugin installation.

## Issue
- Fixes https://github.com/Extra-Chill/data-machine-code/issues/407

## Related PRs
- Data Machine companion PR: https://github.com/Extra-Chill/data-machine/pull/2031

## Validation
- `composer install --no-dev --optimize-autoloader --prefer-dist --no-interaction`
- Locally staged and zipped `dist/data-machine-code.zip`, extracted it, and verified it contains `data-machine-code.php`, `inc/`, and `vendor/autoload.php`.
- Verified extracted ZIP excludes `tests/`, `docs/`, `.github/`, `node_modules/`, and `phpstan-baseline.neon`.
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/homeboy.yml")'`

## Notes
- `homeboy audit` reports existing repo-wide heuristic findings unrelated to this workflow-only change.
- `homeboy lint` reports existing repo-wide PHPCS findings unrelated to this workflow-only change.
- `homeboy test` currently fails before tests run in the local environment because the local dependency load is missing `WP_Agent_Principal_Access_Store` from Agents API/Data Machine bootstrap.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Added the Homeboy/release-asset workflow, validated the local ZIP contents, and drafted the PR description. Chris specified the issue, desired workflow shape, and release artifact requirements.