### PR TITLE
fix: accept worktree base alias

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1992,9 +1992,12 @@ class WorkspaceCommand extends BaseCommand {
 	 * [--from=<ref>]
 	 * : Base ref when creating a branch on add (default origin/HEAD).
 	 *
+	 * [--base=<ref>]
+	 * : Alias for `--from=<ref>`.
+	 *
 	 * [--base-branch=<branch>]
 	 * : Convenience alias for branch-shaped bases. `--base-branch=main`
-	 *   maps to `--from=origin/main`. Use `--from` for exact refs.
+	 *   maps to `--from=origin/main`. Use `--from` or `--base` for exact refs.
 	 *
 	 * [--skip-context-injection]
 	 * : Skip injecting the originating site's agent context into a new
@@ -2323,17 +2326,22 @@ class WorkspaceCommand extends BaseCommand {
 		switch ( $operation ) {
 			case 'add':
 				if ( empty($args[1]) || empty($args[2]) ) {
-					WP_CLI::error('Usage: worktree add <repo> <branch> [--from=<ref>|--base-branch=<branch>] [--skip-context-injection] [--skip-bootstrap] [--allow-stale] [--rebase-base] [--force]');
+					WP_CLI::error('Usage: worktree add <repo> <branch> [--from=<ref>|--base=<ref>|--base-branch=<branch>] [--skip-context-injection] [--skip-bootstrap] [--allow-stale] [--rebase-base] [--force]');
 					return;
 				}
 				$input['repo']   = $args[1];
 				$input['branch'] = $args[2];
-				if ( ! empty($assoc_args['from']) && ! empty($assoc_args['base-branch']) ) {
-					WP_CLI::error('Use either --from=<ref> or --base-branch=<branch>, not both.');
+				$exact_base      = $assoc_args['from'] ?? $assoc_args['base'] ?? '';
+				if ( ! empty($assoc_args['from']) && ! empty($assoc_args['base']) ) {
+					WP_CLI::error('Use either --from=<ref> or --base=<ref>, not both.');
 					return;
 				}
-				if ( ! empty($assoc_args['from']) ) {
-					$input['from'] = (string) $assoc_args['from'];
+				if ( ! empty($exact_base) && ! empty($assoc_args['base-branch']) ) {
+					WP_CLI::error('Use either --from=<ref>/--base=<ref> or --base-branch=<branch>, not both.');
+					return;
+				}
+				if ( ! empty($exact_base) ) {
+					$input['from'] = (string) $exact_base;
 				} elseif ( ! empty($assoc_args['base-branch']) ) {
 					$input['from'] = self::base_branch_to_ref( (string) $assoc_args['base-branch']);
 				}

--- a/tests/smoke-worktree-base-branch-cli.php
+++ b/tests/smoke-worktree-base-branch-cli.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Smoke test for the workspace worktree --base-branch CLI alias.
+ * Smoke test for workspace worktree base-ref CLI aliases.
  *
  *   php tests/smoke-worktree-base-branch-cli.php
  *
@@ -144,18 +144,36 @@ namespace {
     );
     datamachine_code_assert('upstream/develop' === $ability->last_input['from'], 'remote ref preserved');
 
-    echo "\n[4] --from wins by rejecting ambiguous input\n";
+    echo "\n[4] --base aliases exact --from refs\n";
+    $command->worktree(
+        array( 'add', 'data-machine', 'feat/test' ),
+        array( 'base' => 'origin/main' )
+    );
+    datamachine_code_assert('origin/main' === $ability->last_input['from'], '--base forwards exact refs as from');
+
+    echo "\n[5] --from and --base reject ambiguous exact-base input\n";
     try {
         $command->worktree(
             array( 'add', 'data-machine', 'feat/test' ),
-            array( 'from' => 'origin/main', 'base-branch' => 'develop' )
+            array( 'from' => 'origin/main', 'base' => 'upstream/develop' )
+        );
+        datamachine_code_assert(false, 'ambiguous exact-base flags should throw');
+    } catch ( RuntimeException $e ) {
+        datamachine_code_assert(str_contains($e->getMessage(), 'not both'), 'ambiguous exact-base flags fail clearly');
+    }
+
+    echo "\n[6] exact base flags reject ambiguous base-branch input\n";
+    try {
+        $command->worktree(
+            array( 'add', 'data-machine', 'feat/test' ),
+            array( 'base' => 'origin/main', 'base-branch' => 'develop' )
         );
         datamachine_code_assert(false, 'ambiguous flags should throw');
     } catch ( RuntimeException $e ) {
         datamachine_code_assert(str_contains($e->getMessage(), 'not both'), 'ambiguous flags fail clearly');
     }
 
-    echo "\n[5] --force is forwarded for add and JSON output keeps disk budget\n";
+    echo "\n[7] --force is forwarded for add and JSON output keeps disk budget\n";
     \WP_CLI::reset_logs();
     $command->worktree(
         array( 'add', 'data-machine', 'feat/test' ),


### PR DESCRIPTION
## Summary
- Adds `--base=<ref>` as a `workspace worktree add` alias for exact base refs, matching the common mental model for `--from=<ref>`.
- Updates usage/help text and smoke coverage for `--base`, `--from`, and `--base-branch` ambiguity handling.

Fixes #479.

## Testing
- `php tests/smoke-worktree-base-branch-cli.php`
- `homeboy lint --changed-since=origin/main`
- `homeboy audit --changed-since=origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the small CLI alias change, expanded smoke coverage, and ran focused verification. Chris remains responsible for review and merge.