### PR TITLE
Register code abilities after abilities init

### DIFF
--- a/inc/Abilities/CodeTaskAbilities.php
+++ b/inc/Abilities/CodeTaskAbilities.php
@@ -22,7 +22,11 @@ class CodeTaskAbilities {
 			return;
 		}
 
-		add_action( 'wp_abilities_api_init', array( $this, 'register' ) );
+		if ( function_exists( 'doing_action' ) && ( doing_action( 'wp_abilities_api_init' ) || did_action( 'wp_abilities_api_init' ) ) ) {
+			$this->register();
+		} else {
+			add_action( 'wp_abilities_api_init', array( $this, 'register' ) );
+		}
 		self::$registered = true;
 	}
 

--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -1324,9 +1324,9 @@ class GitHubAbilities {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
+		if ( doing_action( 'wp_abilities_api_init' ) || did_action( 'wp_abilities_api_init' ) ) {
 			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+		} else {
 			add_action( 'wp_abilities_api_init', $register_callback );
 		}
 	}

--- a/inc/Abilities/GitSyncAbilities.php
+++ b/inc/Abilities/GitSyncAbilities.php
@@ -303,9 +303,9 @@ class GitSyncAbilities {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
+		if ( doing_action( 'wp_abilities_api_init' ) || did_action( 'wp_abilities_api_init' ) ) {
 			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+		} else {
 			add_action( 'wp_abilities_api_init', $register_callback );
 		}
 	}

--- a/inc/Abilities/WordPressRuntimeAbilities.php
+++ b/inc/Abilities/WordPressRuntimeAbilities.php
@@ -147,7 +147,7 @@ class WordPressRuntimeAbilities {
 			);
 		};
 
-		if ( function_exists( 'doing_action' ) && doing_action( 'wp_abilities_api_init' ) ) {
+		if ( function_exists( 'doing_action' ) && ( doing_action( 'wp_abilities_api_init' ) || did_action( 'wp_abilities_api_init' ) ) ) {
 			$register_callback();
 			return;
 		}

--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -2159,9 +2159,9 @@ class WorkspaceAbilities {
 			}
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
+		if ( doing_action( 'wp_abilities_api_init' ) || did_action( 'wp_abilities_api_init' ) ) {
 			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+		} else {
 			add_action( 'wp_abilities_api_init', $register_callback );
 		}
 	}

--- a/tests/smoke-late-ability-registration.php
+++ b/tests/smoke-late-ability-registration.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Smoke test for ability classes instantiated after wp_abilities_api_init.
+ *
+ * Run: php tests/smoke-late-ability-registration.php
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Abilities {
+	class PermissionHelper {
+		public static function can_manage(): bool {
+			return true;
+		}
+	}
+}
+
+namespace DataMachineCode\Workspace {
+	class Workspace {
+		public const ARTIFACT_CLEANUP_DEFAULT_LIMIT = 100;
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', sys_get_temp_dir() . '/data-machine-code-late-ability-registration/' );
+	}
+
+	if ( ! class_exists( 'WP_Ability' ) ) {
+		class WP_Ability {}
+	}
+
+	$GLOBALS['datamachine_code_registered_abilities'] = array();
+	$GLOBALS['datamachine_code_added_actions']        = array();
+
+	function wp_register_ability( string $name, array $definition ): void {
+		$GLOBALS['datamachine_code_registered_abilities'][ $name ] = $definition;
+	}
+
+	function doing_action( string $hook ): bool {
+		return false;
+	}
+
+	function did_action( string $hook ): int {
+		return 'wp_abilities_api_init' === $hook ? 1 : 0;
+	}
+
+	function add_action( string $hook, callable $callback, int $priority = 10 ): void {
+		$GLOBALS['datamachine_code_added_actions'][] = compact( 'hook', 'callback', 'priority' );
+	}
+
+	require __DIR__ . '/../inc/Abilities/WorkspaceAbilities.php';
+	require __DIR__ . '/../inc/Abilities/CodeTaskAbilities.php';
+
+	new \DataMachineCode\Abilities\WorkspaceAbilities();
+	new \DataMachineCode\Abilities\CodeTaskAbilities();
+
+	$failures = array();
+	$assert   = static function ( string $label, bool $condition ) use ( &$failures ): void {
+		if ( $condition ) {
+			echo "  ok {$label}\n";
+			return;
+		}
+
+		$failures[] = $label;
+		echo "  fail {$label}\n";
+	};
+
+	echo "Data Machine Code late ability registration - smoke\n";
+
+	$assert( 'workspace-show registers after wp_abilities_api_init fired', isset( $GLOBALS['datamachine_code_registered_abilities']['datamachine/workspace-show'] ) );
+	$assert( 'workspace-worktree-add registers after wp_abilities_api_init fired', isset( $GLOBALS['datamachine_code_registered_abilities']['datamachine/workspace-worktree-add'] ) );
+	$assert( 'create-code-task registers after wp_abilities_api_init fired', isset( $GLOBALS['datamachine_code_registered_abilities']['datamachine/create-code-task'] ) );
+	$assert( 'late constructors do not add inert wp_abilities_api_init callbacks', array() === $GLOBALS['datamachine_code_added_actions'] );
+
+	if ( ! empty( $failures ) ) {
+		echo "\nFAIL: " . count( $failures ) . " assertion(s) failed\n";
+		exit( 1 );
+	}
+
+	echo "\nOK\n";
+}


### PR DESCRIPTION
## Summary
- Register Data Machine Code abilities immediately when their classes are instantiated after `wp_abilities_api_init` has already fired.
- Cover the late-registration path for workspace and code-task abilities so `datamachine/workspace-show` remains available in runtimes that activate DMC inside an already-booted WordPress request.

## Why
WP Codebox activates Data Machine Code inside a Playground request. In that shape, `wp_abilities_api_init` may already have fired before DMC ability classes are constructed, so the previous pattern skipped registration instead of registering immediately.

## Testing
- `php tests/smoke-late-ability-registration.php`
- `php -l inc/Abilities/WorkspaceAbilities.php && php -l inc/Abilities/GitHubAbilities.php && php -l inc/Abilities/GitSyncAbilities.php && php -l inc/Abilities/WordPressRuntimeAbilities.php && php -l inc/Abilities/CodeTaskAbilities.php && php -l tests/smoke-late-ability-registration.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Traced the wp-codebox World Creator failure to DMC late ability registration, implemented the registration fix, and added smoke coverage; Chris reviewed the ownership question interactively.