### PR TITLE
Summarize cleanup remaining work

### DIFF
--- a/inc/Cleanup/CleanupRemainingWorkSummary.php
+++ b/inc/Cleanup/CleanupRemainingWorkSummary.php
@@ -1,0 +1,233 @@
+<?php
+/**
+ * Compact cleanup remaining-work summaries.
+ *
+ * @package DataMachineCode\Cleanup
+ */
+
+namespace DataMachineCode\Cleanup;
+
+defined('ABSPATH') || exit;
+
+class CleanupRemainingWorkSummary {
+
+
+
+	private const EXAMPLE_LIMIT = 3;
+
+	/**
+	 * Build a concise summary from DB-backed cleanup items.
+	 *
+	 * @param  array<int,array<string,mixed>> $items Cleanup items.
+	 * @return array<string,mixed>
+	 */
+	public static function from_items( array $items ): array {
+		$summary = self::empty_summary();
+
+		foreach ( $items as $item ) {
+			if ( ! is_array($item) ) {
+				continue;
+			}
+
+			$type     = (string) ( $item['item_type'] ?? 'unknown' );
+			$status   = (string) ( $item['status'] ?? 'unknown' );
+			$evidence = (array) ( $item['evidence'] ?? array() );
+			$row      = array_merge($evidence, $item);
+
+			if ( 'applied' === $status ) {
+				self::increment_type($summary['applied_by_type'], $type, (int) ( $item['bytes_reclaimed'] ?? 0 ));
+				continue;
+			}
+
+			if ( 'skipped' === $status || 'failed' === $status ) {
+				self::increment_reason($summary['skipped_by_reason'], self::reason_code($item), $row);
+			}
+
+			if ( 'blocked' === $status || 'resolver' === $type ) {
+				self::increment_reason($summary['blocked_resolvers_by_reason'], self::reason_code($item), $row);
+			}
+
+			if ( 'artifact_cleanup' === $type && 'applied' !== $status ) {
+				$summary['remaining_reclaimable_artifact_bytes'] += self::row_bytes($row, array( 'artifact_size_bytes', 'size_bytes' ));
+			}
+			if ( 'worktree_removal' === $type && in_array($status, array( 'pending', 'failed' ), true) ) {
+				++$summary['remaining_safely_removable_worktrees'];
+			}
+		}
+
+		return self::finalize($summary);
+	}
+
+	/**
+	 * Build a concise summary from job-backed cleanup run aggregates.
+	 *
+	 * @param  array<string,mixed> $aggregate Cleanup child aggregate.
+	 * @return array<string,mixed>
+	 */
+	public static function from_job_aggregate( array $aggregate ): array {
+		$summary = self::empty_summary();
+		$items   = (array) ( $aggregate['cleanup_items'] ?? array() );
+
+		foreach ( (array) ( $items['by_type'] ?? array() ) as $type => $row ) {
+			if ( ! is_array($row) ) {
+				continue;
+			}
+			self::increment_type($summary['applied_by_type'], (string) $type, (int) ( $row['bytes_reclaimed'] ?? 0 ), (int) ( $row['applied_rows'] ?? 0 ));
+		}
+
+		foreach ( (array) ( $items['skipped_examples_by_reason'] ?? array() ) as $reason => $bucket ) {
+			self::copy_reason_bucket($summary['skipped_by_reason'], (string) $reason, (array) $bucket);
+		}
+		foreach ( (array) ( $items['failed_examples_by_reason'] ?? array() ) as $reason => $bucket ) {
+			self::copy_reason_bucket($summary['skipped_by_reason'], (string) $reason, (array) $bucket);
+		}
+
+		$summary['remaining_reclaimable_artifact_bytes'] = max(0, (int) ( $items['remaining_reclaimable_artifact_bytes'] ?? 0 ));
+		$summary['remaining_safely_removable_worktrees'] = max(0, (int) ( $items['remaining_safely_removable_worktrees'] ?? 0 ));
+
+		return self::finalize($summary);
+	}
+
+	private static function empty_summary(): array {
+		return array(
+			'applied_by_type'                      => array(),
+			'skipped_by_reason'                    => array(),
+			'blocked_resolvers_by_reason'          => array(),
+			'remaining_reclaimable_artifact_bytes' => 0,
+			'remaining_safely_removable_worktrees' => 0,
+			'recommended_commands'                 => array(),
+		);
+	}
+
+	private static function increment_type( array &$types, string $type, int $bytes, int $count = 1 ): void {
+		if ( '' === $type ) {
+			$type = 'unknown';
+		}
+		$types[ $type ]                   ??= array(
+			'count'           => 0,
+			'bytes_reclaimed' => 0,
+		);
+		$types[ $type ]['count']           += max(0, $count);
+		$types[ $type ]['bytes_reclaimed'] += max(0, $bytes);
+	}
+
+	private static function increment_reason( array &$reasons, string $reason, array $row ): void {
+		$reasons[ $reason ] ??= array(
+			'count'    => 0,
+			'examples' => array(),
+		);
+		++$reasons[ $reason ]['count'];
+		if ( count($reasons[ $reason ]['examples']) < self::EXAMPLE_LIMIT ) {
+			$reasons[ $reason ]['examples'][] = self::example_row($row);
+		}
+	}
+
+	private static function copy_reason_bucket( array &$reasons, string $reason, array $bucket ): void {
+		if ( '' === $reason ) {
+			$reason = 'unknown';
+		}
+		$reasons[ $reason ]         ??= array(
+			'count'    => 0,
+			'examples' => array(),
+		);
+		$reasons[ $reason ]['count'] += max(0, (int) ( $bucket['count'] ?? 0 ));
+		foreach ( (array) ( $bucket['examples'] ?? array() ) as $example ) {
+			if ( count($reasons[ $reason ]['examples']) >= self::EXAMPLE_LIMIT ) {
+				break;
+			}
+			$reasons[ $reason ]['examples'][] = is_array($example) ? self::example_row($example) : array( 'handle' => (string) $example );
+		}
+	}
+
+	private static function reason_code( array $row ): string {
+		$reason = (string) ( $row['reason_code'] ?? $row['reason'] ?? 'unknown' );
+		return '' === $reason ? 'unknown' : $reason;
+	}
+
+	private static function example_row( array $row ): array {
+		$example = array(
+			'handle' => (string) ( $row['handle'] ?? '' ),
+		);
+		foreach ( array( 'repo', 'branch', 'reason', 'path' ) as $field ) {
+			if ( isset($row[ $field ]) && '' !== (string) $row[ $field ] ) {
+				$example[ $field ] = (string) $row[ $field ];
+			}
+		}
+		return $example;
+	}
+
+	private static function row_bytes( array $row, array $fields ): int {
+		foreach ( $fields as $field ) {
+			if ( isset($row[ $field ]) ) {
+				return max(0, (int) $row[ $field ]);
+			}
+		}
+		$total = 0;
+		foreach ( (array) ( $row['artifacts'] ?? array() ) as $artifact ) {
+			$total += max(0, (int) ( is_array($artifact) ? ( $artifact['size_bytes'] ?? 0 ) : 0 ));
+		}
+		return $total;
+	}
+
+	private static function finalize( array $summary ): array {
+		ksort($summary['applied_by_type']);
+		ksort($summary['skipped_by_reason']);
+		ksort($summary['blocked_resolvers_by_reason']);
+		$summary['recommended_commands'] = self::recommended_commands($summary);
+		return $summary;
+	}
+
+	private static function recommended_commands( array $summary ): array {
+		$commands = array();
+		if ( (int) $summary['remaining_reclaimable_artifact_bytes'] > 0 ) {
+			$commands[] = array(
+				'bucket'      => 'remaining_artifacts',
+				'command'     => 'studio wp datamachine-code workspace cleanup run --mode=artifacts --dry-run --format=json',
+				'apply'       => 'studio wp datamachine-code workspace cleanup run --mode=artifacts',
+				'destructive' => false,
+			);
+		}
+		if ( (int) $summary['remaining_safely_removable_worktrees'] > 0 ) {
+			$commands[] = array(
+				'bucket'      => 'remaining_worktrees',
+				'command'     => 'studio wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --dry-run --limit=25',
+				'apply'       => 'studio wp datamachine-code workspace cleanup run --mode=retention',
+				'destructive' => false,
+			);
+		}
+		foreach ( array_keys( (array) $summary['skipped_by_reason'] ) as $reason ) {
+			$commands[] = self::command_for_reason( (string) $reason, 'skipped');
+		}
+		foreach ( array_keys( (array) $summary['blocked_resolvers_by_reason'] ) as $reason ) {
+			$commands[] = self::command_for_reason( (string) $reason, 'blocked_resolver');
+		}
+
+		$seen = array();
+		return array_values(array_filter(
+			$commands,
+			function ( array $command ) use ( &$seen ): bool {
+				$key = (string) ( $command['bucket'] ?? '' ) . '|' . (string) ( $command['command'] ?? '' );
+				if ( isset($seen[ $key ]) ) {
+					return false;
+				}
+				$seen[ $key ] = true;
+				return true;
+			}
+		));
+	}
+
+	private static function command_for_reason( string $reason, string $bucket ): array {
+		$command = match ( $reason ) {
+			'needs_metadata_reconcile', 'lifecycle_reconciliation_candidate', 'repaired_metadata' => 'studio wp datamachine-code workspace worktree reconcile-metadata --dry-run --format=json',
+			'dirty_worktree', 'unpushed_commits', 'probe_timeout', 'plan_mismatch' => 'studio wp datamachine-code workspace cleanup run --mode=retention --dry-run --format=json',
+			'artifact_already_removed', 'artifact_plan_mismatch' => 'studio wp datamachine-code workspace cleanup run --mode=artifacts --dry-run --format=json',
+			default => 'studio wp datamachine-code workspace cleanup run --mode=retention --dry-run --format=json',
+		};
+
+		return array(
+			'bucket'      => $bucket . ':' . $reason,
+			'command'     => $command,
+			'destructive' => false,
+		);
+	}
+}

