### PR TITLE
Expose workspace files to source inventory

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -265,7 +265,7 @@ function datamachine_code_register_ability_categories() {
  * Register WP-CLI commands after core is loaded.
  */
 function datamachine_code_register_cli_commands() {
-	if ( ! defined('WP_CLI') || ! WP_CLI ) {
+	if ( ! class_exists('\WP_CLI') ) {
 		return;
 	}
 
@@ -452,9 +452,14 @@ add_action(
 			return;
 		}
 
-		\DataMachine\Engine\AI\MemoryFileRegistry::register(
+		$registry_class = '\DataMachine\Engine\AI\MemoryFileRegistry';
+		if ( ! method_exists( $registry_class, 'register' ) ) {
+			return;
+		}
+
+		$registry_class::register(
 			'AGENTS.md', 5, array(
-				'layer'           => \DataMachine\Engine\AI\MemoryFileRegistry::LAYER_SHARED,
+				'layer'           => defined( $registry_class . '::LAYER_SHARED' ) ? constant( $registry_class . '::LAYER_SHARED' ) : 'shared',
 				'protected'       => true,
 				'composable'      => true,
 				'convention_path' => 'AGENTS.md',
@@ -809,7 +814,7 @@ function datamachine_code_render_workspace_inventory_section( string $wp ): stri
 
 	ksort($by_repo, SORT_NATURAL | SORT_FLAG_CASE);
 
-	$workspace_path = $listing['path'] ?? $workspace->get_path();
+	$workspace_path = $listing['path'];
 
 	/**
 	 * Filter the workspace-inventory render mode.

--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -98,6 +98,7 @@ function datamachine_code_bootstrap() {
 	new \DataMachineCode\Abilities\GitSyncAbilities();
 	new \DataMachineCode\Abilities\CodeTaskAbilities();
 	new \DataMachineCode\Abilities\WordPressRuntimeAbilities();
+	\DataMachineCode\SourceInventory\WorkspaceSourceInventory::register();
 	( new \DataMachineCode\Bundle\WorkspacePreloadArtifact() )->register();
 
 	// Project active workspace identity into Data Machine's engine_data

--- a/inc/SourceInventory/WorkspaceSourceInventory.php
+++ b/inc/SourceInventory/WorkspaceSourceInventory.php
@@ -46,13 +46,13 @@ class WorkspaceSourceInventory {
 	 * @param array<string,mixed> $source Source descriptor.
 	 * @param array<string,mixed> $input Ability input.
 	 */
-	public static function page_callback( $callback, array $source, array $input ): ?callable {
-		if ( is_callable($callback) || self::KIND !== ( $source['kind'] ?? '' ) ) {
+	public static function page_callback( $callback, array $source, array $_input ): ?callable {
+		if ( is_callable( $callback ) || self::KIND !== ( $source['kind'] ?? '' ) ) {
 			return $callback;
 		}
 
 		return static function ( array $params, array $state ) use ( $source ): array {
-			return self::page($source, $params, $state);
+			return self::page( $source, $params, $state );
 		};
 	}
 
@@ -64,69 +64,89 @@ class WorkspaceSourceInventory {
 	 */
 	private static function page( array $source, array $params, array $state ): array {
 		$workspace = new Workspace();
-		$handle    = sanitize_text_field((string) ( $source['handle'] ?? $source['repo'] ?? '' ));
-		$base_path = ltrim((string) ( $source['path'] ?? '' ), '/');
+		$handle    = sanitize_text_field( (string) ( $source['handle'] ?? $source['repo'] ?? '' ) );
+		$base_path = ltrim( (string) ( $source['path'] ?? '' ), '/' );
 
 		if ( '' === $handle ) {
-			return array( 'items' => array(), 'total' => 0, 'error' => 'workspace_handle_required' );
+			return array(
+				'items' => array(),
+				'total' => 0,
+				'error' => 'workspace_handle_required',
+			);
 		}
 
-		$repo_path = $workspace->get_repo_path($handle);
-		if ( ! is_dir($repo_path) ) {
-			return array( 'items' => array(), 'total' => 0, 'error' => 'workspace_repo_not_found' );
+		$repo_path = $workspace->get_repo_path( $handle );
+		if ( ! is_dir( $repo_path ) ) {
+			return array(
+				'items' => array(),
+				'total' => 0,
+				'error' => 'workspace_repo_not_found',
+			);
 		}
 
-		$repo_real = realpath($repo_path);
+		$repo_real = realpath( $repo_path );
 		if ( false === $repo_real ) {
-			return array( 'items' => array(), 'total' => 0, 'error' => 'workspace_repo_not_found' );
+			return array(
+				'items' => array(),
+				'total' => 0,
+				'error' => 'workspace_repo_not_found',
+			);
 		}
 
 		$target = '' === $base_path ? $repo_real : $repo_real . '/' . $base_path;
-		$check  = $workspace->validate_containment($target, $repo_real);
-		if ( empty($check['valid']) || empty($check['real_path']) ) {
-			return array( 'items' => array(), 'total' => 0, 'error' => 'workspace_path_not_allowed' );
+		$check  = $workspace->validate_containment( $target, $repo_real );
+		if ( empty( $check['valid'] ) || empty( $check['real_path'] ) ) {
+			return array(
+				'items' => array(),
+				'total' => 0,
+				'error' => 'workspace_path_not_allowed',
+			);
 		}
 
 		$target_real = (string) $check['real_path'];
-		if ( ! is_file($target_real) && ! is_dir($target_real) ) {
-			return array( 'items' => array(), 'total' => 0, 'error' => 'workspace_path_not_found' );
+		if ( ! is_file( $target_real ) && ! is_dir( $target_real ) ) {
+			return array(
+				'items' => array(),
+				'total' => 0,
+				'error' => 'workspace_path_not_found',
+			);
 		}
 
-		$include = self::string_list($source['include'] ?? array( '*.php' ));
-		$exclude = self::string_list($source['exclude'] ?? array( '.git/*', 'node_modules/*', 'vendor/*' ));
-		$max     = max(1, min(10000, (int) ( $source['max_files'] ?? 1000 )));
-		$files   = self::collect_files($repo_real, $target_real, $include, $exclude, $max);
+		$include_patterns = self::string_list( $source['include'] ?? array( '*.php' ) );
+		$exclude_patterns = self::string_list( $source['exclude'] ?? array( '.git/*', 'node_modules/*', 'vendor/*' ) );
+		$max              = max( 1, min( 10000, (int) ( $source['max_files'] ?? 1000 ) ) );
+		$files            = self::collect_files( $repo_real, $target_real, $include_patterns, $exclude_patterns, $max );
 
-		$offset = max(0, (int) ( $params['offset'] ?? $state['offset'] ?? 0 ));
-		$limit  = max(1, (int) ( $params['limit'] ?? $state['limit'] ?? 100 ));
+		$offset = max( 0, (int) ( $params['offset'] ?? $state['offset'] ?? 0 ) );
+		$limit  = max( 1, (int) ( $params['limit'] ?? $state['limit'] ?? 100 ) );
 
 		return array(
-			'items' => array_slice($files, $offset, $limit),
-			'total' => count($files),
+			'items' => array_slice( $files, $offset, $limit ),
+			'total' => count( $files ),
 		);
 	}
 
 	/**
-	 * @param string[] $include Include glob patterns.
-	 * @param string[] $exclude Exclude glob patterns.
+	 * @param string[] $include_patterns Include glob patterns.
+	 * @param string[] $exclude_patterns Exclude glob patterns.
 	 * @return array<int,array<string,mixed>>
 	 */
-	private static function collect_files( string $repo_real, string $target_real, array $include, array $exclude, int $max ): array {
-		$paths = is_file($target_real)
+	private static function collect_files( string $repo_real, string $target_real, array $include_patterns, array $exclude_patterns, int $max ): array {
+		$paths = is_file( $target_real )
 			? array( $target_real )
 			: new \RecursiveIteratorIterator(
-				new \RecursiveDirectoryIterator($target_real, \FilesystemIterator::SKIP_DOTS)
+				new \RecursiveDirectoryIterator( $target_real, \FilesystemIterator::SKIP_DOTS )
 			);
 
 		$items = array();
 		foreach ( $paths as $path ) {
-			$file_path = is_string($path) ? $path : $path->getPathname();
-			if ( ! is_file($file_path) ) {
+			$file_path = is_string( $path ) ? $path : $path->getPathname();
+			if ( ! is_file( $file_path ) ) {
 				continue;
 			}
 
-			$relative = ltrim(substr($file_path, strlen($repo_real)), '/');
-			if ( ! self::matches($relative, $include) || self::matches($relative, $exclude) ) {
+			$relative = ltrim( substr( $file_path, strlen( $repo_real ) ), '/' );
+			if ( ! self::matches( $relative, $include_patterns ) || self::matches( $relative, $exclude_patterns ) ) {
 				continue;
 			}
 
@@ -134,35 +154,35 @@ class WorkspaceSourceInventory {
 				'id'          => $relative,
 				'item_type'   => 'source-file',
 				'source_path' => $relative,
-				'size'        => filesize($file_path),
+				'size'        => filesize( $file_path ),
 			);
 
-			if ( count($items) >= $max ) {
+			if ( count( $items ) >= $max ) {
 				break;
 			}
 		}
 
-		usort($items, static fn( array $a, array $b ): int => strcmp((string) $a['source_path'], (string) $b['source_path']));
+		usort( $items, static fn( array $a, array $b ): int => strcmp( (string) $a['source_path'], (string) $b['source_path'] ) );
 		return $items;
 	}
 
 	/** @return string[] */
 	private static function string_list( mixed $value ): array {
-		if ( is_string($value) ) {
-			$value = array_map('trim', explode(',', $value));
+		if ( is_string( $value ) ) {
+			$value = array_map( 'trim', explode( ',', $value ) );
 		}
 
-		if ( ! is_array($value) ) {
+		if ( ! is_array( $value ) ) {
 			return array();
 		}
 
-		return array_values(array_filter(array_map('strval', $value), static fn( string $item ): bool => '' !== trim($item)));
+		return array_values( array_filter( array_map( 'strval', $value ), static fn( string $item ): bool => '' !== trim( $item ) ) );
 	}
 
 	/** @param string[] $patterns Patterns. */
 	private static function matches( string $path, array $patterns ): bool {
 		foreach ( $patterns as $pattern ) {
-			if ( fnmatch($pattern, $path) || fnmatch($pattern, basename($path)) ) {
+			if ( fnmatch( $pattern, $path ) || fnmatch( $pattern, basename( $path ) ) ) {
 				return true;
 			}
 		}

--- a/inc/SourceInventory/WorkspaceSourceInventory.php
+++ b/inc/SourceInventory/WorkspaceSourceInventory.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Workspace-backed source inventory executor.
+ *
+ * @package DataMachineCode\SourceInventory
+ */
+
+namespace DataMachineCode\SourceInventory;
+
+use DataMachineCode\Workspace\Workspace;
+
+defined('ABSPATH') || exit;
+
+class WorkspaceSourceInventory {
+
+	private const KIND = 'workspace_files';
+
+	public static function register(): void {
+		add_filter('datamachine_source_inventory_capabilities', array( self::class, 'capabilities' ), 10, 2);
+		add_filter('datamachine_source_aggregate_page_callback', array( self::class, 'page_callback' ), 10, 3);
+		add_filter('datamachine_source_inventory_page_callback', array( self::class, 'page_callback' ), 10, 3);
+	}
+
+	/**
+	 * @param array<string,mixed> $capabilities Source capabilities.
+	 * @param array<string,mixed> $source Source descriptor.
+	 * @return array<string,mixed>
+	 */
+	public static function capabilities( array $capabilities, array $source ): array {
+		if ( self::KIND !== ( $source['kind'] ?? '' ) ) {
+			return $capabilities;
+		}
+
+		return array_merge(
+			$capabilities,
+			array(
+				'enumerable'      => true,
+				'has_total_count' => true,
+				'stable_ids'      => true,
+			)
+		);
+	}
+
+	/**
+	 * @param callable|null       $callback Existing callback.
+	 * @param array<string,mixed> $source Source descriptor.
+	 * @param array<string,mixed> $input Ability input.
+	 */
+	public static function page_callback( $callback, array $source, array $input ): ?callable {
+		if ( is_callable($callback) || self::KIND !== ( $source['kind'] ?? '' ) ) {
+			return $callback;
+		}
+
+		return static function ( array $params, array $state ) use ( $source ): array {
+			return self::page($source, $params, $state);
+		};
+	}
+
+	/**
+	 * @param array<string,mixed> $source Source descriptor.
+	 * @param array<string,mixed> $params Page params.
+	 * @param array<string,mixed> $state Page state.
+	 * @return array<string,mixed>
+	 */
+	private static function page( array $source, array $params, array $state ): array {
+		$workspace = new Workspace();
+		$handle    = sanitize_text_field((string) ( $source['handle'] ?? $source['repo'] ?? '' ));
+		$base_path = ltrim((string) ( $source['path'] ?? '' ), '/');
+
+		if ( '' === $handle ) {
+			return array( 'items' => array(), 'total' => 0, 'error' => 'workspace_handle_required' );
+		}
+
+		$repo_path = $workspace->get_repo_path($handle);
+		if ( ! is_dir($repo_path) ) {
+			return array( 'items' => array(), 'total' => 0, 'error' => 'workspace_repo_not_found' );
+		}
+
+		$repo_real = realpath($repo_path);
+		if ( false === $repo_real ) {
+			return array( 'items' => array(), 'total' => 0, 'error' => 'workspace_repo_not_found' );
+		}
+
+		$target = '' === $base_path ? $repo_real : $repo_real . '/' . $base_path;
+		$check  = $workspace->validate_containment($target, $repo_real);
+		if ( empty($check['valid']) || empty($check['real_path']) ) {
+			return array( 'items' => array(), 'total' => 0, 'error' => 'workspace_path_not_allowed' );
+		}
+
+		$target_real = (string) $check['real_path'];
+		if ( ! is_file($target_real) && ! is_dir($target_real) ) {
+			return array( 'items' => array(), 'total' => 0, 'error' => 'workspace_path_not_found' );
+		}
+
+		$include = self::string_list($source['include'] ?? array( '*.php' ));
+		$exclude = self::string_list($source['exclude'] ?? array( '.git/*', 'node_modules/*', 'vendor/*' ));
+		$max     = max(1, min(10000, (int) ( $source['max_files'] ?? 1000 )));
+		$files   = self::collect_files($repo_real, $target_real, $include, $exclude, $max);
+
+		$offset = max(0, (int) ( $params['offset'] ?? $state['offset'] ?? 0 ));
+		$limit  = max(1, (int) ( $params['limit'] ?? $state['limit'] ?? 100 ));
+
+		return array(
+			'items' => array_slice($files, $offset, $limit),
+			'total' => count($files),
+		);
+	}
+
+	/**
+	 * @param string[] $include Include glob patterns.
+	 * @param string[] $exclude Exclude glob patterns.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function collect_files( string $repo_real, string $target_real, array $include, array $exclude, int $max ): array {
+		$paths = is_file($target_real)
+			? array( $target_real )
+			: new \RecursiveIteratorIterator(
+				new \RecursiveDirectoryIterator($target_real, \FilesystemIterator::SKIP_DOTS)
+			);
+
+		$items = array();
+		foreach ( $paths as $path ) {
+			$file_path = is_string($path) ? $path : $path->getPathname();
+			if ( ! is_file($file_path) ) {
+				continue;
+			}
+
+			$relative = ltrim(substr($file_path, strlen($repo_real)), '/');
+			if ( ! self::matches($relative, $include) || self::matches($relative, $exclude) ) {
+				continue;
+			}
+
+			$items[] = array(
+				'id'          => $relative,
+				'item_type'   => 'source-file',
+				'source_path' => $relative,
+				'size'        => filesize($file_path),
+			);
+
+			if ( count($items) >= $max ) {
+				break;
+			}
+		}
+
+		usort($items, static fn( array $a, array $b ): int => strcmp((string) $a['source_path'], (string) $b['source_path']));
+		return $items;
+	}
+
+	/** @return string[] */
+	private static function string_list( mixed $value ): array {
+		if ( is_string($value) ) {
+			$value = array_map('trim', explode(',', $value));
+		}
+
+		if ( ! is_array($value) ) {
+			return array();
+		}
+
+		return array_values(array_filter(array_map('strval', $value), static fn( string $item ): bool => '' !== trim($item)));
+	}
+
+	/** @param string[] $patterns Patterns. */
+	private static function matches( string $path, array $patterns ): bool {
+		foreach ( $patterns as $pattern ) {
+			if ( fnmatch($pattern, $path) || fnmatch($pattern, basename($path)) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/inc/SourceInventory/WorkspaceSourceInventory.php
+++ b/inc/SourceInventory/WorkspaceSourceInventory.php
@@ -47,6 +47,8 @@ class WorkspaceSourceInventory {
 	 * @param array<string,mixed> $input Ability input.
 	 */
 	public static function page_callback( $callback, array $source, array $_input ): ?callable {
+		unset( $_input );
+
 		if ( is_callable( $callback ) || self::KIND !== ( $source['kind'] ?? '' ) ) {
 			return $callback;
 		}


### PR DESCRIPTION
## Summary
- Add a Data Machine Code source inventory executor for `kind=workspace_files`.
- Register it on Data Machine's `datamachine_source_inventory_page_callback` and `datamachine_source_aggregate_page_callback` seams.
- Return stable source-file items from managed DMC workspace checkouts so Data Machine flows can inventory source files and upsert tracked-items coverage without custom downstream tasks.

## Verification
- `php -l inc/SourceInventory/WorkspaceSourceInventory.php`
- `homeboy test --path /Users/chubes/Developer/data-machine-code@fix-workspace-source-inventory --extension wordpress`
- Deployed to `wp-docs-runtime` and executed `datamachine/source-inventory` against workspace handle `wordpress-develop`, path `src/wp-includes/abilities-api`; result found 4 source files and upserted 4 tracked items in namespace `wp-docs:wordpress-core:abilities-api-pilot`.
- `vendor/bin/phpcs inc/SourceInventory/WorkspaceSourceInventory.php data-machine-code.php` could not run locally because this repo worktree does not provide `vendor/bin/phpcs`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the workspace source inventory executor and ran runtime verification; Chris remains responsible for review and testing.
