### PR TITLE
Support generic fan-out env projection

### DIFF
--- a/inc/Channels/CliChannelRegistry.php
+++ b/inc/Channels/CliChannelRegistry.php
@@ -31,6 +31,7 @@ defined('ABSPATH') || exit;
  *     detach?: bool,
  *     timeout?: int,
  *     env?: array<string, string>,
+ *     env_from?: array<string, string>,
  *     cwd?: string|null,
  * }
  */
@@ -188,18 +189,35 @@ class CliChannelRegistry {
 			$normalized_env[ $env_key ] = (string) $env_value;
 		}
 
+		$env_from = $config['env_from'] ?? array();
+		if ( ! is_array($env_from) ) {
+			$env_from = array();
+		}
+		$normalized_env_from = array();
+		foreach ( $env_from as $env_key => $source_env_key ) {
+			if ( ! is_string($env_key) || '' === $env_key || ! is_scalar($source_env_key) ) {
+				continue;
+			}
+
+			$source_env_key = trim( (string) $source_env_key );
+			if ( '' !== $source_env_key ) {
+				$normalized_env_from[ $env_key ] = $source_env_key;
+			}
+		}
+
 		$cwd = $config['cwd'] ?? null;
 		if ( null !== $cwd && ( ! is_string($cwd) || '' === $cwd ) ) {
 			$cwd = null;
 		}
 
 		return array(
-			'command' => $command,
-			'args'    => $normalized_args,
-			'detach'  => $detach,
-			'timeout' => $timeout,
-			'env'     => $normalized_env,
-			'cwd'     => $cwd,
+			'command'  => $command,
+			'args'     => $normalized_args,
+			'detach'   => $detach,
+			'timeout'  => $timeout,
+			'env'      => $normalized_env,
+			'env_from' => $normalized_env_from,
+			'cwd'      => $cwd,
 		);
 	}
 

--- a/inc/Channels/CliChannelTransport.php
+++ b/inc/Channels/CliChannelTransport.php
@@ -29,6 +29,7 @@
 namespace DataMachineCode\Channels;
 
 use DataMachineCode\Environment;
+use DataMachineCode\Support\SecretRedactor;
 use WP_Error;
 
 defined('ABSPATH') || exit;
@@ -429,6 +430,44 @@ class CliChannelTransport {
 			$env[ $key ] = $value;
 		}
 
+		$gateway_base_url = self::parent_env('WP_AI_GATEWAY_BASE_URL');
+		$gateway_token    = self::parent_env('WP_AI_GATEWAY_TOKEN');
+		if ( '' !== $gateway_base_url && '' !== $gateway_token ) {
+			$env                    = self::without_gateway_forbidden_env($env);
+			$env['OPENAI_BASE_URL'] = $gateway_base_url;
+			$env['OPENAI_API_KEY']  = $gateway_token;
+		}
+
+		return $env;
+	}
+
+	/**
+	 * Read a trimmed parent environment variable.
+	 */
+	private static function parent_env( string $name ): string {
+		$value = getenv($name);
+		return is_string($value) ? trim($value) : '';
+	}
+
+	/**
+	 * Remove parent/upstream secrets before applying the gateway OpenAI shim.
+	 *
+	 * @param  array<string,string> $env Environment map.
+	 * @return array<string,string>
+	 */
+	private static function without_gateway_forbidden_env( array $env ): array {
+		foreach ( array_keys($env) as $key ) {
+			$key_upper = strtoupper( (string) $key );
+			if ( in_array($key_upper, array( 'OPENAI_API_KEY', 'OPENAI_BASE_URL', 'WP_AI_GATEWAY_TOKEN' ), true)
+				|| str_contains($key_upper, 'CODEX')
+				|| str_contains($key_upper, 'OPENCODE_GO')
+				|| str_contains($key_upper, 'COOKIE')
+				|| str_contains($key_upper, 'NONCE')
+			) {
+				unset($env[ $key ]);
+			}
+		}
+
 		return $env;
 	}
 
