### PR TITLE
Auto-finalize active worktrees merged to default

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -1948,6 +1948,46 @@ class WorkspaceAbilities {
 			);
 
 			AbilityRegistry::register(
+				'datamachine/workspace-worktree-active-no-signal-merged-apply',
+				array(
+					'label'               => 'Promote Merged Active Worktrees',
+					'description'         => 'Promote clean active_no_signal rows with suggested_action=merged_to_default into explicit cleanup_eligible metadata. Reviewable and bounded; never deletes worktrees.',
+					'category'            => 'datamachine-code-workspace',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'dry_run' => array(
+								'type'        => 'boolean',
+								'description' => 'If true, preview metadata promotions without writing.',
+							),
+							'limit'   => array(
+								'type'        => 'integer',
+								'description' => 'Maximum active_no_signal rows to inspect in this page. Defaults to 25.',
+							),
+							'offset'  => array(
+								'type'        => 'integer',
+								'description' => 'Pagination offset into the active_no_signal inventory ordering.',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'dry_run' => array( 'type' => 'boolean' ),
+							'planned' => array( 'type' => 'array' ),
+							'written' => array( 'type' => 'array' ),
+							'skipped' => array( 'type' => 'array' ),
+							'summary' => array( 'type' => 'object' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'worktreeActiveNoSignalMergedApply' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			AbilityRegistry::register(
 				'datamachine/workspace-worktree-cleanup-artifacts',
 				array(
 					'label'               => 'Cleanup Worktree Artifacts',
@@ -3257,6 +3297,27 @@ class WorkspaceAbilities {
 		}
 
 		return $workspace->worktree_active_no_signal_equivalent_clean_apply($opts);
+	}
+
+	/**
+	 * Promote merged-to-default active/no-signal evidence into cleanup metadata.
+	 *
+	 * @param  array $input Input parameters (dry_run, limit, offset).
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public static function worktreeActiveNoSignalMergedApply( array $input ): array|\WP_Error {
+		$workspace = new Workspace();
+		$opts      = array(
+			'dry_run' => ! empty($input['dry_run']),
+		);
+		if ( array_key_exists('limit', $input) ) {
+			$opts['limit'] = (int) $input['limit'];
+		}
+		if ( array_key_exists('offset', $input) ) {
+			$opts['offset'] = (int) $input['offset'];
+		}
+
+		return $workspace->worktree_active_no_signal_merged_apply($opts);
 	}
 
 	/**

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -4054,13 +4054,28 @@ class WorkspaceCommand extends BaseCommand {
 
 		WP_CLI::log('Merged-to-default active/no-signal apply summary:');
 		$summary_rows = array(
-			array( 'metric' => 'inspected', 'count' => (int) ( $summary['inspected'] ?? 0 ) ),
-			array( 'metric' => 'planned', 'count' => (int) ( $summary['planned'] ?? count($planned) ) ),
-			array( 'metric' => 'written', 'count' => (int) ( $summary['written'] ?? count($written) ) ),
-			array( 'metric' => 'skipped', 'count' => (int) ( $summary['skipped'] ?? count($skipped) ) ),
+			array(
+				'metric' => 'inspected',
+				'count'  => (int) ( $summary['inspected'] ?? 0 ),
+			),
+			array(
+				'metric' => 'planned',
+				'count'  => (int) ( $summary['planned'] ?? count($planned) ),
+			),
+			array(
+				'metric' => 'written',
+				'count'  => (int) ( $summary['written'] ?? count($written) ),
+			),
+			array(
+				'metric' => 'skipped',
+				'count'  => (int) ( $summary['skipped'] ?? count($skipped) ),
+			),
 		);
 		foreach ( (array) ( $summary['skipped_by_reason'] ?? array() ) as $reason => $count ) {
-			$summary_rows[] = array( 'metric' => 'skipped:' . $reason, 'count' => (int) $count );
+			$summary_rows[] = array(
+				'metric' => 'skipped:' . $reason,
+				'count'  => (int) $count,
+			);
 		}
 		$this->format_items($summary_rows, array( 'metric', 'count' ), array( 'format' => 'table' ), 'metric');
 

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -2065,6 +2065,7 @@ class WorkspaceCommand extends BaseCommand {
 	 *   bounded-cleanup-eligible-apply, emergency-cleanup, reconcile-metadata,
 	 *   active-no-signal-report, active-no-signal-finalized-apply,
 	 *   active-no-signal-equivalent-clean-apply,
+	 *   active-no-signal-merged-apply,
 	 *   refresh-context, finalize, mark-cleanup-eligible.
 	 *
 	 * [<repo>]
@@ -2352,6 +2353,8 @@ class WorkspaceCommand extends BaseCommand {
 	 *     wp datamachine-code workspace worktree active-no-signal-finalized-apply --limit=25 --offset=0 --format=json
 	 *     wp datamachine-code workspace worktree active-no-signal-equivalent-clean-apply --dry-run --limit=25 --offset=0 --format=json
 	 *     wp datamachine-code workspace worktree active-no-signal-equivalent-clean-apply --limit=25 --offset=0 --format=json
+	 *     wp datamachine-code workspace worktree active-no-signal-merged-apply --dry-run --limit=25 --offset=0 --format=json
+	 *     wp datamachine-code workspace worktree active-no-signal-merged-apply --limit=25 --offset=0 --format=json
 	 *
 	 *     # Ignore dirty working-tree safety (caution)
 	 *     wp datamachine-code workspace worktree cleanup --force
@@ -2384,7 +2387,7 @@ class WorkspaceCommand extends BaseCommand {
 		$operation = $args[0] ?? '';
 
 		if ( '' === $operation ) {
-			WP_CLI::error('Usage: wp datamachine-code workspace worktree <add|list|remove|prune|locks|cleanup|cleanup-artifacts|bounded-cleanup-eligible-apply|emergency-cleanup|reconcile-metadata|backfill-origin-session|active-no-signal-report|active-no-signal-finalized-apply|active-no-signal-equivalent-clean-apply|refresh-context|finalize|mark-cleanup-eligible> [<repo>] [<branch>] [--flags]');
+			WP_CLI::error('Usage: wp datamachine-code workspace worktree <add|list|remove|prune|locks|cleanup|cleanup-artifacts|bounded-cleanup-eligible-apply|emergency-cleanup|reconcile-metadata|backfill-origin-session|active-no-signal-report|active-no-signal-finalized-apply|active-no-signal-equivalent-clean-apply|active-no-signal-merged-apply|refresh-context|finalize|mark-cleanup-eligible> [<repo>] [<branch>] [--flags]');
 			return;
 		}
 
@@ -2446,6 +2449,7 @@ class WorkspaceCommand extends BaseCommand {
 			'active-no-signal-report'        => 'datamachine-code/workspace-worktree-active-no-signal-report',
 			'active-no-signal-finalized-apply' => 'datamachine-code/workspace-worktree-active-no-signal-finalized-apply',
 			'active-no-signal-equivalent-clean-apply' => 'datamachine-code/workspace-worktree-active-no-signal-equivalent-clean-apply',
+			'active-no-signal-merged-apply'   => 'datamachine-code/workspace-worktree-active-no-signal-merged-apply',
 			'refresh-context'                => 'datamachine-code/workspace-worktree-refresh-context',
 			'finalize'                       => 'datamachine-code/workspace-worktree-finalize',
 			'mark-cleanup-eligible'          => 'datamachine-code/workspace-worktree-finalize',
@@ -2621,7 +2625,8 @@ class WorkspaceCommand extends BaseCommand {
 			case 'active-no-signal-report':
 			case 'active-no-signal-finalized-apply':
 			case 'active-no-signal-equivalent-clean-apply':
-				if ( in_array($operation, array( 'active-no-signal-finalized-apply', 'active-no-signal-equivalent-clean-apply' ), true) ) {
+			case 'active-no-signal-merged-apply':
+				if ( in_array($operation, array( 'active-no-signal-finalized-apply', 'active-no-signal-equivalent-clean-apply', 'active-no-signal-merged-apply' ), true) ) {
 					$input['dry_run'] = ! empty($assoc_args['dry-run']);
 				}
 				if ( isset($assoc_args['limit']) ) {
@@ -2816,6 +2821,10 @@ class WorkspaceCommand extends BaseCommand {
 
 			case 'active-no-signal-equivalent-clean-apply':
 				$this->render_worktree_active_no_signal_equivalent_clean_apply_result($result, $assoc_args);
+				return;
+
+			case 'active-no-signal-merged-apply':
+				$this->render_worktree_active_no_signal_merged_apply_result($result, $assoc_args);
 				return;
 
 			case 'cleanup-artifacts':
@@ -4020,6 +4029,88 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 		WP_CLI::success(sprintf('Promoted %d equivalent-clean worktree(s) to cleanup_eligible metadata.', count($written)));
+	}
+
+	/**
+	 * Render merged-to-default active/no-signal metadata apply output.
+	 *
+	 * @param  array $result     Apply result.
+	 * @param  array $assoc_args CLI assoc args.
+	 * @return void
+	 */
+	private function render_worktree_active_no_signal_merged_apply_result( array $result, array $assoc_args ): void {
+		$format = isset($assoc_args['format']) ? (string) $assoc_args['format'] : 'table';
+		if ( 'json' === $format ) {
+			$json = wp_json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+			WP_CLI::log(false === $json ? '{}' : $json);
+			return;
+		}
+
+		$summary = (array) ( $result['summary'] ?? array() );
+		$planned = (array) ( $result['planned'] ?? array() );
+		$written = (array) ( $result['written'] ?? array() );
+		$skipped = (array) ( $result['skipped'] ?? array() );
+		$dry_run = ! empty($result['dry_run']);
+
+		WP_CLI::log('Merged-to-default active/no-signal apply summary:');
+		$summary_rows = array(
+			array( 'metric' => 'inspected', 'count' => (int) ( $summary['inspected'] ?? 0 ) ),
+			array( 'metric' => 'planned', 'count' => (int) ( $summary['planned'] ?? count($planned) ) ),
+			array( 'metric' => 'written', 'count' => (int) ( $summary['written'] ?? count($written) ) ),
+			array( 'metric' => 'skipped', 'count' => (int) ( $summary['skipped'] ?? count($skipped) ) ),
+		);
+		foreach ( (array) ( $summary['skipped_by_reason'] ?? array() ) as $reason => $count ) {
+			$summary_rows[] = array( 'metric' => 'skipped:' . $reason, 'count' => (int) $count );
+		}
+		$this->format_items($summary_rows, array( 'metric', 'count' ), array( 'format' => 'table' ), 'metric');
+
+		$rows = $dry_run ? $planned : $written;
+		if ( ! empty($rows) ) {
+			WP_CLI::log('');
+			WP_CLI::log($dry_run ? 'Would promote:' : 'Promoted:');
+			$items = array_map(
+				fn( $row ) => array(
+					'handle'      => $row['handle'] ?? '',
+					'branch'      => $row['branch'] ?? '',
+					'default_ref' => $row['metadata']['cleanup_eligibility_evidence']['default_ref'] ?? '',
+					'state'       => $row['metadata']['lifecycle_state'] ?? '',
+				),
+				$rows
+			);
+			$this->format_items($items, array( 'handle', 'branch', 'default_ref', 'state' ), array( 'format' => 'table' ), 'handle');
+		}
+
+		if ( ! empty($skipped) ) {
+			WP_CLI::log('');
+			WP_CLI::log('Skipped:');
+			$items = array_map(
+				fn( $row ) => array(
+					'handle'      => $row['handle'] ?? '',
+					'action'      => $row['action'] ?? '',
+					'reason_code' => $row['reason_code'] ?? '',
+					'reason'      => $row['reason'] ?? '',
+				),
+				array_slice($skipped, 0, 10)
+			);
+			$this->format_items($items, array( 'handle', 'action', 'reason_code', 'reason' ), array( 'format' => 'table' ), 'handle');
+		}
+
+		if ( isset($result['pagination']['next_offset']) ) {
+			WP_CLI::log('');
+			WP_CLI::log(
+				sprintf(
+					'Next page: wp datamachine-code workspace worktree active-no-signal-merged-apply --limit=%d --offset=%d --format=json',
+					(int) ( $result['pagination']['limit'] ?? 0 ),
+					(int) $result['pagination']['next_offset']
+				)
+			);
+		}
+
+		if ( $dry_run ) {
+			WP_CLI::success(sprintf('%d merged-to-default worktree(s) would be promoted to cleanup_eligible metadata.', count($planned)));
+			return;
+		}
+		WP_CLI::success(sprintf('Promoted %d merged-to-default worktree(s) to cleanup_eligible metadata.', count($written)));
 	}
 
 	/**

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -1630,6 +1630,99 @@ class Workspace {
 	}
 
 	/**
+	 * Promote clean active/no-signal rows already merged to default into cleanup metadata.
+	 *
+	 * This writes lifecycle metadata only. It never removes worktrees; callers use
+	 * bounded cleanup-eligible apply after reviewing the written rows.
+	 *
+	 * @param  array<string,mixed> $opts Apply options.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function worktree_active_no_signal_merged_apply( array $opts = array() ): array|\WP_Error {
+		$dry_run = ! empty($opts['dry_run']);
+		$report  = $this->worktree_active_no_signal_report($opts);
+		if ( is_wp_error($report) ) {
+			return $report;
+		}
+
+		$written = array();
+		$skipped = array();
+		$planned = array();
+
+		foreach ( (array) ( $report['rows'] ?? array() ) as $row ) {
+			if ( ! is_array($row) ) {
+				continue;
+			}
+
+			if ( 'merged_to_default' !== (string) ( $row['suggested_action'] ?? '' ) ) {
+				$skipped[] = $this->build_active_no_signal_finalized_apply_skip($row, 'not_merged_to_default', 'row is not a clean merged-to-default candidate');
+				continue;
+			}
+
+			$metadata = $this->build_active_no_signal_merged_to_default_metadata($row);
+			if ( is_wp_error($metadata) ) {
+				$skipped[] = $this->build_active_no_signal_finalized_apply_skip($row, $metadata->get_error_code(), $metadata->get_error_message());
+				continue;
+			}
+
+			$planned[] = array(
+				'handle'   => (string) ( $row['handle'] ?? '' ),
+				'repo'     => (string) ( $row['repo'] ?? '' ),
+				'branch'   => (string) ( $row['branch'] ?? '' ),
+				'path'     => (string) ( $row['path'] ?? '' ),
+				'evidence' => $metadata['cleanup_eligibility_evidence'] ?? null,
+				'metadata' => $metadata,
+			);
+
+			if ( $dry_run ) {
+				continue;
+			}
+
+			$handle = (string) ( $row['handle'] ?? '' );
+			WorktreeContextInjector::store_lifecycle_metadata($handle, $metadata);
+			$this->worktree_inventory()->upsert($this->build_worktree_inventory_row_from_handle($handle));
+			$written[] = array(
+				'handle'   => $handle,
+				'repo'     => (string) ( $row['repo'] ?? '' ),
+				'branch'   => (string) ( $row['branch'] ?? '' ),
+				'path'     => (string) ( $row['path'] ?? '' ),
+				'metadata' => WorktreeContextInjector::get_metadata($handle),
+			);
+		}
+
+		$summary = array(
+			'inspected'            => (int) ( $report['summary']['inspected'] ?? 0 ),
+			'planned'              => count($planned),
+			'written'              => count($written),
+			'skipped'              => count($skipped),
+			'skipped_by_reason'    => array(),
+			'report_action_counts' => $report['summary']['by_suggested_action'] ?? array(),
+		);
+		foreach ( $skipped as $skip ) {
+			$reason                                  = (string) ( $skip['reason_code'] ?? 'unknown' );
+			$summary['skipped_by_reason'][ $reason ] = (int) ( $summary['skipped_by_reason'][ $reason ] ?? 0 ) + 1;
+		}
+
+		return array(
+			'success'      => true,
+			'mode'         => 'active_no_signal_merged_apply',
+			'dry_run'      => $dry_run,
+			'applied'      => ! $dry_run,
+			'destructive'  => false,
+			'generated_at' => gmdate('c'),
+			'planned'      => $planned,
+			'written'      => $written,
+			'skipped'      => $skipped,
+			'summary'      => $summary,
+			'pagination'   => $report['pagination'] ?? array(),
+			'evidence'     => array(
+				'scope'  => 'promote clean active_no_signal rows contained in remote default into cleanup_eligible metadata',
+				'safety' => 'Revalidates clean worktree, no unpushed commits, containment, primary protection, branch identity, and merged-to-default evidence before writing metadata. Does not delete worktrees.',
+			),
+		);
+	}
+
+	/**
 	 * Build cleanup metadata from one finalized active/no-signal evidence row.
 	 *
 	 * @param  array<string,mixed> $row Evidence row.
@@ -1790,6 +1883,44 @@ class Workspace {
 	}
 
 	/**
+	 * Build cleanup metadata from one clean merged-to-default evidence row.
+	 *
+	 * @param  array<string,mixed> $row Evidence row.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private function build_active_no_signal_merged_to_default_metadata( array $row ): array|\WP_Error {
+		$handle = (string) ( $row['handle'] ?? '' );
+		$repo   = (string) ( $row['repo'] ?? '' );
+		$branch = (string) ( $row['branch'] ?? '' );
+		$path   = (string) ( $row['path'] ?? '' );
+
+		$evidence = $this->build_current_merged_to_default_cleanup_evidence($handle, $repo, $branch, $path);
+		if ( is_wp_error($evidence) ) {
+			return $evidence;
+		}
+
+		$base_metadata                            = is_array($row['metadata'] ?? null) ? $row['metadata'] : array();
+		$metadata                                 = array_merge(
+			$base_metadata,
+			array(
+				'handle'       => $handle,
+				'repo'         => $repo,
+				'branch'       => $branch,
+				'path'         => (string) ( $evidence['path'] ?? $path ),
+				'observed_at'  => gmdate('c'),
+				'last_seen_at' => gmdate('c'),
+			),
+			WorktreeContextInjector::build_finalizer_metadata(WorktreeContextInjector::STATE_MERGED)
+		);
+		$metadata['auto_finalized_by']            = 'active_no_signal_merged_apply';
+		$metadata['auto_finalized_signal']        = 'merged-to-default';
+		$metadata['auto_finalized_reason']        = sprintf('active/no-signal report found branch contained in %s', (string) ( $evidence['default_ref'] ?? 'remote default' ));
+		$metadata['cleanup_eligibility_evidence'] = $evidence;
+
+		return $metadata;
+	}
+
+	/**
 	 * Recompute effective-clean evidence for the current worktree state.
 	 *
 	 * @param  string $repo    Repository name.
@@ -1828,6 +1959,125 @@ class Workspace {
 			'dirty'                => (int) $dirty,
 			'unpushed'             => (int) $unpushed,
 			'upstream_equivalence' => $upstream_equivalence,
+		);
+	}
+
+	/**
+	 * Recompute merged-to-default evidence for the current worktree state.
+	 *
+	 * @param  string $handle Workspace handle.
+	 * @param  string $repo   Repository name.
+	 * @param  string $branch Branch name.
+	 * @param  string $path   Worktree path.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private function build_current_merged_to_default_cleanup_evidence( string $handle, string $repo, string $branch, string $path ): array|\WP_Error {
+		foreach (
+		array(
+			'handle' => $handle,
+			'repo'   => $repo,
+			'branch' => $branch,
+			'path'   => $path,
+		) as $field => $value
+		) {
+			if ( '' === $value ) {
+				return new \WP_Error('missing_identity', 'missing required identity field: ' . $field);
+			}
+		}
+
+		if ( in_array($branch, $this->protected_base_branch_names(), true) ) {
+			return new \WP_Error('primary_protected_branch', 'refusing to auto-finalize a protected primary branch worktree');
+		}
+
+		$validation = $this->validate_containment($path, $this->workspace_path);
+		if ( ! $validation['valid'] ) {
+			return new \WP_Error('external_worktree', 'worktree path is outside the workspace root');
+		}
+
+		$real_path = (string) ( $validation['real_path'] ?? '' );
+		if ( '' === $real_path || ! is_dir($real_path) ) {
+			return new \WP_Error('missing_worktree', 'worktree path no longer exists');
+		}
+
+		$git_marker = rtrim($real_path, '/') . '/.git';
+		if ( is_dir($git_marker) ) {
+			return new \WP_Error('primary_checkout', 'refusing to mark a primary checkout cleanup_eligible');
+		}
+		if ( ! is_file($git_marker) ) {
+			return new \WP_Error('not_a_worktree', 'worktree marker missing');
+		}
+
+		$current_branch = $this->resolve_worktree_branch_from_head_file($real_path);
+		if ( $branch !== $current_branch ) {
+			return new \WP_Error('branch_identity_mismatch', 'worktree branch identity changed before apply');
+		}
+
+		$primary_path = $this->get_primary_path($repo);
+		if ( ! is_dir($primary_path . '/.git') ) {
+			return new \WP_Error('missing_primary', 'primary checkout missing');
+		}
+
+		$dirty = $this->probe_worktree_dirty_count($real_path, self::CLEANUP_GIT_PROBE_TIMEOUT);
+		if ( is_wp_error($dirty) ) {
+			return $dirty;
+		}
+		if ( (int) $dirty > 0 ) {
+			return new \WP_Error('dirty_worktree', 'refusing to mark dirty worktree cleanup_eligible from merged-to-default evidence');
+		}
+
+		$unpushed = $this->count_unpushed_commits($real_path, self::CLEANUP_GIT_PROBE_TIMEOUT);
+		if ( is_wp_error($unpushed) ) {
+			return $unpushed;
+		}
+		if ( (int) $unpushed > 0 ) {
+			return new \WP_Error('unpushed_commits', 'refusing to mark worktree with unpushed commits cleanup_eligible from merged-to-default evidence');
+		}
+
+		$default_ref = $this->resolve_remote_default_ref($primary_path, self::CLEANUP_GIT_PROBE_TIMEOUT);
+		if ( ! is_string($default_ref) || '' === $default_ref ) {
+			return new \WP_Error('missing_default_ref', 'primary checkout default ref could not be resolved');
+		}
+
+		$branch_ref = 'refs/heads/' . $branch;
+		$outside    = $this->run_git(
+			$primary_path,
+			sprintf('rev-list --count %s..%s', escapeshellarg($default_ref), escapeshellarg($branch_ref)),
+			self::CLEANUP_GIT_PROBE_TIMEOUT
+		);
+		if ( is_wp_error($outside) ) {
+			return $outside;
+		}
+
+		$commits_outside_default = (int) trim( (string) ( $outside['output'] ?? '' ));
+		if ( 0 !== $commits_outside_default ) {
+			return new \WP_Error('not_merged_to_default', 'current branch still has commits outside remote default');
+		}
+
+		$branch_head = $this->run_git($primary_path, sprintf('rev-parse --verify %s', escapeshellarg($branch_ref)), self::CLEANUP_GIT_PROBE_TIMEOUT);
+		if ( is_wp_error($branch_head) ) {
+			return $branch_head;
+		}
+		$default_head = $this->run_git($primary_path, sprintf('rev-parse --verify %s', escapeshellarg($default_ref . '^{commit}')), self::CLEANUP_GIT_PROBE_TIMEOUT);
+		if ( is_wp_error($default_head) ) {
+			return $default_head;
+		}
+
+		return array(
+			'signal'                  => 'merged-to-default',
+			'finalized_state'         => WorktreeContextInjector::STATE_MERGED,
+			'reason'                  => 'branch has no commits outside the remote default ref',
+			'detected_at'             => gmdate('c'),
+			'handle'                  => $handle,
+			'repo'                    => $repo,
+			'branch'                  => $branch,
+			'path'                    => $real_path,
+			'default_ref'             => $default_ref,
+			'branch_ref'              => $branch_ref,
+			'branch_head'             => trim( (string) ( $branch_head['output'] ?? '' )),
+			'default_head'            => trim( (string) ( $default_head['output'] ?? '' )),
+			'commits_outside_default' => $commits_outside_default,
+			'dirty'                   => (int) $dirty,
+			'unpushed'                => (int) $unpushed,
 		);
 	}
 

--- a/tests/smoke-worktree-metadata-reconcile.php
+++ b/tests/smoke-worktree-metadata-reconcile.php
@@ -776,6 +776,66 @@ namespace {
     $assert('metadata_reconciliation_page', $job_result['chunk_type'] ?? '', 'metadata reconciliation page job records chunk type');
     $assert(true, isset($job_result['evidence']['summary']), 'metadata reconciliation page job records summary evidence');
 
+    echo "\nMerged-to-default active/no-signal apply\n";
+    $run('git checkout main', $primary);
+    $make_branch('default-merged');
+    $make_branch('dirty-default-merged');
+    $make_branch('unpushed-default-merged');
+    $make_branch('ambiguous-default');
+    foreach (array( 'default-merged', 'dirty-default-merged', 'unpushed-default-merged' ) as $merged_branch ) {
+        $run('git checkout main', $primary);
+        $run(sprintf('git merge --no-ff %s -m %s', escapeshellarg($merged_branch), escapeshellarg('merge ' . $merged_branch)), $primary);
+        $run('git push origin main', $primary);
+    }
+    $run('git checkout main', $primary);
+    foreach (array( 'default-merged', 'dirty-default-merged', 'unpushed-default-merged', 'ambiguous-default' ) as $branch_name ) {
+        $run(sprintf('git worktree add %s %s', escapeshellarg($tmp . '/demo@' . $branch_name), escapeshellarg($branch_name)), $primary);
+        \DataMachineCode\Workspace\WorktreeContextInjector::store_lifecycle_metadata(
+            'demo@' . $branch_name,
+            array(
+            'handle'          => 'demo@' . $branch_name,
+            'repo'            => 'demo',
+            'branch'          => $branch_name,
+            'path'            => $tmp . '/demo@' . $branch_name,
+            'created_at'      => '2026-04-06T00:00:00+00:00',
+            'observed_at'     => '2026-04-06T00:00:00+00:00',
+            'lifecycle_state' => \DataMachineCode\Workspace\WorktreeContextInjector::STATE_ACTIVE,
+            )
+        );
+    }
+    file_put_contents($tmp . '/demo@dirty-default-merged/scratch.txt', 'dirty');
+    file_put_contents($tmp . '/demo@unpushed-default-merged/local-after-merge.txt', 'local');
+    $run('git add local-after-merge.txt && git commit -m local-after-merge', $tmp . '/demo@unpushed-default-merged');
+
+    $merged_report = $ws->worktree_active_no_signal_report(array( 'limit' => 100, 'offset' => 0 ));
+    $assert(true, ! is_wp_error($merged_report) && ( $merged_report['success'] ?? false ), 'merged-to-default active/no-signal report succeeds');
+    $merged_rows = array();
+    foreach ((array) ( $merged_report['rows'] ?? array() ) as $row ) {
+        $merged_rows[ $row['handle'] ?? '' ] = $row;
+    }
+    $assert('merged_to_default', $merged_rows['demo@default-merged']['suggested_action'] ?? '', 'clean contained branch is classified merged_to_default');
+    $assert('unsafe_dirty_or_unpushed', $merged_rows['demo@dirty-default-merged']['suggested_action'] ?? '', 'dirty contained branch remains unsafe');
+    $assert('unsafe_dirty_or_unpushed', $merged_rows['demo@unpushed-default-merged']['suggested_action'] ?? '', 'unpushed contained branch remains unsafe');
+    $assert('no_pr_branch_review', $merged_rows['demo@ambiguous-default']['suggested_action'] ?? '', 'ambiguous unmerged branch remains manual review');
+
+    $merged_dry_run = $ws->worktree_active_no_signal_merged_apply(array( 'dry_run' => true, 'limit' => 100, 'offset' => 0 ));
+    $assert(true, ! is_wp_error($merged_dry_run) && ( $merged_dry_run['success'] ?? false ), 'merged-to-default active/no-signal dry-run succeeds');
+    $assert(true, (bool) ( $merged_dry_run['dry_run'] ?? false ), 'merged-to-default dry-run does not write');
+    $assert(1, (int) ( $merged_dry_run['summary']['planned'] ?? 0 ), 'merged-to-default dry-run plans only safe merged rows');
+    $assert('', \DataMachineCode\Workspace\WorktreeContextInjector::get_metadata('demo@default-merged')['cleanup_eligible_at'] ?? '', 'merged-to-default dry-run leaves metadata unchanged');
+
+    $merged_apply = $ws->worktree_active_no_signal_merged_apply(array( 'limit' => 100, 'offset' => 0 ));
+    $assert(true, ! is_wp_error($merged_apply) && ( $merged_apply['success'] ?? false ), 'merged-to-default active/no-signal apply succeeds');
+    $assert(1, (int) ( $merged_apply['summary']['written'] ?? 0 ), 'merged-to-default apply writes only safe merged row metadata');
+    $stored_default_merged = \DataMachineCode\Workspace\WorktreeContextInjector::get_metadata('demo@default-merged');
+    $assert('cleanup_eligible', $stored_default_merged['lifecycle_state'] ?? '', 'merged-to-default apply stores cleanup_eligible state');
+    $assert('merged', $stored_default_merged['finalized_state'] ?? '', 'merged-to-default apply records merged finalizer state');
+    $assert('merged-to-default', $stored_default_merged['cleanup_eligibility_evidence']['signal'] ?? '', 'merged-to-default apply records merge evidence signal');
+    $assert(0, (int) ( $stored_default_merged['cleanup_eligibility_evidence']['commits_outside_default'] ?? -1 ), 'merged-to-default evidence records containment count');
+    $assert('', \DataMachineCode\Workspace\WorktreeContextInjector::get_metadata('demo@dirty-default-merged')['cleanup_eligible_at'] ?? '', 'dirty merged-to-default row remains active');
+    $assert('', \DataMachineCode\Workspace\WorktreeContextInjector::get_metadata('demo@unpushed-default-merged')['cleanup_eligible_at'] ?? '', 'unpushed merged-to-default row remains active');
+    $assert('', \DataMachineCode\Workspace\WorktreeContextInjector::get_metadata('demo@ambiguous-default')['cleanup_eligible_at'] ?? '', 'ambiguous row remains active');
+
     if ($failures > 0 ) {
         echo "\n{$failures} / {$total} assertions failed.\n";
         exit(1);


### PR DESCRIPTION
## Summary
- Adds `active-no-signal-merged-apply` to promote clean `active-no-signal-report` rows with `suggested_action=merged_to_default` into `cleanup_eligible` lifecycle metadata.
- Revalidates containment, primary/worktree identity, protected branch names, dirty state, unpushed commits, and remote-default containment immediately before metadata writes.
- Records merge-to-default cleanup evidence including transition reason, detected timestamp, default/branch refs, heads, dirty/unpushed counts, and `commits_outside_default`.

Fixes https://github.com/Extra-Chill/data-machine-code/issues/497

## Testing
- `php -l inc/Workspace/Workspace.php`
- `php -l inc/Cli/Commands/WorkspaceCommand.php`
- `php -l inc/Abilities/WorkspaceAbilities.php`
- `php -l tests/smoke-worktree-metadata-reconcile.php`
- `php tests/smoke-worktree-metadata-reconcile.php`
- `php tests/smoke-worktree-finalizer-cli.php`
- `php tests/smoke-tool-schemas.php`
- `php tests/smoke-deferred-ability-registration.php`
- `php tests/smoke-agents-md-marker.php`
- `git diff --check`
- `homeboy test --path . --extension wordpress`

## Notes
- `for test_file in tests/smoke-*.php; do php "$test_file" || exit $?; done` stops in the unrelated `tests/smoke-github-fetch-exclude-labels.php` test with existing `exclude_labels` parsing/logging assertions.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** implementation draft, tests, and verification; Chris remains responsible.