### PR TITLE
fix: select GitHub credentials by operation

### DIFF
--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -1571,7 +1571,12 @@ class GitHubAbilities {
 			return new \WP_Error('missing_head', 'Pull request head branch is required.', array( 'status' => 400 ));
 		}
 
-		$pat = self::getPat();
+		$pat = self::getPat(
+			array(
+				'repo'       => $repo,
+				'capability' => 'pull_request_create',
+			)
+		);
 		if ( empty($pat) ) {
 			return self::patError();
 		}

--- a/inc/Support/GitHubCredentialResolver.php
+++ b/inc/Support/GitHubCredentialResolver.php
@@ -332,6 +332,8 @@ final class GitHubCredentialResolver {
 	 * - `repo` selects the profile whose `allowed_repos` contains the
 	 *   repo, falling back to the profile whose `default_repo` matches,
 	 *   then to the default profile.
+	 * - Pass `capability` with `repo` to prefer a matching profile whose
+	 *   `capabilities` list includes that operation before normal repo matching.
 	 * - No selector → default profile.
 	 *
 	 * @param  array<string,mixed>|null $selector
@@ -355,21 +357,26 @@ final class GitHubCredentialResolver {
 				);
 			}
 
-			$repo = isset($selector['repo']) ? strtolower(trim( (string) $selector['repo'])) : '';
+			$repo       = isset($selector['repo']) ? strtolower(trim( (string) $selector['repo'])) : '';
+			$capability = isset($selector['capability']) ? strtolower(trim( (string) $selector['capability'])) : '';
 			if ( '' !== $repo ) {
+				if ( '' !== $capability ) {
+					foreach ( $profiles as $profile ) {
+						if ( self::profileMatchesRepo($profile, $repo) && self::profileSupportsCapability($profile, $capability) ) {
+							return $profile;
+						}
+					}
+				}
+
 				// Prefer profiles that explicitly list the repo in allowed_repos.
 				foreach ( $profiles as $profile ) {
-					$allowed = isset($profile['allowed_repos']) && is_array($profile['allowed_repos'])
-					? array_map('strtolower', array_map('strval', $profile['allowed_repos']))
-					: array();
-					if ( in_array($repo, $allowed, true) ) {
+					if ( self::profileAllowedForRepo($profile, $repo) ) {
 						return $profile;
 					}
 				}
 				// Fall back to a profile whose default_repo matches.
 				foreach ( $profiles as $profile ) {
-					$default_repo = strtolower(trim( (string) ( $profile['default_repo'] ?? '' )));
-					if ( '' !== $default_repo && $default_repo === $repo ) {
+					if ( self::profileDefaultRepoMatches($profile, $repo) ) {
 						return $profile;
 					}
 				}
@@ -409,6 +416,7 @@ final class GitHubCredentialResolver {
 				'app_private_key'     => $app_private_key,
 				'default_repo'        => $default_repo,
 				'allowed_repos'       => array(),
+				'capabilities'        => array(),
 			),
 		);
 	}
@@ -435,6 +443,16 @@ final class GitHubCredentialResolver {
 			}
 		}
 
+		$capabilities = array();
+		if ( isset($entry['capabilities']) && is_array($entry['capabilities']) ) {
+			foreach ( $entry['capabilities'] as $capability ) {
+				$capability = strtolower(trim( (string) $capability));
+				if ( '' !== $capability ) {
+					$capabilities[] = $capability;
+				}
+			}
+		}
+
 		return array(
 			'id'                  => $id,
 			'label'               => (string) ( $entry['label'] ?? $id ),
@@ -445,6 +463,7 @@ final class GitHubCredentialResolver {
 			'app_private_key'     => (string) ( $entry['app_private_key'] ?? '' ),
 			'default_repo'        => (string) ( $entry['default_repo'] ?? '' ),
 			'allowed_repos'       => $allowed,
+			'capabilities'        => array_values(array_unique($capabilities)),
 		);
 	}
 
@@ -459,7 +478,33 @@ final class GitHubCredentialResolver {
 			'app_private_key'     => '',
 			'default_repo'        => '',
 			'allowed_repos'       => array(),
+			'capabilities'        => array(),
 		);