@@ -439,7 +478,8 @@ class CliChannelTransport {
 	 * @return string Truncated output.
 	 */
 	private static function truncate_output( string $output ): string {
-		$limit = 8192;
+		$output = SecretRedactor::redact($output);
+		$limit  = 8192;
 		if ( strlen($output) <= $limit ) {
 			return $output;
 		}

--- a/inc/Channels/CliChannelTransport.php
+++ b/inc/Channels/CliChannelTransport.php
@@ -164,13 +164,16 @@ class CliChannelTransport {
 		$detach  = (bool) ( $config['detach'] ?? true );
 		$timeout = isset($config['timeout']) && is_int($config['timeout']) ? $config['timeout'] : self::DEFAULT_TIMEOUT_SECONDS;
 		$cwd     = isset($config['cwd']) && is_string($config['cwd']) && '' !== $config['cwd'] ? $config['cwd'] : null;
-		$env     = self::build_env_map(isset($config['env']) && is_array($config['env']) ? $config['env'] : array());
+		$env     = self::build_env_map(
+			isset($config['env']) && is_array($config['env']) ? $config['env'] : array(),
+			isset($config['env_from']) && is_array($config['env_from']) ? $config['env_from'] : array()
+		);
 
 		if ( $detach ) {
-			return self::dispatch_detached($channel, $recipient, $command_args, $cwd, $env);
+			return self::dispatch_detached($channel, $recipient, $command_args, $cwd, $env['values']);
 		}
 
-		return self::dispatch_sync($channel, $recipient, $command_args, $cwd, $env, $timeout);
+		return self::dispatch_sync($channel, $recipient, $command_args, $cwd, $env['values'], $env['secrets'], $timeout);
 	}
 
 	/**
@@ -233,7 +236,7 @@ class CliChannelTransport {
 	 * @param  int                        $timeout   Timeout in seconds.
 	 * @return array<string, mixed>|WP_Error
 	 */
-	private static function dispatch_sync( string $channel, string $recipient, array $argv, ?string $cwd, ?array $env, int $timeout ) {
+	private static function dispatch_sync( string $channel, string $recipient, array $argv, ?string $cwd, ?array $env, array $secrets, int $timeout ) {
 		$descriptors = array(
 			0 => array( 'pipe', 'r' ),
 			1 => array( 'pipe', 'w' ),
@@ -329,8 +332,8 @@ class CliChannelTransport {
 				array(
 					'channel'     => $channel,
 					'recipient'   => $recipient,
-					'stdout'      => self::truncate_output($stdout),
-					'stderr'      => self::truncate_output($stderr),
+					'stdout'      => self::truncate_output($stdout, $secrets),
+					'stderr'      => self::truncate_output($stderr, $secrets),
 					'duration_ms' => $duration_ms,
 				)
 			);
@@ -344,8 +347,8 @@ class CliChannelTransport {
 					'channel'     => $channel,
 					'recipient'   => $recipient,
 					'exit_code'   => $exit_code,
-					'stdout'      => self::truncate_output($stdout),
-					'stderr'      => self::truncate_output($stderr),
+					'stdout'      => self::truncate_output($stdout, $secrets),
+					'stderr'      => self::truncate_output($stderr, $secrets),
 					'duration_ms' => $duration_ms,
 				)
 			);
@@ -360,8 +363,8 @@ class CliChannelTransport {
 				'mode'        => 'sync',
 				'exit_code'   => $exit_code,
 				'duration_ms' => $duration_ms,
-				'stdout'      => self::truncate_output($stdout),
-				'stderr'      => self::truncate_output($stderr),
+				'stdout'      => self::truncate_output($stdout, $secrets),
+				'stderr'      => self::truncate_output($stderr, $secrets),
 			),
 		);
 	}
@@ -416,10 +419,12 @@ class CliChannelTransport {
 	 * the inherited PATH if it provides one.
 	 *
 	 * @param  array<string, string> $configured Configured env map.
-	 * @return array<string, string>
+	 * @param  array<string, string> $env_from   Child env name => parent env name.
+	 * @return array{values:array<string,string>,secrets:string[]}
 	 */
-	private static function build_env_map( array $configured ): array {
-		$env = array();
+	private static function build_env_map( array $configured, array $env_from ): array {
+		$env     = array();
+		$secrets = array();
 
 		$parent_path = getenv('PATH');
 		if ( is_string($parent_path) && '' !== $parent_path ) {
@@ -428,17 +433,27 @@ class CliChannelTransport {
 
 		foreach ( $configured as $key => $value ) {
 			$env[ $key ] = $value;
+			if ( self::is_secret_like_env_key( (string) $key ) ) {
+				$secrets[] = $value;
+			}
 		}
 
-		$gateway_base_url = self::parent_env('WP_AI_GATEWAY_BASE_URL');
-		$gateway_token    = self::parent_env('WP_AI_GATEWAY_TOKEN');
-		if ( '' !== $gateway_base_url && '' !== $gateway_token ) {
-			$env                    = self::without_gateway_forbidden_env($env);
-			$env['OPENAI_BASE_URL'] = $gateway_base_url;
-			$env['OPENAI_API_KEY']  = $gateway_token;
+		foreach ( $env_from as $target_key => $source_key ) {
+			$value = self::parent_env( (string) $source_key );
+			if ( '' === $value ) {
+				continue;
+			}
+
+			$env[ $target_key ] = $value;
+			if ( self::is_secret_like_env_key( (string) $target_key ) || self::is_secret_like_env_key( (string) $source_key ) ) {
+				$secrets[] = $value;
+			}
 		}
 
-		return $env;
+		return array(
+			'values'  => $env,
+			'secrets' => array_values(array_unique(array_filter($secrets, static fn( string $secret ): bool => strlen(trim($secret)) >= 8))),
+		);
 	}
 
 	/**
@@ -450,25 +465,10 @@ class CliChannelTransport {
 	}
 
 	/**
-	 * Remove parent/upstream secrets before applying the gateway OpenAI shim.
-	 *
-	 * @param  array<string,string> $env Environment map.
-	 * @return array<string,string>
+	 * Determine whether an environment key conventionally carries a secret.
 	 */
-	private static function without_gateway_forbidden_env( array $env ): array {
-		foreach ( array_keys($env) as $key ) {
-			$key_upper = strtoupper( (string) $key );
-			if ( in_array($key_upper, array( 'OPENAI_API_KEY', 'OPENAI_BASE_URL', 'WP_AI_GATEWAY_TOKEN' ), true)
-				|| str_contains($key_upper, 'CODEX')
-				|| str_contains($key_upper, 'OPENCODE_GO')
-				|| str_contains($key_upper, 'COOKIE')
-				|| str_contains($key_upper, 'NONCE')
-			) {
-				unset($env[ $key ]);
-			}
-		}
-
-		return $env;
+	private static function is_secret_like_env_key( string $key ): bool {
+		return 1 === preg_match('/(?:^|_)(TOKEN|SECRET|PASSWORD|PASSWD|PRIVATE_KEY|API_KEY|ACCESS_KEY|AUTH|COOKIE|NONCE)(?:_|$)/i', $key);
 	}
 
 	/**
@@ -477,8 +477,8 @@ class CliChannelTransport {
 	 * @param  string $output Captured output.
 	 * @return string Truncated output.
 	 */
-	private static function truncate_output( string $output ): string {
-		$output = SecretRedactor::redact($output);
+	private static function truncate_output( string $output, array $secrets = array() ): string {
+		$output = SecretRedactor::redact($output, $secrets);
 		$limit  = 8192;
 		if ( strlen($output) <= $limit ) {
 			return $output;

--- a/inc/Support/RunArtifactPrSectionRenderer.php
+++ b/inc/Support/RunArtifactPrSectionRenderer.php
@@ -344,7 +344,7 @@ class RunArtifactPrSectionRenderer {
 		}
 
 		if ( is_string($value) ) {
-			return self::redactSecretLikeString($value);
+			return SecretRedactor::redact($value);
 		}
 
 		return $value;
@@ -352,14 +352,6 @@ class RunArtifactPrSectionRenderer {
 
 	private static function isSecretLikeKey( string $key ): bool {
 		return 1 === preg_match('/(authorization|credential|secret|token|password|passwd|private[_-]?key|api[_-]?key|github[_-]?pat|bearer)/i', $key);
-	}
-
-	private static function redactSecretLikeString( string $value ): string {
-		$value = preg_replace('/\b(gh[pousr]_[A-Za-z0-9_]{12,})\b/', '[redacted]', $value) ?? $value;
-		$value = preg_replace('/\b(sk-[A-Za-z0-9_-]{12,})\b/', '[redacted]', $value) ?? $value;
-		$value = preg_replace('/\b(xox[baprs]-[A-Za-z0-9-]{12,})\b/', '[redacted]', $value) ?? $value;
-
-		return preg_replace('/\b(authorization|token|password|secret|api[_-]?key)\s*[:=]\s*\S+/i', '$1: [redacted]', $value) ?? $value;
 	}
 
 	/**

--- a/inc/Support/SecretRedactor.php
+++ b/inc/Support/SecretRedactor.php
@@ -14,8 +14,8 @@ class SecretRedactor {
 	/**
 	 * Redact secret-looking values from arbitrary text.
 	 */
-	public static function redact( string $value ): string {
-		foreach ( self::runtime_secret_values() as $secret ) {
+	public static function redact( string $value, array $secrets = array() ): string {
+		foreach ( self::normalize_secrets($secrets) as $secret ) {
 			$value = str_replace($secret, '[redacted]', $value);
 		}
 
@@ -24,19 +24,19 @@ class SecretRedactor {
 		$value = preg_replace('/\b(xox[baprs]-[A-Za-z0-9-]{12,})\b/', '[redacted]', $value) ?? $value;
 		$value = preg_replace('/\b(Bearer)\s+[A-Za-z0-9._~+\/-]{8,}/i', '$1 [redacted]', $value) ?? $value;
 
-		return preg_replace('/\b(authorization|token|password|secret|api[_-]?key|wp_ai_gateway_token|openai_api_key)\s*[:=]\s*\S+/i', '$1: [redacted]', $value) ?? $value;
+		return preg_replace('/\b(authorization|token|password|secret|api[_-]?key)\s*[:=]\s*\S+/i', '$1: [redacted]', $value) ?? $value;
 	}
 
 	/**
-	 * Runtime secret values that must be redacted when present in process env.
+	 * Normalize explicit secret values that must be redacted.
 	 *
+	 * @param  array<int,string> $secrets Secret values.
 	 * @return string[]
 	 */
-	private static function runtime_secret_values(): array {
+	private static function normalize_secrets( array $secrets ): array {
 		$values = array();
-		foreach ( array( 'WP_AI_GATEWAY_TOKEN', 'OPENAI_API_KEY' ) as $name ) {
-			$value = getenv($name);
-			if ( is_string($value) && strlen(trim($value)) >= 8 ) {
+		foreach ( $secrets as $value ) {
+			if ( strlen(trim($value)) >= 8 ) {
 				$values[] = trim($value);
 			}
 		}

--- a/inc/Support/SecretRedactor.php
+++ b/inc/Support/SecretRedactor.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Shared secret redaction helpers.
+ *
+ * @package DataMachineCode\Support
+ */
+
+namespace DataMachineCode\Support;
+
+defined('ABSPATH') || exit;
+
+class SecretRedactor {
+
+	/**
+	 * Redact secret-looking values from arbitrary text.
+	 */
+	public static function redact( string $value ): string {
+		foreach ( self::runtime_secret_values() as $secret ) {
+			$value = str_replace($secret, '[redacted]', $value);
+		}
+
+		$value = preg_replace('/\b(gh[pousr]_[A-Za-z0-9_]{12,})\b/', '[redacted]', $value) ?? $value;
+		$value = preg_replace('/\b(sk-[A-Za-z0-9_-]{12,})\b/', '[redacted]', $value) ?? $value;
+		$value = preg_replace('/\b(xox[baprs]-[A-Za-z0-9-]{12,})\b/', '[redacted]', $value) ?? $value;
+		$value = preg_replace('/\b(Bearer)\s+[A-Za-z0-9._~+\/-]{8,}/i', '$1 [redacted]', $value) ?? $value;
+
+		return preg_replace('/\b(authorization|token|password|secret|api[_-]?key|wp_ai_gateway_token|openai_api_key)\s*[:=]\s*\S+/i', '$1: [redacted]', $value) ?? $value;
+	}
+
+	/**
+	 * Runtime secret values that must be redacted when present in process env.
+	 *
+	 * @return string[]
+	 */
+	private static function runtime_secret_values(): array {
+		$values = array();
+		foreach ( array( 'WP_AI_GATEWAY_TOKEN', 'OPENAI_API_KEY' ) as $name ) {
+			$value = getenv($name);
+			if ( is_string($value) && strlen(trim($value)) >= 8 ) {
+				$values[] = trim($value);
+			}
+		}
+
+		return array_values(array_unique($values));
+	}
+}

--- a/tests/smoke-cli-channel-transport.php
+++ b/tests/smoke-cli-channel-transport.php
@@ -146,12 +146,14 @@ namespace {
     'args'    => array( '--', '{recipient}', '{message}' ),
     'detach'  => false,
     'timeout' => 5,
+    'env_from' => array( 'CHILD_SECRET_TOKEN' => 'PARENT_SECRET_TOKEN' ),
     );
     $normalized  = \DataMachineCode\Channels\CliChannelRegistry::normalize_entry($valid_entry);
     $assert('valid entry normalizes', is_array($normalized) && $normalized['command'] === $echo_bin);
     $assert('normalized entry has args array', is_array($normalized['args'] ?? null) && count($normalized['args']) === 3);
     $assert('normalized entry preserves detach false', false === ( $normalized['detach'] ?? null ));
     $assert('normalized entry preserves timeout', 5 === ( $normalized['timeout'] ?? null ));
+    $assert('normalized entry preserves generic env_from references', array( 'CHILD_SECRET_TOKEN' => 'PARENT_SECRET_TOKEN' ) === ( $normalized['env_from'] ?? null ));
 
     $bad_no_command = \DataMachineCode\Channels\CliChannelRegistry::normalize_entry(array( 'args' => array() ));
     $assert('missing command is rejected', null === $bad_no_command);
@@ -391,70 +393,67 @@ namespace {
     }
 
     // ---------------------------------------------------------------
-    // WP AI Gateway env contract: gateway mode maps to OpenAI-compatible
-    // child env, strips upstream secrets, and redacts captured output.
+    // Generic env projection: caller-provided parent env references are
+    // projected into child env and secret-like values are redacted.
     // ---------------------------------------------------------------
 
-    putenv('WP_AI_GATEWAY_BASE_URL=https://gateway.example/v1');
-    putenv('WP_AI_GATEWAY_TOKEN=gateway-token-1234567890');
+    putenv('DMC_TEST_PARENT_BASE_URL=https://runtime.example/v1');
+    putenv('DMC_TEST_PARENT_SECRET_TOKEN=caller-secret-token-1234567890');
     $datamachine_code_test_options['datamachine_code_cli_channels'] = array(
-    'gateway-env'     => array(
+    'projected-env'   => array(
     'command' => $php_bin,
     'args'    => array(
     '-r',
-    '$ok = getenv("OPENAI_BASE_URL") === "https://gateway.example/v1" && getenv("OPENAI_API_KEY") === "gateway-token-1234567890" && false === getenv("CODEX_REFRESH_TOKEN") && false === getenv("CODEX_ACCESS_TOKEN") && false === getenv("OPENCODE_GO_KEY") && false === getenv("WP_AUTH_COOKIE") && false === getenv("WP_NONCE") && false === getenv("WP_AI_GATEWAY_TOKEN"); echo "OPENAI_BASE_URL=" . getenv("OPENAI_BASE_URL") . "\n"; echo "OPENAI_API_KEY=" . getenv("OPENAI_API_KEY") . "\n"; exit($ok ? 0 : 7);',
+    '$ok = getenv("CHILD_BASE_URL") === "https://runtime.example/v1" && getenv("CHILD_API_TOKEN") === "caller-secret-token-1234567890"; echo "CHILD_BASE_URL=" . getenv("CHILD_BASE_URL") . "\n"; echo "CHILD_API_TOKEN=" . getenv("CHILD_API_TOKEN") . "\n"; exit($ok ? 0 : 7);',
     ),
     'detach'  => false,
     'timeout' => 5,
     'env'     => array(
-    'OPENAI_BASE_URL'     => 'https://raw-openai.example/v1',
-    'OPENAI_API_KEY'      => 'raw-openai-key',
-    'CODEX_REFRESH_TOKEN' => 'codex-refresh-token',
-    'CODEX_ACCESS_TOKEN'  => 'codex-access-token',
-    'OPENCODE_GO_KEY'     => 'opencode-go-key',
-    'WP_AUTH_COOKIE'      => 'wordpress-cookie',
-    'WP_NONCE'            => 'wordpress-nonce',
-    'WP_AI_GATEWAY_TOKEN' => 'configured-gateway-token',
+    'STATIC_ENV' => 'static-value',
+    ),
+    'env_from' => array(
+    'CHILD_BASE_URL'   => 'DMC_TEST_PARENT_BASE_URL',
+    'CHILD_API_TOKEN' => 'DMC_TEST_PARENT_SECRET_TOKEN',
     ),
     ),
-    'nongateway-env'  => array(
+    'static-env'      => array(
     'command' => $php_bin,
     'args'    => array(
     '-r',
-    'exit(getenv("OPENAI_API_KEY") === "raw-openai-key" ? 0 : 9);',
+    'exit(getenv("STATIC_SECRET_TOKEN") === "static-secret-value" ? 0 : 9);',
     ),
     'detach'  => false,
     'timeout' => 5,
     'env'     => array(
-    'OPENAI_API_KEY' => 'raw-openai-key',
+    'STATIC_SECRET_TOKEN' => 'static-secret-value',
     ),
     ),
     );
 
-    $gateway = \DataMachineCode\Channels\CliChannelTransport::execute(
+    $projected = \DataMachineCode\Channels\CliChannelTransport::execute(
         array(
-        'channel'   => 'gateway-env',
+        'channel'   => 'projected-env',
         'recipient' => 'r',
         'message'   => 'm',
         )
     );
-    $assert('gateway env dispatch succeeds', is_array($gateway) && true === ( $gateway['sent'] ?? false ));
-    if (is_array($gateway) ) {
-        $stdout = (string) ( $gateway['metadata']['stdout'] ?? '' );
-        $assert('gateway base URL is passed as OPENAI_BASE_URL', str_contains($stdout, 'OPENAI_BASE_URL=https://gateway.example/v1'));
-        $assert('gateway token is redacted from captured stdout', str_contains($stdout, 'OPENAI_API_KEY: [redacted]') && ! str_contains($stdout, 'gateway-token-1234567890'));
+    $assert('projected env dispatch succeeds', is_array($projected) && true === ( $projected['sent'] ?? false ));
+    if (is_array($projected) ) {
+        $stdout = (string) ( $projected['metadata']['stdout'] ?? '' );
+        $assert('caller-provided base URL reference is projected', str_contains($stdout, 'CHILD_BASE_URL=https://runtime.example/v1'));
+        $assert('projected secret value is redacted from captured stdout', str_contains($stdout, '[redacted]') && ! str_contains($stdout, 'caller-secret-token-1234567890'));
     }
 
-    putenv('WP_AI_GATEWAY_BASE_URL');
-    putenv('WP_AI_GATEWAY_TOKEN');
-    $nongateway = \DataMachineCode\Channels\CliChannelTransport::execute(
+    putenv('DMC_TEST_PARENT_BASE_URL');
+    putenv('DMC_TEST_PARENT_SECRET_TOKEN');
+    $static_env = \DataMachineCode\Channels\CliChannelTransport::execute(
         array(
-        'channel'   => 'nongateway-env',
+        'channel'   => 'static-env',
         'recipient' => 'r',
         'message'   => 'm',
         )
     );
-    $assert('non-gateway configured env continues to work', is_array($nongateway) && true === ( $nongateway['sent'] ?? false ));
+    $assert('static configured env continues to work', is_array($static_env) && true === ( $static_env['sent'] ?? false ));
 
     // ---------------------------------------------------------------
     // Summary

--- a/tests/smoke-cli-channel-transport.php
+++ b/tests/smoke-cli-channel-transport.php
@@ -95,6 +95,7 @@ namespace {
     }
 
     include __DIR__ . '/../inc/Environment.php';
+    include __DIR__ . '/../inc/Support/SecretRedactor.php';
     include __DIR__ . '/../inc/Channels/CliChannelRegistry.php';
     include __DIR__ . '/../inc/Channels/CliChannelTransport.php';
 
@@ -112,13 +113,22 @@ namespace {
 
     // Resolve standard stub binaries. Bail with a clear diagnostic if
     // the host is missing them — the runtime needs real subprocess capability.
-    $echo_bin  = '/bin/echo';
-    $true_bin  = '/bin/true';
-    $false_bin = '/bin/false';
-    $sleep_bin = '/bin/sleep';
-    foreach ( array( $echo_bin, $true_bin, $false_bin, $sleep_bin ) as $candidate ) {
-        if (! is_executable($candidate) ) {
-            echo "  [SKIP] stub binary {$candidate} not present; smoke cannot run on this host\n";
+    $resolve_bin = static function ( array $candidates ): ?string {
+        foreach ( $candidates as $candidate ) {
+            if (is_executable($candidate) ) {
+                return $candidate;
+            }
+        }
+        return null;
+    };
+    $echo_bin  = $resolve_bin(array( '/bin/echo', '/usr/bin/echo' ));
+    $true_bin  = $resolve_bin(array( '/bin/true', '/usr/bin/true' ));
+    $false_bin = $resolve_bin(array( '/bin/false', '/usr/bin/false' ));
+    $sleep_bin = $resolve_bin(array( '/bin/sleep', '/usr/bin/sleep' ));
+    $php_bin = PHP_BINARY;
+    foreach ( array( $echo_bin, $true_bin, $false_bin, $sleep_bin, $php_bin ) as $candidate ) {
+        if (! is_string($candidate) || ! is_executable($candidate) ) {
+            echo "  [SKIP] required stub binary not present; smoke cannot run on this host\n";
             exit(0);
         }
     }
@@ -379,6 +389,72 @@ namespace {
         $metadata = $detached['metadata'] ?? array();
         $assert('detached metadata mode=detached', 'detached' === ( $metadata['mode'] ?? null ));
     }
+
+    // ---------------------------------------------------------------
+    // WP AI Gateway env contract: gateway mode maps to OpenAI-compatible
+    // child env, strips upstream secrets, and redacts captured output.
+    // ---------------------------------------------------------------
+
+    putenv('WP_AI_GATEWAY_BASE_URL=https://gateway.example/v1');
+    putenv('WP_AI_GATEWAY_TOKEN=gateway-token-1234567890');
+    $datamachine_code_test_options['datamachine_code_cli_channels'] = array(
+    'gateway-env'     => array(
+    'command' => $php_bin,
+    'args'    => array(
+    '-r',
+    '$ok = getenv("OPENAI_BASE_URL") === "https://gateway.example/v1" && getenv("OPENAI_API_KEY") === "gateway-token-1234567890" && false === getenv("CODEX_REFRESH_TOKEN") && false === getenv("CODEX_ACCESS_TOKEN") && false === getenv("OPENCODE_GO_KEY") && false === getenv("WP_AUTH_COOKIE") && false === getenv("WP_NONCE") && false === getenv("WP_AI_GATEWAY_TOKEN"); echo "OPENAI_BASE_URL=" . getenv("OPENAI_BASE_URL") . "\n"; echo "OPENAI_API_KEY=" . getenv("OPENAI_API_KEY") . "\n"; exit($ok ? 0 : 7);',
+    ),
+    'detach'  => false,
+    'timeout' => 5,
+    'env'     => array(
+    'OPENAI_BASE_URL'     => 'https://raw-openai.example/v1',
+    'OPENAI_API_KEY'      => 'raw-openai-key',
+    'CODEX_REFRESH_TOKEN' => 'codex-refresh-token',
+    'CODEX_ACCESS_TOKEN'  => 'codex-access-token',
+    'OPENCODE_GO_KEY'     => 'opencode-go-key',
+    'WP_AUTH_COOKIE'      => 'wordpress-cookie',
+    'WP_NONCE'            => 'wordpress-nonce',
+    'WP_AI_GATEWAY_TOKEN' => 'configured-gateway-token',
+    ),
+    ),
+    'nongateway-env'  => array(
+    'command' => $php_bin,
+    'args'    => array(
+    '-r',
+    'exit(getenv("OPENAI_API_KEY") === "raw-openai-key" ? 0 : 9);',
+    ),
+    'detach'  => false,
+    'timeout' => 5,
+    'env'     => array(
+    'OPENAI_API_KEY' => 'raw-openai-key',
+    ),
+    ),
+    );
+
+    $gateway = \DataMachineCode\Channels\CliChannelTransport::execute(
+        array(
+        'channel'   => 'gateway-env',
+        'recipient' => 'r',
+        'message'   => 'm',
+        )
+    );
+    $assert('gateway env dispatch succeeds', is_array($gateway) && true === ( $gateway['sent'] ?? false ));
+    if (is_array($gateway) ) {
+        $stdout = (string) ( $gateway['metadata']['stdout'] ?? '' );
+        $assert('gateway base URL is passed as OPENAI_BASE_URL', str_contains($stdout, 'OPENAI_BASE_URL=https://gateway.example/v1'));
+        $assert('gateway token is redacted from captured stdout', str_contains($stdout, 'OPENAI_API_KEY: [redacted]') && ! str_contains($stdout, 'gateway-token-1234567890'));
+    }
+
+    putenv('WP_AI_GATEWAY_BASE_URL');
+    putenv('WP_AI_GATEWAY_TOKEN');
+    $nongateway = \DataMachineCode\Channels\CliChannelTransport::execute(
+        array(
+        'channel'   => 'nongateway-env',
+        'recipient' => 'r',
+        'message'   => 'm',
+        )
+    );
+    $assert('non-gateway configured env continues to work', is_array($nongateway) && true === ( $nongateway['sent'] ?? false ));
 
     // ---------------------------------------------------------------
     // Summary

--- a/tests/smoke-run-artifact-pr-section-renderer.php
+++ b/tests/smoke-run-artifact-pr-section-renderer.php
@@ -53,13 +53,11 @@ $artifacts = array(
     array(
         'name' => 'transcript_summary',
         'data' => array(
-            'summary'     => 'Ran smoke tests and PHP syntax checks. gateway used Bearer gateway-token-1234567890.',
+            'summary'     => 'Ran smoke tests and PHP syntax checks. runtime used Bearer caller-secret-token-1234567890.',
             'private_key' => '-----BEGIN PRIVATE KEY-----',
         ),
     ),
 );
-
-putenv('WP_AI_GATEWAY_TOKEN=gateway-token-1234567890');
 
 echo "Run artifact PR section renderer - smoke\n";
 
@@ -77,7 +75,7 @@ $assert('renders transcript summary when provided', str_contains($section, 'Ran 
 $assert('omits secret-like keys', ! str_contains($section, 'never-render-me') && ! str_contains($section, 'BEGIN PRIVATE KEY'));
 $assert('redacts secret-like strings', str_contains($section, 'token: [redacted]') && ! str_contains($section, 'ghp_abcdefghijklmnopqrstuvwxyz123456'));
 $assert('does not leak api key values', ! str_contains($section, 'sk-test-secret-value'));
-$assert('redacts current gateway token values', ! str_contains($section, 'gateway-token-1234567890') && str_contains($section, 'Bearer [redacted]'));
+$assert('redacts bearer token values', ! str_contains($section, 'caller-secret-token-1234567890') && str_contains($section, 'Bearer [redacted]'));
 
 $body    = "# Existing PR\n\nHuman-authored description.";
 $updated = RunArtifactPrSectionRenderer::replaceSection($body, $artifacts);
@@ -127,8 +125,6 @@ $assert('body-section mode removes stale section for empty artifacts', str_start
 
 $empty_mode_comment = RunArtifactPrSectionRenderer::renderForMode(RunArtifactPrSectionRenderer::MODE_COMMENT, array(), $body);
 $assert('comment mode renders nothing for empty artifacts', '' === $empty_mode_comment);
-
-putenv('WP_AI_GATEWAY_TOKEN');
 
 if (! empty($failures) ) {
     echo "\nFAIL: " . count($failures) . " assertion(s)\n";

--- a/tests/smoke-run-artifact-pr-section-renderer.php
+++ b/tests/smoke-run-artifact-pr-section-renderer.php
@@ -11,6 +11,7 @@ if (! defined('ABSPATH') ) {
     define('ABSPATH', __DIR__ . '/');
 }
 
+require __DIR__ . '/../inc/Support/SecretRedactor.php';
 require __DIR__ . '/../inc/Support/RunArtifactPrSectionRenderer.php';
 
 use DataMachineCode\Support\RunArtifactPrSectionRenderer;
@@ -52,11 +53,13 @@ $artifacts = array(
     array(
         'name' => 'transcript_summary',
         'data' => array(
-            'summary'     => 'Ran smoke tests and PHP syntax checks.',
+            'summary'     => 'Ran smoke tests and PHP syntax checks. gateway used Bearer gateway-token-1234567890.',
             'private_key' => '-----BEGIN PRIVATE KEY-----',
         ),
     ),
 );
+
+putenv('WP_AI_GATEWAY_TOKEN=gateway-token-1234567890');
 
 echo "Run artifact PR section renderer - smoke\n";
 
@@ -74,6 +77,7 @@ $assert('renders transcript summary when provided', str_contains($section, 'Ran 
 $assert('omits secret-like keys', ! str_contains($section, 'never-render-me') && ! str_contains($section, 'BEGIN PRIVATE KEY'));
 $assert('redacts secret-like strings', str_contains($section, 'token: [redacted]') && ! str_contains($section, 'ghp_abcdefghijklmnopqrstuvwxyz123456'));
 $assert('does not leak api key values', ! str_contains($section, 'sk-test-secret-value'));
+$assert('redacts current gateway token values', ! str_contains($section, 'gateway-token-1234567890') && str_contains($section, 'Bearer [redacted]'));
 
 $body    = "# Existing PR\n\nHuman-authored description.";
 $updated = RunArtifactPrSectionRenderer::replaceSection($body, $artifacts);
@@ -123,6 +127,8 @@ $assert('body-section mode removes stale section for empty artifacts', str_start
 
 $empty_mode_comment = RunArtifactPrSectionRenderer::renderForMode(RunArtifactPrSectionRenderer::MODE_COMMENT, array(), $body);
 $assert('comment mode renders nothing for empty artifacts', '' === $empty_mode_comment);
+
+putenv('WP_AI_GATEWAY_TOKEN');
 
 if (! empty($failures) ) {
     echo "\nFAIL: " . count($failures) . " assertion(s)\n";


### PR DESCRIPTION
## Summary
- Extend the generic CLI channel registry with caller-provided `env_from` references so integrations can project parent environment values into child sessions without storing raw values in DMC config.
- Redact projected secret-like values from synchronous CLI stdout/stderr metadata and reuse the same redactor for run artifact PR sections.
- Keep DMC provider-agnostic: no product-specific gateway names, plugin references, env var names, or OpenCode gateway-mode logic are introduced.

Fixes #488.

## Tests
- `php tests/smoke-cli-channel-transport.php` ✅
- `php tests/smoke-run-artifact-pr-section-renderer.php` ✅
- `php -l inc/Channels/CliChannelRegistry.php && php -l inc/Channels/CliChannelTransport.php && php -l inc/Support/SecretRedactor.php && php -l inc/Support/RunArtifactPrSectionRenderer.php && php -l tests/smoke-cli-channel-transport.php && php -l tests/smoke-run-artifact-pr-section-renderer.php` ✅
- `homeboy lint --path /Users/chubes/Developer/data-machine-code@codex-oauth-provider --extension wordpress` ⚠️ PHPCS passed; PHPStan still reports existing repo-wide findings plus existing strictness around touched files.
- `homeboy test --path /Users/chubes/Developer/data-machine-code@codex-oauth-provider --extension wordpress` ⚠️ blocked by WP Codebox bootstrap failure: resolved `data-machine` dependency is missing `vendor/autoload.php`.

## Risks
- `env_from` reads values from the PHP process environment at dispatch time; integrations still own configuring those parent env vars securely.
- Redaction is heuristic for configured/static env names and explicit projected secret values; integrations should continue avoiding command echo of secrets where possible.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, smoke coverage, verification, and PR description; Chris remains responsible for review and merge.