### PR TITLE
Fix workspace hygiene lock double-counting

### DIFF
--- a/inc/Workspace/WorkspaceLockStore.php
+++ b/inc/Workspace/WorkspaceLockStore.php
@@ -135,12 +135,14 @@ final class WorkspaceLockStore {
 
      // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name from $wpdb->prefix, not user input.
 		return array(
-			'available' => true,
-			'table'     => $table,
-			'active'    => (int) $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM {$table} WHERE status = %s AND expires_at >= %s", 'active', $now)),
-			'stale'     => (int) $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM {$table} WHERE status = %s AND expires_at < %s", 'active', $now)),
-			'released'  => (int) $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM {$table} WHERE status = %s", 'released')),
-			'total'     => (int) $wpdb->get_var("SELECT COUNT(*) FROM {$table}"),
+			'available'   => true,
+			'table'       => $table,
+			'active'      => (int) $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM {$table} WHERE status = %s AND expires_at >= %s", 'active', $now)),
+			'active_keys' => self::lock_keys_for_status('active', false),
+			'stale'       => (int) $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM {$table} WHERE status = %s AND expires_at < %s", 'active', $now)),
+			'stale_keys'  => self::lock_keys_for_status('active', true),
+			'released'    => (int) $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM {$table} WHERE status = %s", 'released')),
+			'total'       => (int) $wpdb->get_var("SELECT COUNT(*) FROM {$table}"),
 		);
      // phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 	}
@@ -229,6 +231,36 @@ final class WorkspaceLockStore {
 	private static function table_name(): string {
 		global $wpdb;
 		return $wpdb->prefix . 'datamachine_code_locks';
+	}
+
+	/**
+	 * Return distinct lock keys for active or expired active DB rows.
+	 *
+	 * @return array<int,string>
+	 */
+	private static function lock_keys_for_status( string $status, bool $expired ): array {
+		global $wpdb;
+		if ( ! is_object($wpdb) || ! is_callable(array( $wpdb, 'prepare' )) || ! is_callable(array( $wpdb, 'get_col' )) ) {
+			return array();
+		}
+
+		$table    = self::table_name();
+		$now      = gmdate('Y-m-d H:i:s');
+		$operator = $expired ? '<' : '>=';
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name from $wpdb->prefix, operator is constant-selected above.
+		$query = call_user_func(array( $wpdb, 'prepare' ), "SELECT DISTINCT lock_key FROM {$table} WHERE status = %s AND expires_at {$operator} %s", $status, $now);
+		$keys  = call_user_func(array( $wpdb, 'get_col' ), $query);
+		if ( ! is_array($keys) ) {
+			return array();
+		}
+
+		return array_values(
+			array_filter(
+				array_map('strval', $keys),
+				static fn( string $key ): bool => '' !== $key
+			)
+		);
 	}
 
 	private static function expires_seconds(): int {

--- a/inc/Workspace/WorkspaceMutationLock.php
+++ b/inc/Workspace/WorkspaceMutationLock.php
@@ -180,8 +180,8 @@ final class WorkspaceMutationLock {
 		return array(
 			'database'          => $database,
 			'filesystem'        => $filesystem,
-			'active'            => (int) ( $database['active'] ?? 0 ) + (int) ( $filesystem['active'] ?? 0 ),
-			'stale'             => (int) ( $database['stale'] ?? 0 ) + (int) ( $filesystem['stale'] ?? 0 ),
+			'active'            => self::logical_lock_count($database, $filesystem, 'active'),
+			'stale'             => self::logical_lock_count($database, $filesystem, 'stale'),
 			'retention_enabled' => true,
 			'policy'            => self::retention_policy(),
 		);
@@ -217,6 +217,47 @@ final class WorkspaceMutationLock {
 	}
 
 	/**
+	 * Count logical locks once when DB rows and flock files describe the same key.
+	 *
+	 * @param array<string,mixed> $database   DB lock status.
+	 * @param array<string,mixed> $filesystem Filesystem lock status.
+	 */
+	private static function logical_lock_count( array $database, array $filesystem, string $state ): int {
+		$database_count   = (int) ( $database[ $state ] ?? 0 );
+		$filesystem_count = (int) ( $filesystem[ $state ] ?? 0 );
+		$database_keys    = self::lock_status_keys($database, $state);
+		$filesystem_keys  = self::lock_status_keys($filesystem, $state);
+
+		if ( array() === $database_keys && array() === $filesystem_keys ) {
+			return $database_count + $filesystem_count;
+		}
+
+		$known_count = count(array_unique(array_merge($database_keys, $filesystem_keys)));
+		$unknown_db  = max(0, $database_count - count($database_keys));
+		$unknown_fs  = max(0, $filesystem_count - count($filesystem_keys));
+
+		return $known_count + $unknown_db + $unknown_fs;
+	}
+
+	/**
+	 * @param array<string,mixed> $status Lock status.
+	 * @return array<int,string>
+	 */
+	private static function lock_status_keys( array $status, string $state ): array {
+		$keys = $status[ $state . '_keys' ] ?? array();
+		if ( ! is_array($keys) ) {
+			return array();
+		}
+
+		return array_values(
+			array_filter(
+				array_map('strval', $keys),
+				static fn( string $key ): bool => '' !== $key
+			)
+		);
+	}
+
+	/**
 	 * @return array<string,mixed>
 	 */
 	private static function filesystem_status( string $workspace_path ): array {
@@ -225,9 +266,11 @@ final class WorkspaceMutationLock {
 		$files    = false === $files ? array() : $files;
 		$policy   = self::retention_policy();
 		$cutoff   = time() - (int) $policy['filesystem_stale_after_seconds'];
-		$active   = 0;
-		$stale    = 0;
-		$recent   = 0;
+		$active      = 0;
+		$stale       = 0;
+		$recent      = 0;
+		$active_keys = array();
+		$stale_keys  = array();
 
 		foreach ( $files as $file ) {
 			$handle = fopen($file, 'c'); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
@@ -237,6 +280,7 @@ final class WorkspaceMutationLock {
 
 			if ( ! flock($handle, LOCK_EX | LOCK_NB) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock
 				++$active;
+				$active_keys[] = self::lock_key_from_path($file);
 				fclose($handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 				continue;
 			}
@@ -246,18 +290,26 @@ final class WorkspaceMutationLock {
 			$mtime = filemtime($file);
 			if ( false !== $mtime && $mtime < $cutoff ) {
 				++$stale;
+				$stale_keys[] = self::lock_key_from_path($file);
 			} else {
 				++$recent;
 			}
 		}
 
 		return array(
-			'lock_dir' => $lock_dir,
-			'total'    => count($files),
-			'active'   => $active,
-			'stale'    => $stale,
-			'recent'   => $recent,
+			'lock_dir'    => $lock_dir,
+			'total'       => count($files),
+			'active'      => $active,
+			'active_keys' => array_values(array_filter($active_keys)),
+			'stale'       => $stale,
+			'stale_keys'  => array_values(array_filter($stale_keys)),
+			'recent'      => $recent,
 		);
+	}
+
+	private static function lock_key_from_path( string $path ): string {
+		$filename = basename($path);
+		return str_ends_with($filename, '.lock') ? substr($filename, 0, -5) : $filename;
 	}
 
 	/**

--- a/tests/smoke-workspace-mutation-lock.php
+++ b/tests/smoke-workspace-mutation-lock.php
@@ -51,15 +51,115 @@ namespace {
         }
     }
 
-    if (! function_exists('wp_mkdir_p') ) {
-        function wp_mkdir_p( string $path ): bool
-        {
-            return is_dir($path) || mkdir($path, 0755, true);
-        }
-    }
+	if (! function_exists('wp_mkdir_p') ) {
+		function wp_mkdir_p( string $path ): bool
+		{
+			return is_dir($path) || mkdir($path, 0755, true);
+		}
+	}
 
-    include __DIR__ . '/../inc/Workspace/WorkspaceLockStore.php';
-    include __DIR__ . '/../inc/Workspace/WorkspaceMutationLock.php';
+	if (! function_exists('wp_json_encode') ) {
+		function wp_json_encode( $data, int $flags = 0 )
+		{
+			return json_encode($data, $flags);
+		}
+	}
+
+	class Workspace_Mutation_Lock_Test_Wpdb
+	{
+		public string $prefix = 'wp_';
+		public int $insert_id = 0;
+		public int $rows_affected = 0;
+		public string $last_error = '';
+
+		/** @var array<int,array<string,mixed>> */
+		public array $rows = array();
+
+		public function insert( string $table, array $data, array $format ): int  // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		{
+			$this->insert_id++;
+			$data['id']                 = $this->insert_id;
+			$this->rows[ $this->insert_id ] = $data;
+			return 1;
+		}
+
+		public function update( string $table, array $data, array $where, array $format, array $where_format ): int  // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		{
+			$id = (int) ( $where['id'] ?? 0 );
+			if (! isset($this->rows[ $id ]) ) {
+				return 0;
+			}
+			$this->rows[ $id ] = array_merge($this->rows[ $id ], $data);
+			return 1;
+		}
+
+		public function get_var( string $sql ): mixed
+		{
+			if (str_contains($sql, 'SHOW TABLES LIKE') ) {
+				return $this->prefix . 'datamachine_code_locks';
+			}
+
+			if (! str_contains($sql, 'COUNT(*)') ) {
+				return null;
+			}
+
+			return count($this->matching_rows($sql));
+		}
+
+		/**
+		 * @return array<int,string>
+		 */
+		public function get_col( string $sql ): array
+		{
+			$keys = array_map(
+				static fn( array $row ): string => (string) ( $row['lock_key'] ?? '' ),
+				$this->matching_rows($sql)
+			);
+			return array_values(array_unique(array_filter($keys)));
+		}
+
+		public function prepare( string $query, mixed ...$args ): string
+		{
+			foreach ( $args as $arg ) {
+				$replacement = is_int($arg) ? (string) $arg : "'" . str_replace("'", "''", (string) $arg) . "'";
+				$query       = preg_replace('/%[sd]/', $replacement, $query, 1) ?? $query;
+			}
+			return $query;
+		}
+
+		/**
+		 * @return array<int,array<string,mixed>>
+		 */
+		private function matching_rows( string $sql ): array
+		{
+			$now = gmdate('Y-m-d H:i:s');
+			return array_values(
+				array_filter(
+					$this->rows,
+					static function ( array $row ) use ( $sql, $now ): bool {
+						$status = (string) ( $row['status'] ?? '' );
+						$expiry = (string) ( $row['expires_at'] ?? '' );
+						if (str_contains($sql, "status = 'active'") && 'active' !== $status ) {
+							return false;
+						}
+						if (str_contains($sql, "status = 'released'") ) {
+							return 'released' === $status;
+						}
+						if (str_contains($sql, 'expires_at <') ) {
+							return '' !== $expiry && $expiry < $now;
+						}
+						if (str_contains($sql, 'expires_at >=') ) {
+							return '' !== $expiry && $expiry >= $now;
+						}
+						return true;
+					}
+				)
+			);
+		}
+	}
+
+	include __DIR__ . '/../inc/Workspace/WorkspaceLockStore.php';
+	include __DIR__ . '/../inc/Workspace/WorkspaceMutationLock.php';
 
     $failures = 0;
     $total    = 0;
@@ -109,11 +209,23 @@ namespace {
     if (! is_wp_error($first) ) {
         $first->release();
     }
-    $status = \DataMachineCode\Workspace\WorkspaceMutationLock::status($tmp);
-    $assert(0, (int) $status['active'], 'released filesystem lock is no longer active');
-    $assert(2, (int) $status['filesystem']['recent'], 'released filesystem lock files are visible as recent retention residue');
+	$status = \DataMachineCode\Workspace\WorkspaceMutationLock::status($tmp);
+	$assert(0, (int) $status['active'], 'released filesystem lock is no longer active');
+	$assert(2, (int) $status['filesystem']['recent'], 'released filesystem lock files are visible as recent retention residue');
 
-    $stale_path = $tmp . '/.locks/worktree-stale.lock';
+	$GLOBALS['wpdb'] = new Workspace_Mutation_Lock_Test_Wpdb();
+	$db_backed = \DataMachineCode\Workspace\WorkspaceMutationLock::acquire($tmp, 'db-demo', 1);
+	$assert(false, is_wp_error($db_backed), 'DB-backed acquisition succeeds');
+	$db_backed_status = \DataMachineCode\Workspace\WorkspaceMutationLock::status($tmp);
+	$assert(1, (int) $db_backed_status['database']['active'], 'DB-backed acquisition records one active DB row');
+	$assert(1, (int) $db_backed_status['filesystem']['active'], 'DB-backed acquisition also holds one filesystem lock');
+	$assert(1, (int) $db_backed_status['active'], 'same DB row and filesystem lock count as one logical active lock');
+	if (! is_wp_error($db_backed) ) {
+		$db_backed->release();
+	}
+	unset($GLOBALS['wpdb']);
+
+	$stale_path = $tmp . '/.locks/worktree-stale.lock';
     touch($stale_path, time() - 172800);
     $stale_status = \DataMachineCode\Workspace\WorkspaceMutationLock::status($tmp);
     $assert(1, (int) $stale_status['stale'], 'old unlocked filesystem lock is counted stale');


### PR DESCRIPTION
## Summary
- Deduplicate top-level workspace hygiene lock counts by logical lock key so a DB row and matching filesystem flock file count as one active lock.
- Preserve DB row counts and filesystem lock-file counts under their existing implementation detail sections.
- Extend the mutation lock smoke test to cover the DB + filesystem same-lock case.

Fixes #473.

## Tests
- `php tests/smoke-workspace-mutation-lock.php`
- `php tests/smoke-workspace-hygiene-report.php`
- `php tests/smoke-workspace-hygiene-cli.php`
- `php -l inc/Workspace/WorkspaceMutationLock.php && php -l inc/Workspace/WorkspaceLockStore.php && php -l tests/smoke-workspace-mutation-lock.php`
- `git diff --check`

## Caveats
- `homeboy test --path /Users/chubes/Developer/data-machine-code@fix-issue-473-lock-counts --extension wordpress` failed before running tests because the lab dependency checkout for `data-machine` was missing `vendor/autoload.php`.
- `homeboy lint --path /Users/chubes/Developer/data-machine-code@fix-issue-473-lock-counts --extension wordpress` still reports existing repo-wide PHPStan findings unrelated to this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the lock-count deduplication and smoke coverage; Chris remains responsible for review and merge.