### PR TITLE
fix: control active cleanup child jobs

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -666,22 +666,56 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 
-		$input = array( 'job_id' => $job_id );
+		$target_job_ids = $this->cleanup_run_control_job_ids( $operation, $job_id );
+		$results        = array();
+		foreach ( $target_job_ids as $target_job_id ) {
+			$input = array( 'job_id' => $target_job_id );
+			if ( 'resume' === $operation ) {
+				$input['force'] = ! empty( $assoc_args['force'] );
+			} else {
+				$input['reason'] = 'cleanup_cancelled';
+			}
+
+			$result = $ability->execute( $input );
+			if ( ! ( $result['success'] ?? false ) ) {
+				WP_CLI::error( (string) ( $result['error'] ?? 'Cleanup run control failed.' ) );
+				return;
+			}
+			$results[] = $result;
+		}
+
+		$output = $results[0] ?? array( 'success' => true, 'job_id' => $job_id );
+		$output['run_id']             = $this->cleanup_run_id( $job_id );
+		$output['state']              = 'resume' === $operation ? 'running' : 'cancelled';
+		$output['controlled_job_ids'] = $target_job_ids;
+		$output['results']            = $results;
+		$this->render_cleanup_control_result( $output, $assoc_args );
+	}
+
+	/**
+	 * Resolve which Data Machine jobs should be controlled for a job-backed cleanup run.
+	 *
+	 * @param string $operation Cleanup control operation.
+	 * @param int    $job_id    Cleanup parent job ID.
+	 * @return array<int,int>
+	 */
+	private function cleanup_run_control_job_ids( string $operation, int $job_id ): array {
+		$output = $this->cleanup_run_evidence_store()->read( $this->cleanup_run_id( $job_id ), true, true );
+		if ( $output instanceof \WP_Error ) {
+			return array( $job_id );
+		}
+
+		$children       = (array) ( $output['evidence']['children'] ?? array() );
+		$processing_ids = array_map( 'intval', (array) ( $children['processing_job_ids'] ?? array() ) );
+		$failed_ids     = array_map( 'intval', (array) ( $children['failed_job_ids'] ?? array() ) );
+		$pending_ids    = array_map( 'intval', (array) ( $children['pending_job_ids'] ?? array() ) );
+
 		if ( 'resume' === $operation ) {
-			$input['force'] = ! empty( $assoc_args['force'] );
-		} else {
-			$input['reason'] = 'cleanup_cancelled';
+			$child_targets = array_values( array_unique( array_filter( array_merge( $processing_ids, $failed_ids ) ) ) );
+			return array() !== $child_targets ? $child_targets : array( $job_id );
 		}
 
-		$result = $ability->execute( $input );
-		if ( ! ( $result['success'] ?? false ) ) {
-			WP_CLI::error( (string) ( $result['error'] ?? 'Cleanup run control failed.' ) );
-			return;
-		}
-
-		$result['run_id'] = $this->cleanup_run_id( $job_id );
-		$result['state']  = 'resume' === $operation ? 'running' : 'cancelled';
-		$this->render_cleanup_control_result( $result, $assoc_args );
+		return array_values( array_unique( array_filter( array_merge( array( $job_id ), $pending_ids, $processing_ids ) ) ) );
 	}
 
 	private function render_cleanup_control_result( array $result, array $assoc_args ): void {

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -684,7 +684,10 @@ class WorkspaceCommand extends BaseCommand {
 			$results[] = $result;
 		}
 
-		$output = $results[0] ?? array( 'success' => true, 'job_id' => $job_id );
+		$output = $results[0] ?? array(
+			'success' => true,
+			'job_id'  => $job_id,
+		);
 		$output['run_id']             = $this->cleanup_run_id( $job_id );
 		$output['state']              = 'resume' === $operation ? 'running' : 'cancelled';
 		$output['controlled_job_ids'] = $target_job_ids;

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -684,7 +684,7 @@ class WorkspaceCommand extends BaseCommand {
 			$results[] = $result;
 		}
 
-		$output = $results[0] ?? array(
+		$output                       = $results[0] ?? array(
 			'success' => true,
 			'job_id'  => $job_id,
 		);

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -553,9 +553,11 @@ namespace {
 
 	class FakeRetryJobAbility {
 		public array $last_input = array();
+		public array $inputs = array();
 
 		public function execute( array $input ): array {
 			$this->last_input = $input;
+			$this->inputs[]   = $input;
 			return array(
 				'success'         => true,
 				'job_id'          => (int) $input['job_id'],
@@ -567,9 +569,11 @@ namespace {
 
 	class FakeFailJobAbility {
 		public array $last_input = array();
+		public array $inputs = array();
 
 		public function execute( array $input ): array {
 			$this->last_input = $input;
+			$this->inputs[]   = $input;
 			return array(
 				'success'         => true,
 				'job_id'          => (int) $input['job_id'],
@@ -714,11 +718,16 @@ namespace {
 	WP_CLI::$logs      = array();
 	WP_CLI::$successes = array();
 	$command->cleanup( array( 'resume', 'cleanup-run-123' ), array( 'force' => true, 'format' => 'json' ) );
+	$resume_json = json_decode( WP_CLI::$logs[0] ?? '', true );
+	datamachine_code_cleanup_assert( array( 125, 127 ) === ( $resume_json['controlled_job_ids'] ?? array() ), 'cleanup resume controls active child jobs before the parent' );
 	datamachine_code_cleanup_assert( true === ( $retry_job_ability->last_input['force'] ?? null ), 'cleanup resume forwards force retry flag' );
+	datamachine_code_cleanup_assert( array( 125, 127 ) === array_map( fn( $input ) => (int) ( $input['job_id'] ?? 0 ), $retry_job_ability->inputs ), 'cleanup resume retries processing and failed child jobs' );
 
 	WP_CLI::$logs      = array();
 	WP_CLI::$successes = array();
 	$command->cleanup( array( 'cancel', 'cleanup-run-123' ), array( 'format' => 'json' ) );
+	$cancel_json = json_decode( WP_CLI::$logs[0] ?? '', true );
+	datamachine_code_cleanup_assert( array( 123, 125 ) === ( $cancel_json['controlled_job_ids'] ?? array() ), 'cleanup cancel controls parent and active child jobs' );
 	datamachine_code_cleanup_assert( 'cleanup_cancelled' === ( $fail_job_ability->last_input['reason'] ?? '' ), 'cleanup cancel fails job with cleanup cancellation reason' );
 
 	echo "\n[0] list stale output exposes disk fields\n";


### PR DESCRIPTION
## Summary
- Route job-backed cleanup `resume`/`cancel` through active child jobs when a cleanup run has pending/processing/failed descendants.
- Return `controlled_job_ids` and per-job control results so operators can see what was actually retried or cancelled.
- Cover resume/cancel behavior in the worktree cleanup CLI smoke test.

## Testing
- `php -l inc/Cli/Commands/WorkspaceCommand.php`
- `php -l tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-worktree-cleanup-cli.php`

## Context
A local artifact cleanup run got stuck with parent job `2359` waiting on child job `2360`. The existing `workspace cleanup resume cleanup-run-2359` only controlled the parent job, leaving the active child in `processing` and the run summary blocked.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the stuck cleanup run, drafting the targeted CLI control fix, and adding smoke coverage. Chris remains responsible for review and merge.