### PR TITLE
Fix repeated GitHub issue list calls

### DIFF
--- a/inc/Tools/GitHubTools.php
+++ b/inc/Tools/GitHubTools.php
@@ -260,8 +260,7 @@ class GitHubTools extends BaseTool
      */
     public function getListIssuesDefinition(): array
     {
-        return $this->repeatableDefinition(
-            array(
+        return array(
             'class'       => __CLASS__,
             'method'      => 'handleListIssues',
             'description' => 'List issues from a GitHub repository. Returns issue numbers, titles, states, labels, assignees, comment counts, timestamps, and a generated_at timestamp. Use to review open issues, track progress, or find specific issues by label.',
@@ -287,7 +286,6 @@ class GitHubTools extends BaseTool
             ),
             'required'   => array( 'repo' ),
             ),
-            ) 
         );
     }
 

--- a/tests/smoke-github-create-tools.php
+++ b/tests/smoke-github-create-tools.php
@@ -218,6 +218,9 @@ namespace {
     $assert('remove_label_from_issue is available in chat', in_array('chat', $github_tools->registered['remove_label_from_issue']['contexts'] ?? array(), true));
     $assert('remove_label_from_issue is available in pipeline', in_array('pipeline', $github_tools->registered['remove_label_from_issue']['contexts'] ?? array(), true));
 
+    $list_issues_definition = $github_tools->getListIssuesDefinition();
+    $assert('list_github_issues uses default duplicate guard', 'repeatable' !== ( $list_issues_definition['runtime']['duplicate_policy'] ?? '' ));
+
     $issue_definition = $issue_tool->getToolDefinition();
     $issue_params     = $issue_definition['parameters']['properties'] ?? array();
     $assert('create_github_issue exposes assignees from ability schema', array_key_exists('assignees', $issue_params));


### PR DESCRIPTION
## Summary
- Let `list_github_issues` use Data Machine's default duplicate-call guard instead of opting out as repeatable.
- Add smoke coverage so identical issue-list calls cannot regain unbounded repeat behavior through the tool definition.

## Why
Static validation iterator runs were exhausting `max_turns` by repeatedly calling `list_github_issues` with identical parameters. Since the tool was marked `duplicate_policy=repeatable`, Data Machine could not reject the duplicate and nudge the agent toward the next required pipeline action.

## Tests
- `php -l inc/Tools/GitHubTools.php`
- `php tests/smoke-github-create-tools.php`

## Notes
- `php tests/smoke-github-pr-comment-tool.php` currently has unrelated stale schema-shape assertions for `comment_github_pull_request`; left out of this focused fix.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed repeated iterator tool calls from runtime artifacts, drafted the tool duplicate-policy fix and smoke assertion, and ran targeted verification. Chris remains responsible for review and merge.