### PR TITLE
Expose workspace tools in sandbox mode

### DIFF
--- a/inc/Tools/WorkspaceTools.php
+++ b/inc/Tools/WorkspaceTools.php
@@ -76,8 +76,8 @@ class WorkspaceTools extends BaseTool
      */
     public function __construct()
     {
-        $contexts        = array( 'chat', 'pipeline' );
-        $policy_contexts = array( 'chat', 'pipeline' );
+        $contexts        = array( 'chat', 'pipeline', 'sandbox' );
+        $policy_contexts = array( 'chat', 'pipeline', 'sandbox' );
         $policy_meta     = array( 'requires_opt_in' => true );
         $this->registerTool('workspace_path', array( $this, 'getPathDefinition' ), $contexts, array( 'ability' => 'datamachine/workspace-path' ));
         $this->registerTool('workspace_capabilities', array( $this, 'getCapabilitiesDefinition' ), $contexts, array( 'ability' => 'datamachine/workspace-capabilities' ));

--- a/inc/Workspace/RemoteWorkspaceBackend.php
+++ b/inc/Workspace/RemoteWorkspaceBackend.php
@@ -22,7 +22,10 @@ class RemoteWorkspaceBackend {
 	 * Whether the remote backend should handle workspace operations.
 	 */
 	public static function should_handle(): bool {
-		return ! \DataMachineCode\Support\GitRunner::is_available();
+		$should_handle = ! \DataMachineCode\Support\GitRunner::is_available();
+		return function_exists('apply_filters')
+			? (bool) apply_filters('datamachine_code_remote_workspace_backend_should_handle', $should_handle)
+			: $should_handle;
 	}
 
 	/**

--- a/tests/smoke-workspace-policy-tools.php
+++ b/tests/smoke-workspace-policy-tools.php
@@ -91,7 +91,7 @@ namespace {
     );
 
     foreach ( $default_pipeline_tools as $tool ) {
-        $assert("{$tool} remains default pipeline-visible", array( 'chat', 'pipeline' ) === ( $tools[ $tool ]['modes'] ?? null ));
+        $assert("{$tool} remains default pipeline-visible and sandbox-visible", array( 'chat', 'pipeline', 'sandbox' ) === ( $tools[ $tool ]['modes'] ?? null ));
     }
 
     $policy_tools = array(
@@ -114,7 +114,7 @@ namespace {
     );
 
     foreach ( $policy_tools as $tool ) {
-        $assert("{$tool} is available in real chat and pipeline modes", array( 'chat', 'pipeline' ) === ( $tools[ $tool ]['modes'] ?? null ));
+        $assert("{$tool} is available in real chat, pipeline, and sandbox modes", array( 'chat', 'pipeline', 'sandbox' ) === ( $tools[ $tool ]['modes'] ?? null ));
         $assert("{$tool} requires explicit opt-in for pipeline use", true === ( $tools[ $tool ]['requires_opt_in'] ?? null ));
     }
 


### PR DESCRIPTION
## Summary
- Register Data Machine Code workspace tools for `sandbox` mode in addition to `chat` and `pipeline`.
- Keep write/edit/git tools marked as explicit opt-in tools.
- Add a `datamachine_code_remote_workspace_backend_should_handle` filter so sandbox hosts can force the mounted local workspace backend even when `git` is unavailable.
- Update the workspace policy smoke test to cover sandbox mode exposure.

## Tests
- `php tests/smoke-workspace-policy-tools.php`
- `php tests/smoke-remote-workspace-backend.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine-code@fix-workspace-tools-sandbox-mode --extension wordpress --changed-since origin/main --errors-only`

Fixes https://github.com/chubes4/wp-codebox/issues/175

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Traced WP Codebox sandbox failures to missing Data Machine Code tool mode registration and backend routing, drafted the minimal mode/filter updates and smoke-test coverage, and ran focused verification.