### PR TITLE
Normalize mounted workspace paths in workspace tools

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -546,6 +546,14 @@ class WorkspaceAbilities {
 								'type'        => 'string',
 								'description' => 'Alias for new_string.',
 							),
+							'old'         => array(
+								'type'        => 'string',
+								'description' => 'Alias for old_string.',
+							),
+							'new'         => array(
+								'type'        => 'string',
+								'description' => 'Alias for new_string.',
+							),
 							'replace_all' => array(
 								'type'        => 'boolean',
 								'description' => 'Replace all occurrences (default false).',
@@ -2445,14 +2453,14 @@ class WorkspaceAbilities {
 	 */
 	public static function editFile( array $input ): array|\WP_Error {
 		$input      = self::normalize_mounted_workspace_path_input($input, array( 'repo' ));
-		$old_string = (string) ( $input['old_string'] ?? $input['search'] ?? '' );
-		$new_string = (string) ( $input['new_string'] ?? $input['replace'] ?? '' );
+		$old_string = (string) ( $input['old_string'] ?? $input['search'] ?? $input['old'] ?? '' );
+		$new_string = (string) ( $input['new_string'] ?? $input['replace'] ?? $input['new'] ?? '' );
 
 		if ( '' === $old_string ) {
 			return new \WP_Error('missing_old_string', 'old_string is required.', array( 'status' => 400 ));
 		}
 
-		if ( ! array_key_exists('new_string', $input) && ! array_key_exists('replace', $input) ) {
+		if ( ! array_key_exists('new_string', $input) && ! array_key_exists('replace', $input) && ! array_key_exists('new', $input) ) {
 			return new \WP_Error('missing_new_string', 'new_string is required.', array( 'status' => 400 ));
 		}
 

--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -2444,6 +2444,7 @@ class WorkspaceAbilities {
 	 * @return array Result.
 	 */
 	public static function editFile( array $input ): array|\WP_Error {
+		$input      = self::normalize_mounted_workspace_path_input($input, array( 'repo' ));
 		$old_string = (string) ( $input['old_string'] ?? $input['search'] ?? '' );
 		$new_string = (string) ( $input['new_string'] ?? $input['replace'] ?? '' );
 

--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -538,12 +538,20 @@ class WorkspaceAbilities {
 								'type'        => 'string',
 								'description' => 'Replacement text.',
 							),
+							'search'      => array(
+								'type'        => 'string',
+								'description' => 'Alias for old_string.',
+							),
+							'replace'     => array(
+								'type'        => 'string',
+								'description' => 'Alias for new_string.',
+							),
 							'replace_all' => array(
 								'type'        => 'boolean',
 								'description' => 'Replace all occurrences (default false).',
 							),
 						),
-						'required'   => array( 'path', 'old_string', 'new_string' ),
+						'required'   => array( 'path' ),
 					),
 					'output_schema'       => array(
 						'type'       => 'object',
@@ -2436,12 +2444,23 @@ class WorkspaceAbilities {
 	 * @return array Result.
 	 */
 	public static function editFile( array $input ): array|\WP_Error {
+		$old_string = (string) ( $input['old_string'] ?? $input['search'] ?? '' );
+		$new_string = (string) ( $input['new_string'] ?? $input['replace'] ?? '' );
+
+		if ( '' === $old_string ) {
+			return new \WP_Error('missing_old_string', 'old_string is required.', array( 'status' => 400 ));
+		}
+
+		if ( ! array_key_exists('new_string', $input) && ! array_key_exists('replace', $input) ) {
+			return new \WP_Error('missing_new_string', 'new_string is required.', array( 'status' => 400 ));
+		}
+
 		if ( RemoteWorkspaceBackend::should_handle() ) {
 			return ( new RemoteWorkspaceBackend() )->edit_file(
 				$input['repo'] ?? '',
 				$input['path'] ?? '',
-				$input['old_string'] ?? '',
-				$input['new_string'] ?? '',
+				$old_string,
+				$new_string,
 				! empty($input['replace_all'])
 			);
 		}
@@ -2452,8 +2471,8 @@ class WorkspaceAbilities {
 		return $writer->edit_file(
 			$input['repo'] ?? '',
 			$input['path'] ?? '',
-			$input['old_string'] ?? '',
-			$input['new_string'] ?? '',
+			$old_string,
+			$new_string,
 			! empty($input['replace_all'])
 		);
 	}

--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -233,7 +233,7 @@ class WorkspaceAbilities {
 								'description' => 'Maximum number of lines to return.',
 							),
 						),
-						'required'   => array( 'repo', 'path' ),
+						'required'   => array( 'path' ),
 					),
 					'output_schema'       => array(
 						'type'       => 'object',
@@ -270,7 +270,7 @@ class WorkspaceAbilities {
 								'description' => 'Relative directory path within the repo (omit for root).',
 							),
 						),
-						'required'   => array( 'repo' ),
+						'required'   => array(),
 					),
 					'output_schema'       => array(
 						'type'       => 'object',
@@ -331,7 +331,7 @@ class WorkspaceAbilities {
 								'description' => 'Number of surrounding lines to include for each match (default 0, max 10).',
 							),
 						),
-						'required'   => array( 'repo', 'pattern' ),
+						'required'   => array( 'pattern' ),
 					),
 					'output_schema'       => array(
 						'type'       => 'object',
@@ -496,7 +496,7 @@ class WorkspaceAbilities {
 								'description' => 'File content to write.',
 							),
 						),
-						'required'   => array( 'repo', 'path', 'content' ),
+						'required'   => array( 'path', 'content' ),
 					),
 					'output_schema'       => array(
 						'type'       => 'object',
@@ -543,7 +543,7 @@ class WorkspaceAbilities {
 								'description' => 'Replace all occurrences (default false).',
 							),
 						),
-						'required'   => array( 'repo', 'path', 'old_string', 'new_string' ),
+						'required'   => array( 'path', 'old_string', 'new_string' ),
 					),
 					'output_schema'       => array(
 						'type'       => 'object',
@@ -617,7 +617,7 @@ class WorkspaceAbilities {
 								'description' => 'Workspace handle: `<repo>` (primary) or `<repo>@<branch-slug>` (worktree).',
 							),
 						),
-						'required'   => array( 'name' ),
+						'required'   => array(),
 					),
 					'output_schema'       => array(
 						'type'       => 'object',
@@ -843,7 +843,7 @@ class WorkspaceAbilities {
 								'description' => 'Permit mutation on the primary checkout (default false). Worktrees are always allowed.',
 							),
 						),
