### PR TITLE
Fix cleanup plan branch slug revalidation

### DIFF
--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -3228,6 +3228,13 @@ class Workspace {
 			foreach ( array( 'repo', 'branch', 'path', 'signal' ) as $field ) {
 				$planned = (string) ( $plan_row[ $field ] ?? '' );
 				$actual  = (string) ( $current[ $field ] ?? '' );
+				if ( 'branch' === $field ) {
+					$planned_slug = $this->slugify_branch($planned);
+					$actual_slug  = $this->slugify_branch($actual);
+					if ( '' !== $planned_slug && $planned_slug === $actual_slug ) {
+						continue;
+					}
+				}
 				if ( $planned !== $actual ) {
 					$mismatches[] = sprintf('%s planned=%s current=%s', $field, $planned, $actual);
 				}

--- a/tests/smoke-worktree-cleanup-plan-scope.php
+++ b/tests/smoke-worktree-cleanup-plan-scope.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Smoke test for cleanup apply-plan revalidation branch/slug matching.
+ *
+ * Run: php tests/smoke-worktree-cleanup-plan-scope.php
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Core\FilesRepository {
+	if ( ! class_exists(__NAMESPACE__ . '\\FilesystemHelper') ) {
+		class FilesystemHelper {
+			public static function get() {
+				return null;
+			}
+		}
+	}
+}
+
+namespace {
+	if ( ! defined('ABSPATH') ) {
+		define('ABSPATH', __DIR__ . '/');
+	}
+
+	if ( ! class_exists('WP_Error') ) {
+		class WP_Error {
+			public string $code;
+			public string $message;
+			public array $data;
+			public function __construct( $code = '', $message = '', $data = array() ) {
+				$this->code    = (string) $code;
+				$this->message = (string) $message;
+				$this->data    = (array) $data;
+			}
+			public function get_error_message(): string {
+				return $this->message;
+			}
+		}
+	}
+
+	if ( ! function_exists('is_wp_error') ) {
+		function is_wp_error( $thing ): bool {
+			return $thing instanceof \WP_Error;
+		}
+	}
+
+	if ( ! function_exists('apply_filters') ) {
+		function apply_filters( string $hook_name, $value ) {
+			return $value;
+		}
+	}
+
+	if ( ! function_exists('wp_json_encode') ) {
+		function wp_json_encode( $value, int $flags = 0, int $depth = 512 ): string|false {
+			return json_encode($value, $flags, $depth);
+		}
+	}
+
+	include __DIR__ . '/../inc/Support/GitHubRemote.php';
+	include __DIR__ . '/../inc/Support/GitRunner.php';
+	include __DIR__ . '/../inc/Support/PathSecurity.php';
+	include __DIR__ . '/../inc/Workspace/WorkspaceMutationLock.php';
+	include __DIR__ . '/../inc/Workspace/WorktreeDiskBudget.php';
+	include __DIR__ . '/../inc/Workspace/WorktreeContextInjector.php';
+	include __DIR__ . '/../inc/Workspace/Workspace.php';
+
+	$failures = 0;
+	$total    = 0;
+	$assert   = function ( $expected, $actual, string $message ) use ( &$failures, &$total ): void {
+		++$total;
+		if ( $expected === $actual ) {
+			echo "  ✓ {$message}\n";
+			return;
+		}
+
+		++$failures;
+		echo "  ✗ {$message}\n";
+		echo '    expected: ' . var_export($expected, true) . "\n";
+		echo '    actual:   ' . var_export($actual, true) . "\n";
+	};
+
+	$ws               = new \DataMachineCode\Workspace\Workspace();
+	$scope_reflection = new \ReflectionMethod(\DataMachineCode\Workspace\Workspace::class, 'scope_worktree_cleanup_to_plan');
+
+	$scoped = $scope_reflection->invoke(
+		$ws,
+		array(
+			array(
+				'handle' => 'demo@fix-foo',
+				'repo'   => 'demo',
+				'branch' => 'fix-foo',
+				'path'   => '/workspace/demo@fix-foo',
+				'signal' => 'pr-merged',
+			),
+		),
+		array(
+			array(
+				'handle' => 'demo@fix-foo',
+				'repo'   => 'demo',
+				'branch' => 'fix/foo',
+				'path'   => '/workspace/demo@fix-foo',
+				'signal' => 'pr-merged',
+			),
+		),
+		array()
+	);
+
+	$assert(1, count($scoped['candidates'] ?? array()), 'slugified planned branch matches current slash branch');
+	$assert(array(), $scoped['skipped'] ?? array(), 'matching branch slug is not skipped as plan_mismatch');
+
+	$scoped_mismatch = $scope_reflection->invoke(
+		$ws,
+		array(
+			array(
+				'handle' => 'demo@fix-foo',
+				'repo'   => 'demo',
+				'branch' => 'fix-foo',
+				'path'   => '/workspace/demo@fix-foo',
+				'signal' => 'pr-merged',
+			),
+		),
+		array(
+			array(
+				'handle' => 'demo@fix-foo',
+				'repo'   => 'demo',
+				'branch' => 'other/foo',
+				'path'   => '/workspace/demo@fix-foo',
+				'signal' => 'pr-merged',
+			),
+		),
+		array()
+	);
+
+	$assert(0, count($scoped_mismatch['candidates'] ?? array()), 'different branch slug remains blocked');
+	$assert('plan_mismatch', $scoped_mismatch['skipped'][0]['reason_code'] ?? '', 'different branch slug reports plan_mismatch');
+
+	echo "\nResult: " . ( $total - $failures ) . "/{$total} passed\n";
+	exit($failures > 0 ? 1 : 0);
+}

--- a/tests/smoke-worktree-cleanup.php
+++ b/tests/smoke-worktree-cleanup.php
@@ -113,6 +113,13 @@ namespace {
         }
     }
 
+    if (! function_exists('wp_json_encode') ) {
+        function wp_json_encode( $value, int $flags = 0, int $depth = 512 ): string|false
+        {
+            return json_encode($value, $flags, $depth);
+        }
+    }
+
     include __DIR__ . '/../inc/Support/GitHubRemote.php';
     include __DIR__ . '/../inc/Support/GitRunner.php';
     include __DIR__ . '/../inc/Support/PathSecurity.php';
@@ -606,6 +613,31 @@ namespace {
     );
     $assert(0, count($scoped_mismatch['candidates'] ?? array()), 'plan mismatch does not leave a removable candidate');
     $assert('plan_mismatch', $scoped_mismatch['skipped'][0]['reason_code'] ?? '', 'plan mismatch reports a stable reason code');
+
+    $scoped_slug_branch = $scope_reflection->invoke(
+        $ws,
+        array(
+        array(
+                'handle' => 'demo@fix-foo',
+                'repo'   => 'demo',
+                'branch' => 'fix-foo',
+                'path'   => $tmp . '/demo@fix-foo',
+                'signal' => 'pr-merged',
+        ),
+        ),
+        array(
+        array(
+                'handle' => 'demo@fix-foo',
+                'repo'   => 'demo',
+                'branch' => 'fix/foo',
+                'path'   => $tmp . '/demo@fix-foo',
+                'signal' => 'pr-merged',
+        ),
+        ),
+        array()
+    );
+    $assert(1, count($scoped_slug_branch['candidates'] ?? array()), 'plan revalidation accepts slugged branch matching slash branch');
+    $assert(array(), $scoped_slug_branch['skipped'] ?? array(), 'slugged branch match is not reported as plan_mismatch');
 
     // External worktrees are reported with routing metadata, but never owned by cleanup.
     $external_skips = array_filter($plan['skipped'] ?? array(), fn( $s ) => ( $s['path'] ?? '' ) === $external_real);


### PR DESCRIPTION
## Summary
- Normalize planned and current cleanup branches through the existing worktree branch slugifier during apply-plan revalidation.
- Keep repo/path/signal matching exact, while allowing reviewed rows with `fix-foo` to match current branch `fix/foo` for the same handle/path.
- Add focused smoke coverage for slash-branch cleanup plan scoping and update the broader cleanup smoke harness for standalone `wp_json_encode()` use.

Fixes https://github.com/Extra-Chill/data-machine-code/issues/494

## Verification
- `php tests/smoke-worktree-cleanup-plan-scope.php` passed, 4/4.
- `php -l inc/Workspace/Workspace.php && php -l tests/smoke-worktree-cleanup-plan-scope.php && php -l tests/smoke-worktree-cleanup.php` passed.
- `homeboy test --path /Users/chubes/Developer/data-machine-code@fix-issue-494-branch-slug-cleanup-revalidation --extension wordpress` passed.
- `php tests/smoke-worktree-cleanup.php` reached and passed the new branch-slug assertion, but the existing full smoke still reports 134/137 due to pre-existing summary-size assertions unrelated to this branch-slug fix.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** implementation draft, tests, and verification; Chris remains responsible.