### PR TITLE
fix: include issue comments in GitHub fetch content

### DIFF
--- a/inc/Handlers/GitHub/GitHub.php
+++ b/inc/Handlers/GitHub/GitHub.php
@@ -956,6 +956,13 @@ class GitHub extends FetchHandler {
 			$parts[] = sprintf('**Assignees:** %s', implode(', ', $issue['assignees']));
 		}
 		$parts[] = sprintf('**Comments:** %d', $issue['comments'] ?? 0);
+		if ( ! empty($issue['latest_comment']) && is_array($issue['latest_comment']) ) {
+			$latest_comment = $issue['latest_comment'];
+			$parts[]        = sprintf('**Latest Comment Author:** %s', $latest_comment['user'] ?? 'unknown');
+			$parts[]        = sprintf('**Latest Comment Created:** %s', $latest_comment['created_at'] ?? '');
+			$parts[]        = '**Latest Comment:**';
+			$parts[]        = (string) ( $latest_comment['body'] ?? '' );
+		}
 		$parts[] = sprintf('**Created:** %s', $issue['created_at'] ?? '');
 		$parts[] = sprintf('**URL:** %s', $issue['html_url'] ?? '');
 		$parts[] = '';

--- a/tests/smoke-github-fetch-by-number.php
+++ b/tests/smoke-github-fetch-by-number.php
@@ -51,9 +51,10 @@ $assert(false !== strpos($handler, 'targeted fetch ignores list filters'), 'hand
 $assert(false !== strpos($handler, 'does not match configured state'), 'handler drops items whose state does not match configured state');
 
 // DataPacket shape parity (same dedup_key format as list path).
-$assert(false !== strpos($handler, "sprintf( 'github_%s_%s_%d', \$repo, \$data_source, \$item['number'] )"), 'targeted packet uses the same dedup_key shape as the list path');
+$assert(false !== strpos($handler, "sprintf('github_%s_%s_%d', \$repo, \$data_source, \$item['number'])"), 'targeted packet uses the same dedup_key shape as the list path');
 $assert(false !== strpos($handler, "'source_type'       => 'github'"), 'targeted packet metadata uses source_type=github');
 $assert(false !== strpos($handler, 'buildIssueContent') && false !== strpos($handler, 'buildPrContent'), 'targeted path reuses buildIssueContent / buildPrContent for parity');
+$assert(false !== strpos($handler, '**Latest Comment:**') && false !== strpos($handler, "\$issue['latest_comment']"), 'issue content includes latest comment body when available');
 
 // Settings schema fields.
 $assert(false !== strpos($settings, "'issue_number'"), 'settings expose issue_number field');


### PR DESCRIPTION
## Summary
- Include the latest issue comment body in GitHub issue fetch packet content when available.
- Cover the targeted fetch content path so downstream agents receive design/context comments without extra tool loops.

## Tests
- `php tests/smoke-github-fetch-by-number.php`
- `php tests/smoke-github-create-abilities.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed missing fetched issue-comment context, drafted the fetch-content change and smoke coverage, and ran focused verification.