### PR TITLE
refactor: remove vendor brand names from generic-layer description and docblock

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Data Machine Code
  * Plugin URI: https://github.com/Extra-Chill/data-machine-code
- * Description: Bridge between WordPress and an external coding-agent runtime (Claude Code, OpenCode, kimaki, etc.). Owns AGENTS.md, the workspace area, and the GitHub / workspace / git abilities the runtime calls back into. Activation is the declarative "a coding agent lives here" signal.
+ * Description: Bridge between WordPress and an external coding-agent runtime. Owns AGENTS.md, the workspace area, and the GitHub / workspace / git abilities the runtime calls back into. Activation is the declarative "a coding agent lives here" signal.
  * Version: 0.47.4
  * Requires at least: 6.9
  * Requires PHP: 8.2
@@ -439,8 +439,8 @@ add_filter(
 | contributed by DM core, this plugin, and other extensions (mattic, etc.)
 | via SectionRegistry.
 |
-| Convention copy at ABSPATH/AGENTS.md ensures coding agents (Claude Code,
-| OpenCode, etc.) discover it at the expected location.
+| Convention copy at ABSPATH/AGENTS.md ensures coding agents discover it at
+| the expected location.
 |
 | Registered at plugins_loaded priority 22 (after DM core bootstrap at 20)
 | to ensure MemoryFileRegistry and SectionRegistry are available.


### PR DESCRIPTION
## Summary

`data-machine-code` is a **generic coding-agent-runtime bridge**. Its plugin Description header and an inline docblock enumerated specific vendor brands (Claude Code, OpenCode, kimaki) — a layer-purity violation. A generic layer must not name anything below it; vendor brands belong only in the integration plugin.

Closes #471.

## Changes (`data-machine-code.php`)

- **Line 5 (plugin Description header):** dropped the `(Claude Code, OpenCode, kimaki, etc.)` parenthetical entirely. The generic phrasing already present ("an external coding-agent runtime") makes the brand list redundant.
- **Lines 442-443 (docblock):** replaced `coding agents (Claude Code, OpenCode, etc.) discover it...` with `coding agents discover it...`.

## Verification

- `grep -rniE 'claude code|opencode|kimaki' data-machine-code.php` → **zero matches** (exit 1).
- `php -l data-machine-code.php` → no syntax errors.
- Docblock box `|` alignment preserved.

## Knock-on benefit

This Description is surfaced verbatim in the network's auto-generated `SITE.md` memory context, so removing brand enumeration here also cleans the agent-facing memory surface.

## Other violations surfaced (NOT fixed here — out of scope for #471)

The repo-wide grep `grep -rniE 'kimaki|discord|telegram|slack|whatsapp|cc-connect'` surfaced additional vendor-name occurrences in **documentation** files (tracked, but a separate surface from the code/docblock scope of this issue):

- `README.md` (lines 7, 31, 160, 255) — enumerates "Claude Code, OpenCode, kimaki, Studio Code" as setup examples.
- `docs/memory-disk-projection.md` (line 27) — "Data Machine core should not learn about OpenCode, Claude Code, or Kimaki." (this one is illustrative-of-the-rule prose, arguably acceptable).

These were left untouched to keep this PR scoped to issue #471 (plugin description + docblock). Recommend a follow-up issue if the docs should also be scrubbed.

> Note: `.claude/CLAUDE.local.md` also matched but is injected agent context (gitignored via `.git/info/exclude`), not part of the repo.