### PR TITLE
Prefilter metadata reconciliation candidates

### DIFF
--- a/inc/Workspace/WorkspaceMetadataReconciliation.php
+++ b/inc/Workspace/WorkspaceMetadataReconciliation.php
@@ -88,8 +88,10 @@ trait WorkspaceMetadataReconciliation {
 				fn( $wt ) => empty($wt['is_primary'])
 			)
 		);
-		$total_worktrees = count($all_worktrees);
-		$page_worktrees  = $paged ? array_slice($all_worktrees, $offset, $limit) : $all_worktrees;
+		$prefilter      = $this->prefilter_worktree_metadata_reconciliation_rows($all_worktrees);
+		$page_scope     = $prefilter['candidates'];
+		$total_worktrees = count($page_scope);
+		$page_worktrees  = $paged ? array_slice($page_scope, $offset, $limit) : $page_scope;
 
 		$proposals    = array();
 		$skipped      = array();
@@ -136,14 +138,16 @@ trait WorkspaceMetadataReconciliation {
 			'skipped'            => $skipped,
 			'still_unsafe'       => $classified_skips['still_unsafe'],
 			'external_worktrees' => $classified_skips['external_worktrees'],
-			'summary'            => $this->build_worktree_metadata_reconciliation_summary($paged ? count($page_worktrees) : count( (array) ( $listing['worktrees'] ?? array() )), $proposals, array(), $skipped),
+			'summary'            => $this->build_worktree_metadata_reconciliation_summary($paged ? count($page_worktrees) : count($page_scope), $proposals, array(), $skipped),
 		);
