### PR TITLE
Fix remote workspace alias formatting

### DIFF
--- a/inc/Workspace/RemoteWorkspaceBackend.php
+++ b/inc/Workspace/RemoteWorkspaceBackend.php
@@ -1066,7 +1066,7 @@ class RemoteWorkspaceBackend {
 	 */
 	private function resolve_handle( string $handle ): array|\WP_Error {
 		$handle = $this->resolve_alias($handle);
-		$state = $this->state();
+		$state  = $this->state();
 		if ( isset($state['worktrees'][ $handle ]) ) {
 			$worktree             = (array) $state['worktrees'][ $handle ];
 			$worktree['handle']   = $handle;
@@ -1093,7 +1093,7 @@ class RemoteWorkspaceBackend {
 
 	private function resolve_repo( string $repo_name ): string|\WP_Error {
 		$repo_name = $this->resolve_alias($repo_name);
-		$state = $this->state();
+		$state     = $this->state();
 		if ( isset($state['repos'][ $repo_name ]['repo']) ) {
 			return (string) $state['repos'][ $repo_name ]['repo'];
 		}


### PR DESCRIPTION
## Summary
- Align the new remote workspace alias assignments with the repository PHPCS rules.
- Keeps the v0.47.3 remote alias behavior intact while restoring the lint gate.

## Testing
- `php -l inc/Workspace/RemoteWorkspaceBackend.php`
- `php tests/smoke-remote-workspace-backend.php`
- `git diff --check origin/main...HEAD`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Applied the lint-only follow-up after the original PR merged before the lint job completed.