-						'required'   => array( 'repo', 'path' ),
+						'required'   => array( 'path' ),
 					),
 					'output_schema'       => array(
 						'type'       => 'object',
@@ -2275,6 +2275,7 @@ class WorkspaceAbilities {
 	 * @return array Result.
 	 */
 	public static function readFile( array $input ): array|\WP_Error {
+		$input = self::normalize_mounted_workspace_path_input($input, array( 'repo' ));
 		if ( RemoteWorkspaceBackend::should_handle() ) {
 			return ( new RemoteWorkspaceBackend() )->read_file(
 				$input['repo'] ?? '',
@@ -2304,6 +2305,7 @@ class WorkspaceAbilities {
 	 * @return array Result.
 	 */
 	public static function listDirectory( array $input ): array|\WP_Error {
+		$input = self::normalize_mounted_workspace_path_input($input, array( 'repo' ));
 		if ( RemoteWorkspaceBackend::should_handle() ) {
 			return ( new RemoteWorkspaceBackend() )->list_directory(
 				$input['repo'] ?? '',
@@ -2327,6 +2329,7 @@ class WorkspaceAbilities {
 	 * @return array Result.
 	 */
 	public static function grepFiles( array $input ): array|\WP_Error {
+		$input = self::normalize_mounted_workspace_path_input($input, array( 'repo' ));
 		if ( RemoteWorkspaceBackend::should_handle() ) {
 			return ( new RemoteWorkspaceBackend() )->grep(
 				$input['repo'] ?? '',
@@ -3310,6 +3313,100 @@ class WorkspaceAbilities {
 	}
 
 	/**
+	 * Normalize mounted workspace absolute paths into ability-native inputs.
+	 *
+	 * @param  array<string,mixed> $input       Ability input.
+	 * @param  string[]            $handle_keys Keys that can hold workspace handles.
+	 * @return array<string,mixed>
+	 */
+	private static function normalize_mounted_workspace_path_input( array $input, array $handle_keys ): array {
+		$workspace_root = defined('DATAMACHINE_WORKSPACE_PATH') ? self::normalize_workspace_root( (string) DATAMACHINE_WORKSPACE_PATH ) : '';
+		if ( '' === $workspace_root ) {
+			return $input;
+		}
+
+		foreach ( $handle_keys as $key ) {
+			if ( isset($input[ $key ]) && is_string($input[ $key ]) && self::is_absolute_path($input[ $key ]) ) {
+				$parts = self::split_workspace_root_path($input[ $key ], $workspace_root);
+				if ( null === $parts ) {
+					return $input;
+				}
+
+				$input[ $key ] = $parts['repo'];
+				if ( '' !== $parts['path'] ) {
+					$existing_path = isset($input['path']) && is_string($input['path']) ? trim($input['path'], '/') : '';
+					$input['path'] = '' === $existing_path ? $parts['path'] : $parts['path'] . '/' . $existing_path;
+				}
+			}
+		}
+
+		if ( isset($input['path']) && is_string($input['path']) && self::is_absolute_path($input['path']) ) {
+			$parts = self::split_workspace_root_path($input['path'], $workspace_root);
+			if ( null === $parts ) {
+				return $input;
+			}
+
+			$current_handle = '';
+			foreach ( $handle_keys as $key ) {
+				if ( isset($input[ $key ]) && is_string($input[ $key ]) && '' !== trim($input[ $key ]) ) {
+					$current_handle = trim($input[ $key ]);
+					break;
+				}
+			}
+
+			if ( '' === $current_handle && ! empty($handle_keys) ) {
+				$input[ $handle_keys[0] ] = $parts['repo'];
+			}
+			if ( '' === $current_handle || $current_handle === $parts['repo'] ) {
+				$input['path'] = $parts['path'];
+			}
+		}
+
+		return $input;
+	}
+
+	private static function normalize_workspace_root( string $root ): string {
+		$root = trim(str_replace('\\', '/', trim($root)), '/');
+		return '' === $root ? '' : '/' . $root;
+	}
+
+	private static function is_absolute_path( string $path ): bool {
+		$path = str_replace('\\', '/', trim($path));
+		return str_starts_with($path, '/') || (bool) preg_match('#^[a-zA-Z][a-zA-Z0-9+.-]*://#', $path);
+	}
+
+	/**
+	 * @return array{repo:string,path:string}|null
+	 */
+	private static function split_workspace_root_path( string $path, string $workspace_root ): ?array {
+		$path = str_replace('\\', '/', trim($path));
+		if ( preg_match('#^[a-zA-Z][a-zA-Z0-9+.-]*://#', $path) ) {
+			return null;
+		}
+
+		$root = rtrim($workspace_root, '/');
+		if ( $path !== $root && ! str_starts_with($path, $root . '/') ) {
+			return null;
+		}
+
+		$relative = ltrim(substr($path, strlen($root)), '/');
+		if ( '' === $relative ) {
+			return null;
+		}
+
+		$segments = array_values(array_filter(explode('/', $relative), static fn( string $segment ): bool => '' !== $segment && '.' !== $segment));
+		if ( empty($segments) || in_array('..', $segments, true) ) {
+			return null;
+		}
+
+		$repo = array_shift($segments);
+		return array(
+			'repo' => $repo,
+			'path' => implode('/', $segments),
+		);
+	}
+
+	/**
 	 * Read git log entries for a workspace repository.
 	 *
 	 * @param  array $input Input parameters with 'name', optional 'limit'.
@@ -3330,6 +3427,7 @@ class WorkspaceAbilities {
 	 * @return array
 	 */
 	public static function gitDiff( array $input ): array|\WP_Error {
+		$input = self::normalize_mounted_workspace_path_input($input, array( 'name' ));
 		if ( RemoteWorkspaceBackend::should_handle() ) {
 			return ( new RemoteWorkspaceBackend() )->git_diff(
 				$input['name'] ?? '',

--- a/inc/Tools/WorkspaceTools.php
+++ b/inc/Tools/WorkspaceTools.php
@@ -1063,7 +1063,7 @@ class WorkspaceTools extends BaseTool
                         'description' => 'Optional relative directory path inside the repo.',
                     ),
             ),
-            'required'   => array( 'repo' ),
+            'required'   => array(),
             ),
             ) 
         );
@@ -1105,7 +1105,7 @@ class WorkspaceTools extends BaseTool
                         'description' => 'Maximum number of lines to return.',
                     ),
             ),
-            'required'   => array( 'repo', 'path' ),
+            'required'   => array( 'path' ),
             ),
             ) 
         );
@@ -1151,7 +1151,7 @@ class WorkspaceTools extends BaseTool
                         'description' => 'Number of surrounding lines to include for each match (default 0, max 10).',
                     ),
             ),
-            'required'   => array( 'repo', 'pattern' ),
+            'required'   => array( 'pattern' ),
             ),
             ) 
         );
@@ -1174,7 +1174,7 @@ class WorkspaceTools extends BaseTool
             'path'    => array( 'type' => 'string', 'description' => 'Relative file path within the repo.' ),
             'content' => array( 'type' => 'string', 'description' => 'File content to write.' ),
             ),
