### PR TITLE
Prevent repeated workspace show loops

### DIFF
--- a/inc/Tools/WorkspaceTools.php
+++ b/inc/Tools/WorkspaceTools.php
@@ -908,8 +908,7 @@ class WorkspaceTools extends BaseTool
      */
     public function getShowDefinition(): array
     {
-        return $this->repeatableDefinition(
-            array(
+        return array(
             'class'       => __CLASS__,
             'method'      => 'handleShow',
             'description' => 'Show detailed information about a workspace repository (branch, remote, latest commit, dirty count).',
@@ -923,7 +922,6 @@ class WorkspaceTools extends BaseTool
             ),
             'required'   => array( 'name' ),
             ),
-            ) 
         );
     }
 

--- a/tests/smoke-workspace-policy-tools.php
+++ b/tests/smoke-workspace-policy-tools.php
@@ -77,7 +77,7 @@ namespace {
 
     echo "Workspace policy tools - smoke\n";
 
-    new \DataMachineCode\Tools\WorkspaceTools();
+    $workspace_tools = new \DataMachineCode\Tools\WorkspaceTools();
     $tools = apply_filters('datamachine_tools', array());
 
     $default_pipeline_tools = array(
@@ -93,6 +93,12 @@ namespace {
     foreach ( $default_pipeline_tools as $tool ) {
         $assert("{$tool} remains default pipeline-visible", array( 'chat', 'pipeline' ) === ( $tools[ $tool ]['modes'] ?? null ));
     }
+
+    $show_definition = $workspace_tools->getShowDefinition();
+    $assert('workspace_show does not allow duplicate repeat calls', 'repeatable' !== ( $show_definition['runtime']['duplicate_policy'] ?? null ));
+
+    $ls_definition = $workspace_tools->getLsDefinition();
+    $assert('workspace_ls still allows intentional repeat calls', 'repeatable' === ( $ls_definition['runtime']['duplicate_policy'] ?? null ));
 
     $policy_tools = array(
     'workspace_write',


### PR DESCRIPTION
## Summary
- stop marking `workspace_show` as repeatable so exact duplicate calls can be rejected by Data Machine
- keep `workspace_ls` repeatable for intentional repeated directory inspection
- cover the runtime duplicate policy in the workspace policy smoke test

## Testing
- php tests/smoke-workspace-policy-tools.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the World Creator loop, drafted the workspace tool policy fix, and ran the targeted smoke test; Chris remains responsible for review and merge.