--- a/inc/Cleanup/DataMachineJobCleanupRunEvidenceStore.php
+++ b/inc/Cleanup/DataMachineJobCleanupRunEvidenceStore.php
@@ -41,16 +41,17 @@ class DataMachineJobCleanupRunEvidenceStore implements CleanupRunEvidenceStoreIn
 
 		$children_for_output = ( $include_evidence || $include_details ) ? $children : $this->summarize_cleanup_children($children);
 		$output              = array(
-			'success'             => true,
-			'state'               => $state,
-			'run_id'              => $this->cleanup_run_id($job_id),
-			'job_id'              => $job_id,
-			'status'              => in_array($state, array( 'children_processing', 'partial_failed' ), true) ? $state : ( $job['status'] ?? '' ),
-			'created_at'          => $job['created_at'] ?? '',
-			'parent_completed_at' => $job['completed_at'] ?? '',
-			'artifact_cleanup'    => $aggregate['artifact_cleanup'],
-			'cleanup_items'       => $aggregate['cleanup_items'],
-			'children'            => $children_for_output,
+			'success'                => true,
+			'state'                  => $state,
+			'run_id'                 => $this->cleanup_run_id($job_id),
+			'job_id'                 => $job_id,
+			'status'                 => in_array($state, array( 'children_processing', 'partial_failed' ), true) ? $state : ( $job['status'] ?? '' ),
+			'created_at'             => $job['created_at'] ?? '',
+			'parent_completed_at'    => $job['completed_at'] ?? '',
+			'artifact_cleanup'       => $aggregate['artifact_cleanup'],
+			'cleanup_items'          => $aggregate['cleanup_items'],
+			'remaining_work_summary' => CleanupRemainingWorkSummary::from_job_aggregate($aggregate),
+			'children'               => $children_for_output,
 		);
 
 		$output_aggregate             = $aggregate;
