### PR TITLE
Revert sandbox-specific workspace changes

### DIFF
--- a/inc/Tools/WorkspaceTools.php
+++ b/inc/Tools/WorkspaceTools.php
@@ -76,8 +76,8 @@ class WorkspaceTools extends BaseTool
      */
     public function __construct()
     {
-        $contexts        = array( 'chat', 'pipeline', 'sandbox' );
-        $policy_contexts = array( 'chat', 'pipeline', 'sandbox' );
+        $contexts        = array( 'chat', 'pipeline' );
+        $policy_contexts = array( 'chat', 'pipeline' );
         $policy_meta     = array( 'requires_opt_in' => true );
         $this->registerTool('workspace_path', array( $this, 'getPathDefinition' ), $contexts, array( 'ability' => 'datamachine/workspace-path' ));
         $this->registerTool('workspace_capabilities', array( $this, 'getCapabilitiesDefinition' ), $contexts, array( 'ability' => 'datamachine/workspace-capabilities' ));

--- a/inc/Workspace/RemoteWorkspaceBackend.php
+++ b/inc/Workspace/RemoteWorkspaceBackend.php
@@ -22,10 +22,7 @@ class RemoteWorkspaceBackend {
 	 * Whether the remote backend should handle workspace operations.
 	 */
 	public static function should_handle(): bool {
-		$should_handle = ! \DataMachineCode\Support\GitRunner::is_available();
-		return function_exists('apply_filters')
-			? (bool) apply_filters('datamachine_code_remote_workspace_backend_should_handle', $should_handle)
-			: $should_handle;
+		return ! \DataMachineCode\Support\GitRunner::is_available();
 	}
 
 	/**

--- a/tests/smoke-workspace-policy-tools.php
+++ b/tests/smoke-workspace-policy-tools.php
@@ -91,7 +91,7 @@ namespace {
     );
 
     foreach ( $default_pipeline_tools as $tool ) {
-        $assert("{$tool} remains default pipeline-visible and sandbox-visible", array( 'chat', 'pipeline', 'sandbox' ) === ( $tools[ $tool ]['modes'] ?? null ));
+        $assert("{$tool} remains default pipeline-visible", array( 'chat', 'pipeline' ) === ( $tools[ $tool ]['modes'] ?? null ));
     }
 
     $show_definition = $workspace_tools->getShowDefinition();
@@ -123,7 +123,7 @@ namespace {
     );
 
     foreach ( $policy_tools as $tool ) {
-        $assert("{$tool} is available in real chat, pipeline, and sandbox modes", array( 'chat', 'pipeline', 'sandbox' ) === ( $tools[ $tool ]['modes'] ?? null ));
+        $assert("{$tool} is available in real chat and pipeline modes", array( 'chat', 'pipeline' ) === ( $tools[ $tool ]['modes'] ?? null ));
         $assert("{$tool} requires explicit opt-in for pipeline use", true === ( $tools[ $tool ]['requires_opt_in'] ?? null ));
     }
 


### PR DESCRIPTION
## Summary
- Revert PR #459 so Data Machine Code no longer registers workspace tools for a consumer-specific `sandbox` mode.
- Remove the remote workspace backend override filter added for sandbox-host routing.
- Restore the workspace policy smoke test to assert DMC generic `chat` and `pipeline` exposure only.

## Rationale
Data Machine Code should stay generic and should not know about WP Codebox or sandbox-mode naming. Consumers that need sandbox behavior should adapt at their boundary instead of adding consumer-specific modes or routing escape hatches to DMC.

## Tests
- `php tests/smoke-workspace-policy-tools.php`
- `php tests/smoke-remote-workspace-backend.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine-code@revert-sandbox-specific-dmc --extension wordpress --changed-since origin/main --errors-only --force-hot`

Reverts #459

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspected merged PR #459, reverted the consumer-specific DMC changes, ran focused smoke/lint verification, and opened this corrective PR.