-            'required'   => array( 'repo', 'path', 'content' ),
+            'required'   => array( 'path', 'content' ),
             ),
             ) 
         );
@@ -1199,7 +1199,7 @@ class WorkspaceTools extends BaseTool
             'new_string'  => array( 'type' => 'string', 'description' => 'Replacement text.' ),
             'replace_all' => array( 'type' => 'boolean', 'description' => 'Replace all occurrences. Default false.' ),
             ),
-            'required'   => array( 'repo', 'path', 'old_string', 'new_string' ),
+            'required'   => array( 'path', 'old_string', 'new_string' ),
             ),
             ) 
         );
@@ -1246,7 +1246,7 @@ class WorkspaceTools extends BaseTool
             'recursive'              => array( 'type' => 'boolean', 'description' => 'Required when target is a directory. Default false.' ),
             'allow_primary_mutation' => array( 'type' => 'boolean', 'description' => 'Permit mutation on a primary checkout. Default false.' ),
             ),
-            'required'   => array( 'repo', 'path' ),
+            'required'   => array( 'path' ),
             ),
             ) 
         );
@@ -1283,7 +1283,7 @@ class WorkspaceTools extends BaseTool
             'to'     => array( 'type' => 'string', 'description' => 'Optional to git ref.' ),
             'staged' => array( 'type' => 'boolean', 'description' => 'Read staged diff instead of working tree diff.' ),
             'path'   => array( 'type' => 'string', 'description' => 'Optional relative path filter.' ),
