### PR TITLE
Fix Studio worktree context projection crash

### DIFF
--- a/inc/Workspace/WorktreeContextInjector.php
+++ b/inc/Workspace/WorktreeContextInjector.php
@@ -1078,6 +1078,10 @@ class WorktreeContextInjector {
 			return array();
 		}
 
+		if ( ! self::can_symlink_site_agents_md($source) ) {
+			return self::project_virtual_site_agents_md_via_opencode_config($worktree_path);
+		}
+
 		$target = rtrim($worktree_path, '/') . '/' . self::PROJECTED_AGENTS_PATH;
 		if ( file_exists($target) || is_link($target) ) {
 			return self::project_site_agents_md_via_opencode_config($worktree_path, $source);
@@ -1097,25 +1101,13 @@ class WorktreeContextInjector {
 		}
 
 		$projection_kind = 'symlink';
-		if ( self::can_symlink_site_agents_md($source) ) {
-            // phpcs:ignore WordPress.WP.AlternativeFunctions.symlink_symlink -- Local checkout projection to a DMC-owned generated file.
-			if ( ! symlink($source, $target) ) {
-				return new \WP_Error(
-					'agents_md_projection_failed',
-					sprintf('Failed to symlink site AGENTS.md into worktree: %s', $target),
-					array( 'status' => 500 )
-				);
-			}
-		} else {
-			$projection_kind = 'inline';
-            // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-			if ( false === file_put_contents($target, self::render($payload)) ) {
-				return new \WP_Error(
-					'agents_md_projection_failed',
-					sprintf('Failed to write inline site AGENTS.md into worktree: %s', $target),
-					array( 'status' => 500 )
-				);
-			}
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.symlink_symlink -- Local checkout projection to a DMC-owned generated file.
+		if ( ! symlink($source, $target) ) {
+			return new \WP_Error(
+				'agents_md_projection_failed',
+				sprintf('Failed to symlink site AGENTS.md into worktree: %s', $target),
+				array( 'status' => 500 )
+			);
 		}
 
      // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
@@ -1144,6 +1136,27 @@ class WorktreeContextInjector {
 	 */
 	private static function can_symlink_site_agents_md( string $source ): bool {
 		return ! str_starts_with($source, '/wordpress/');
+	}
+
+	/**
+	 * Project Studio PHP-WASM site context through host-visible local files only.
+	 *
+	 * Root-level inline AGENTS.md projections for `/wordpress/...` sources can
+	 * crash Studio's PHP-WASM filesystem sync after WP-CLI exits. The rendered
+	 * `.claude/CLAUDE.local.md` snapshot was already written by `inject()`, so
+	 * point OpenCode at that host-visible file instead of creating a root
+	 * projection from the virtual source path.
+	 *
+	 * @param  string $worktree_path Absolute path to the worktree directory.
+	 * @return string[]|\WP_Error Absolute written paths, or WP_Error on failure.
+	 */
+	private static function project_virtual_site_agents_md_via_opencode_config( string $worktree_path ): array|\WP_Error {
+		$local_context = rtrim($worktree_path, '/') . '/' . self::INJECTED_PATHS[0];
+		if ( ! is_file($local_context) ) {
+			return array();
+		}
+
+		return self::project_site_agents_md_via_opencode_config($worktree_path, $local_context);
 	}
 
 	/**

--- a/tests/smoke-worktree-context-injection.php
+++ b/tests/smoke-worktree-context-injection.php
@@ -175,10 +175,11 @@ $virtual_injection = \DataMachineCode\Workspace\WorktreeContextInjector::inject(
     )
 );
 datamachine_code_context_assert(! is_wp_error($virtual_injection), 'virtual context injection succeeds');
-datamachine_code_context_assert(! is_link($virtual_agents), 'virtual AGENTS.md projection is not a host symlink');
-datamachine_code_context_assert(is_file($virtual_agents), 'virtual AGENTS.md projection is written inline');
-datamachine_code_context_assert(str_contains((string) file_get_contents($virtual_agents), '# Virtual Memory'), 'inline virtual projection contains rendered context');
-datamachine_code_context_assert(trim(file_get_contents($virtual_root . '/.datamachine/AGENTS.md.source')) === "inline\n/wordpress/AGENTS.md", 'virtual projection marker records inline source');
+datamachine_code_context_assert(! file_exists($virtual_agents) && ! is_link($virtual_agents), 'virtual AGENTS.md projection is not written at the worktree root');
+$virtual_config = json_decode((string) file_get_contents($virtual_root . '/.opencode/opencode.json'), true);
+datamachine_code_context_assert(is_array($virtual_config), 'virtual context writes local OpenCode config');
+datamachine_code_context_assert(in_array($virtual_root . '/.claude/CLAUDE.local.md', $virtual_config['instructions'] ?? array(), true), 'virtual context points OpenCode at host-visible local snapshot');
+datamachine_code_context_assert(! file_exists($virtual_root . '/.datamachine/AGENTS.md.source'), 'virtual context does not write root projection marker');
 
 $existing_injection = \DataMachineCode\Workspace\WorktreeContextInjector::inject(
     $existing_root,
@@ -200,8 +201,8 @@ datamachine_code_context_assert(! file_exists($worktree_agents) && ! is_link($wo
 datamachine_code_context_assert(! file_exists($worktree_root . '/.datamachine/AGENTS.md.source'), 'projection marker is gone after uninject');
 datamachine_code_context_assert(! file_exists($worktree_root . '/.opencode/AGENTS.local.md'), 'uninject removes legacy fake OpenCode local snapshot');
 $virtual_removed = \DataMachineCode\Workspace\WorktreeContextInjector::uninject($virtual_root);
-datamachine_code_context_assert(in_array($virtual_agents, $virtual_removed['removed'], true), 'uninject removes inline virtual AGENTS.md projection');
-datamachine_code_context_assert(! file_exists($virtual_agents), 'inline virtual projection is gone after uninject');
+datamachine_code_context_assert(in_array($virtual_root . '/.opencode/opencode.json', $virtual_removed['removed'], true), 'uninject removes virtual OpenCode projection config');
+datamachine_code_context_assert(! file_exists($virtual_root . '/.opencode/opencode.json'), 'virtual OpenCode projection config is gone after uninject');
 $existing_removed = \DataMachineCode\Workspace\WorktreeContextInjector::uninject($existing_root);
 datamachine_code_context_assert(! file_exists($existing_root . '/.opencode/opencode.json'), 'uninject removes DMC-created OpenCode projection config');
 datamachine_code_context_assert(in_array($existing_root . '/.opencode/opencode.json', $existing_removed['removed'], true), 'removed OpenCode projection config is reported');
@@ -211,6 +212,7 @@ array_map('unlink', glob($worktree_root . '/.opencode/*') ?: array());
 array_map('unlink', glob($existing_root . '/.claude/*') ?: array());
 array_map('unlink', glob($existing_root . '/.opencode/*') ?: array());
 array_map('unlink', glob($virtual_root . '/.claude/*') ?: array());
+array_map('unlink', glob($virtual_root . '/.opencode/*') ?: array());
 array_map('rmdir', array_filter(glob($worktree_root . '/*') ?: array(), 'is_dir'));
 array_map('rmdir', array_filter(glob($existing_root . '/*') ?: array(), 'is_dir'));
 array_map('rmdir', array_filter(glob($virtual_root . '/*') ?: array(), 'is_dir'));
@@ -223,6 +225,7 @@ rmdir($existing_root . '/.claude');
 rmdir($existing_root . '/.opencode');
 rmdir($existing_root . '/.datamachine');
 rmdir($virtual_root . '/.claude');
+rmdir($virtual_root . '/.opencode');
 rmdir($virtual_root . '/.datamachine');
 rmdir($worktree_root);
 rmdir($existing_root);


### PR DESCRIPTION
## Summary
- avoid writing root `AGENTS.md` projections for Studio PHP-WASM `/wordpress/...` sources during managed worktree creation
- route virtual-site context through the already-written `.claude/CLAUDE.local.md` snapshot via local OpenCode config instead
- update context-injection smoke coverage for the PHP-WASM-safe projection path

Fixes #503.

## Testing
- `php tests/smoke-worktree-context-injection.php`
- `php -l inc/Workspace/WorktreeContextInjector.php && php -l tests/smoke-worktree-context-injection.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Reproduced the Studio PHP-WASM `ErrnoError errno 33` worktree-add crash, isolated it to context projection after successful worktree creation, drafted the narrow projection fix and regression coverage, and ran targeted verification. Chris remains responsible for review and merge.