### PR TITLE
Expose owner diagnostics for busy workspace locks

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -133,7 +133,7 @@ class WorkspaceCommand extends BaseCommand {
 		$result = $ability->execute($input);
 
 		if ( is_wp_error($result) ) {
-			WP_CLI::error($result->get_error_message());
+			$this->render_workspace_error($result);
 			return;
 		}
 
@@ -2756,6 +2756,37 @@ class WorkspaceCommand extends BaseCommand {
 				WP_CLI::success($result['message'] ?? 'Worktree operation complete.');
 				return;
 		}
+	}
+
+	private function render_workspace_error( \WP_Error $error ): void {
+		$data = (array) $error->get_error_data();
+		if ( 'workspace_repo_busy' !== $error->get_error_code() ) {
+			WP_CLI::error($error->get_error_message());
+			return;
+		}
+
+		$lock = is_array($data['active_lock'] ?? null) ? (array) $data['active_lock'] : array();
+		if ( ! empty($lock) ) {
+			WP_CLI::warning(sprintf('Lock owner: %s', (string) ( $lock['owner'] ?? 'unknown' )));
+			WP_CLI::log(sprintf('Lock key:   %s', (string) ( $lock['lock_key'] ?? $data['lock_key'] ?? '-' )));
+			WP_CLI::log(sprintf('Scope:      %s', (string) ( $lock['scope'] ?? $data['scope'] ?? $data['repo'] ?? '-' )));
+			WP_CLI::log(sprintf('Path:       %s', (string) ( $lock['metadata']['lock_path'] ?? $data['lock_path'] ?? '-' )));
+			WP_CLI::log(sprintf('Acquired:   %s', (string) ( $lock['acquired_at'] ?? '-' )));
+			WP_CLI::log(sprintf('Heartbeat:  %s', (string) ( $lock['heartbeat_at'] ?? '-' )));
+			WP_CLI::log(sprintf('Expires:    %s', (string) ( $lock['expires_at'] ?? '-' )));
+			if ( isset($lock['age_seconds']) || isset($lock['retry_after_seconds']) ) {
+				WP_CLI::log(sprintf('Age/retry:  %ss old; retry after up to %ss', (string) ( $lock['age_seconds'] ?? '-' ), (string) ( $lock['retry_after_seconds'] ?? '-' )));
+			}
+			$owner_context = (array) ( $lock['metadata']['owner_context'] ?? array() );
+			if ( ! empty($owner_context['wp_cli_args']) ) {
+				WP_CLI::log(sprintf('Command:    %s', (string) $owner_context['wp_cli_args']));
+			}
+			if ( ! empty($owner_context['kimaki_session_id']) || ! empty($owner_context['opencode_session_id']) ) {
+				WP_CLI::log(sprintf('Session:    %s', (string) ( $owner_context['kimaki_session_id'] ?? $owner_context['opencode_session_id'] ?? '' )));
+			}
+		}
+
+		WP_CLI::error($error->get_error_message());
 	}
 
 	/**

--- a/inc/Workspace/WorkspaceLockStore.php
+++ b/inc/Workspace/WorkspaceLockStore.php
@@ -146,6 +146,65 @@ final class WorkspaceLockStore {
 	}
 
 	/**
+	 * Return the active DB-visible lock row for a specific lock target.
+	 *
+	 * @return array<string,mixed>|null|\WP_Error
+	 */
+	public static function active_lock( string $lock_key, string $scope ): array|null|\WP_Error {
+		if ( ! self::is_available() ) {
+			return null;
+		}
+
+		$ensured = self::ensure_table();
+		if ( $ensured instanceof \WP_Error ) {
+			return $ensured;
+		}
+
+		global $wpdb;
+		$table = self::table_name();
+		$now   = gmdate('Y-m-d H:i:s');
+
+     // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name from $wpdb->prefix, not user input.
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT id, lock_key, purpose, scope, owner, run_id, job_id, status, acquired_at, heartbeat_at, expires_at, released_at, metadata_json FROM {$table} WHERE lock_key = %s AND scope = %s AND status = %s AND expires_at >= %s ORDER BY acquired_at DESC, id DESC LIMIT 1",
+				$lock_key,
+				$scope,
+				'active',
+				$now
+			),
+			ARRAY_A
+		);
+     // phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		if ( empty($row) || ! is_array($row) ) {
+			return null;
+		}
+
+		$row['id']       = (int) ( $row['id'] ?? 0 );
+		$row['job_id']   = isset($row['job_id']) ? (int) $row['job_id'] : null;
+		$row['metadata'] = self::decode_metadata( (string) ( $row['metadata_json'] ?? '' ) );
+		unset($row['metadata_json']);
+
+		$acquired  = self::timestamp_seconds( (string) ( $row['acquired_at'] ?? '' ) );
+		$heartbeat = self::timestamp_seconds( (string) ( $row['heartbeat_at'] ?? '' ) );
+		$expires   = self::timestamp_seconds( (string) ( $row['expires_at'] ?? '' ) );
+		$time      = time();
+		if ( null !== $acquired ) {
+			$row['age_seconds'] = max(0, $time - $acquired);
+		}
+		if ( null !== $heartbeat ) {
+			$row['heartbeat_age_seconds'] = max(0, $time - $heartbeat);
+		}
+		if ( null !== $expires ) {
+			$row['expires_in_seconds']  = max(0, $expires - $time);
+			$row['retry_after_seconds'] = max(0, $expires - $time);
+		}
+
+		return $row;
+	}
+
+	/**
 	 * Prune expired DB lock rows according to retention policy.
 	 *
 	 * @return array<string,mixed>
@@ -247,9 +306,37 @@ final class WorkspaceLockStore {
 		return max(3600, $seconds);
 	}
 
+	public static function default_owner_context(): array {
+		$context = array(
+			'host' => function_exists('gethostname') ? (string) gethostname() : 'unknown-host',
+			'pid'  => function_exists('getmypid') ? (string) getmypid() : 'unknown-pid',
+		);
+		$env_map = array(
+			'kimaki_session_id'      => 'KIMAKI_SESSION_ID',
+			'opencode_session_id'    => 'OPENCODE_SESSION_ID',
+			'datamachine_task_url'   => 'DATAMACHINE_TASK_URL',
+			'datamachine_task_ref'   => 'DATAMACHINE_TASK_REF',
+			'datamachine_agent'      => 'DATAMACHINE_AGENT',
+			'datamachine_agent_name' => 'DATAMACHINE_AGENT_NAME',
+		);
+		foreach ( $env_map as $key => $env ) {
+			$value = getenv($env);
+			if ( false !== $value && '' !== trim( (string) $value) ) {
+				$context[ $key ] = self::bounded_string( (string) $value, 300);
+			}
+		}
+
+		if ( isset($_SERVER['argv']) && is_array($_SERVER['argv']) ) {
+			$context['wp_cli_args'] = self::bounded_string(self::redact_secret_values(implode(' ', array_map('strval', $_SERVER['argv']))), 1000);
+		}
+
+		return $context;
+	}
+
 	private static function default_owner(): string {
-		$host = function_exists('gethostname') ? (string) gethostname() : 'unknown-host';
-		$pid  = function_exists('getmypid') ? (string) getmypid() : 'unknown-pid';
+		$context = self::default_owner_context();
+		$host    = (string) ( $context['host'] ?? 'unknown-host' );
+		$pid     = function_exists('getmypid') ? (string) getmypid() : 'unknown-pid';
 		return $host . ':' . $pid;
 	}
 
@@ -276,5 +363,26 @@ final class WorkspaceLockStore {
 		$json     = wp_json_encode($metadata);
 		$json     = false === $json ? '{}' : (string) $json;
 		return substr($json, 0, 8192);
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	private static function decode_metadata( string $json ): array {
+		$decoded = json_decode($json, true);
+		return is_array($decoded) ? $decoded : array();
+	}
+
+	private static function timestamp_seconds( string $timestamp ): ?int {
+		if ( '' === trim($timestamp) ) {
+			return null;
+		}
+
+		$seconds = strtotime($timestamp . ' UTC');
+		return false === $seconds ? null : (int) $seconds;
+	}
+
+	private static function redact_secret_values( string $value ): string {
+		return (string) preg_replace('/(--(?:password|token|key|secret|authorization)(?:=|\s+))\S+/i', '$1[redacted]', $value);
 	}
 }

--- a/inc/Workspace/WorkspaceMutationLock.php
+++ b/inc/Workspace/WorkspaceMutationLock.php
@@ -122,6 +122,7 @@ final class WorkspaceMutationLock {
 						'metadata' => array(
 							'workspace_path' => $workspace_path,
 							'lock_path'      => $lock_path,
+							'owner_context'  => WorkspaceLockStore::default_owner_context(),
 						),
 					)
 				);
@@ -142,12 +143,7 @@ final class WorkspaceMutationLock {
 						'Workspace repo "%s" is busy with another worktree lifecycle mutation. Retry after the current add/remove/cleanup/prune operation completes.',
 						$repo
 					),
-					array(
-						'status'    => 423,
-						'retryable' => true,
-						'repo'      => $repo,
-						'lock_path' => $lock_path,
-					)
+					self::busy_error_data($repo, $lock_path)
 				);
 			}
 
@@ -214,6 +210,36 @@ final class WorkspaceMutationLock {
 	private static function sanitize_repo_key( string $repo ): string {
 		$repo = preg_replace('/[^a-zA-Z0-9._-]/', '', $repo);
 		return trim( (string) $repo, '-.');
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	private static function busy_error_data( string $repo, string $lock_path ): array {
+		$lock_key = 'worktree-' . $repo;
+		$data     = array(
+			'status'    => 423,
+			'retryable' => true,
+			'repo'      => $repo,
+			'scope'     => $repo,
+			'lock_key'  => $lock_key,
+			'lock_path' => $lock_path,
+		);
+
+		$active_lock = WorkspaceLockStore::active_lock($lock_key, $repo);
+		if ( is_array($active_lock) ) {
+			$data['active_lock'] = $active_lock;
+			if ( isset($active_lock['retry_after_seconds']) ) {
+				$data['retry_after_seconds'] = (int) $active_lock['retry_after_seconds'];
+			}
+			if ( isset($active_lock['age_seconds']) ) {
+				$data['age_seconds'] = (int) $active_lock['age_seconds'];
+			}
+		} elseif ( is_wp_error($active_lock) ) {
+			$data['lock_store_error'] = $active_lock->get_error_message();
+		}
+
+		return $data;
 	}
 
 	/**

--- a/tests/smoke-workspace-mutation-lock.php
+++ b/tests/smoke-workspace-mutation-lock.php
@@ -51,11 +51,88 @@ namespace {
         }
     }
 
-    if (! function_exists('wp_mkdir_p') ) {
+	if (! function_exists('wp_mkdir_p') ) {
         function wp_mkdir_p( string $path ): bool
         {
             return is_dir($path) || mkdir($path, 0755, true);
-        }
+	}
+
+	if (! defined('ARRAY_A') ) {
+		define('ARRAY_A', 'ARRAY_A');
+	}
+
+	if (! function_exists('wp_json_encode') ) {
+		function wp_json_encode( $data ) {
+			return json_encode($data);
+		}
+	}
+
+	if (! function_exists('dbDelta') ) {
+		function dbDelta( $sql ) {
+			return array();
+		}
+	}
+
+	class DataMachineCode_Fake_WPDB
+	{
+		public string $prefix = 'wp_';
+		public string $last_error = '';
+		public int $insert_id = 0;
+		public int $rows_affected = 0;
+		public array $rows = array();
+
+		public function prepare( string $query, ...$args ): string
+		{
+			return $query;
+		}
+
+		public function get_var( string $query )
+		{
+			if (str_starts_with($query, 'SHOW TABLES LIKE') ) {
+				return $this->prefix . 'datamachine_code_locks';
+			}
+
+			return 0;
+		}
+
+		public function insert( string $table, array $data, array $format )
+		{
+			$this->insert_id++;
+			$data['id'] = $this->insert_id;
+			$this->rows[] = $data;
+			return 1;
+		}
+
+		public function update( string $table, array $data, array $where, array $format, array $where_format )
+		{
+			foreach ( $this->rows as &$row ) {
+				if ((int) ( $row['id'] ?? 0 ) === (int) ( $where['id'] ?? 0 ) ) {
+					$row = array_merge($row, $data);
+					$this->rows_affected = 1;
+					return 1;
+				}
+			}
+
+			$this->rows_affected = 0;
+			return 0;
+		}
+
+		public function get_row( string $query, string $output )
+		{
+			$active = array_values(array_filter($this->rows, fn( $row ) => 'active' === ( $row['status'] ?? '' )));
+			if (empty($active) ) {
+				return null;
+			}
+
+			return $active[count($active) - 1];
+		}
+
+		public function query( string $query )
+		{
+			$this->rows_affected = 0;
+			return 0;
+		}
+	}
     }
 
     include __DIR__ . '/../inc/Workspace/WorkspaceLockStore.php';
@@ -95,10 +172,11 @@ namespace {
     $assert(1, (int) $status['active'], 'held filesystem lock is visible in aggregate active count');
     $assert(false, (bool) $status['database']['available'], 'DB lock store reports unavailable in pure-PHP smoke context');
 
-    $busy = \DataMachineCode\Workspace\WorkspaceMutationLock::acquire($tmp, 'demo', 0);
-    $assert(true, is_wp_error($busy), 'same repo acquisition fails fast while held');
-    $assert('workspace_repo_busy', is_wp_error($busy) ? $busy->get_error_code() : '', 'busy failure uses DMC-shaped retryable code');
-    $assert(true, is_wp_error($busy) ? (bool) ( $busy->get_error_data()['retryable'] ?? false ) : false, 'busy failure is marked retryable');
+	$busy = \DataMachineCode\Workspace\WorkspaceMutationLock::acquire($tmp, 'demo', 0);
+	$assert(true, is_wp_error($busy), 'same repo acquisition fails fast while held');
+	$assert('workspace_repo_busy', is_wp_error($busy) ? $busy->get_error_code() : '', 'busy failure uses DMC-shaped retryable code');
+	$assert(true, is_wp_error($busy) ? (bool) ( $busy->get_error_data()['retryable'] ?? false ) : false, 'busy failure is marked retryable');
+	$assert('worktree-demo', is_wp_error($busy) ? (string) ( $busy->get_error_data()['lock_key'] ?? '' ) : '', 'busy failure includes lock key');
 
     $other = \DataMachineCode\Workspace\WorkspaceMutationLock::acquire($tmp, 'other', 0);
     $assert(false, is_wp_error($other), 'different repo acquisition is independent');
@@ -160,10 +238,37 @@ namespace {
 
     $post_exception = \DataMachineCode\Workspace\WorkspaceMutationLock::acquire($tmp, 'demo', 0);
     $assert(false, is_wp_error($post_exception), 'with_repo releases after callback exception');
-    if (! is_wp_error($post_exception) ) {
-        $post_exception->release();
-    }
+	if (! is_wp_error($post_exception) ) {
+		$post_exception->release();
+	}
 
-    echo "\nResult: " . ( $total - $failures ) . "/{$total} passed\n";
+	$GLOBALS['wpdb'] = new DataMachineCode_Fake_WPDB();
+	$db_tmp = sys_get_temp_dir() . '/dmc-workspace-lock-db-smoke-' . bin2hex(random_bytes(4));
+	mkdir($db_tmp, 0755, true);
+	register_shutdown_function(
+		function () use ( $db_tmp ) {
+			if (is_dir($db_tmp) ) {
+				exec('rm -rf ' . escapeshellarg($db_tmp));
+			}
+		}
+	);
+	$db_first = \DataMachineCode\Workspace\WorkspaceMutationLock::acquire($db_tmp, 'demo', 1);
+	$db_busy = \DataMachineCode\Workspace\WorkspaceMutationLock::acquire($db_tmp, 'demo', 0);
+	$db_data = is_wp_error($db_busy) ? $db_busy->get_error_data() : array();
+	$assert(true, is_wp_error($db_busy), 'DB-backed same repo acquisition fails fast while held');
+	$assert('demo', (string) ( $db_data['active_lock']['scope'] ?? '' ), 'busy failure includes active DB lock scope');
+	$assert('worktree-demo', (string) ( $db_data['active_lock']['lock_key'] ?? '' ), 'busy failure includes active DB lock key');
+	$assert(true, isset($db_data['active_lock']['owner']), 'busy failure includes active DB lock owner');
+	$assert(true, isset($db_data['active_lock']['acquired_at']), 'busy failure includes acquired timestamp');
+	$assert(true, isset($db_data['active_lock']['heartbeat_at']), 'busy failure includes heartbeat timestamp');
+	$assert(true, isset($db_data['active_lock']['expires_at']), 'busy failure includes expires timestamp');
+	$assert(true, isset($db_data['active_lock']['retry_after_seconds']), 'busy failure includes retry-after seconds');
+	$assert(true, isset($db_data['active_lock']['age_seconds']), 'busy failure includes age seconds');
+	$assert(true, isset($db_data['active_lock']['metadata']['owner_context']), 'busy failure includes owner context metadata');
+	if (! is_wp_error($db_first) ) {
+		$db_first->release();
+	}
+
+	echo "\nResult: " . ( $total - $failures ) . "/{$total} passed\n";
     exit($failures > 0 ? 1 : 0);
 }


### PR DESCRIPTION
## Summary
- Enrich `workspace_repo_busy` error data with matching active DB lock metadata, including scope, lock key/path, owner, timestamps, age, and retry-after seconds.
- Record bounded owner context metadata for lock acquisitions so Studio/WASM invocations expose command/session context even when the process owner is `emscripten:1`.
- Render busy-lock owner diagnostics in local `workspace worktree` CLI errors before the final WP-CLI error.

Fixes #474

## Testing
- `php tests/smoke-workspace-mutation-lock.php`
- `php -l inc/Workspace/WorkspaceLockStore.php && php -l inc/Workspace/WorkspaceMutationLock.php && php -l inc/Cli/Commands/WorkspaceCommand.php && php -l tests/smoke-workspace-mutation-lock.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine-code@fix-issue-474-lock-diagnostics --changed-only --summary`

## Caveats
- Full `homeboy lint --path /Users/chubes/Developer/data-machine-code@fix-issue-474-lock-diagnostics` still reports the existing repository-wide PHPStan backlog outside this change.
- Full `homeboy test --path /Users/chubes/Developer/data-machine-code@fix-issue-474-lock-diagnostics` did not reach tests because the lab dependency checkout for `data-machine` was missing `vendor/autoload.php`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, smoke coverage, and verification notes; Chris remains responsible for review and merge.