-            ), array( 'name' ), array( 'duplicate_policy' => 'repeatable' ) 
+            ), array(), array( 'duplicate_policy' => 'repeatable' )
         );
     }
 

--- a/inc/Tools/WorkspaceTools.php
+++ b/inc/Tools/WorkspaceTools.php
@@ -407,12 +407,12 @@ class WorkspaceTools extends BaseTool
      */
     public function handleEdit( array $parameters ): array
     {
-        $input = array(
-        'repo'       => $parameters['repo'] ?? '',
-        'path'       => $parameters['path'] ?? '',
-        'old_string' => $parameters['old_string'] ?? '',
-        'new_string' => $parameters['new_string'] ?? '',
-        );
+		$input = array(
+		'repo'       => $parameters['repo'] ?? '',
+		'path'       => $parameters['path'] ?? '',
+		'old_string' => $parameters['old_string'] ?? $parameters['search'] ?? '',
+		'new_string' => $parameters['new_string'] ?? $parameters['replace'] ?? '',
+		);
 
         if (array_key_exists('replace_all', $parameters) ) {
             $input['replace_all'] = (bool) $parameters['replace_all'];
@@ -1195,12 +1195,14 @@ class WorkspaceTools extends BaseTool
             'properties' => array(
             'repo'        => array( 'type' => 'string', 'description' => 'Workspace handle: <repo> or <repo>@<branch-slug>.' ),
             'path'        => array( 'type' => 'string', 'description' => 'Relative file path within the repo.' ),
-            'old_string'  => array( 'type' => 'string', 'description' => 'Exact text to find.' ),
-            'new_string'  => array( 'type' => 'string', 'description' => 'Replacement text.' ),
-            'replace_all' => array( 'type' => 'boolean', 'description' => 'Replace all occurrences. Default false.' ),
-            ),
-            'required'   => array( 'path', 'old_string', 'new_string' ),
-            ),
+			'old_string'  => array( 'type' => 'string', 'description' => 'Exact text to find.' ),
+			'new_string'  => array( 'type' => 'string', 'description' => 'Replacement text.' ),
+			'search'      => array( 'type' => 'string', 'description' => 'Alias for old_string.' ),
+			'replace'     => array( 'type' => 'string', 'description' => 'Alias for new_string.' ),
+			'replace_all' => array( 'type' => 'boolean', 'description' => 'Replace all occurrences. Default false.' ),
+			),
+			'required'   => array( 'path' ),
+			),
             ) 
         );
     }