+	}
+
+	private static function profileMatchesRepo( array $profile, string $repo ): bool {
+		return self::profileAllowedForRepo($profile, $repo) || self::profileDefaultRepoMatches($profile, $repo);
+	}
+
+	private static function profileAllowedForRepo( array $profile, string $repo ): bool {
+		$allowed = isset($profile['allowed_repos']) && is_array($profile['allowed_repos'])
+		? array_map('strtolower', array_map('strval', $profile['allowed_repos']))
+		: array();
+
+		return in_array($repo, $allowed, true);
+	}
+
+	private static function profileDefaultRepoMatches( array $profile, string $repo ): bool {
+		$default_repo = strtolower(trim( (string) ( $profile['default_repo'] ?? '' )));
+		return '' !== $default_repo && $default_repo === $repo;
+	}
+
+	private static function profileSupportsCapability( array $profile, string $capability ): bool {
+		$capabilities = isset($profile['capabilities']) && is_array($profile['capabilities'])
+		? array_map('strtolower', array_map('strval', $profile['capabilities']))
+		: array();
+
+		return in_array($capability, $capabilities, true);
 	}
 
 	private static function profileIsConfigured( array $profile ): bool {
@@ -487,6 +532,9 @@ final class GitHubCredentialResolver {
 			'default_repo'                => (string) ( $profile['default_repo'] ?? '' ),
 			'allowed_repos'               => isset($profile['allowed_repos']) && is_array($profile['allowed_repos'])
 			? array_values(array_map('strval', $profile['allowed_repos']))
+			: array(),
+			'capabilities'                => isset($profile['capabilities']) && is_array($profile['capabilities'])
+			? array_values(array_map('strval', $profile['capabilities']))
 			: array(),
 			'configured'                  => self::profileIsConfigured($profile),
 		);

--- a/inc/Support/GitHubProfileSanitizer.php
+++ b/inc/Support/GitHubProfileSanitizer.php
@@ -52,6 +52,16 @@ final class GitHubProfileSanitizer {
 				}
 			}
 
+			$capabilities = array();
+			if ( isset($entry['capabilities']) && is_array($entry['capabilities']) ) {
+				foreach ( $entry['capabilities'] as $capability ) {
+					$capability = sanitize_key( (string) $capability);
+					if ( '' !== $capability ) {
+						$capabilities[] = $capability;
+					}
+				}
+			}
+
 			$mode = strtolower(sanitize_text_field( (string) ( $entry['mode'] ?? 'pat' )));
 			if ( ! in_array($mode, array( 'pat', 'app' ), true) ) {
 				$mode = 'pat';
@@ -67,6 +77,7 @@ final class GitHubProfileSanitizer {
 				'app_private_key'     => trim( (string) ( $entry['app_private_key'] ?? '' )),
 				'default_repo'        => sanitize_text_field( (string) ( $entry['default_repo'] ?? '' )),
 				'allowed_repos'       => $allowed,
+				'capabilities'        => array_values(array_unique($capabilities)),
 			);
 		}
 		return $sanitized;

