### PR TITLE
fix: register code abilities during API hook replay

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -67,7 +67,16 @@ add_action( 'plugins_loaded', 'datamachine_code_maybe_upgrade_schema', 5 );
  * data-machine-code loads before data-machine).
  */
 function datamachine_code_bootstrap() {
+	static $bootstrapped = false;
+
+	if ( $bootstrapped ) {
+		return;
+	}
+
 	if ( ! class_exists( 'DataMachine\Abilities\PermissionHelper' ) ) {
+		add_action( 'init', 'datamachine_code_bootstrap', 1 );
+		add_action( 'wp_abilities_api_init', 'datamachine_code_bootstrap', 1 );
+
 		add_action( 'admin_notices', function () {
 			?>
 			<div class="notice notice-error">
@@ -77,6 +86,8 @@ function datamachine_code_bootstrap() {
 		} );
 		return;
 	}
+
+	$bootstrapped = true;
 
 	// Load Abilities (they self-register).
 	new \DataMachineCode\Abilities\GitHubAbilities();

--- a/inc/Abilities/CodeTaskAbilities.php
+++ b/inc/Abilities/CodeTaskAbilities.php
@@ -22,9 +22,9 @@ class CodeTaskAbilities {
 			return;
 		}
 
-		if ( ! class_exists( 'WP_Ability' ) ) {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
 			add_action( 'wp_abilities_api_init', function (): void {
-				if ( self::$registered || ! class_exists( 'WP_Ability' ) ) {
+				if ( self::$registered || ! function_exists( 'wp_register_ability' ) ) {
 					return;
 				}
 
@@ -34,7 +34,7 @@ class CodeTaskAbilities {
 			return;
 		}
 
-		if ( function_exists( 'doing_action' ) && ( doing_action( 'wp_abilities_api_init' ) || did_action( 'wp_abilities_api_init' ) ) ) {
+		if ( function_exists( 'doing_action' ) && doing_action( 'wp_abilities_api_init' ) ) {
 			$this->register();
 		} else {
 			add_action( 'wp_abilities_api_init', array( $this, 'register' ) );

--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -86,9 +86,9 @@ class GitHubAbilities {
 		if ( self::$registered ) {
 			return;
 		}
-		if ( ! class_exists( 'WP_Ability' ) ) {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
 			add_action( 'wp_abilities_api_init', function (): void {
-				if ( self::$registered || ! class_exists( 'WP_Ability' ) ) {
+				if ( self::$registered || ! function_exists( 'wp_register_ability' ) ) {
 					return;
 				}
 
@@ -1332,7 +1332,7 @@ class GitHubAbilities {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) || did_action( 'wp_abilities_api_init' ) ) {
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
 			$register_callback();
 		} else {
 			add_action( 'wp_abilities_api_init', $register_callback );

--- a/inc/Abilities/GitSyncAbilities.php
+++ b/inc/Abilities/GitSyncAbilities.php
@@ -30,9 +30,9 @@ class GitSyncAbilities {
 		if ( self::$registered ) {
 			return;
 		}
-		if ( ! class_exists( 'WP_Ability' ) ) {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
 			add_action( 'wp_abilities_api_init', function (): void {
-				if ( self::$registered || ! class_exists( 'WP_Ability' ) ) {
+				if ( self::$registered || ! function_exists( 'wp_register_ability' ) ) {
 					return;
 				}
 
@@ -311,7 +311,7 @@ class GitSyncAbilities {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) || did_action( 'wp_abilities_api_init' ) ) {
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
 			$register_callback();
 		} else {
 			add_action( 'wp_abilities_api_init', $register_callback );

--- a/inc/Abilities/WordPressRuntimeAbilities.php
+++ b/inc/Abilities/WordPressRuntimeAbilities.php
@@ -21,9 +21,9 @@ class WordPressRuntimeAbilities {
 			return;
 		}
 
-		if ( ! class_exists( 'WP_Ability' ) ) {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
 			add_action( 'wp_abilities_api_init', function (): void {
-				if ( self::$registered || ! class_exists( 'WP_Ability' ) ) {
+				if ( self::$registered || ! function_exists( 'wp_register_ability' ) ) {
 					return;
 				}
 
@@ -155,7 +155,7 @@ class WordPressRuntimeAbilities {
 			);
 		};
 
-		if ( function_exists( 'doing_action' ) && ( doing_action( 'wp_abilities_api_init' ) || did_action( 'wp_abilities_api_init' ) ) ) {
+		if ( function_exists( 'doing_action' ) && doing_action( 'wp_abilities_api_init' ) ) {
 			$register_callback();
 			return;
 		}

--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -33,9 +33,9 @@ class WorkspaceAbilities {
 			return;
 		}
 
-		if ( ! class_exists( 'WP_Ability' ) ) {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
 			add_action( 'wp_abilities_api_init', function (): void {
-				if ( self::$registered || ! class_exists( 'WP_Ability' ) ) {
+				if ( self::$registered || ! function_exists( 'wp_register_ability' ) ) {
 					return;
 				}
 
@@ -2167,7 +2167,7 @@ class WorkspaceAbilities {
 			}
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) || did_action( 'wp_abilities_api_init' ) ) {
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
 			$register_callback();
 		} else {
 			add_action( 'wp_abilities_api_init', $register_callback );

--- a/inc/Abilities/WorkspaceDiffAbilities.php
+++ b/inc/Abilities/WorkspaceDiffAbilities.php
@@ -99,7 +99,7 @@ class WorkspaceDiffAbilities {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
 			$register_callback();
 			return;
 		}

--- a/tests/smoke-deferred-ability-registration.php
+++ b/tests/smoke-deferred-ability-registration.php
@@ -29,10 +29,6 @@ namespace {
 	$GLOBALS['datamachine_code_registered_abilities'] = array();
 	$GLOBALS['datamachine_code_added_actions']        = array();
 
-	function wp_register_ability( string $name, array $definition ): void {
-		$GLOBALS['datamachine_code_registered_abilities'][ $name ] = $definition;
-	}
-
 	function doing_action( string $hook ): bool {
 		return false;
 	}
@@ -67,7 +63,9 @@ namespace {
 	$assert( 'constructors defer when WP_Ability is unavailable', 2 === count( $GLOBALS['datamachine_code_added_actions'] ) );
 	$assert( 'constructors do not register before WP_Ability is available', array() === $GLOBALS['datamachine_code_registered_abilities'] );
 
-	class WP_Ability {}
+	function wp_register_ability( string $name, array $definition ): void {
+		$GLOBALS['datamachine_code_registered_abilities'][ $name ] = $definition;
+	}
 
 	foreach ( $GLOBALS['datamachine_code_added_actions'] as $action ) {
 		if ( 'wp_abilities_api_init' === $action['hook'] ) {

--- a/tests/smoke-late-ability-registration.php
+++ b/tests/smoke-late-ability-registration.php
@@ -38,7 +38,7 @@ namespace {
 	}
 
 	function doing_action( string $hook ): bool {
-		return false;
+		return 'wp_abilities_api_init' === $hook;
 	}
 
 	function did_action( string $hook ): int {


### PR DESCRIPTION
## Summary
- Register DMC abilities only while `wp_abilities_api_init` is running, otherwise defer to the next hook run.
- Retry DMC bootstrap on later runtime hooks when Data Machine core becomes available after DMC is first loaded.
- Update smoke coverage for hook-time and deferred Abilities API registration.

## Verification
- `php tests/smoke-late-ability-registration.php`
- `php tests/smoke-deferred-ability-registration.php`
- `php -l data-machine-code.php && php -l inc/Abilities/WorkspaceAbilities.php && php -l inc/Abilities/GitHubAbilities.php && php -l inc/Abilities/GitSyncAbilities.php && php -l inc/Abilities/WordPressRuntimeAbilities.php && php -l inc/Abilities/CodeTaskAbilities.php && php -l inc/Abilities/WorkspaceDiffAbilities.php && php -l tests/smoke-deferred-ability-registration.php`
- Local wp-codebox probe confirmed `datamachine/workspace-show` and `datamachine/workspace-worktree-add` resolve inside `agent-sandbox-run`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Diagnosed the Abilities API hook replay behavior, drafted the bootstrap/registration fix and smoke updates, and ran local verification. Chris remains responsible for review and merge.