### PR TITLE
Fix cleanup reclaimed-byte aggregation

### DIFF
--- a/inc/Cleanup/DataMachineJobCleanupRunEvidenceStore.php
+++ b/inc/Cleanup/DataMachineJobCleanupRunEvidenceStore.php
@@ -30,11 +30,12 @@ class DataMachineJobCleanupRunEvidenceStore implements CleanupRunEvidenceStoreIn
 			return new \WP_Error( 'cleanup_run_not_found', sprintf( 'Cleanup run not found: %s', $this->cleanup_run_id( $job_id ) ), array( 'status' => 404 ) );
 		}
 
-		$engine_data = $this->normalize_engine_data( $job['engine_data'] ?? array() );
-		$child_jobs  = $this->get_cleanup_run_descendant_jobs( $job_id );
-		$aggregate   = $this->aggregate_cleanup_child_jobs( $child_jobs );
-		$children    = $aggregate['children'];
-		$state       = $this->cleanup_run_state( (string) ( $job['status'] ?? '' ), $children );
+		$engine_data   = $this->normalize_engine_data( $job['engine_data'] ?? array() );
+		$parent_result = $this->extract_system_task_result( $engine_data );
+		$child_jobs    = $this->get_cleanup_run_descendant_jobs( $job_id );
+		$aggregate     = $this->aggregate_cleanup_child_jobs( $child_jobs );
+		$children      = $aggregate['children'];
+		$state         = $this->cleanup_run_state( (string) ( $job['status'] ?? '' ), $children );
 
 		$children_for_output = ( $include_evidence || $include_details ) ? $children : $this->summarize_cleanup_children( $children );
 		$output              = array(
@@ -53,8 +54,8 @@ class DataMachineJobCleanupRunEvidenceStore implements CleanupRunEvidenceStoreIn
 		$output_aggregate             = $aggregate;
 		$output_aggregate['children'] = $children_for_output;
 
-		if ( isset( $engine_data['system_task_result'] ) && is_array( $engine_data['system_task_result'] ) ) {
-			$engine_data['system_task_result'] = $this->with_cleanup_aggregate_report( $engine_data['system_task_result'], $output_aggregate );
+		if ( array() !== $parent_result ) {
+			$engine_data['system_task_result'] = $this->with_cleanup_aggregate_report( $parent_result, $output_aggregate );
 		}
 
 		if ( $include_evidence ) {
@@ -130,7 +131,7 @@ class DataMachineJobCleanupRunEvidenceStore implements CleanupRunEvidenceStoreIn
 			$child_job_id = (int) ( $child['job_id'] ?? 0 );
 			$status       = (string) ( $child['status'] ?? '' );
 			$engine_data  = $this->normalize_engine_data( $child['engine_data'] ?? array() );
-			$result       = is_array( $engine_data['system_task_result'] ?? null ) ? $engine_data['system_task_result'] : array();
+			$result       = $this->extract_system_task_result( $engine_data );
 
 			++$summary['children']['total'];
 			if ( $child_job_id > 0 ) {
@@ -161,13 +162,16 @@ class DataMachineJobCleanupRunEvidenceStore implements CleanupRunEvidenceStoreIn
 			if ( 'worktree_cleanup_chunk' !== (string) ( $engine_data['task_type'] ?? '' ) && ! isset( $result['chunk_type'] ) ) {
 				continue;
 			}
+			if ( array() === $result ) {
+				continue;
+			}
 
 			if ( $child_job_id > 0 ) {
 				$summary['children']['chunk_job_ids'][] = $child_job_id;
 			}
 
 			$this->merge_cleanup_item_result( $summary['cleanup_items'], $result );
-			if ( 'artifacts' === (string) ( $result['chunk_type'] ?? '' ) ) {
+			if ( in_array( (string) ( $result['chunk_type'] ?? '' ), array( 'artifacts', 'artifact_discovery' ), true ) ) {
 				$this->merge_cleanup_item_result( $summary['artifact_cleanup'], $result );
 			}
 		}
@@ -368,6 +372,26 @@ class DataMachineJobCleanupRunEvidenceStore implements CleanupRunEvidenceStoreIn
 		if ( is_string( $engine_data ) && '' !== trim( $engine_data ) ) {
 			$decoded = json_decode( $engine_data, true );
 			return is_array( $decoded ) ? $decoded : array();
+		}
+
+		return array();
+	}
+
+	/**
+	 * Extract a task result from either nested packets or direct task engine data.
+	 *
+	 * @param array $engine_data Job engine data.
+	 * @return array<string,mixed>
+	 */
+	private function extract_system_task_result( array $engine_data ): array {
+		if ( isset( $engine_data['system_task_result'] ) && is_array( $engine_data['system_task_result'] ) ) {
+			return $engine_data['system_task_result'];
+		}
+
+		foreach ( array( 'chunk_type', 'planned_count', 'applied_count', 'skipped_count', 'failed_count', 'bytes_reclaimed', 'report', 'job_backed' ) as $key ) {
+			if ( array_key_exists( $key, $engine_data ) ) {
+				return $engine_data;
+			}
 		}
 
 		return array();

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -472,20 +472,18 @@ namespace {
 							'source'        => 'system',
 							'status'        => 'completed',
 							'engine_data'   => array(
-								'task_type'          => 'worktree_cleanup_chunk',
-								'system_task_result' => array(
-									'success'         => true,
-									'chunk_type'      => 'artifacts',
-									'planned_count'   => 3,
-									'applied_count'   => 2,
-									'skipped_count'   => 1,
-									'failed_count'    => 0,
-									'bytes_reclaimed' => 4096,
-									'skipped'         => array(
-										array( 'handle' => 'repo@dirty', 'reason_code' => 'dirty_worktree' ),
-									),
-									'failed'          => array(),
+								'task_type'        => 'worktree_cleanup_chunk',
+								'success'          => true,
+								'chunk_type'       => 'artifact_discovery',
+								'planned_count'    => 3,
+								'applied_count'    => 2,
+								'skipped_count'    => 1,
+								'failed_count'     => 0,
+								'bytes_reclaimed'  => 4096,
+								'skipped'          => array(
+									array( 'handle' => 'repo@dirty', 'reason_code' => 'dirty_worktree' ),
 								),
+								'failed'           => array(),
 							),
 						),
 						array(
@@ -494,19 +492,17 @@ namespace {
 							'source'        => 'system',
 							'status'        => 'failed - apply_failed',
 							'engine_data'   => array(
-								'task_type'          => 'worktree_cleanup_chunk',
-								'system_task_result' => array(
-									'success'         => false,
-									'chunk_type'      => 'artifacts',
-									'planned_count'   => 1,
-									'applied_count'   => 0,
-									'skipped_count'   => 0,
-									'failed_count'    => 1,
-									'bytes_reclaimed' => 0,
-									'skipped'         => array(),
-									'failed'          => array(
-										array( 'handle' => 'repo@failed', 'reason_code' => 'apply_failed' ),
-									),
+								'task_type'        => 'worktree_cleanup_chunk',
+								'success'          => false,
+								'chunk_type'       => 'artifacts',
+								'planned_count'    => 1,
+								'applied_count'    => 0,
+								'skipped_count'    => 0,
+								'failed_count'     => 1,
+								'bytes_reclaimed'  => 0,
+								'skipped'          => array(),
+								'failed'           => array(
+									array( 'handle' => 'repo@failed', 'reason_code' => 'apply_failed' ),
 								),
 							),
 						),
@@ -542,13 +538,11 @@ namespace {
 								'mode'   => 'retention',
 								'source' => 'workspace_cleanup_cli',
 							),
-							'system_task_result' => array(
-								'success'    => true,
-								'job_backed' => true,
-								'report'     => array(
-									'bytes_reclaimed' => 0,
-									'freed_human'     => 'pending child jobs',
-								),
+							'success'     => true,
+							'job_backed'  => true,
+							'report'      => array(
+								'bytes_reclaimed' => 0,
+								'freed_human'     => 'pending child jobs',
 							),
 						),
 					),
@@ -680,6 +674,9 @@ namespace {
 	datamachine_code_cleanup_assert( 4096 === (int) ( $status_json['artifact_cleanup']['bytes_reclaimed'] ?? 0 ), 'cleanup status aggregates artifact bytes from child chunks' );
 	datamachine_code_cleanup_assert( 4 === (int) ( $status_json['cleanup_items']['planned_rows'] ?? 0 ), 'cleanup status aggregates planned rows from DB-backed cleanup item evidence' );
 	datamachine_code_cleanup_assert( 4096 === (int) ( $status_json['cleanup_items']['bytes_reclaimed'] ?? 0 ), 'cleanup status reconstructs reclaimed bytes from cleanup item evidence' );
+	datamachine_code_cleanup_assert( 3 === (int) ( $status_json['cleanup_items']['by_type']['artifact_discovery']['planned_rows'] ?? 0 ), 'cleanup status preserves artifact discovery chunk type aggregation' );
+	datamachine_code_cleanup_assert( 1 === (int) ( $status_json['cleanup_items']['by_type']['artifacts']['planned_rows'] ?? 0 ), 'cleanup status preserves artifact apply chunk type aggregation' );
+	datamachine_code_cleanup_assert( ! isset( $status_json['cleanup_items']['by_type']['unknown'] ), 'cleanup status does not aggregate completed chunks under unknown type' );
 	datamachine_code_cleanup_assert( '4.0 KiB' === ( $status_json['system_task_result']['report']['freed_human'] ?? '' ), 'cleanup status replaces pending child job freed placeholder' );
 	datamachine_code_cleanup_assert( ! isset( $status_json['system_task_result']['children']['job_ids'] ), 'cleanup status system task result omits full child job ids by default' );
 


### PR DESCRIPTION
## Summary
- Read cleanup chunk task results from direct child job engine data as well as nested system task packets.
- Count artifact discovery chunks toward artifact cleanup reclaimed-byte totals.
- Avoid aggregating empty completed chunks under an unknown type.

Fixes #431

## Testing
- php tests/smoke-worktree-cleanup-cli.php
- php tests/smoke-worktree-cleanup-chunks.php
- php -l inc/Cleanup/DataMachineJobCleanupRunEvidenceStore.php
- php -l tests/smoke-worktree-cleanup-cli.php
- git diff --check
- homeboy test --path /Users/chubes/Developer/data-machine-code@fix-cleanup-reclaimed-byte-aggregation --extension wordpress

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the targeted cleanup evidence aggregation fix and smoke test coverage; Chris remains responsible for review and merge.