--- a/tests/smoke-github-create-abilities.php
+++ b/tests/smoke-github-create-abilities.php
@@ -59,9 +59,11 @@ namespace DataMachineCode\Support {
     {
         public static string $mode = 'pat';
         public static $resolution = null;
+        public static array $selectors = array();
 
-        public static function resolve()
+        public static function resolve( ?callable $http_request = null, ?int $now = null, ?array $selector = null )
         {
+            self::$selectors[] = $selector;
             if (null === self::$resolution ) {
                 return array( 'token' => 'test-token', 'mode' => self::$mode );
             }
@@ -410,6 +412,7 @@ namespace {
 
     // ---- createPullRequest: success path with explicit base, draft default false
     $reset_http();
+    \DataMachineCode\Support\GitHubCredentialResolver::$selectors = array();
     $queue_response(200, array());
     $queue_response(
         201, array(
@@ -432,6 +435,7 @@ namespace {
         ) 
     );
     $assert('createPullRequest success returns success=true', is_array($result) && true === ( $result['success'] ?? false ));
+    $assert('createPullRequest selects pull_request_create credential by repo', array( 'repo' => 'owner/repo', 'capability' => 'pull_request_create' ) === ( \DataMachineCode\Support\GitHubCredentialResolver::$selectors[0] ?? null ));
     $assert('createPullRequest result kind identifies pull request', is_array($result) && 'pull_request' === ( $result['kind'] ?? '' ));
     $assert('createPullRequest result exposes repo', is_array($result) && 'owner/repo' === ( $result['repo'] ?? '' ));
     $assert('createPullRequest result exposes top-level number', is_array($result) && 88 === ( $result['number'] ?? 0 ));

--- a/tests/smoke-github-credential-profiles.php
+++ b/tests/smoke-github-credential-profiles.php
@@ -223,6 +223,31 @@ namespace {
     $by_default_repo = GitHubCredentialResolver::resolve(null, null, array( 'repo' => 'team/project-b' ));
     $assert('repo selector falls back to default_repo match', ! is_wp_error($by_default_repo) && 'project-b-token' === $by_default_repo['token']);
 
+    $reset(
+        array(
+        'github_credential_profiles' => array(
+        array(
+                'id'            => 'repo-token',
+                'mode'          => 'pat',
+                'pat'           => 'repo-token-value',
+                'allowed_repos' => array( 'owner/repo' ),
+        ),
+        array(
+                'id'            => 'app-token',
+                'mode'          => 'pat',
+                'pat'           => 'app-token-value',
+                'allowed_repos' => array( 'owner/repo' ),
+                'capabilities'  => array( 'pull_request_create' ),
+        ),
+        ),
+        'github_default_profile_id'  => 'repo-token',
+        )
+    );
+    $repo_default = GitHubCredentialResolver::resolve(null, null, array( 'repo' => 'owner/repo' ));
+    $assert('repo selector without capability keeps first matching profile', ! is_wp_error($repo_default) && 'repo-token-value' === $repo_default['token']);
+    $pr_credential = GitHubCredentialResolver::resolve(null, null, array( 'repo' => 'owner/repo', 'capability' => 'pull_request_create' ));
+    $assert('repo selector with capability prefers matching operation profile', ! is_wp_error($pr_credential) && 'app-token-value' === $pr_credential['token']);
+
     // 7. Profile with empty PAT fails closed (does not silently use default).
     $reset(
         array(
@@ -254,6 +279,7 @@ namespace {
                 'mode'          => 'pat',
                 'pat'           => 'p1-secret',
                 'allowed_repos' => array( 'a/b' ),
+                'capabilities'  => array( 'pull_request_create' ),
         ),
         array(
                 'id'    => 'p2',
@@ -270,6 +296,7 @@ namespace {
     $assert('status default_profile_id matches setting', 'p1' === $status['default_profile_id']);
     $assert('status profile entry hides PAT body', ! str_contains(wp_json_encode($status), 'p1-secret'));
     $assert('status profile reports configured booleans', $status['profiles'][0]['pat_configured'] && ! $status['profiles'][1]['pat_configured']);
+    $assert('status profile reports non-secret capabilities', array( 'pull_request_create' ) === $status['profiles'][0]['capabilities']);
 
     // 9. Migration shape: legacy single-cred install still resolves.
     $reset(
@@ -292,6 +319,7 @@ namespace {
     'pat'           => 'marketing-secret',
     'default_repo'  => 'team/marketing',
     'allowed_repos' => array( 'team/marketing', '   team/sub  ' ),
+    'capabilities'  => array( 'PULL_REQUEST_CREATE', 'issues_write' ),
     ),
     array(
     // Missing id → must be dropped.
@@ -305,6 +333,7 @@ namespace {
     $assert('sanitizer normalizes id via sanitize_key', 'marketing' === $sanitized[0]['id']);
     $assert('sanitizer preserves PAT', 'marketing-secret' === $sanitized[0]['pat']);
     $assert('sanitizer trims allowed_repos entries', $sanitized[0]['allowed_repos'] === array( 'team/marketing', 'team/sub' ));
+    $assert('sanitizer normalizes capabilities', $sanitized[0]['capabilities'] === array( 'pull_request_create', 'issues_write' ));
 
     if ($failures ) {
         echo "\nFailures:\n";


### PR DESCRIPTION
## Summary
- Add non-secret credential profile capabilities and capability-aware repo selection.
- Use `pull_request_create` credentials for GitHub PR creation while leaving ordinary repo operations on the first repo-matching profile.
- Preserve capability metadata through settings sanitization and status output.

## Tests
- `php tests/smoke-github-credential-profiles.php`
- `php tests/smoke-github-create-abilities.php`
- `php tests/smoke-github-fetch-by-number.php`
- `php tests/smoke-github-merge-pull-request.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the operation-level credential routing issue, drafted the resolver and PR creation changes, and ran focused smoke tests.