### PR TITLE
ci: restore release-asset.yml as Playground unblock

### DIFF
--- a/.github/workflows/release-asset.yml
+++ b/.github/workflows/release-asset.yml
@@ -1,0 +1,67 @@
+name: Release asset
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag to (re)build and upload an asset for.'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  build-release-asset:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve release tag
+        id: tag
+        run: |
+          if [ -n "${{ github.event.release.tag_name }}" ]; then
+            echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          tools: composer:v2
+
+      - run: composer install --no-dev --optimize-autoloader --prefer-dist --no-interaction
+
+      - name: Build plugin ZIP
+        run: |
+          mkdir -p dist/data-machine-code
+          rsync -a ./ dist/data-machine-code/ \
+            --exclude='.git' \
+            --exclude='.github' \
+            --exclude='.claude' \
+            --exclude='.datamachine' \
+            --exclude='AGENTS.md' \
+            --exclude='dist' \
+            --exclude='docs' \
+            --exclude='node_modules' \
+            --exclude='tests' \
+            --exclude='*.zip' \
+            --exclude='*.tar.gz' \
+            --exclude='*.log' \
+            --exclude='*.tmp' \
+            --exclude='*.temp' \
+            --exclude='*.cache' \
+            --exclude='*.bak' \
+            --exclude='*.backup' \
+            --exclude='phpstan-baseline.neon' \
+            --exclude='phpunit.xml*'
+          cd dist
+          zip -r data-machine-code.zip data-machine-code
+
+      - run: gh release upload "${{ steps.tag.outputs.tag }}" dist/data-machine-code.zip --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Bridge until [homeboy#2581](https://github.com/Extra-Chill/homeboy/issues/2581) (full dogfooding refactor) lands. Restores the standalone `release-asset.yml` workflow that was deleted in PR #417.

Same shape as the [Extra-Chill/data-machine restore PR](https://github.com/Extra-Chill/data-machine/pulls?q=restore-release-asset).

## Why

The homeboy-native release workflow tags and pushes but produces zero assets because homeboy-action hardcodes `--skip-publish`, which short-circuits the wordpress extension's `release.publish` action. Restoring `release-asset.yml` (triggered on `release.published`) rebuilds the vendor-bundled ZIP and uploads it via `gh release upload`.

## Temporary

Gets deleted again once phase 4 of homeboy#2581 makes `--skip-publish` opt-in and the homeboy-native pipeline ships ZIPs automatically.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Restored the file from git history. Same band-aid as the parallel DM PR.