@@ -93,25 +94,33 @@ class DataMachineJobCleanupRunEvidenceStore implements CleanupRunEvidenceStoreIn
 	private function aggregate_cleanup_child_jobs( array $child_jobs ): array {
 		$summary = array(
 			'artifact_cleanup' => array(
-				'planned_rows'      => 0,
-				'applied_rows'      => 0,
-				'skipped_rows'      => 0,
-				'failed_rows'       => 0,
-				'bytes_reclaimed'   => 0,
-				'freed_human'       => $this->format_bytes(0),
-				'skipped_by_reason' => array(),
-				'failed_by_reason'  => array(),
+				'planned_rows'                         => 0,
+				'applied_rows'                         => 0,
+				'skipped_rows'                         => 0,
+				'failed_rows'                          => 0,
+				'bytes_reclaimed'                      => 0,
+				'freed_human'                          => $this->format_bytes(0),
+				'skipped_by_reason'                    => array(),
+				'failed_by_reason'                     => array(),
+				'skipped_examples_by_reason'           => array(),
+				'failed_examples_by_reason'            => array(),
+				'remaining_reclaimable_artifact_bytes' => 0,
+				'remaining_safely_removable_worktrees' => 0,
 			),
 			'cleanup_items'    => array(
-				'planned_rows'      => 0,
-				'applied_rows'      => 0,
-				'skipped_rows'      => 0,
-				'failed_rows'       => 0,
-				'bytes_reclaimed'   => 0,
-				'freed_human'       => $this->format_bytes(0),
-				'by_type'           => array(),
-				'skipped_by_reason' => array(),
-				'failed_by_reason'  => array(),
+				'planned_rows'                         => 0,
+				'applied_rows'                         => 0,
+				'skipped_rows'                         => 0,
+				'failed_rows'                          => 0,
+				'bytes_reclaimed'                      => 0,
+				'freed_human'                          => $this->format_bytes(0),
+				'by_type'                              => array(),
+				'skipped_by_reason'                    => array(),
+				'failed_by_reason'                     => array(),
+				'skipped_examples_by_reason'           => array(),
+				'failed_examples_by_reason'            => array(),
+				'remaining_reclaimable_artifact_bytes' => 0,
+				'remaining_safely_removable_worktrees' => 0,
 			),
 			'children'         => array(
 				'batch_job_ids'      => array(),
@@ -262,8 +271,19 @@ class DataMachineJobCleanupRunEvidenceStore implements CleanupRunEvidenceStoreIn
 		$summary['by_type'][ $chunk_type ]['failed_rows']     += $failed;
 		$summary['by_type'][ $chunk_type ]['bytes_reclaimed'] += $bytes_reclaimed;
 
-		$this->merge_cleanup_reason_counts($summary['skipped_by_reason'], (array) ( $result['skipped'] ?? array() ));
-		$this->merge_cleanup_reason_counts($summary['failed_by_reason'], (array) ( $result['failed'] ?? array() ));
+		$skipped_rows = (array) ( $result['skipped'] ?? array() );
+		$failed_rows  = (array) ( $result['failed'] ?? array() );
+		$this->merge_cleanup_reason_counts($summary['skipped_by_reason'], $skipped_rows);
+		$this->merge_cleanup_reason_counts($summary['failed_by_reason'], $failed_rows);
+		$this->merge_cleanup_reason_examples($summary['skipped_examples_by_reason'], $skipped_rows);
+		$this->merge_cleanup_reason_examples($summary['failed_examples_by_reason'], $failed_rows);
+
+		if ( in_array($chunk_type, array( 'artifacts', 'artifact_discovery' ), true) ) {
+			$summary['remaining_reclaimable_artifact_bytes'] += $this->sum_cleanup_rows_bytes(array_merge($skipped_rows, $failed_rows), array( 'artifact_size_bytes', 'size_bytes' ));
+		}
+		if ( 'worktrees' === $chunk_type ) {
+			$summary['remaining_safely_removable_worktrees'] += $failed;
+		}
 	}
 
 	/**
@@ -435,6 +455,73 @@ class DataMachineJobCleanupRunEvidenceStore implements CleanupRunEvidenceStoreIn
 			}
 			$counts[ $reason ] = (int) ( $counts[ $reason ] ?? 0 ) + 1;
 		}
+	}
+
+	/**
+	 * Merge bounded examples by cleanup reason.
+	 *
+	 * @param  array $examples Reason examples.
+	 * @param  array $rows     Rows with reason_code/reason.
+	 * @return void
+	 */
+	private function merge_cleanup_reason_examples( array &$examples, array $rows ): void {
+		$limit = 3;
+		foreach ( $rows as $row ) {
+			if ( ! is_array($row) ) {
+				continue;
+			}
+			$reason = (string) ( $row['reason_code'] ?? $row['reason'] ?? 'unknown' );
+			if ( '' === $reason ) {
+				$reason = 'unknown';
+			}
+			$examples[ $reason ] ??= array(
+				'count'    => 0,
+				'examples' => array(),
+			);
+			++$examples[ $reason ]['count'];
+			if ( count($examples[ $reason ]['examples']) >= $limit ) {
+				continue;
+			}
+			$examples[ $reason ]['examples'][] = array_filter(
+				array(
+					'handle' => (string) ( $row['handle'] ?? '' ),
+					'repo'   => (string) ( $row['repo'] ?? '' ),
+					'branch' => (string) ( $row['branch'] ?? '' ),
+					'reason' => (string) ( $row['reason'] ?? '' ),
+				)
+			);
+		}
+	}
+
+	/**
+	 * Sum byte fields across cleanup rows.
+	 *
+	 * @param  array<int,array<string,mixed>> $rows   Rows.
+	 * @param  array<int,string>              $fields Byte field preference order.
+	 * @return int
+	 */
+	private function sum_cleanup_rows_bytes( array $rows, array $fields ): int {
+		$total = 0;
+		foreach ( $rows as $row ) {
+			if ( ! is_array($row) ) {
+				continue;
+			}
+			$found = false;
+			foreach ( $fields as $field ) {
+				if ( isset($row[ $field ]) ) {
+					$total += max(0, (int) $row[ $field ]);
+					$found  = true;
+					break;
+				}
+			}
+			if ( $found ) {
+				continue;
+			}
+			foreach ( (array) ( $row['artifacts'] ?? array() ) as $artifact ) {
+				$total += max(0, (int) ( is_array($artifact) ? ( $artifact['size_bytes'] ?? 0 ) : 0 ));
+			}
+		}
+		return $total;
 	}
 
 	/**

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -742,9 +742,93 @@ class WorkspaceCommand extends BaseCommand {
 				WP_CLI::log(sprintf('%s: %s', ucfirst(str_replace('_', ' ', $key)), (string) $result[ $key ]));
 			}
 		}
+		if ( ! empty($result['remaining_work_summary']) && is_array($result['remaining_work_summary']) ) {
+			$this->render_cleanup_remaining_work_summary( (array) $result['remaining_work_summary']);
+		}
 		if ( ! empty($result['evidence']) ) {
 			WP_CLI::log( (string) wp_json_encode($result['evidence'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
 		}
+	}
+
+	/**
+	 * Render compact cleanup remaining-work summary.
+	 *
+	 * @param  array<string,mixed> $summary Remaining-work summary.
+	 * @return void
+	 */
+	private function render_cleanup_remaining_work_summary( array $summary ): void {
+		WP_CLI::log('');
+		WP_CLI::log('Remaining work summary:');
+		$this->format_items(
+			array(
+				array(
+					'metric' => 'remaining_reclaimable_artifact_bytes',
+					'value'  => $this->format_bytes($summary['remaining_reclaimable_artifact_bytes'] ?? 0),
+				),
+				array(
+					'metric' => 'remaining_safely_removable_worktrees',
+					'value'  => (int) ( $summary['remaining_safely_removable_worktrees'] ?? 0 ),
+				),
+			),
+			array( 'metric', 'value' ),
+			array( 'format' => 'table' ),
+			'metric'
+		);
+
+		$this->render_cleanup_summary_type_rows('Applied rows by type:', (array) ( $summary['applied_by_type'] ?? array() ));
+		$this->render_cleanup_summary_reason_rows('Skipped rows by reason:', (array) ( $summary['skipped_by_reason'] ?? array() ));
+		$this->render_cleanup_summary_reason_rows('Blocked resolver rows by reason:', (array) ( $summary['blocked_resolvers_by_reason'] ?? array() ));
+
+		$commands = (array) ( $summary['recommended_commands'] ?? array() );
+		if ( array() !== $commands ) {
+			WP_CLI::log('');
+			WP_CLI::log('Recommended next commands:');
+			$rows = array_map(
+				fn( $row ) => array(
+					'bucket'  => is_array($row) ? (string) ( $row['bucket'] ?? '' ) : '',
+					'command' => is_array($row) ? (string) ( $row['command'] ?? '' ) : '',
+				),
+				array_slice($commands, 0, 10)
+			);
+			$this->format_items($rows, array( 'bucket', 'command' ), array( 'format' => 'table' ), 'bucket');
+		}
+	}
+
+	private function render_cleanup_summary_type_rows( string $label, array $types ): void {
+		if ( array() === $types ) {
+			return;
+		}
+		WP_CLI::log('');
+		WP_CLI::log($label);
+		$rows = array();
+		foreach ( $types as $type => $bucket ) {
+			$bucket = (array) $bucket;
+			$rows[] = array(
+				'type'            => (string) $type,
+				'count'           => (int) ( $bucket['count'] ?? 0 ),
+				'bytes_reclaimed' => $this->format_bytes($bucket['bytes_reclaimed'] ?? 0),
+			);
+		}
+		$this->format_items($rows, array( 'type', 'count', 'bytes_reclaimed' ), array( 'format' => 'table' ), 'type');
+	}
+
+	private function render_cleanup_summary_reason_rows( string $label, array $reasons ): void {
+		if ( array() === $reasons ) {
+			return;
+		}
+		WP_CLI::log('');
+		WP_CLI::log($label);
+		$rows = array();
+		foreach ( $reasons as $reason => $bucket ) {
+			$bucket   = (array) $bucket;
+			$examples = array_map(fn( $row ) => is_array($row) ? (string) ( $row['handle'] ?? '' ) : (string) $row, (array) ( $bucket['examples'] ?? array() ));
+			$rows[]   = array(
+				'reason'   => (string) $reason,
+				'count'    => (int) ( $bucket['count'] ?? 0 ),
+				'examples' => implode(', ', array_filter($examples)),
+			);
+		}
+		$this->format_items($rows, array( 'reason', 'count', 'examples' ), array( 'format' => 'table' ), 'reason');
 	}
 
 	private function render_cleanup_plan_result( array $result, array $assoc_args ): void {

--- a/inc/Workspace/CleanupRunService.php
+++ b/inc/Workspace/CleanupRunService.php
@@ -7,6 +7,7 @@
 
 namespace DataMachineCode\Workspace;
 
+use DataMachineCode\Cleanup\CleanupRemainingWorkSummary;
 use DataMachineCode\Storage\CleanupRunRepository;
 
 defined('ABSPATH') || exit;
@@ -164,13 +165,14 @@ class CleanupRunService {
 		ksort($summary['items_by_type']);
 
 		return array(
-			'success' => true,
-			'state'   => (string) ( $run['status'] ?? 'unknown' ),
-			'run_id'  => $run_id,
-			'status'  => $run['status'] ?? 'unknown',
-			'mode'    => $run['mode'] ?? '',
-			'run'     => $run,
-			'summary' => $summary,
+			'success'                => true,
+			'state'                  => (string) ( $run['status'] ?? 'unknown' ),
+			'run_id'                 => $run_id,
+			'status'                 => $run['status'] ?? 'unknown',
+			'mode'                   => $run['mode'] ?? '',
+			'run'                    => $run,
+			'summary'                => $summary,
+			'remaining_work_summary' => CleanupRemainingWorkSummary::from_items($items),
 		);
 	}
 

--- a/tests/smoke-cleanup-run-storage.php
+++ b/tests/smoke-cleanup-run-storage.php
@@ -138,22 +138,37 @@ class DataMachineCodeCleanupRunFakeWorkspace extends \DataMachineCode\Workspace\
         'rows'          => array(
         'artifact_cleanup' => array(
         array( 'handle' => 'demo@old', 'row_type' => 'artifact_cleanup', 'reason_code' => 'profile_artifact', 'artifact_size_bytes' => 15 ),
+        array( 'handle' => 'demo@stale-artifact', 'row_type' => 'artifact_cleanup', 'reason_code' => 'profile_artifact', 'artifact_size_bytes' => 9 ),
         ),
         'worktree_removal' => array(
                     array( 'handle' => 'demo@merged', 'repo' => 'demo', 'branch' => 'merged', 'path' => '/tmp/demo@merged', 'row_type' => 'worktree_removal', 'reason_code' => 'cleanup_eligible', 'size_bytes' => 20 ),
+                    array( 'handle' => 'demo@dirty', 'repo' => 'demo', 'branch' => 'dirty', 'path' => '/tmp/demo@dirty', 'row_type' => 'worktree_removal', 'reason_code' => 'cleanup_eligible', 'size_bytes' => 30 ),
         ),
-        'resolver' => array(),
+        'resolver' => array(
+        array( 'handle' => 'demo@needs-metadata-1', 'row_type' => 'resolver', 'reason_code' => 'needs_metadata_reconcile', 'reason' => 'missing metadata' ),
+        array( 'handle' => 'demo@needs-metadata-2', 'row_type' => 'resolver', 'reason_code' => 'needs_metadata_reconcile', 'reason' => 'missing metadata' ),
+        array( 'handle' => 'demo@needs-metadata-3', 'row_type' => 'resolver', 'reason_code' => 'needs_metadata_reconcile', 'reason' => 'missing metadata' ),
+        array( 'handle' => 'demo@needs-metadata-4', 'row_type' => 'resolver', 'reason_code' => 'needs_metadata_reconcile', 'reason' => 'missing metadata' ),
         ),
-        'summary'       => array( 'total_rows' => 2, 'total_size_bytes' => 35 ),
+        ),
+        'summary'       => array( 'total_rows' => 8, 'total_size_bytes' => 74 ),
         );
     }
     public function worktree_cleanup_artifacts( array $opts = array() ): array|WP_Error
     {
-        return array( 'removed' => array( array( 'handle' => 'demo@old' ) ), 'skipped' => array(), 'summary' => array() );
+        return array(
+        'removed' => array( array( 'handle' => 'demo@old', 'artifact_size_bytes' => 15 ) ),
+        'skipped' => array( array( 'handle' => 'demo@stale-artifact', 'reason_code' => 'plan_mismatch', 'reason' => 'artifact plan no longer matches', 'artifact_size_bytes' => 9 ) ),
+        'summary' => array(),
+        );
     }
     public function worktree_cleanup_merged( array $opts = array() ): array|WP_Error
     {
-        return array( 'removed' => array( array( 'handle' => 'demo@merged' ) ), 'skipped' => array(), 'summary' => array() );
+        return array(
+        'removed' => array( array( 'handle' => 'demo@merged', 'size_bytes' => 20 ) ),
+        'skipped' => array( array( 'handle' => 'demo@dirty', 'reason_code' => 'dirty_worktree', 'reason' => 'working tree is dirty' ) ),
+        'summary' => array(),
+        );
     }
 }
 
