### PR TITLE
fix: avoid nested gitsync proposal refs

### DIFF
--- a/inc/Abilities/GitSyncAbilities.php
+++ b/inc/Abilities/GitSyncAbilities.php
@@ -224,9 +224,9 @@ class GitSyncAbilities {
 						'type'       => 'object',
 						'required'   => array( 'slug', 'message' ),
 						'properties' => array(
-							'slug'    => array( 'type' => 'string' ),
-							'message' => array( 'type' => 'string' ),
-							'paths'   => array(
+							'slug'     => array( 'type' => 'string' ),
+							'message'  => array( 'type' => 'string' ),
+							'paths'    => array(
 								'type'        => 'array',
 								'items'       => array( 'type' => 'string' ),
 								'description' => 'Optional explicit list of relative paths. If omitted, every file with a SHA mismatch against upstream (filtered by allowed_paths) is submitted.',

--- a/inc/Abilities/GitSyncAbilities.php
+++ b/inc/Abilities/GitSyncAbilities.php
@@ -218,7 +218,7 @@ class GitSyncAbilities {
 				'datamachine/gitsync-submit',
 				array(
 					'label'               => 'Submit GitSync Binding as Pull Request',
-					'description'         => 'Upload changed local files to the sticky proposal branch (gitsync/<slug>) by default, or to a keyed proposal branch (gitsync/<slug>/<proposal-slug>) when proposal is provided, and open or update a PR against the pinned branch.',
+					'description'         => 'Upload changed local files to the sticky proposal branch (gitsync/<slug>) by default, or to a keyed proposal branch (gitsync/<slug>-<proposal-slug>) when proposal is provided, and open or update a PR against the pinned branch.',
 					'category'            => 'datamachine-code-gitsync',
 					'input_schema'        => array(
 						'type'       => 'object',
@@ -235,7 +235,7 @@ class GitSyncAbilities {
 							'body'     => array( 'type' => 'string' ),
 							'proposal' => array(
 								'type'        => 'string',
-								'description' => 'Optional proposal key. Omit to reuse gitsync/<slug>; pass a key to use gitsync/<slug>/<proposal-slug>.',
+								'description' => 'Optional proposal key. Omit to reuse gitsync/<slug>; pass a key to use gitsync/<slug>-<proposal-slug>.',
 							),
 						),
 					),

--- a/inc/Cli/Commands/GitSyncCommand.php
+++ b/inc/Cli/Commands/GitSyncCommand.php
@@ -340,7 +340,7 @@ class GitSyncCommand extends BaseCommand {
 	 *
 	 * [--proposal=<proposal>]
 	 * : Optional proposal key. Omit to reuse the sticky branch gitsync/<slug>;
-	 *   pass a key to use an isolated branch gitsync/<slug>/<proposal-slug>.
+	 *   pass a key to use an isolated branch gitsync/<slug>-<proposal-slug>.
 	 *
 	 * [--title=<title>]
 	 * : PR title. Defaults to --message.

--- a/inc/GitSync/GitSyncProposer.php
+++ b/inc/GitSync/GitSyncProposer.php
@@ -93,7 +93,7 @@ final class GitSyncProposer {
 			);
 		}
 
-		$proposal       = $this->normalizeProposalKey( (string) ( $args['proposal'] ?? '' ));
+		$proposal = $this->normalizeProposalKey( (string) ( $args['proposal'] ?? '' ));
 		if ( is_wp_error($proposal) ) {
 			return $proposal;
 		}

--- a/inc/GitSync/GitSyncProposer.php
+++ b/inc/GitSync/GitSyncProposer.php
@@ -60,7 +60,7 @@ final class GitSyncProposer {
 	 * @type   string   $title   PR title. Defaults to $message.
 	 * @type   string   $body    PR body. Defaults to an auto-summary.
 	 * @type   string   $proposal Optional proposal key. When present,
-	 *                             submits to gitsync/<slug>/<proposal-slug>.
+	 *                             submits to gitsync/<slug>-<proposal-slug>.
 	 * }
 	 * @return array<string, mixed>|\WP_Error
 	 */
@@ -99,7 +99,7 @@ final class GitSyncProposer {
 		}
 		$feature_branch = self::BRANCH_PREFIX . $binding->slug;
 		if ( null !== $proposal ) {
-			$feature_branch .= '/' . $proposal;
+			$feature_branch .= '-' . $proposal;
 		}
 
 		// Ensure the feature branch exists and points at the current

--- a/tests/smoke-gitsync.php
+++ b/tests/smoke-gitsync.php
@@ -458,9 +458,26 @@ namespace {
     // =========================================================================
     echo "\nSubmit (keyed proposal branch)\n";
     $GLOBALS['__dmc_http_mock']['GET https://api.github.com/repos/Automattic/a8c-wiki-woocommerce/git/ref/heads/gitsync%2Fwiki%2Fscript-modules'] = array(
+    'response' => array( 'code' => 500 ),
+    'body'     => json_encode(array( 'message' => 'Nested proposal ref must not be used' )),
+    );
+    $GLOBALS['__dmc_http_mock']['GET https://api.github.com/repos/Automattic/a8c-wiki-woocommerce/git/ref/heads/gitsync%2Fwiki-script-modules'] = array(
     'response' => array( 'code' => 404 ),
     'body'     => json_encode(array( 'message' => 'Not Found' )),
     );
+    $GLOBALS['__dmc_http_mock']['POST https://api.github.com/repos/Automattic/a8c-wiki-woocommerce/git/refs'] = static function ( string $url, array $args ): array {
+        $body = json_decode((string) ( $args['body'] ?? '' ), true);
+        if ( ! is_array($body) || 'refs/heads/gitsync/wiki-script-modules' !== ( $body['ref'] ?? null ) ) {
+            return array(
+            'response' => array( 'code' => 500 ),
+            'body'     => json_encode(array( 'message' => 'Unexpected proposal ref' )),
+            );
+        }
+        return array(
+        'response' => array( 'code' => 201 ),
+        'body'     => json_encode(array( 'ref' => 'refs/heads/gitsync/wiki-script-modules', 'object' => array( 'sha' => 'base-sha-1' ) )),
+        );
+    };
     $GLOBALS['__dmc_http_mock']['GET https://api.github.com/repos/Automattic/a8c-wiki-woocommerce/pulls'] = array(
     'response' => array( 'code' => 200 ),
     'body'     => '[]',
@@ -474,7 +491,7 @@ namespace {
     $keyed = $gs->submit('wiki', array( 'message' => 'script modules update', 'proposal' => 'Script Modules' ));
     $assert(! is_wp_error($keyed), 'keyed submit succeeded — ' . ( is_wp_error($keyed) ? $keyed->get_error_message() : '' ));
     $assert('script-modules' === ( $keyed['proposal'] ?? null ), 'proposal key normalized to script-modules');
-    $assert('gitsync/wiki/script-modules' === ( $keyed['branch'] ?? null ), 'keyed feature branch includes proposal slug');
+    $assert('gitsync/wiki-script-modules' === ( $keyed['branch'] ?? null ), 'keyed feature branch uses sibling proposal slug');
     $assert(8 === ( $keyed['pr']['number'] ?? null ), 'keyed proposal opened separate PR');
     $keyed_requests = array_slice($GLOBALS['__dmc_http_capture'], $capture_before_keyed);
     $keyed_pr_body  = null;
@@ -483,7 +500,45 @@ namespace {
             $keyed_pr_body = json_decode((string) $request['body'], true);
         }
     }
-    $assert('gitsync/wiki/script-modules' === ( $keyed_pr_body['head'] ?? null ), 'keyed PR uses keyed branch head');
+    $assert('gitsync/wiki-script-modules' === ( $keyed_pr_body['head'] ?? null ), 'keyed PR uses keyed branch head');
+    $used_nested_keyed_ref = false;
+    foreach ( $keyed_requests as $request ) {
+        $used_nested_keyed_ref = $used_nested_keyed_ref || str_contains((string) $request['url'], 'gitsync%2Fwiki%2Fscript-modules');
+    }
+    $assert(! $used_nested_keyed_ref, 'keyed submit avoids nested proposal ref URLs');
+
+    $GLOBALS['__dmc_http_mock']['GET https://api.github.com/repos/Automattic/a8c-wiki-woocommerce/git/ref/heads/gitsync%2Fwiki-script-modules'] = array(
+    'response' => array( 'code' => 200 ),
+    'body'     => json_encode(array( 'object' => array( 'sha' => 'keyed-feature-old-sha' ) )),
+    );
+    $GLOBALS['__dmc_http_mock']['PATCH https://api.github.com/repos/Automattic/a8c-wiki-woocommerce/git/refs/heads/gitsync%2Fwiki-script-modules'] = array(
+    'response' => array( 'code' => 200 ),
+    'body'     => json_encode(array( 'object' => array( 'sha' => 'base-sha-1' ) )),
+    );
+    $GLOBALS['__dmc_http_mock']['GET https://api.github.com/repos/Automattic/a8c-wiki-woocommerce/pulls'] = array(
+    'response' => array( 'code' => 200 ),
+    'body'     => json_encode(
+        array(
+        array( 'number' => 8, 'html_url' => 'https://github.com/a/b/pull/8', 'state' => 'open' ),
+        )
+    ),
+    );
+    $GLOBALS['__dmc_http_mock']['PATCH https://api.github.com/repos/Automattic/a8c-wiki-woocommerce/pulls/8'] = array(
+    'response' => array( 'code' => 200 ),
+    'body'     => json_encode(array( 'number' => 8, 'html_url' => 'https://github.com/a/b/pull/8', 'state' => 'open' )),
+    );
+    file_put_contents(ABSPATH . 'content/wiki/articles/a.md', "article a script modules proposal v2\n");
+    $capture_before_keyed_reuse = count($GLOBALS['__dmc_http_capture']);
+    $keyed_reuse                = $gs->submit('wiki', array( 'message' => 'script modules follow-up', 'proposal' => 'Script Modules' ));
+    $assert(! is_wp_error($keyed_reuse), 'keyed submit reuses sibling branch — ' . ( is_wp_error($keyed_reuse) ? $keyed_reuse->get_error_message() : '' ));
+    $assert('gitsync/wiki-script-modules' === ( $keyed_reuse['branch'] ?? null ), 'keyed branch reuse keeps sibling branch shape');
+    $assert('updated' === ( $keyed_reuse['pr']['action'] ?? null ), 'keyed proposal PR reported as updated');
+    $keyed_reuse_requests = array_slice($GLOBALS['__dmc_http_capture'], $capture_before_keyed_reuse);
+    $used_nested_keyed_ref = false;
+    foreach ( $keyed_reuse_requests as $request ) {
+        $used_nested_keyed_ref = $used_nested_keyed_ref || str_contains((string) $request['url'], 'gitsync%2Fwiki%2Fscript-modules');
+    }
+    $assert(! $used_nested_keyed_ref, 'keyed branch reuse avoids nested proposal ref URLs');
 
     // =========================================================================
     // 10. Submit with nothing changed → nothing_to_submit.


### PR DESCRIPTION
## Summary
- Keep default GitSync submit branches on the sticky `gitsync/<slug>` ref.
- Move keyed proposal branches to sibling refs like `gitsync/<slug>-<proposal-slug>` so they can coexist with the sticky branch.
- Update CLI/ability descriptions and smoke coverage for create/reuse of keyed sibling refs.

Fixes #453.
Related: #451.

## Verification
- `php tests/smoke-gitsync.php`
- `php -l inc/GitSync/GitSyncProposer.php`
- `php -l inc/Cli/Commands/GitSyncCommand.php`
- `php -l inc/Abilities/GitSyncAbilities.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the branch derivation fix, updated docs/tests, and ran verification; Chris remains responsible for review and merge.