### PR TITLE
fix: avoid gitsync proposal ref conflicts

### DIFF
--- a/inc/Abilities/GitSyncAbilities.php
+++ b/inc/Abilities/GitSyncAbilities.php
@@ -218,7 +218,7 @@ class GitSyncAbilities {
 				'datamachine/gitsync-submit',
 				array(
 					'label'               => 'Submit GitSync Binding as Pull Request',
-					'description'         => 'Upload changed local files to the sticky proposal branch (gitsync/<slug>) by default, or to a keyed proposal branch (gitsync/<slug>/<proposal-slug>) when proposal is provided, and open or update a PR against the pinned branch.',
+					'description'         => 'Upload changed local files to the sticky proposal branch (gitsync/<slug>) by default, or to a keyed proposal branch (gitsync/<slug>-<proposal-slug>) when proposal is provided, and open or update a PR against the pinned branch.',
 					'category'            => 'datamachine-code-gitsync',
 					'input_schema'        => array(
 						'type'       => 'object',
@@ -235,7 +235,7 @@ class GitSyncAbilities {
 							'body'     => array( 'type' => 'string' ),
 							'proposal' => array(
 								'type'        => 'string',
-								'description' => 'Optional proposal key. Omit to reuse gitsync/<slug>; pass a key to use gitsync/<slug>/<proposal-slug>.',
+								'description' => 'Optional proposal key. Omit to reuse gitsync/<slug>; pass a key to use gitsync/<slug>-<proposal-slug>.',
 							),
 						),
 					),

--- a/inc/Cli/Commands/GitSyncCommand.php
+++ b/inc/Cli/Commands/GitSyncCommand.php
@@ -340,7 +340,7 @@ class GitSyncCommand extends BaseCommand {
 	 *
 	 * [--proposal=<proposal>]
 	 * : Optional proposal key. Omit to reuse the sticky branch gitsync/<slug>;
-	 *   pass a key to use an isolated branch gitsync/<slug>/<proposal-slug>.
+	 *   pass a key to use an isolated branch gitsync/<slug>-<proposal-slug>.
 	 *
 	 * [--title=<title>]
 	 * : PR title. Defaults to --message.

--- a/inc/GitSync/GitSyncProposer.php
+++ b/inc/GitSync/GitSyncProposer.php
@@ -60,7 +60,7 @@ final class GitSyncProposer {
 	 * @type   string   $title   PR title. Defaults to $message.
 	 * @type   string   $body    PR body. Defaults to an auto-summary.
 	 * @type   string   $proposal Optional proposal key. When present,
-	 *                             submits to gitsync/<slug>/<proposal-slug>.
+	 *                             submits to gitsync/<slug>-<proposal-slug>.
 	 * }
 	 * @return array<string, mixed>|\WP_Error
 	 */
@@ -99,7 +99,7 @@ final class GitSyncProposer {
 		}
 		$feature_branch = self::BRANCH_PREFIX . $binding->slug;
 		if ( null !== $proposal ) {
-			$feature_branch .= '/' . $proposal;
+			$feature_branch .= '-' . $proposal;
 		}
 
 		// Ensure the feature branch exists and points at the current

--- a/tests/smoke-gitsync.php
+++ b/tests/smoke-gitsync.php
@@ -457,7 +457,9 @@ namespace {
     // 9. Submit with a proposal key — isolated branch and PR lookup.
     // =========================================================================
     echo "\nSubmit (keyed proposal branch)\n";
-    $GLOBALS['__dmc_http_mock']['GET https://api.github.com/repos/Automattic/a8c-wiki-woocommerce/git/ref/heads/gitsync%2Fwiki%2Fscript-modules'] = array(
+    // Sticky branch gitsync/wiki already exists from the default submit flow;
+    // keyed proposals must use a sibling ref so both branches can coexist.
+    $GLOBALS['__dmc_http_mock']['GET https://api.github.com/repos/Automattic/a8c-wiki-woocommerce/git/ref/heads/gitsync%2Fwiki-script-modules'] = array(
     'response' => array( 'code' => 404 ),
     'body'     => json_encode(array( 'message' => 'Not Found' )),
     );
@@ -474,16 +476,26 @@ namespace {
     $keyed = $gs->submit('wiki', array( 'message' => 'script modules update', 'proposal' => 'Script Modules' ));
     $assert(! is_wp_error($keyed), 'keyed submit succeeded — ' . ( is_wp_error($keyed) ? $keyed->get_error_message() : '' ));
     $assert('script-modules' === ( $keyed['proposal'] ?? null ), 'proposal key normalized to script-modules');
-    $assert('gitsync/wiki/script-modules' === ( $keyed['branch'] ?? null ), 'keyed feature branch includes proposal slug');
+    $assert('gitsync/wiki-script-modules' === ( $keyed['branch'] ?? null ), 'keyed feature branch is sibling of sticky branch');
     $assert(8 === ( $keyed['pr']['number'] ?? null ), 'keyed proposal opened separate PR');
-    $keyed_requests = array_slice($GLOBALS['__dmc_http_capture'], $capture_before_keyed);
-    $keyed_pr_body  = null;
+    $keyed_requests       = array_slice($GLOBALS['__dmc_http_capture'], $capture_before_keyed);
+    $keyed_pr_body        = null;
+    $keyed_ref_body       = null;
+    $saw_nested_keyed_ref = false;
     foreach ( $keyed_requests as $request ) {
         if ( 'POST' === $request['method'] && str_ends_with($request['url'], '/pulls') ) {
             $keyed_pr_body = json_decode((string) $request['body'], true);
         }
+        if ( 'POST' === $request['method'] && str_ends_with($request['url'], '/git/refs') ) {
+            $keyed_ref_body = json_decode((string) $request['body'], true);
+        }
+        if ( str_contains($request['url'], 'gitsync%2Fwiki%2Fscript-modules') ) {
+            $saw_nested_keyed_ref = true;
+        }
     }
-    $assert('gitsync/wiki/script-modules' === ( $keyed_pr_body['head'] ?? null ), 'keyed PR uses keyed branch head');
+    $assert('refs/heads/gitsync/wiki-script-modules' === ( $keyed_ref_body['ref'] ?? null ), 'keyed branch ref coexists with sticky branch namespace');
+    $assert('gitsync/wiki-script-modules' === ( $keyed_pr_body['head'] ?? null ), 'keyed PR uses keyed branch head');
+    $assert(false === $saw_nested_keyed_ref, 'keyed submit does not request nested sticky-branch ref');
 
     // =========================================================================
     // 10. Submit with nothing changed → nothing_to_submit.


### PR DESCRIPTION
## Summary
- Derive keyed GitSync proposal branches as `gitsync/<slug>-<proposal>` so they do not nest under the sticky `gitsync/<slug>` ref.
- Preserve default submit behavior on `gitsync/<slug>`.
- Update CLI/ability help and smoke coverage for sticky/keyed branch coexistence.

Fixes #453.
Related: #451.

## Verification
- `php tests/smoke-gitsync.php`
- `php -l inc/GitSync/GitSyncProposer.php && php -l inc/Cli/Commands/GitSyncCommand.php && php -l inc/Abilities/GitSyncAbilities.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the branch derivation fix, updated docs/tests, and ran verification; Chris remains responsible for review and merge.