+		$plan['summary']['prefiltered'] = $prefilter['summary'];
 		if ( null !== $pagination ) {
 			$plan['pagination'] = $pagination;
 			$plan['evidence']   = array(
 				'scope'                     => 'paginated metadata reconciliation dry-run',
-				'note'                      => 'Only this page ran per-worktree dirty, unpushed, merge-signal, and GitHub probes. Run the next_offset page until complete for full inventory review.',
+				'note'                      => 'Only candidate rows with missing, incomplete, invalid, or finalizable metadata ran per-worktree dirty, unpushed, merge-signal, and GitHub probes. Run the next_offset page until complete for full inventory review.',
 				'fields_skipped_by_listing' => (array) ( $listing['fields_skipped'] ?? array() ),
+				'prefilter'                 => $prefilter['summary'],
 			);
 			if ( null !== $budget_context ) {
 				$plan['evidence']['budget'] = $this->summarize_worktree_loop_budget_context($budget_context, $budget_stopped);
@@ -456,6 +460,74 @@ trait WorkspaceMetadataReconciliation {
 			'budget_exhausted'  => $exhausted,
 			'remaining_seconds' => round(max(0.0, (float) ( $context['seconds'] ?? 0 ) - $elapsed), 3),
 		);
+	}
+
+	/**
+	 * Keep expensive reconciliation probes focused on rows that can change.
+	 *
+	 * @param  array<int,array<string,mixed>> $worktrees Non-primary worktree rows.
+	 * @return array{candidates:array<int,array<string,mixed>>,summary:array<string,mixed>}
+	 */
+	private function prefilter_worktree_metadata_reconciliation_rows( array $worktrees ): array {
+		$candidates = array();
+		$skipped    = 0;
+		$reasons    = array();
+
+		foreach ( $worktrees as $wt ) {
+			$reason = $this->worktree_metadata_reconciliation_candidate_reason($wt);
+			if ( null !== $reason ) {
+				$candidates[] = $wt;
+				$reasons[ $reason ] = (int) ( $reasons[ $reason ] ?? 0 ) + 1;
+				continue;
+			}
+
+			++$skipped;
+			$reasons['complete_metadata'] = (int) ( $reasons['complete_metadata'] ?? 0 ) + 1;
+		}
+
+		return array(
+			'candidates' => array_values($candidates),
+			'summary'    => array(
+				'input_rows'      => count($worktrees),
+				'candidate_rows'  => count($candidates),
+				'skipped_rows'    => $skipped,
+				'reasons'         => $reasons,
+				'candidate_scope' => 'missing_or_incomplete_metadata_and_stored_finalizer_signals',
+			),
+		);
+	}
+
+	/**
+	 * Return a cheap candidate reason when reconciliation may write metadata.
+	 *
+	 * @param  array<string,mixed> $wt Worktree list row.
+	 */
+	private function worktree_metadata_reconciliation_candidate_reason( array $wt ): ?string {
+		if ( ! empty($wt['external']) ) {
+			return 'external_worktree';
+		}
+
+		$metadata = is_array($wt['metadata'] ?? null) ? (array) $wt['metadata'] : null;
+		if ( null === $metadata || array() === $metadata ) {
+			return 'missing_metadata';
+		}
+
+		foreach ( array( 'handle', 'repo', 'branch', 'path', 'created_at', 'observed_at', 'lifecycle_state' ) as $field ) {
+			if ( ! array_key_exists($field, $metadata) || '' === trim( (string) $metadata[ $field ] ) ) {
+				return 'incomplete_metadata';
+			}
+		}
+
+		$state = WorktreeContextInjector::normalize_state( (string) $metadata['lifecycle_state'] );
+		if ( null === $state ) {
+			return 'invalid_lifecycle_state';
+		}
+
+		if ( WorktreeContextInjector::STATE_CLEANUP_ELIGIBLE !== $state && ( ! empty($metadata['pr_url']) || ! empty($metadata['pr_number']) ) ) {
+			return 'stored_pr_signal';
+		}
+
+		return null;
 	}
 
 	/**

--- a/inc/Workspace/WorkspaceMetadataReconciliation.php
+++ b/inc/Workspace/WorkspaceMetadataReconciliation.php
@@ -88,8 +88,8 @@ trait WorkspaceMetadataReconciliation {
 				fn( $wt ) => empty($wt['is_primary'])
 			)
 		);
-		$prefilter      = $this->prefilter_worktree_metadata_reconciliation_rows($all_worktrees);
-		$page_scope     = $prefilter['candidates'];
+		$prefilter       = $this->prefilter_worktree_metadata_reconciliation_rows($all_worktrees);
+		$page_scope      = $prefilter['candidates'];
 		$total_worktrees = count($page_scope);
 		$page_worktrees  = $paged ? array_slice($page_scope, $offset, $limit) : $page_scope;
 
@@ -127,7 +127,7 @@ trait WorkspaceMetadataReconciliation {
 			$pagination['next_command'] = sprintf('studio wp datamachine-code workspace worktree reconcile-metadata --%s --limit=%d --offset=%d%s --format=json', $apply ? 'apply' : 'dry-run', $limit, (int) $pagination['next_offset'], null !== $budget_context ? ' --until-budget=' . (string) $budget_context['label'] : '');
 		}
 
-		$plan = array(
+		$plan                           = array(
 			'success'            => true,
 			'dry_run'            => $dry_run,
 			'applied'            => false,
@@ -476,7 +476,7 @@ trait WorkspaceMetadataReconciliation {
 		foreach ( $worktrees as $wt ) {
 			$reason = $this->worktree_metadata_reconciliation_candidate_reason($wt);
 			if ( null !== $reason ) {
-				$candidates[] = $wt;
+				$candidates[]       = $wt;
 				$reasons[ $reason ] = (int) ( $reasons[ $reason ] ?? 0 ) + 1;
 				continue;
 			}

--- a/tests/smoke-worktree-metadata-reconcile.php
+++ b/tests/smoke-worktree-metadata-reconcile.php
@@ -360,6 +360,7 @@ namespace {
         $run('git checkout main', $primary);
     };
     $make_branch('unmanaged-missing');
+    $make_branch('unmanaged-empty');
     $make_branch('unmanaged-partial');
     $make_branch('unmanaged-dirty');
     $make_branch('unmanaged-invalid');
@@ -377,6 +378,7 @@ namespace {
     $run('git checkout main', $primary);
 
     $run(sprintf('git worktree add %s unmanaged-missing', escapeshellarg($tmp . '/demo@unmanaged-missing')), $primary);
+    $run(sprintf('git worktree add %s unmanaged-empty', escapeshellarg($tmp . '/demo@unmanaged-empty')), $primary);
     $run(sprintf('git worktree add %s unmanaged-partial', escapeshellarg($tmp . '/demo@unmanaged-partial')), $primary);
     $run(sprintf('git worktree add %s unmanaged-dirty', escapeshellarg($tmp . '/demo@unmanaged-dirty')), $primary);
     $run(sprintf('git worktree add %s unmanaged-invalid', escapeshellarg($tmp . '/demo@unmanaged-invalid')), $primary);
@@ -403,6 +405,10 @@ namespace {
     $run(sprintf('git --git-dir=%s update-ref -d refs/heads/upstream-gone', escapeshellarg($remote)));
     $run(sprintf('git --git-dir=%s update-ref -d refs/heads/dirty-merged', escapeshellarg($remote)));
 
+    \DataMachineCode\Workspace\WorktreeContextInjector::store_metadata(
+        'demo@unmanaged-empty',
+        array()
+    );
     \DataMachineCode\Workspace\WorktreeContextInjector::store_metadata(
         'demo@unmanaged-partial',
         array(
@@ -570,10 +576,10 @@ namespace {
     $plan = $ws->worktree_reconcile_metadata(array( 'dry_run' => true ));
     $assert(true, ! is_wp_error($plan) && ( $plan['success'] ?? false ), 'dry-run succeeds');
     $assert(true, $plan['dry_run'] ?? false, 'dry-run flag is true');
-    $assert(7, (int) ( $plan['summary']['proposed'] ?? 0 ), 'dry-run proposes unmanaged rows and safe merged lifecycle finalizers');
+    $assert(8, (int) ( $plan['summary']['proposed'] ?? 0 ), 'dry-run proposes unmanaged rows and safe merged lifecycle finalizers');
     $assert(0, (int) ( $plan['summary']['written'] ?? 0 ), 'dry-run writes nothing');
     $assert(1, (int) ( $plan['summary']['skipped_by_reason']['external_worktree'] ?? 0 ), 'dry-run distinguishes external worktrees');
-    $assert(3, (int) ( $plan['summary']['skipped_by_reason']['unsafe_cleanup_eligible_state'] ?? 0 ), 'dry-run keeps dirty and unpushed merged worktrees out of auto-finalize proposals');
+    $assert(2, (int) ( $plan['summary']['skipped_by_reason']['unsafe_cleanup_eligible_state'] ?? 0 ), 'dry-run keeps dirty and unpushed merged worktrees out of auto-finalize proposals');
     $assert(1, count($plan['external_worktrees'] ?? array()), 'dry-run exposes external worktree bucket');
 
     $by_handle = array();
@@ -585,7 +591,11 @@ namespace {
     $assert('reconcile_run', $by_handle['demo@unmanaged-missing']['source_map']['observed_at'] ?? '', 'missing metadata observed_at source is reconcile run');
     $assert('current_site', $by_handle['demo@unmanaged-missing']['source_map']['origin_site'] ?? '', 'missing metadata origin site is inferred from current site');
     $assert(true, isset($by_handle['demo@unmanaged-missing']['elapsed_ms']), 'metadata reconciliation proposal rows include elapsed timing');
+    $assert('operator_plan', $by_handle['demo@unmanaged-empty']['source_map']['lifecycle_state'] ?? '', 'empty-array metadata lifecycle source is operator_plan');
     $assert(true, isset($plan['summary']['slow_rows'][0]['elapsed_ms']), 'metadata reconciliation summary includes slow row timing samples');
+    $assert(true, (int) ( $plan['summary']['prefiltered']['skipped_rows'] ?? 0 ) > 0, 'metadata reconciliation prefilter skips valid complete metadata rows before expensive probes');
+    $assert(true, (int) ( $plan['summary']['prefiltered']['reasons']['missing_metadata'] ?? 0 ) >= 2, 'metadata reconciliation prefilter includes null and empty-array metadata rows');
+    $assert(true, (int) ( $plan['summary']['prefiltered']['reasons']['stored_pr_signal'] ?? 0 ) >= 2, 'metadata reconciliation prefilter keeps stored PR finalizer signals');
     $assert('metadata', $by_handle['demo@unmanaged-partial']['source_map']['created_at'] ?? '', 'partial metadata preserves created_at source');
     $assert('git', $by_handle['demo@unmanaged-partial']['source_map']['branch'] ?? '', 'branch source is git');
     $assert(array( 'lifecycle_state' ), $by_handle['demo@unmanaged-invalid']['invalid_fields'] ?? array(), 'invalid lifecycle state is planned for repair');
@@ -645,10 +655,10 @@ namespace {
     echo "\nApply reviewed plan\n";
     $apply = $ws->worktree_reconcile_metadata(array( 'apply_plan' => $plan ));
     $assert(true, ! is_wp_error($apply) && ( $apply['success'] ?? false ), 'apply succeeds');
-    $assert(7, (int) ( $apply['summary']['written'] ?? 0 ), 'apply writes exact current matches');
-    $assert(7, (int) ( $apply['summary']['written'] ?? 0 ), 'apply reports written metadata rows');
+    $assert(8, (int) ( $apply['summary']['written'] ?? 0 ), 'apply writes exact current matches');
+    $assert(8, (int) ( $apply['summary']['written'] ?? 0 ), 'apply reports written metadata rows');
     $assert(0, (int) ( $apply['summary']['skipped'] ?? 0 ), 'apply skips nothing for current plan');
-    $assert(7, count($apply['written'] ?? array()), 'apply exposes written rows distinctly');
+    $assert(8, count($apply['written'] ?? array()), 'apply exposes written rows distinctly');
     $stored = \DataMachineCode\Workspace\WorktreeContextInjector::get_metadata('demo@unmanaged-missing');
     $assert('demo@unmanaged-missing', $stored['handle'] ?? '', 'stored metadata includes handle');
     $assert(true, ! empty($stored['observed_at']), 'stored metadata includes observed_at');
@@ -676,14 +686,14 @@ namespace {
     $assert(true, ! is_wp_error($bounded_auto_apply) && ( $bounded_auto_apply['success'] ?? false ), 'bounded direct reconciliation apply runs without a manual plan file');
     $assert(true, (bool) ( $bounded_auto_apply['direct_apply'] ?? false ), 'bounded direct apply identifies direct apply source');
     $assert(false, (bool) ( $bounded_auto_apply['dry_run'] ?? true ), 'bounded direct apply is not a dry-run');
-    $assert(2, (int) ( $bounded_auto_apply['summary']['inspected'] ?? 0 ), 'bounded direct apply summary stays page-scoped');
+    $assert(1, (int) ( $bounded_auto_apply['summary']['inspected'] ?? 0 ), 'bounded direct apply summary stays candidate-page scoped');
     $assert(2, (int) ( $bounded_auto_apply['pagination']['limit'] ?? 0 ), 'bounded direct apply preserves pagination limit');
     $assert(2, (int) ( $bounded_auto_apply['pagination']['offset'] ?? 0 ), 'bounded direct apply preserves pagination offset');
     $assert('direct_apply', $bounded_auto_apply['evidence']['apply_source'] ?? '', 'bounded direct apply exposes evidence source');
 
     $inventory_after = $ws->worktree_cleanup_merged(array( 'dry_run' => true, 'inventory_only' => true, 'skip_github' => true ));
     $assert(1, (int) ( $inventory_after['summary']['skipped_by_reason']['needs_metadata_reconcile'] ?? 0 ), 'inventory cleanup requires fewer metadata reconciliation passes after apply');
-    $assert(8, (int) ( $inventory_after['summary']['skipped_by_reason']['active_no_signal'] ?? 0 ), 'inventory cleanup treats reconciled active metadata like current active metadata');
+    $assert(9, (int) ( $inventory_after['summary']['skipped_by_reason']['active_no_signal'] ?? 0 ), 'inventory cleanup treats reconciled active metadata like current active metadata');
     $assert(false, isset($inventory_after['summary']['repair_status']), 'inventory cleanup no longer exposes migration status');
 
     $run('git remote set-url origin https://github.com/acme/demo.git', $primary);
@@ -725,10 +735,11 @@ namespace {
 
     \DataMachineCode\Workspace\WorktreeContextInjector::forget_metadata('demo@unmanaged-missing');
     $budget_offset = 0;
-    $budget_listing = $ws->worktree_list(null, null, array( 'include_status' => false, 'include_disk' => false ));
-    foreach ( array_values(array_filter((array) ( $budget_listing['worktrees'] ?? array() ), fn( $wt ) => empty($wt['is_primary']))) as $index => $wt ) {
-        if ('demo@unmanaged-missing' === ( $wt['handle'] ?? '' ) ) {
-            $budget_offset = (int) $index;
+    for ( $probe_offset = 0; $probe_offset < 20; ++$probe_offset ) {
+        $budget_probe = $ws->worktree_reconcile_metadata(array( 'dry_run' => true, 'limit' => 1, 'offset' => $probe_offset ));
+        $proposal = $budget_probe['proposals'][0] ?? array();
+        if ('demo@unmanaged-missing' === ( $proposal['handle'] ?? '' ) ) {
+            $budget_offset = $probe_offset;
             break;
         }
     }


### PR DESCRIPTION
## Summary
- Prefilter metadata reconciliation pages to only run expensive worktree probes for missing, empty, incomplete, invalid, external, or stored-PR-signal metadata candidates.
- Report prefilter counts in reconciliation summaries/evidence so operators can see how many complete rows were skipped and continue from candidate-scoped pagination.
- Extend the metadata reconciliation smoke fixture for empty-array metadata and candidate-scoped continuation output.

Fixes https://github.com/Extra-Chill/data-machine-code/issues/495

## Verification
- `php tests/smoke-worktree-metadata-reconcile.php` — passed, 140 assertions
- `php tests/smoke-worktree-list-scaling.php` — passed, 28 assertions
- `php -l inc/Workspace/WorkspaceMetadataReconciliation.php` — passed
- `php -l tests/smoke-worktree-metadata-reconcile.php` — passed
- `homeboy test --path /Users/chubes/Developer/data-machine-code@perf-issue-495-metadata-hygiene-scaling --extension wordpress` — passed; host-smoke reported no matching `tests/**/*-smoke.php` files

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implementation draft, tests, and verification. Chris remains responsible.