### PR TITLE
fix: select issue read credentials

### DIFF
--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -1357,7 +1357,7 @@ class GitHubAbilities {
 			return new \WP_Error('missing_repo', 'Repository is required (owner/repo format).', array( 'status' => 400 ));
 		}
 
-		$pat = self::getPatForRepo($repo);
+		$pat = self::getPatForRepoCapability($repo, 'issues_read');
 		if ( empty($pat) ) {
 			return self::patError();
 		}
@@ -1406,7 +1406,7 @@ class GitHubAbilities {
 			return new \WP_Error('missing_params', 'Repository (owner/repo) and issue_number are required.', array( 'status' => 400 ));
 		}
 
-		$pat = self::getPatForRepo($repo);
+		$pat = self::getPatForRepoCapability($repo, 'issues_read');
 		if ( empty($pat) ) {
 			return self::patError();
 		}

--- a/tests/smoke-github-create-abilities.php
+++ b/tests/smoke-github-create-abilities.php
@@ -845,8 +845,10 @@ namespace {
         ),
         ) 
     );
+    \DataMachineCode\Support\GitHubCredentialResolver::$selectors = array();
     $result = GitHubAbilities::getIssue(array( 'repo' => 'owner/repo', 'issue_number' => 123 ));
     $issue  = is_array($result) ? ( $result['issue'] ?? array() ) : array();
+    $assert('getIssue selects issues_read credential by repo', array( 'repo' => 'owner/repo', 'capability' => 'issues_read' ) === ( \DataMachineCode\Support\GitHubCredentialResolver::$selectors[0] ?? null ));
     $assert('getIssue returns generated_at', is_array($result) && ! empty($result['generated_at']));
     $assert('getIssue preserves comments count', 2 === ( $issue['comments'] ?? null ) && 2 === ( $issue['comment_count'] ?? null ));
     $assert('getIssue fetches latest issue comment page', is_string($GLOBALS['dmc_http_calls'][1]['url'] ?? null) && str_contains($GLOBALS['dmc_http_calls'][1]['url'], '/repos/owner/repo/issues/123/comments') && str_contains($GLOBALS['dmc_http_calls'][1]['url'], 'per_page=1') && str_contains($GLOBALS['dmc_http_calls'][1]['url'], 'page=2'));


### PR DESCRIPTION
## Summary
- Routes GitHub issue listing and targeted issue reads through the `issues_read` credential selector.
- Adds smoke coverage so `getIssue()` proves it requests an issue-read-capable repo credential.

## Verification
- `php tests/smoke-github-create-abilities.php`
- `php tests/smoke-github-fetch-by-number.php`
- `php -l inc/Abilities/GitHubAbilities.php && php -l tests/smoke-github-create-abilities.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed failed Data Machine Agent CI static-site runs, implemented the credential routing fix, and ran targeted smoke/lint checks; Chris remains responsible for review and merge.