@@ -173,17 +188,28 @@ $service = new \DataMachineCode\Workspace\CleanupRunService($repo, new DataMachi
 $plan = $service->plan(array( 'mode' => 'retention' ));
 datamachine_code_cleanup_run_assert(! is_wp_error($plan), 'plan succeeds');
 datamachine_code_cleanup_run_assert(isset($plan['run_id']), 'plan returns run_id');
-datamachine_code_cleanup_run_assert(2 === (int) ( $plan['cleanup_storage']['item_count'] ?? 0 ), 'plan persists cleanup items');
+datamachine_code_cleanup_run_assert(8 === (int) ( $plan['cleanup_storage']['item_count'] ?? 0 ), 'plan persists cleanup items');
 
 $status = $service->status($plan['run_id']);
-datamachine_code_cleanup_run_assert(2 === (int) ( $status['summary']['total_items'] ?? 0 ), 'status aggregates items');
-datamachine_code_cleanup_run_assert(2 === (int) ( $status['summary']['items_by_status']['pending'] ?? 0 ), 'status tracks pending items');
+datamachine_code_cleanup_run_assert(8 === (int) ( $status['summary']['total_items'] ?? 0 ), 'status aggregates items');
+datamachine_code_cleanup_run_assert(4 === (int) ( $status['summary']['items_by_status']['pending'] ?? 0 ), 'status tracks pending items');
+datamachine_code_cleanup_run_assert(4 === (int) ( $status['remaining_work_summary']['blocked_resolvers_by_reason']['needs_metadata_reconcile']['count'] ?? 0 ), 'status groups blocked resolver rows by reason');
+datamachine_code_cleanup_run_assert(3 === count($status['remaining_work_summary']['blocked_resolvers_by_reason']['needs_metadata_reconcile']['examples'] ?? array()), 'blocked resolver examples are truncated');
+datamachine_code_cleanup_run_assert(24 === (int) ( $status['remaining_work_summary']['remaining_reclaimable_artifact_bytes'] ?? 0 ), 'status reports remaining reclaimable artifact bytes');
+datamachine_code_cleanup_run_assert(2 === (int) ( $status['remaining_work_summary']['remaining_safely_removable_worktrees'] ?? 0 ), 'status reports remaining safely removable worktrees');
 
 $apply = $service->apply($plan['run_id']);
 datamachine_code_cleanup_run_assert(! is_wp_error($apply), 'apply succeeds');
 
 $evidence = $service->evidence($plan['run_id']);
 datamachine_code_cleanup_run_assert(2 === (int) ( $evidence['summary']['items_by_status']['applied'] ?? 0 ), 'evidence reflects applied rows');
+datamachine_code_cleanup_run_assert(2 === (int) ( $evidence['summary']['items_by_status']['skipped'] ?? 0 ), 'evidence reflects skipped rows');
 datamachine_code_cleanup_run_assert(35 === (int) ( $evidence['summary']['bytes_reclaimed'] ?? 0 ), 'evidence aggregates reclaimed bytes');
+datamachine_code_cleanup_run_assert(1 === (int) ( $evidence['remaining_work_summary']['applied_by_type']['artifact_cleanup']['count'] ?? 0 ), 'evidence groups applied artifact rows');
+datamachine_code_cleanup_run_assert(15 === (int) ( $evidence['remaining_work_summary']['applied_by_type']['artifact_cleanup']['bytes_reclaimed'] ?? 0 ), 'evidence reports artifact bytes reclaimed');
+datamachine_code_cleanup_run_assert(1 === (int) ( $evidence['remaining_work_summary']['skipped_by_reason']['plan_mismatch']['count'] ?? 0 ), 'evidence groups skipped plan mismatches');
+datamachine_code_cleanup_run_assert('demo@stale-artifact' === (string) ( $evidence['remaining_work_summary']['skipped_by_reason']['plan_mismatch']['examples'][0]['handle'] ?? '' ), 'skipped examples include representative handle');
+datamachine_code_cleanup_run_assert(4 === (int) ( $evidence['remaining_work_summary']['blocked_resolvers_by_reason']['needs_metadata_reconcile']['count'] ?? 0 ), 'evidence keeps blocked resolver bucket');
+datamachine_code_cleanup_run_assert(str_contains((string) wp_json_encode($evidence['remaining_work_summary']['recommended_commands']), 'workspace worktree reconcile-metadata'), 'summary recommends next DMC commands');
 
 echo "DB-backed cleanup run storage smoke passed.\n";

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -68,6 +68,7 @@ namespace DataMachine\Cli {
 
 namespace {
     include_once dirname(__DIR__) . '/inc/Cleanup/CleanupRunEvidenceStoreInterface.php';
+    include_once dirname(__DIR__) . '/inc/Cleanup/CleanupRemainingWorkSummary.php';
     include_once dirname(__DIR__) . '/inc/Cleanup/DataMachineJobCleanupRunEvidenceStore.php';
     include_once dirname(__DIR__) . '/inc/Cli/Commands/WorkspaceCommand.php';
 
@@ -509,7 +510,7 @@ namespace {
                  'failed_count'     => 0,
                  'bytes_reclaimed'  => 4096,
                  'skipped'          => array(
-                  array( 'handle' => 'repo@dirty', 'reason_code' => 'dirty_worktree' ),
+                  array( 'handle' => 'repo@dirty', 'reason_code' => 'dirty_worktree', 'artifact_size_bytes' => 8192 ),
                  ),
                  'failed'           => array(),
                    ),
@@ -530,7 +531,7 @@ namespace {
                  'bytes_reclaimed'  => 0,
                  'skipped'          => array(),
                  'failed'           => array(
-                  array( 'handle' => 'repo@failed', 'reason_code' => 'apply_failed' ),
+                   array( 'handle' => 'repo@failed', 'reason_code' => 'apply_failed', 'artifact_size_bytes' => 2048 ),
                  ),
                    ),
                   ),
@@ -722,8 +723,22 @@ namespace {
     datamachine_code_cleanup_assert(3 === (int) ( $status_json['cleanup_items']['by_type']['artifact_discovery']['planned_rows'] ?? 0 ), 'cleanup status preserves artifact discovery chunk type aggregation');
     datamachine_code_cleanup_assert(1 === (int) ( $status_json['cleanup_items']['by_type']['artifacts']['planned_rows'] ?? 0 ), 'cleanup status preserves artifact apply chunk type aggregation');
     datamachine_code_cleanup_assert(! isset($status_json['cleanup_items']['by_type']['unknown']), 'cleanup status does not aggregate completed chunks under unknown type');
+    datamachine_code_cleanup_assert(2 === (int) ( $status_json['remaining_work_summary']['applied_by_type']['artifact_discovery']['count'] ?? 0 ), 'cleanup status groups applied rows by type in remaining-work summary');
+    datamachine_code_cleanup_assert(4096 === (int) ( $status_json['remaining_work_summary']['applied_by_type']['artifact_discovery']['bytes_reclaimed'] ?? 0 ), 'cleanup status reports reclaimed bytes by applied type');
+    datamachine_code_cleanup_assert(1 === (int) ( $status_json['remaining_work_summary']['skipped_by_reason']['dirty_worktree']['count'] ?? 0 ), 'cleanup status groups skipped rows by reason in remaining-work summary');
+    datamachine_code_cleanup_assert('repo@dirty' === (string) ( $status_json['remaining_work_summary']['skipped_by_reason']['dirty_worktree']['examples'][0]['handle'] ?? '' ), 'cleanup status includes skipped examples');
+    datamachine_code_cleanup_assert(10240 === (int) ( $status_json['remaining_work_summary']['remaining_reclaimable_artifact_bytes'] ?? 0 ), 'cleanup status reports remaining reclaimable artifact bytes');
+    datamachine_code_cleanup_assert(str_contains((string) wp_json_encode($status_json['remaining_work_summary']['recommended_commands'] ?? array()), 'workspace cleanup run --mode=artifacts'), 'cleanup status recommends next DMC commands per bucket');
     datamachine_code_cleanup_assert('4.0 KiB' === ( $status_json['system_task_result']['report']['freed_human'] ?? '' ), 'cleanup status replaces pending child job freed placeholder');
     datamachine_code_cleanup_assert(! isset($status_json['system_task_result']['children']['job_ids']), 'cleanup status system task result omits full child job ids by default');
+
+    WP_CLI::$logs      = array();
+    WP_CLI::$successes = array();
+    $command->cleanup(array( 'status', 'cleanup-run-123' ), array());
+    datamachine_code_cleanup_assert(in_array('Remaining work summary:', WP_CLI::$logs, true), 'human cleanup status renders compact remaining-work summary');
+    datamachine_code_cleanup_assert(in_array('Applied rows by type:', WP_CLI::$logs, true), 'human cleanup status renders applied grouped section');
+    datamachine_code_cleanup_assert(in_array('Skipped rows by reason:', WP_CLI::$logs, true), 'human cleanup status renders skipped grouped section');
+    datamachine_code_cleanup_assert(in_array('Recommended next commands:', WP_CLI::$logs, true), 'human cleanup status renders next command section');
 
     WP_CLI::$logs      = array();
     WP_CLI::$successes = array();


### PR DESCRIPTION
## Summary
- Adds a compact `remaining_work_summary` for DB-backed and job-backed cleanup run status/evidence output.
- Groups applied rows by type and bytes reclaimed, skipped/blocked rows by reason with bounded examples, remaining artifact/worktree cleanup, and recommended next DMC commands.
- Renders the summary in human `workspace cleanup status/evidence` output so operators do not need to inspect huge evidence JSON.

Fixes https://github.com/Extra-Chill/data-machine-code/issues/496

## Verification
- `php tests/smoke-cleanup-run-storage.php`
- `php tests/smoke-worktree-cleanup-cli.php`
- `php -l inc/Cleanup/CleanupRemainingWorkSummary.php`
- `php -l inc/Cleanup/DataMachineJobCleanupRunEvidenceStore.php`
- `php -l inc/Workspace/CleanupRunService.php`
- `php -l inc/Cli/Commands/WorkspaceCommand.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine-code@feat-issue-496-cleanup-summary --changed-only`
- `homeboy test --path /Users/chubes/Developer/data-machine-code@feat-issue-496-cleanup-summary`

Note: full `homeboy lint --path /Users/chubes/Developer/data-machine-code@feat-issue-496-cleanup-summary` still reports the repository's existing broad PHPStan/PHPCS backlog; changed-only lint passes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implementation draft, tests, and verification; Chris remains responsible.