### PR TITLE
Register bundle artifact hooks early

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -25,6 +25,10 @@ define( 'DATAMACHINE_CODE_URL', plugin_dir_url( __FILE__ ) );
 // PSR-4 Autoloading.
 require_once __DIR__ . '/vendor/autoload.php';
 
+// Bundle artifact types must be registered as soon as the plugin is loaded so
+// Data Machine can validate DMC-owned artifacts during early import paths.
+( new \DataMachineCode\Bundle\WorkspacePreloadArtifact() )->register();
+
 /**
  * Install DMC-owned database tables.
  */
@@ -99,7 +103,6 @@ function datamachine_code_bootstrap() {
 	new \DataMachineCode\Abilities\CodeTaskAbilities();
 	new \DataMachineCode\Abilities\WordPressRuntimeAbilities();
 	\DataMachineCode\SourceInventory\WorkspaceSourceInventory::register();
-	( new \DataMachineCode\Bundle\WorkspacePreloadArtifact() )->register();
 
 	// Project active workspace identity into Data Machine's engine_data
 	// snapshot at job init. Requires DM's datamachine_engine_snapshot

--- a/tests/smoke-bundle-artifact-early-registration.php
+++ b/tests/smoke-bundle-artifact-early-registration.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Smoke test that DMC bundle artifact hooks register at plugin load time.
+ *
+ * Run: php tests/smoke-bundle-artifact-early-registration.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+declare( strict_types=1 );
+
+if ( ! defined( 'WPINC' ) ) {
+	define( 'WPINC', 'wp-includes' );
+}
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$filters = array();
+$actions = array();
+
+function plugin_dir_path( string $file ): string {
+	return dirname( $file ) . '/';
+}
+
+function plugin_dir_url( string $file ): string {
+	return 'https://example.test/wp-content/plugins/' . basename( dirname( $file ) ) . '/';
+}
+
+function register_activation_hook( string $file, callable|string $callback ): void {
+	unset( $file, $callback );
+}
+
+function add_action( string $hook, callable|string|array $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	global $actions;
+	$actions[ $hook ][ $priority ][] = array( $callback, $accepted_args );
+}
+
+function add_filter( string $hook, callable|string|array $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	global $filters;
+	$filters[ $hook ][ $priority ][] = array( $callback, $accepted_args );
+}
+
+function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed {
+	global $filters;
+	if ( empty( $filters[ $hook ] ) ) {
+		return $value;
+	}
+
+	ksort( $filters[ $hook ] );
+	foreach ( $filters[ $hook ] as $callbacks ) {
+		foreach ( $callbacks as $callback ) {
+			$value = call_user_func_array( $callback[0], array_slice( array_merge( array( $value ), $args ), 0, (int) $callback[1] ) );
+		}
+	}
+
+	return $value;
+}
+
+require __DIR__ . '/../data-machine-code.php';
+
+$types = apply_filters( 'datamachine_agent_bundle_artifact_types', array( 'agent' ) );
+$ok    = in_array( 'datamachine-code/workspace_preload', $types, true );
+
+echo 'Bundle artifact early registration - smoke' . PHP_EOL;
+echo ( $ok ? '  ok registers workspace preload artifact before bootstrap' : '  fail registers workspace preload artifact before bootstrap' ) . PHP_EOL;
+echo PHP_EOL . 'Result: ' . ( $ok ? '1/1 passed' : '0/1 passed' ) . PHP_EOL;
+
+exit( $ok ? 0 : 1 );


### PR DESCRIPTION
## Summary
- Register Data Machine Code bundle artifact hooks at plugin load time so Data Machine can validate DMC-owned bundle artifacts on early import paths.
- Add a smoke test covering workspace preload artifact type registration before DMC bootstrap runs.

## Testing
- `php -l data-machine-code.php && php -l tests/smoke-bundle-artifact-early-registration.php && php -l tests/smoke-workspace-preload-artifact.php`
- `php tests/smoke-bundle-artifact-early-registration.php`
- `php tests/smoke-workspace-preload-artifact.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the bundle artifact registration timing failure, drafted the minimal code/test change, and ran focused verification. Chris remains responsible for review and merge.