### PR TITLE
fix: defer code ability registration until API loads

### DIFF
--- a/inc/Abilities/CodeTaskAbilities.php
+++ b/inc/Abilities/CodeTaskAbilities.php
@@ -18,7 +18,19 @@ class CodeTaskAbilities {
 	private static bool $registered = false;
 
 	public function __construct() {
-		if ( ! class_exists( 'WP_Ability' ) || self::$registered ) {
+		if ( self::$registered ) {
+			return;
+		}
+
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			add_action( 'wp_abilities_api_init', function (): void {
+				if ( self::$registered || ! class_exists( 'WP_Ability' ) ) {
+					return;
+				}
+
+				$this->register();
+				self::$registered = true;
+			} );
 			return;
 		}
 

--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -83,10 +83,18 @@ class GitHubAbilities {
 	const MAX_PER_PAGE = 100;
 
 	public function __construct() {
-		if ( ! class_exists( 'WP_Ability' ) ) {
+		if ( self::$registered ) {
 			return;
 		}
-		if ( self::$registered ) {
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			add_action( 'wp_abilities_api_init', function (): void {
+				if ( self::$registered || ! class_exists( 'WP_Ability' ) ) {
+					return;
+				}
+
+				$this->registerAbilities();
+				self::$registered = true;
+			} );
 			return;
 		}
 		$this->registerAbilities();

--- a/inc/Abilities/GitSyncAbilities.php
+++ b/inc/Abilities/GitSyncAbilities.php
@@ -27,10 +27,18 @@ class GitSyncAbilities {
 	private static bool $registered = false;
 
 	public function __construct() {
-		if ( ! class_exists( 'WP_Ability' ) ) {
+		if ( self::$registered ) {
 			return;
 		}
-		if ( self::$registered ) {
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			add_action( 'wp_abilities_api_init', function (): void {
+				if ( self::$registered || ! class_exists( 'WP_Ability' ) ) {
+					return;
+				}
+
+				$this->registerAbilities();
+				self::$registered = true;
+			} );
 			return;
 		}
 		$this->registerAbilities();

--- a/inc/Abilities/WordPressRuntimeAbilities.php
+++ b/inc/Abilities/WordPressRuntimeAbilities.php
@@ -17,11 +17,19 @@ class WordPressRuntimeAbilities {
 	private static bool $registered = false;
 
 	public function __construct() {
-		if ( ! class_exists( 'WP_Ability' ) ) {
+		if ( self::$registered ) {
 			return;
 		}
 
-		if ( self::$registered ) {
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			add_action( 'wp_abilities_api_init', function (): void {
+				if ( self::$registered || ! class_exists( 'WP_Ability' ) ) {
+					return;
+				}
+
+				$this->registerAbilities();
+				self::$registered = true;
+			} );
 			return;
 		}
 

--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -29,11 +29,19 @@ class WorkspaceAbilities {
 	private static bool $registered = false;
 
 	public function __construct() {
-		if ( ! class_exists( 'WP_Ability' ) ) {
+		if ( self::$registered ) {
 			return;
 		}
 
-		if ( self::$registered ) {
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			add_action( 'wp_abilities_api_init', function (): void {
+				if ( self::$registered || ! class_exists( 'WP_Ability' ) ) {
+					return;
+				}
+
+				$this->registerAbilities();
+				self::$registered = true;
+			} );
 			return;
 		}
 

--- a/tests/smoke-deferred-ability-registration.php
+++ b/tests/smoke-deferred-ability-registration.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Smoke test for ability classes instantiated before WP_Ability is loaded.
+ *
+ * Run: php tests/smoke-deferred-ability-registration.php
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Abilities {
+	class PermissionHelper {
+		public static function can_manage(): bool {
+			return true;
+		}
+	}
+}
+
+namespace DataMachineCode\Workspace {
+	class Workspace {
+		public const ARTIFACT_CLEANUP_DEFAULT_LIMIT = 100;
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', sys_get_temp_dir() . '/data-machine-code-deferred-ability-registration/' );
+	}
+
+	$GLOBALS['datamachine_code_registered_abilities'] = array();
+	$GLOBALS['datamachine_code_added_actions']        = array();
+
+	function wp_register_ability( string $name, array $definition ): void {
+		$GLOBALS['datamachine_code_registered_abilities'][ $name ] = $definition;
+	}
+
+	function doing_action( string $hook ): bool {
+		return false;
+	}
+
+	function did_action( string $hook ): int {
+		return 0;
+	}
+
+	function add_action( string $hook, callable $callback, int $priority = 10 ): void {
+		$GLOBALS['datamachine_code_added_actions'][] = compact( 'hook', 'callback', 'priority' );
+	}
+
+	require __DIR__ . '/../inc/Abilities/WorkspaceAbilities.php';
+	require __DIR__ . '/../inc/Abilities/CodeTaskAbilities.php';
+
+	new \DataMachineCode\Abilities\WorkspaceAbilities();
+	new \DataMachineCode\Abilities\CodeTaskAbilities();
+
+	$failures = array();
+	$assert   = static function ( string $label, bool $condition ) use ( &$failures ): void {
+		if ( $condition ) {
+			echo "  ok {$label}\n";
+			return;
+		}
+
+		$failures[] = $label;
+		echo "  fail {$label}\n";
+	};
+
+	echo "Data Machine Code deferred ability registration - smoke\n";
+
+	$assert( 'constructors defer when WP_Ability is unavailable', 2 === count( $GLOBALS['datamachine_code_added_actions'] ) );
+	$assert( 'constructors do not register before WP_Ability is available', array() === $GLOBALS['datamachine_code_registered_abilities'] );
+
+	class WP_Ability {}
+
+	foreach ( $GLOBALS['datamachine_code_added_actions'] as $action ) {
+		if ( 'wp_abilities_api_init' === $action['hook'] ) {
+			$action['callback']();
+		}
+	}
+
+	$assert( 'workspace-show registers on deferred wp_abilities_api_init', isset( $GLOBALS['datamachine_code_registered_abilities']['datamachine/workspace-show'] ) );
+	$assert( 'workspace-worktree-add registers on deferred wp_abilities_api_init', isset( $GLOBALS['datamachine_code_registered_abilities']['datamachine/workspace-worktree-add'] ) );
+	$assert( 'create-code-task registers on deferred wp_abilities_api_init', isset( $GLOBALS['datamachine_code_registered_abilities']['datamachine/create-code-task'] ) );
+
+	if ( ! empty( $failures ) ) {
+		echo "\nFAIL: " . count( $failures ) . " assertion(s) failed\n";
+		exit( 1 );
+	}
+
+	echo "\nOK\n";
+}


### PR DESCRIPTION
## Summary
- Defer DMC ability registration to `wp_abilities_api_init` when ability classes are constructed before `WP_Ability` is loaded.
- Preserve immediate registration when the Abilities API is already available.
- Add smoke coverage for the deferred constructor path that wp-codebox exercises.

## Verification
- `php tests/smoke-late-ability-registration.php`
- `php tests/smoke-deferred-ability-registration.php`
- `php -l inc/Abilities/WorkspaceAbilities.php && php -l inc/Abilities/GitHubAbilities.php && php -l inc/Abilities/GitSyncAbilities.php && php -l inc/Abilities/WordPressRuntimeAbilities.php && php -l inc/Abilities/CodeTaskAbilities.php && php -l tests/smoke-deferred-ability-registration.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Diagnosed the wp-codebox canary registration ordering failure, drafted the code change and smoke test, and ran local verification. Chris remains responsible for review and merge.