### PR TITLE
Fix remote workspace alias resolution

### DIFF
--- a/inc/Workspace/RemoteWorkspaceBackend.php
+++ b/inc/Workspace/RemoteWorkspaceBackend.php
@@ -1065,6 +1065,7 @@ class RemoteWorkspaceBackend {
 	 * @return array<string,mixed>
 	 */
 	private function resolve_handle( string $handle ): array|\WP_Error {
+		$handle = $this->resolve_alias($handle);
 		$state = $this->state();
 		if ( isset($state['worktrees'][ $handle ]) ) {
 			$worktree             = (array) $state['worktrees'][ $handle ];
@@ -1091,6 +1092,7 @@ class RemoteWorkspaceBackend {
 	}
 
 	private function resolve_repo( string $repo_name ): string|\WP_Error {
+		$repo_name = $this->resolve_alias($repo_name);
 		$state = $this->state();
 		if ( isset($state['repos'][ $repo_name ]['repo']) ) {
 			return (string) $state['repos'][ $repo_name ]['repo'];
@@ -1101,6 +1103,14 @@ class RemoteWorkspaceBackend {
 		}
 
 		return new \WP_Error('remote_workspace_repo_not_found', sprintf('Remote workspace repository "%s" is not registered. Call workspace_clone first.', $repo_name), array( 'status' => 404 ));
+	}
+
+	private function resolve_alias( string $handle ): string {
+		if ( class_exists(WorkspaceAliasResolver::class) ) {
+			return WorkspaceAliasResolver::resolve($handle);
+		}
+
+		return $handle;
 	}
 
 	private function repo_from_url( string $url ): string|\WP_Error {

--- a/tests/smoke-remote-workspace-backend.php
+++ b/tests/smoke-remote-workspace-backend.php
@@ -142,6 +142,7 @@ namespace {
     }
 
     include __DIR__ . '/../inc/Support/GitRunner.php';
+    include __DIR__ . '/../inc/Workspace/WorkspaceAliasResolver.php';
     include __DIR__ . '/../inc/Workspace/RemoteWorkspaceBackend.php';
 
     use DataMachineCode\Abilities\GitHubAbilities;
@@ -168,8 +169,21 @@ namespace {
     $worktree = $backend->worktree_add('example', 'fix/example');
     $assert('worktree add returns DMC handle', ! is_wp_error($worktree) && 'example@fix-example' === $worktree['handle']);
 
+    update_option(
+        'datamachine_code_workspace_aliases',
+        array(
+            'current-project' => array(
+                'target' => 'example@fix-example',
+                'root'   => '.agent-workspace/current-project',
+            ),
+        )
+    );
+
     $read = $backend->read_file('example@fix-example', 'src/example.php', 1000000);
     $assert('read falls back to default branch content', ! is_wp_error($read) && str_contains($read['content'], 'old'));
+
+    $alias_read = $backend->read_file('current-project', 'src/example.php', 1000000);
+    $assert('read resolves current-project alias to remote worktree', ! is_wp_error($alias_read) && str_contains($alias_read['content'], 'old'));
 
     $primary_grep = $backend->grep('example', 'old', 'src', '*.php', 10, 1);
     $assert('grep searches registered primary before worktree edits', ! is_wp_error($primary_grep) && 1 === $primary_grep['count'] && 'src/example.php' === $primary_grep['matches'][0]['path'] && 2 === $primary_grep['matches'][0]['line'] && ! empty($primary_grep['matches'][0]['context']));
@@ -190,6 +204,9 @@ namespace {
 
     $status = $backend->git_status('example@fix-example');
     $assert('status reports pending file as dirty', ! is_wp_error($status) && 1 === $status['dirty'] && array( 'src/example.php' ) === $status['files']);
+
+    $alias_status = $backend->git_status('current-project');
+    $assert('status resolves current-project alias to remote worktree', ! is_wp_error($alias_status) && 1 === $alias_status['dirty'] && array( 'src/example.php' ) === $alias_status['files']);
 
     $commit = $backend->git_commit('example@fix-example', 'fix: update example');
     $assert('commit writes via GitHub API', ! is_wp_error($commit) && 'commit-1' === $commit['commit']);


### PR DESCRIPTION
## Summary
- Resolve workspace aliases inside the GitHub-backed remote workspace backend before looking up worktrees or primary repos.
- Add smoke coverage proving `current-project` works for remote reads and status calls.

## Testing
- `php -l inc/Workspace/RemoteWorkspaceBackend.php`
- `php -l tests/smoke-remote-workspace-backend.php`
- `php tests/smoke-remote-workspace-backend.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the remote backend alias gap, drafted the code/test changes, and ran focused local validation for Chris to review.