### PR TITLE
fix: skip actor lookup for fresh issue comments

### DIFF
--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -2219,11 +2219,6 @@ class GitHubAbilities {
 	 * @return true|\WP_Error True when a comment may be posted, or an error explaining why not.
 	 */
 	private static function checkIssueAutomationCommentTurn( string $repo, int $issue_number, string $pat ): true|\WP_Error {
-		$actor = self::getAuthenticatedGitHubLogin($pat);
-		if ( is_wp_error($actor) ) {
-			return $actor;
-		}
-
 		$issue = self::apiGet(sprintf('%s/repos/%s/issues/%d', self::API_BASE, $repo, $issue_number), array(), $pat);
 		if ( is_wp_error($issue) ) {
 			return $issue;
@@ -2232,6 +2227,11 @@ class GitHubAbilities {
 		$comment_count = max(0, (int) ( $issue['data']['comments'] ?? 0 ));
 		if ( 0 === $comment_count ) {
 			return true;
+		}
+
+		$actor = self::getAuthenticatedGitHubLogin($pat);
+		if ( is_wp_error($actor) ) {
+			return $actor;
 		}
 
 		$comments = self::apiGet(

--- a/tests/smoke-github-create-abilities.php
+++ b/tests/smoke-github-create-abilities.php
@@ -803,6 +803,21 @@ namespace {
     $assert('createOrUpdateFile existing branch only checks ref, contents, and PUTs', 3 === count($GLOBALS['dmc_http_calls']));
     $assert('createOrUpdateFile existing branch does not create git ref', ! str_ends_with((string) ( $GLOBALS['dmc_http_calls'][1]['url'] ?? '' ), '/git/refs') && ! str_ends_with((string) ( $GLOBALS['dmc_http_calls'][2]['url'] ?? '' ), '/git/refs'));
 
+    // ---- commentOnIssue: fresh issues do not need authenticated actor lookup.
+    $reset_http();
+    $queue_response(200, array( 'comments' => 0 ));
+    $queue_response(
+        201, array(
+        'id'         => 321,
+        'html_url'   => 'https://github.com/owner/repo/issues/123#issuecomment-321',
+        'created_at' => '2026-05-10T00:00:00Z',
+        )
+    );
+    $result = GitHubAbilities::commentOnIssue(array( 'repo' => 'owner/repo', 'issue_number' => 123, 'body' => 'Fresh design direction' ));
+    $assert('commentOnIssue succeeds for issue with no comments', is_array($result) && true === ( $result['success'] ?? false ));
+    $assert('commentOnIssue checks issue comment count before posting', 2 === count($GLOBALS['dmc_http_calls']) && str_contains((string) ( $GLOBALS['dmc_http_calls'][0]['url'] ?? '' ), '/repos/owner/repo/issues/123'));
+    $assert('commentOnIssue skips GET /user for issue with no comments', ! str_contains((string) ( $GLOBALS['dmc_http_calls'][0]['url'] ?? '' ), '/user') && ! str_contains((string) ( $GLOBALS['dmc_http_calls'][1]['url'] ?? '' ), '/user'));
+
     // ---- getIssue: metadata includes comment counts and the latest issue comment.
     $reset_http();
     $queue_response(


### PR DESCRIPTION
## Summary
- Avoids calling `GET /user` before commenting on an issue that has no existing comments.
- Keeps the automation repeat-comment guard intact for issues that already have comments, where actor comparison is actually needed.

## Verification
- `php tests/smoke-github-create-abilities.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed GitHub App issue-comment failures from E2E artifacts, implemented the guard ordering fix, and added smoke coverage; Chris remains responsible for review and merge.