### PR TITLE
refactor: route lock owner-context runtime IDs through signatures registry

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -2781,12 +2781,48 @@ class WorkspaceCommand extends BaseCommand {
 			if ( ! empty($owner_context['wp_cli_args']) ) {
 				WP_CLI::log(sprintf('Command:    %s', (string) $owner_context['wp_cli_args']));
 			}
-			if ( ! empty($owner_context['kimaki_session_id']) || ! empty($owner_context['opencode_session_id']) ) {
-				WP_CLI::log(sprintf('Session:    %s', (string) ( $owner_context['kimaki_session_id'] ?? $owner_context['opencode_session_id'] ?? '' )));
+			$session_id = $this->resolve_owner_context_session_id($owner_context);
+			if ( '' !== $session_id ) {
+				WP_CLI::log(sprintf('Session:    %s', $session_id));
 			}
 		}
 
 		WP_CLI::error($error->get_error_message());
+	}
+
+	/**
+	 * Resolve a displayable runtime session identifier from a lock owner context.
+	 *
+	 * Runtime-specific session IDs live under the generic `runtime_ids` envelope
+	 * (runtime-id => { subkey => value }) populated by WorkspaceLockStore from the
+	 * `datamachine_code_worktree_runtime_signatures` registry. DMC names no
+	 * runtimes here: it prefers a `session_id` subkey, then falls back to the
+	 * first available subkey value, scanning runtimes in registration order.
+	 *
+	 * @param  array $owner_context Decoded lock owner context.
+	 * @return string Session identifier, or '' when none is available.
+	 */
+	private function resolve_owner_context_session_id( array $owner_context ): string {
+		$runtime_ids = (array) ( $owner_context['runtime_ids'] ?? array() );
+
+		foreach ( $runtime_ids as $entry ) {
+			if ( is_array($entry) && '' !== trim( (string) ( $entry['session_id'] ?? '' )) ) {
+				return (string) $entry['session_id'];
+			}
+		}
+
+		foreach ( $runtime_ids as $entry ) {
+			if ( ! is_array($entry) ) {
+				continue;
+			}
+			foreach ( $entry as $value ) {
+				if ( '' !== trim( (string) $value) ) {
+					return (string) $value;
+				}
+			}
+		}
+
+		return '';
 	}
 
 	/**

--- a/inc/Workspace/WorkspaceLockStore.php
+++ b/inc/Workspace/WorkspaceLockStore.php
@@ -343,9 +343,8 @@ final class WorkspaceLockStore {
 			'host' => function_exists('gethostname') ? (string) gethostname() : 'unknown-host',
 			'pid'  => function_exists('getmypid') ? (string) getmypid() : 'unknown-pid',
 		);
+		// DMC's own namespace — these are not vendor leaks.
 		$env_map = array(
-			'kimaki_session_id'      => 'KIMAKI_SESSION_ID',
-			'opencode_session_id'    => 'OPENCODE_SESSION_ID',
 			'datamachine_task_url'   => 'DATAMACHINE_TASK_URL',
 			'datamachine_task_ref'   => 'DATAMACHINE_TASK_REF',
 			'datamachine_agent'      => 'DATAMACHINE_AGENT',
@@ -358,11 +357,72 @@ final class WorkspaceLockStore {
 			}
 		}
 
+		// Runtime-specific session identifiers are NOT hardcoded here. Integration
+		// layers (e.g. wp-coding-agents) declare which env vars to sniff and how to
+		// project them into a runtime-keyed envelope via the
+		// `datamachine_code_worktree_runtime_signatures` filter — the same registry
+		// WorktreeContextInjector reads. DMC enumerates no runtime IDs and no
+		// vendor-specific env-var names.
+		$runtime_ids = self::resolve_runtime_ids();
+		if ( ! empty($runtime_ids) ) {
+			$context['runtime_ids'] = $runtime_ids;
+		}
+
 		if ( isset($_SERVER['argv']) && is_array($_SERVER['argv']) ) {
 			$context['wp_cli_args'] = self::bounded_string(self::redact_secret_values(implode(' ', array_map('strval', $_SERVER['argv']))), 1000);
 		}
 
 		return $context;
+	}
+
+	/**
+	 * Resolve runtime-specific session identifiers from registered signatures.
+	 *
+	 * Reads the `datamachine_code_worktree_runtime_signatures` filter (the same
+	 * public contract WorktreeContextInjector consumes) and projects any env
+	 * vars the surrounding runtime exposes into a runtime-keyed envelope:
+	 *
+	 *   array(
+	 *       '<runtime-id>' => array( '<subkey>' => '<value>', ... ),
+	 *   )
+	 *
+	 * DMC enumerates no runtime IDs and no vendor-specific env-var names; the
+	 * integration layer declares both. Missing fields stay missing.
+	 *
+	 * @return array<string,array<string,string>>
+	 */
+	private static function resolve_runtime_ids(): array {
+		if ( ! function_exists('apply_filters') ) {
+			return array();
+		}
+
+		$signatures = apply_filters('datamachine_code_worktree_runtime_signatures', array());
+		if ( ! is_array($signatures) ) {
+			return array();
+		}
+
+		$runtime_ids = array();
+		foreach ( $signatures as $runtime_id => $entry ) {
+			if ( ! is_string($runtime_id) || '' === $runtime_id || ! is_array($entry) ) {
+				continue;
+			}
+			$resolved = array();
+			foreach ( $entry as $subkey => $env_var ) {
+				if ( ! is_string($subkey) || '' === $subkey || ! is_string($env_var) || '' === $env_var ) {
+					continue;
+				}
+				$value = getenv($env_var);
+				if ( false === $value || '' === trim( (string) $value) ) {
+					continue;
+				}
+				$resolved[ $subkey ] = self::bounded_string( (string) $value, 300);
+			}
+			if ( ! empty($resolved) ) {
+				$runtime_ids[ $runtime_id ] = $resolved;
+			}
+		}
+
+		return $runtime_ids;
 	}
 
 	private static function default_owner(): string {


### PR DESCRIPTION
## Summary

Fixes the RULES.md layer-purity violation in #481: `WorkspaceLockStore::default_owner_context()` hardcoded `kimaki_*`/`opencode_*` runtime-ID env-var literals in DMC's generic core, and `WorkspaceCommand.php` special-cased `kimaki_session_id` in display logic.

Both now read runtime session identifiers from the **existing** `datamachine_code_worktree_runtime_signatures` filter — the same registry `WorktreeContextInjector::runtime_signatures()` already consumes (populated by the `wp-coding-agents-runtimes.php` MU-plugin). `WorkspaceLockStore` was simply never migrated onto it. Adding a new runtime is now a filter/config change, never a DMC core edit.

## Which signatures API I re-pointed onto

`apply_filters('datamachine_code_worktree_runtime_signatures', array())` — runtime-id => `{ subkey => ENV_VAR_NAME }`. Resolved env values are projected into a generic runtime-keyed envelope (`runtime_ids` => `{ runtime-id => { subkey => value } }`), mirroring the `ids` envelope `WorktreeContextInjector` builds. DMC's own `DATAMACHINE_*` keys are kept (DMC namespace, not a vendor leak).

## Before / after — `default_owner_context()` env_map

Before:
```php
$env_map = array(
    'kimaki_session_id'      => 'KIMAKI_SESSION_ID',
    'opencode_session_id'    => 'OPENCODE_SESSION_ID',
    'datamachine_task_url'   => 'DATAMACHINE_TASK_URL',
    'datamachine_task_ref'   => 'DATAMACHINE_TASK_REF',
    'datamachine_agent'      => 'DATAMACHINE_AGENT',
    'datamachine_agent_name' => 'DATAMACHINE_AGENT_NAME',
);
```

After:
```php
// DMC's own namespace — these are not vendor leaks.
$env_map = array(
    'datamachine_task_url'   => 'DATAMACHINE_TASK_URL',
    'datamachine_task_ref'   => 'DATAMACHINE_TASK_REF',
    'datamachine_agent'      => 'DATAMACHINE_AGENT',
    'datamachine_agent_name' => 'DATAMACHINE_AGENT_NAME',
);
// ...
$runtime_ids = self::resolve_runtime_ids(); // reads the signatures filter
if ( ! empty($runtime_ids) ) {
    $context['runtime_ids'] = $runtime_ids;
}
```

A new private `resolve_runtime_ids()` reads the filter and projects exposed env vars into the runtime-keyed envelope.

## Before / after — `WorkspaceCommand` display branch

Before:
```php
if ( ! empty($owner_context['kimaki_session_id']) || ! empty($owner_context['opencode_session_id']) ) {
    WP_CLI::log(sprintf('Session:    %s', (string) ( $owner_context['kimaki_session_id'] ?? $owner_context['opencode_session_id'] ?? '' )));
}
```

After:
```php
$session_id = $this->resolve_owner_context_session_id($owner_context);
if ( '' !== $session_id ) {
    WP_CLI::log(sprintf('Session:    %s', $session_id));
}
```

New `resolve_owner_context_session_id()` renders generically from `runtime_ids`: prefers a `session_id` subkey, falls back to the first available subkey value, scanning runtimes in registration order. No runtime names.

## grep test (RULES.md acceptance)

The runtime-ID literals are gone from both files' logic:
```
$ grep -riE 'kimaki|opencode' inc/Workspace/WorkspaceLockStore.php inc/Cli/Commands/WorkspaceCommand.php
inc/Cli/Commands/WorkspaceCommand.php:	 *   composed AGENTS.md visible to OpenCode: symlink it into the worktree root
inc/Cli/Commands/WorkspaceCommand.php:	 *   when no repo-owned AGENTS.md exists, otherwise add it via local OpenCode
```

The only remaining matches are **two docblock lines** in an unrelated `worktree add` command, describing the on-disk **AGENTS.md filesystem convention** (`.opencode/` config-file path discovery, sitting alongside an equivalent `.claude/CLAUDE.local.md` reference). That's a config-file-layout integration contract, not the runtime-session-ID leak #481 targets, so it's intentionally left out of scope to keep this PR focused. The session-ID vendor leak — the actual subject of the issue — is fully removed.

`php -l` passes on both files.

Closes #481