### PR TITLE
feat: add GitSync pull system task

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -303,6 +303,7 @@ add_filter( 'datamachine_tasks', function ( array $tasks ): array {
 	$tasks['workspace_disk_emergency_cleanup'] = \DataMachineCode\Tasks\WorkspaceDiskEmergencyCleanupTask::class;
 	$tasks['workspace_retention_cleanup']      = \DataMachineCode\Tasks\WorkspaceRetentionCleanupTask::class;
 	$tasks['workspace_hygiene_report']         = \DataMachineCode\Tasks\WorkspaceHygieneReportTask::class;
+	$tasks['gitsync_pull']                     = \DataMachineCode\Tasks\GitSyncPullTask::class;
 	return $tasks;
 } );
 

--- a/docs/gitsync.md
+++ b/docs/gitsync.md
@@ -92,6 +92,20 @@ wp datamachine-code gitsync unbind intelligence-wiki
 wp datamachine-code gitsync unbind intelligence-wiki --purge --yes
 ```
 
+## System task
+
+GitSync pull is also available as a Data Machine system task for flows that need
+to refresh a binding after a schedule or webhook trigger without shelling out to
+WP-CLI:
+
+```bash
+wp datamachine system run gitsync_pull --param=slug:intelligence-wiki
+wp datamachine system run gitsync_pull --param=slug:intelligence-wiki --param=allow_dirty:1
+```
+
+The task delegates to the same API-first `GitSync::pull()` path as the CLI and
+therefore does not require a local git binary, `.git` directory, or shell access.
+
 ## Abilities
 
 Every CLI subcommand is a thin shell over the matching ability. Consumers should call abilities directly, not the service class.

--- a/inc/Tasks/GitSyncPullTask.php
+++ b/inc/Tasks/GitSyncPullTask.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * GitSync Pull System Task.
+ *
+ * @package DataMachineCode\Tasks
+ */
+
+namespace DataMachineCode\Tasks;
+
+use DataMachine\Engine\AI\System\Tasks\SystemTask;
+use DataMachineCode\GitSync\GitSync;
+
+defined( 'ABSPATH' ) || exit;
+
+class GitSyncPullTask extends SystemTask {
+
+	public function getTaskType(): string {
+		return 'gitsync_pull';
+	}
+
+	/**
+	 * Task metadata for Data Machine system-task surfaces.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public static function getTaskMeta(): array {
+		return array(
+			'label'           => 'GitSync Pull',
+			'description'     => 'Pull a registered GitSync binding from GitHub into its site-owned local directory. Designed for webhook-triggered flows and managed hosts.',
+			'setting_key'     => null,
+			'default_enabled' => true,
+			'trigger'         => 'Manual, scheduled, or webhook-triggered Data Machine system task',
+			'trigger_type'    => 'manual_or_background',
+			'supports_run'    => true,
+		);
+	}
+
+	/**
+	 * Pull one GitSync binding.
+	 *
+	 * Params:
+	 * - slug: required GitSync binding slug.
+	 * - allow_dirty: optional bool to override conflict policy for this pull.
+	 *
+	 * @param int   $jobId  Data Machine job ID.
+	 * @param array $params Task params.
+	 */
+	public function executeTask( int $jobId, array $params ): void {
+		$slug = sanitize_key( (string) ( $params['slug'] ?? '' ) );
+		if ( '' === $slug ) {
+			$this->failJob( $jobId, 'gitsync_pull requires a slug parameter.' );
+			return;
+		}
+
+		$args = array();
+		if ( array_key_exists( 'allow_dirty', $params ) ) {
+			$args['allow_dirty'] = self::truthy( $params['allow_dirty'] );
+		}
+
+		$result = ( new GitSync() )->pull( $slug, $args );
+		if ( $result instanceof \WP_Error ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'GitSync pull failed',
+				array(
+					'task'  => $this->getTaskType(),
+					'jobId' => $jobId,
+					'slug'  => $slug,
+					'error' => $result->get_error_message(),
+					'code'  => $result->get_error_code(),
+				)
+			);
+			$this->failJob( $jobId, $result->get_error_message() );
+			return;
+		}
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'GitSync pull completed',
+			array(
+				'task'   => $this->getTaskType(),
+				'jobId'  => $jobId,
+				'slug'   => $slug,
+				'result' => $result,
+			)
+		);
+
+		$this->completeJob( $jobId, $result );
+	}
+
+	private static function truthy( mixed $value ): bool {
+		if ( is_bool( $value ) ) {
+			return $value;
+		}
+		return in_array( strtolower( (string) $value ), array( '1', 'true', 'yes', 'on' ), true );
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a `gitsync_pull` Data Machine system task that delegates to the existing API-first `GitSync::pull()` primitive.
- Registers the task so scheduled or webhook-triggered flows can refresh GitSync bindings without shelling out to WP-CLI.
- Documents the system-task usage in the GitSync docs.

## Verification
- `php -l inc/Tasks/GitSyncPullTask.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the task wrapper and documentation based on Chris's requested docs publishing workflow; Chris remains responsible for review and testing.