--- a/inc/Tools/WorkspaceTools.php
+++ b/inc/Tools/WorkspaceTools.php
@@ -696,6 +696,11 @@ class WorkspaceTools extends BaseTool
      */
     private function resolveWorkspaceInputAliases( array $input, array $handle_keys ): array
     {
+        $input = $this->normalizeWorkspaceRootPathInput($input, $handle_keys);
+        if (isset($input['_workspace_alias_error']) ) {
+            return $input;
+        }
+
         foreach ( $handle_keys as $key ) {
             if (! isset($input[ $key ]) || ! is_string($input[ $key ]) ) {
                 continue;
@@ -723,6 +728,115 @@ class WorkspaceTools extends BaseTool
         }
 
         return $input;
+    }
+
+    /**
+     * Normalize mounted workspace absolute paths into repo handles and relative paths.
+     *
+     * Runners can expose repositories under DATAMACHINE_WORKSPACE_PATH. Models then
+     * naturally use paths like /workspace/example/README.md even though the
+     * canonical workspace tools accept repo=example and path=README.md.
+     *
+     * @param array<string,mixed> $input Tool input.
+     * @param string[]            $handle_keys Keys that hold workspace handles.
+     * @return array<string,mixed>
+     */
+    private function normalizeWorkspaceRootPathInput( array $input, array $handle_keys ): array
+    {
+        $workspace_root = defined('DATAMACHINE_WORKSPACE_PATH') ? (string) DATAMACHINE_WORKSPACE_PATH : '';
+        $workspace_root = $this->normalizeWorkspaceRoot($workspace_root);
+        if ('' === $workspace_root ) {
+            return $input;
+        }
+
+        foreach ( $handle_keys as $key ) {
+            if (isset($input[ $key ]) && is_string($input[ $key ]) && $this->isAbsolutePath($input[ $key ]) ) {
+                $parts = $this->splitWorkspaceRootPath($input[ $key ], $workspace_root);
+                if (null === $parts ) {
+                    $input['_workspace_alias_error'] = 'Workspace path is outside the configured workspace root.';
+                    return $input;
+                }
+
+                $input[ $key ] = $parts['repo'];
+                if ('' !== $parts['path'] ) {
+                    $existing_path = isset($input['path']) && is_string($input['path']) ? trim($input['path'], '/') : '';
+                    $input['path'] = '' === $existing_path ? $parts['path'] : $parts['path'] . '/' . $existing_path;
+                }
+            }
+        }
+
+        if (isset($input['path']) && is_string($input['path']) && $this->isAbsolutePath($input['path']) ) {
+            $parts = $this->splitWorkspaceRootPath($input['path'], $workspace_root);
+            if (null === $parts ) {
+                $input['_workspace_alias_error'] = 'Workspace path is outside the configured workspace root.';
+                return $input;
+            }
+
+            $current_handle = '';
+            foreach ( $handle_keys as $key ) {
+                if (isset($input[ $key ]) && is_string($input[ $key ]) && '' !== trim($input[ $key ]) ) {
+                    $current_handle = trim($input[ $key ]);
+                    break;
+                }
+            }
+
+            if ('' !== $current_handle && $current_handle !== $parts['repo'] ) {
+                $input['_workspace_alias_error'] = 'Workspace path belongs to a different workspace repository.';
+                return $input;
+            }
+
+            if ('' === $current_handle && ! empty($handle_keys) ) {
+                $input[ $handle_keys[0] ] = $parts['repo'];
+            }
+            $input['path'] = $parts['path'];
+        }
+
+        return $input;
+    }
+
+    private function normalizeWorkspaceRoot( string $root ): string
+    {
+        $root = str_replace('\\', '/', trim($root));
+        $root = trim($root, '/');
+        return '' === $root ? '' : '/' . $root;
+    }
+
+    private function isAbsolutePath( string $path ): bool
+    {
+        $path = str_replace('\\', '/', trim($path));
+        return str_starts_with($path, '/') || preg_match('#^[a-zA-Z][a-zA-Z0-9+.-]*://#', $path);
+    }
+
+    /**
+     * @return array{repo:string,path:string}|null
+     */
+    private function splitWorkspaceRootPath( string $path, string $workspace_root ): ?array
+    {
+        $path = str_replace('\\', '/', trim($path));
+        if (preg_match('#^[a-zA-Z][a-zA-Z0-9+.-]*://#', $path) ) {
+            return null;
+        }
+
+        $root = rtrim($workspace_root, '/');
+        if ($path !== $root && ! str_starts_with($path, $root . '/') ) {
+            return null;
+        }
+
+        $relative = ltrim(substr($path, strlen($root)), '/');
+        if ('' === $relative ) {
+            return null;
+        }
+
+        $segments = array_values(array_filter(explode('/', $relative), static fn( string $segment ): bool => '' !== $segment && '.' !== $segment));
+        if (empty($segments) || in_array('..', $segments, true) ) {
+            return null;
+        }
+
+        $repo = array_shift($segments);
+        return array(
+            'repo' => $repo,
+            'path' => implode('/', $segments),
+        );
     }
 
     /**

--- a/inc/Tools/WorkspaceTools.php
+++ b/inc/Tools/WorkspaceTools.php
@@ -410,8 +410,8 @@ class WorkspaceTools extends BaseTool
 		$input = array(
 		'repo'       => $parameters['repo'] ?? '',
 		'path'       => $parameters['path'] ?? '',
-		'old_string' => $parameters['old_string'] ?? $parameters['search'] ?? '',
-		'new_string' => $parameters['new_string'] ?? $parameters['replace'] ?? '',
+		'old_string' => $parameters['old_string'] ?? $parameters['search'] ?? $parameters['old'] ?? '',
+		'new_string' => $parameters['new_string'] ?? $parameters['replace'] ?? $parameters['new'] ?? '',
 		);
 
         if (array_key_exists('replace_all', $parameters) ) {
@@ -1199,6 +1199,8 @@ class WorkspaceTools extends BaseTool
 			'new_string'  => array( 'type' => 'string', 'description' => 'Replacement text.' ),
 			'search'      => array( 'type' => 'string', 'description' => 'Alias for old_string.' ),
 			'replace'     => array( 'type' => 'string', 'description' => 'Alias for new_string.' ),
+			'old'         => array( 'type' => 'string', 'description' => 'Alias for old_string.' ),
+			'new'         => array( 'type' => 'string', 'description' => 'Alias for new_string.' ),
 			'replace_all' => array( 'type' => 'boolean', 'description' => 'Replace all occurrences. Default false.' ),
 			),
 			'required'   => array( 'path' ),

--- a/inc/Workspace/RemoteWorkspaceBackend.php
+++ b/inc/Workspace/RemoteWorkspaceBackend.php
@@ -22,7 +22,10 @@ class RemoteWorkspaceBackend {
 	 * Whether the remote backend should handle workspace operations.
 	 */
 	public static function should_handle(): bool {
-		return ! \DataMachineCode\Support\GitRunner::is_available();
+		return (bool) apply_filters(
+			'datamachine_code_remote_workspace_backend_should_handle',
+			! \DataMachineCode\Support\GitRunner::is_available()
+		);
 	}
 
 	/**

--- a/tests/smoke-remote-workspace-backend-filter.php
+++ b/tests/smoke-remote-workspace-backend-filter.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Smoke test for remote workspace backend override filter.
+ *
+ * Run: php tests/smoke-remote-workspace-backend-filter.php
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachineCode\Support {
+	class GitRunner
+	{
+		public static bool $available = true;
+
+		public static function is_available(): bool
+		{
+			return self::$available;
+		}
+	}
+}
+
+namespace {
+	if ( ! defined('ABSPATH') ) {
+		define('ABSPATH', __DIR__ . '/');
+	}
+
+	$GLOBALS['dmc_remote_backend_filters'] = array();
+
+	function add_filter( string $tag, callable $callback, int $priority = 10 ): void
+	{
+		$GLOBALS['dmc_remote_backend_filters'][ $tag ][ $priority ][] = $callback;
+	}
+
+	function apply_filters( string $tag, $value )
+	{
+		if ( empty($GLOBALS['dmc_remote_backend_filters'][ $tag ]) ) {
+			return $value;
+		}
+
+		ksort($GLOBALS['dmc_remote_backend_filters'][ $tag ]);
+		foreach ( $GLOBALS['dmc_remote_backend_filters'][ $tag ] as $callbacks ) {
+			foreach ( $callbacks as $callback ) {
+				$value = $callback($value);
+			}
+		}
+
+		return $value;
+	}
+
+	require __DIR__ . '/../inc/Workspace/RemoteWorkspaceBackend.php';
+
+	$failures = array();
+	$passes   = 0;
+	$assert   = function ( string $label, bool $condition ) use ( &$failures, &$passes ): void {
+		if ( $condition ) {
+			++$passes;
+			echo "  ok {$label}\n";
+			return;
+		}
+
+		$failures[] = $label;
+		echo "  fail {$label}\n";
+	};
+
+	echo "Remote workspace backend filter - smoke\n";
+
+	\DataMachineCode\Support\GitRunner::$available = true;
+	$assert('defaults to local git when git is available', false === \DataMachineCode\Workspace\RemoteWorkspaceBackend::should_handle());
+
+	add_filter('datamachine_code_remote_workspace_backend_should_handle', static fn(): bool => true, 100);
+	$assert('filter can force remote backend on', true === \DataMachineCode\Workspace\RemoteWorkspaceBackend::should_handle());
+
+	$GLOBALS['dmc_remote_backend_filters'] = array();
+	\DataMachineCode\Support\GitRunner::$available = false;
+	$assert('defaults to remote backend when git is unavailable', true === \DataMachineCode\Workspace\RemoteWorkspaceBackend::should_handle());
+
+	add_filter('datamachine_code_remote_workspace_backend_should_handle', static fn(): bool => false, 100);
+	$assert('filter can force mounted local backend on', false === \DataMachineCode\Workspace\RemoteWorkspaceBackend::should_handle());
+
+	if ( $failures ) {
+		echo "\nFailures:\n";
+		foreach ( $failures as $failure ) {
+			echo " - {$failure}\n";
+		}
+		exit(1);
+	}
+
+	echo "\nOK ({$passes} assertions)\n";
+}

--- a/tests/smoke-workspace-alias-tools.php
+++ b/tests/smoke-workspace-alias-tools.php
@@ -130,6 +130,13 @@ namespace {
     $ability                                  = new DataMachineCodeWorkspaceAliasFakeAbility();
     $GLOBALS['dmc_workspace_alias_ability'] = $ability;
     $tools                                    = new \DataMachineCode\Tools\WorkspaceTools();
+    $read_definition                          = $tools->getReadDefinition();
+    $grep_definition                          = $tools->getGrepDefinition();
+    $git_diff_definition                      = $tools->getGitDiffDefinition();
+    $assert('workspace_read schema allows path-only mounted workspace calls', array( 'path' ) === ( $read_definition['parameters']['required'] ?? null ));
+    $assert('workspace_grep schema allows path-only mounted workspace calls', array( 'pattern' ) === ( $grep_definition['parameters']['required'] ?? null ));
+    $assert('workspace_git_diff schema allows path-only mounted workspace calls', array() === ( $git_diff_definition['parameters']['required'] ?? null ));
+
     $absolute_read                           = $tools->handleRead(array( 'path' => '/workspace/homeboy-extensions/wordpress/scripts/build/build.sh' ));
     $assert('absolute workspace path read succeeds', true === ( $absolute_read['success'] ?? false ));
     $assert('absolute workspace path infers repo', 'homeboy-extensions' === ( $ability->last_input['repo'] ?? '' ));

--- a/tests/smoke-workspace-alias-tools.php
+++ b/tests/smoke-workspace-alias-tools.php
@@ -162,6 +162,18 @@ namespace {
 	$assert('workspace_edit maps search to old_string', 'npm install --silent' === ( $ability->last_input['old_string'] ?? '' ));
 	$assert('workspace_edit maps replace to new_string', 'npm install --legacy-peer-deps' === ( $ability->last_input['new_string'] ?? '' ));
 
+	$edit_short_alias = $tools->handleEdit(
+		array(
+			'repo' => 'homeboy-extensions',
+			'path' => 'wordpress/scripts/build/build.sh',
+			'old'  => 'npm install --silent',
+			'new'  => 'npm install --legacy-peer-deps',
+		)
+	);
+	$assert('workspace_edit accepts old/new aliases', true === ( $edit_short_alias['success'] ?? false ));
+	$assert('workspace_edit maps old to old_string', 'npm install --silent' === ( $ability->last_input['old_string'] ?? '' ));
+	$assert('workspace_edit maps new to new_string', 'npm install --legacy-peer-deps' === ( $ability->last_input['new_string'] ?? '' ));
+
 	$result                                   = $tools->handleGitStatus(array( 'name' => 'current-project' ));
     $data                                     = $result['data'] ?? array();
 

--- a/tests/smoke-workspace-alias-tools.php
+++ b/tests/smoke-workspace-alias-tools.php
@@ -11,6 +11,9 @@ namespace {
     if (! defined('ABSPATH') ) {
         define('ABSPATH', __DIR__ . '/');
     }
+    if (! defined('DATAMACHINE_WORKSPACE_PATH') ) {
+        define('DATAMACHINE_WORKSPACE_PATH', '/workspace');
+    }
 
     $GLOBALS['dmc_workspace_alias_filters'] = array();
     $GLOBALS['dmc_workspace_alias_ability'] = null;
@@ -127,6 +130,19 @@ namespace {
     $ability                                  = new DataMachineCodeWorkspaceAliasFakeAbility();
     $GLOBALS['dmc_workspace_alias_ability'] = $ability;
     $tools                                    = new \DataMachineCode\Tools\WorkspaceTools();
+    $absolute_read                           = $tools->handleRead(array( 'path' => '/workspace/homeboy-extensions/wordpress/scripts/build/build.sh' ));
+    $assert('absolute workspace path read succeeds', true === ( $absolute_read['success'] ?? false ));
+    $assert('absolute workspace path infers repo', 'homeboy-extensions' === ( $ability->last_input['repo'] ?? '' ));
+    $assert('absolute workspace path becomes relative path', 'wordpress/scripts/build/build.sh' === ( $ability->last_input['path'] ?? '' ));
+
+    $absolute_repo_read = $tools->handleRead(array( 'repo' => '/workspace/homeboy-extensions', 'path' => 'wordpress/scripts/build/build.sh' ));
+    $assert('absolute workspace repo read succeeds', true === ( $absolute_repo_read['success'] ?? false ));
+    $assert('absolute workspace repo normalizes to handle', 'homeboy-extensions' === ( $ability->last_input['repo'] ?? '' ));
+    $assert('absolute workspace repo preserves relative path', 'wordpress/scripts/build/build.sh' === ( $ability->last_input['path'] ?? '' ));
+
+    $absolute_escape = $tools->handleRead(array( 'path' => '/tmp/homeboy-extensions/README.md' ));
+    $assert('absolute path outside workspace root is rejected', false === ( $absolute_escape['success'] ?? true ));
+
     $result                                   = $tools->handleGitStatus(array( 'name' => 'current-project' ));
     $data                                     = $result['data'] ?? array();
 

--- a/tests/smoke-workspace-alias-tools.php
+++ b/tests/smoke-workspace-alias-tools.php
@@ -147,10 +147,22 @@ namespace {
     $assert('absolute workspace repo normalizes to handle', 'homeboy-extensions' === ( $ability->last_input['repo'] ?? '' ));
     $assert('absolute workspace repo preserves relative path', 'wordpress/scripts/build/build.sh' === ( $ability->last_input['path'] ?? '' ));
 
-    $absolute_escape = $tools->handleRead(array( 'path' => '/tmp/homeboy-extensions/README.md' ));
-    $assert('absolute path outside workspace root is rejected', false === ( $absolute_escape['success'] ?? true ));
+	$absolute_escape = $tools->handleRead(array( 'path' => '/tmp/homeboy-extensions/README.md' ));
+	$assert('absolute path outside workspace root is rejected', false === ( $absolute_escape['success'] ?? true ));
 
-    $result                                   = $tools->handleGitStatus(array( 'name' => 'current-project' ));
+	$edit_alias = $tools->handleEdit(
+		array(
+			'repo'    => 'homeboy-extensions',
+			'path'    => 'wordpress/scripts/build/build.sh',
+			'search'  => 'npm install --silent',
+			'replace' => 'npm install --legacy-peer-deps',
+		)
+	);
+	$assert('workspace_edit accepts search/replace aliases', true === ( $edit_alias['success'] ?? false ));
+	$assert('workspace_edit maps search to old_string', 'npm install --silent' === ( $ability->last_input['old_string'] ?? '' ));
+	$assert('workspace_edit maps replace to new_string', 'npm install --legacy-peer-deps' === ( $ability->last_input['new_string'] ?? '' ));
+
+	$result                                   = $tools->handleGitStatus(array( 'name' => 'current-project' ));
     $data                                     = $result['data'] ?? array();
 
     $assert('alias resolves before ability execution', 'wp-rl@agent-runs-modern-api-openai-gpt-5-5' === ( $ability->last_input['name'] ?? '' ));


### PR DESCRIPTION
## Summary
- Normalize absolute paths under `DATAMACHINE_WORKSPACE_PATH` into canonical workspace tool inputs.
- Allow mounted-workspace agents to call tools with paths like `/workspace/example/README.md` while preserving the existing `repo` + relative `path` contract.
- Reject absolute paths outside the configured workspace root.

## Verification
- `php -l inc/Tools/WorkspaceTools.php`
- `php -l tests/smoke-workspace-alias-tools.php`
- `php tests/smoke-workspace-alias-tools.php`
- `php tests/smoke-workspace-policy-tools.php`
- `php tests/smoke-tool-schemas.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementation, test updates, and verification; Chris reviews and owns the final change.