### PR TITLE
Prevent repeated workspace git status loops

### DIFF
--- a/inc/Tools/WorkspaceTools.php
+++ b/inc/Tools/WorkspaceTools.php
@@ -1143,7 +1143,7 @@ class WorkspaceTools extends BaseTool
      */
     public function getGitStatusDefinition(): array
     {
-        return $this->simpleGitDefinition('handleGitStatus', 'Get git status information for a workspace handle.', array(), array( 'name' ), array( 'duplicate_policy' => 'repeatable' ));
+        return $this->simpleGitDefinition('handleGitStatus', 'Get git status information for a workspace handle. Use once to inspect cleanliness, then move to a concrete edit, commit, or completion outcome.', array());
     }
 
     /**

--- a/tests/smoke-workspace-policy-tools.php
+++ b/tests/smoke-workspace-policy-tools.php
@@ -97,6 +97,9 @@ namespace {
     $show_definition = $workspace_tools->getShowDefinition();
     $assert('workspace_show does not allow duplicate repeat calls', 'repeatable' !== ( $show_definition['runtime']['duplicate_policy'] ?? null ));
 
+    $git_status_definition = $workspace_tools->getGitStatusDefinition();
+    $assert('workspace_git_status does not allow duplicate repeat calls', 'repeatable' !== ( $git_status_definition['runtime']['duplicate_policy'] ?? null ));
+
     $ls_definition = $workspace_tools->getLsDefinition();
     $assert('workspace_ls still allows intentional repeat calls', 'repeatable' === ( $ls_definition['runtime']['duplicate_policy'] ?? null ));
 


### PR DESCRIPTION
## Summary
- remove repeatable duplicate policy from `workspace_git_status`
- clarify the tool description so agents move from status inspection to edits, commits, or completion outcomes
- add smoke coverage that `workspace_git_status` is not repeatable while `workspace_ls` remains intentionally repeatable

## Testing
- `php tests/smoke-workspace-policy-tools.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the repeated `workspace_git_status` loop from the World Creator run artifact, drafted the narrow DMC tool-policy change, and ran the targeted smoke test. Chris remains responsible for review and merge.