### PR TITLE
Fix workspace mutation lock recovery evidence

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -2302,10 +2302,12 @@ class WorkspaceCommand extends BaseCommand {
 		}
 
 		if ( 'locks' === $operation ) {
-			$dry_run = ! empty($assoc_args['dry-run']) || empty($assoc_args['prune-stale']);
-			$result  = ! empty($assoc_args['prune-stale'])
-				? WorkspaceMutationLock::prune_stale($this->workspace_path, $dry_run)
-				: WorkspaceMutationLock::status($this->workspace_path);
+			$workspace      = new Workspace();
+			$workspace_path = $workspace->get_path();
+			$dry_run        = ! empty($assoc_args['dry-run']) || empty($assoc_args['prune-stale']);
+			$result         = ! empty($assoc_args['prune-stale'])
+				? WorkspaceMutationLock::prune_stale($workspace_path, $dry_run)
+				: WorkspaceMutationLock::status($workspace_path);
 			$this->render_workspace_lock_result($result, $assoc_args, ! empty($assoc_args['prune-stale']));
 			return;
 		}
@@ -2838,7 +2840,7 @@ class WorkspaceCommand extends BaseCommand {
 		if ( ! empty($guidance) ) {
 			WP_CLI::log(sprintf('Status: %s', (string) ( $guidance['status_command'] ?? 'wp datamachine-code workspace worktree locks --format=json' )));
 			WP_CLI::log(sprintf('Prune:  %s', (string) ( $guidance['dry_run_command'] ?? 'wp datamachine-code workspace worktree locks --prune-stale --dry-run --format=json' )));
-			WP_CLI::log((string) ( $guidance['safety'] ?? 'Active filesystem flocks are not pruned.' ));
+			WP_CLI::log( (string) ( $guidance['safety'] ?? 'Active filesystem flocks are not pruned.' ) );
 		}
 	}
 

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -20,6 +20,7 @@ use DataMachine\Cli\BaseCommand;
 use DataMachineCode\Cleanup\CleanupRunEvidenceStoreInterface;
 use DataMachineCode\Cleanup\DataMachineJobCleanupRunEvidenceStore;
 use DataMachineCode\Workspace\Workspace;
+use DataMachineCode\Workspace\WorkspaceMutationLock;
 
 defined('ABSPATH') || exit;
 
@@ -133,7 +134,7 @@ class WorkspaceCommand extends BaseCommand {
 		$result = $ability->execute($input);
 
 		if ( is_wp_error($result) ) {
-			$this->render_workspace_error($result);
+			WP_CLI::error($result->get_error_message());
 			return;
 		}
 
@@ -1975,7 +1976,7 @@ class WorkspaceCommand extends BaseCommand {
 	 * ## OPTIONS
 	 *
 	 * <operation>
-	 * : Worktree operation: add, list, remove, prune, cleanup, cleanup-artifacts,
+	 * : Worktree operation: add, list, remove, prune, locks, cleanup, cleanup-artifacts,
 	 *   bounded-cleanup-eligible-apply, emergency-cleanup, reconcile-metadata,
 	 *   active-no-signal-report, active-no-signal-finalized-apply,
 	 *   active-no-signal-equivalent-clean-apply,
@@ -2065,7 +2066,11 @@ class WorkspaceCommand extends BaseCommand {
 	 * : Lifecycle state to record when finalizing a worktree.
 	 *
 	 * [--dry-run]
-	 * : Preview cleanup candidates without removing anything (cleanup only).
+	 * : Preview cleanup candidates without removing anything (cleanup and locks only).
+	 *
+	 * [--prune-stale]
+	 * : For `locks`, prune expired DB lock rows and old unlocked filesystem lock
+	 *   files. Active filesystem flocks are reported but never removed.
 	 *
 	 * [--apply-plan=<file>]
 	 * : Low-level escape hatch for applying a previously reviewed JSON report.
@@ -2211,6 +2216,11 @@ class WorkspaceCommand extends BaseCommand {
 	 *     # Prune stale worktree registry entries across all primaries
 	 *     wp datamachine-code workspace worktree prune
 	 *
+	 *     # Inspect and safely prune stale workspace mutation locks
+	 *     wp datamachine-code workspace worktree locks --format=json
+	 *     wp datamachine-code workspace worktree locks --prune-stale --dry-run --format=json
+	 *     wp datamachine-code workspace worktree locks --prune-stale --format=json
+	 *
 	 *     # Preview worktrees that would be removed (upstream gone or PR merged)
 	 *     wp datamachine-code workspace worktree cleanup --dry-run
 	 *
@@ -2287,7 +2297,16 @@ class WorkspaceCommand extends BaseCommand {
 		$operation = $args[0] ?? '';
 
 		if ( '' === $operation ) {
-			WP_CLI::error('Usage: wp datamachine-code workspace worktree <add|list|remove|prune|cleanup|cleanup-artifacts|bounded-cleanup-eligible-apply|emergency-cleanup|reconcile-metadata|active-no-signal-report|active-no-signal-finalized-apply|active-no-signal-equivalent-clean-apply|refresh-context|finalize|mark-cleanup-eligible> [<repo>] [<branch>] [--flags]');
+			WP_CLI::error('Usage: wp datamachine-code workspace worktree <add|list|remove|prune|locks|cleanup|cleanup-artifacts|bounded-cleanup-eligible-apply|emergency-cleanup|reconcile-metadata|active-no-signal-report|active-no-signal-finalized-apply|active-no-signal-equivalent-clean-apply|refresh-context|finalize|mark-cleanup-eligible> [<repo>] [<branch>] [--flags]');
+			return;
+		}
+
+		if ( 'locks' === $operation ) {
+			$dry_run = ! empty($assoc_args['dry-run']) || empty($assoc_args['prune-stale']);
+			$result  = ! empty($assoc_args['prune-stale'])
+				? WorkspaceMutationLock::prune_stale($this->workspace_path, $dry_run)
+				: WorkspaceMutationLock::status($this->workspace_path);
+			$this->render_workspace_lock_result($result, $assoc_args, ! empty($assoc_args['prune-stale']));
 			return;
 		}
 
@@ -2543,7 +2562,7 @@ class WorkspaceCommand extends BaseCommand {
 		$result = $ability->execute($input);
 
 		if ( is_wp_error($result) ) {
-			WP_CLI::error($result->get_error_message());
+			$this->render_workspace_error($result);
 			return;
 		}
 
@@ -2766,6 +2785,63 @@ class WorkspaceCommand extends BaseCommand {
 		}
 	}
 
+	/**
+	 * Render workspace mutation lock status or prune results.
+	 *
+	 * @param array<string,mixed> $result Lock status or prune result.
+	 */
+	private function render_workspace_lock_result( array $result, array $assoc_args, bool $prune ): void {
+		if ( 'json' === (string) ( $assoc_args['format'] ?? '' ) ) {
+			$json = wp_json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+			WP_CLI::log(false === $json ? '{}' : $json);
+			return;
+		}
+
+		$status = $prune ? (array) ( $result['after'] ?? array() ) : $result;
+		$fs     = (array) ( $status['filesystem'] ?? array() );
+		$db     = (array) ( $status['database'] ?? array() );
+
+		WP_CLI::log($prune ? 'Workspace mutation locks: stale prune complete' : 'Workspace mutation locks:');
+		WP_CLI::log(sprintf('Active: %d  Stale: %d', (int) ( $status['active'] ?? 0 ), (int) ( $status['stale'] ?? 0 )));
+		WP_CLI::log(sprintf('Database: %s active, %s stale, available=%s', (string) ( $db['active'] ?? 0 ), (string) ( $db['stale'] ?? 0 ), ! empty($db['available']) ? 'yes' : 'no'));
+		WP_CLI::log(sprintf('Filesystem: %s active, %s stale, %s recent', (string) ( $fs['active'] ?? 0 ), (string) ( $fs['stale'] ?? 0 ), (string) ( $fs['recent'] ?? 0 )));
+
+		if ( $prune ) {
+			$filesystem = (array) ( $result['filesystem'] ?? array() );
+			WP_CLI::log(sprintf('Filesystem removed: %d; skipped: %d', (int) ( $filesystem['removed_count'] ?? 0 ), (int) ( $filesystem['skipped_count'] ?? 0 )));
+			if ( ! empty($result['dry_run']) ) {
+				WP_CLI::log('Dry-run only. Re-run without --dry-run to remove stale unlocked lock files.');
+			}
+		}
+
+		$locks = (array) ( $fs['locks'] ?? array() );
+		if ( ! empty($locks) ) {
+			$items = array_map(
+				static function ( array $lock ): array {
+					$owner = (array) ( $lock['owner_evidence'] ?? array() );
+					return array(
+						'lock_key'      => (string) ( $lock['lock_key'] ?? '' ),
+						'scope'         => (string) ( $lock['scope'] ?? '' ),
+						'state'         => (string) ( $lock['state'] ?? '' ),
+						'age_seconds'   => $lock['age_seconds'] ?? null,
+						'safe_to_prune' => ! empty($lock['safe_to_prune']) ? 'yes' : 'no',
+						'owner_source'  => (string) ( $owner['source'] ?? '' ),
+						'path'          => (string) ( $lock['path'] ?? '' ),
+					);
+				},
+				$locks
+			);
+			$this->format_items($items, array( 'lock_key', 'scope', 'state', 'age_seconds', 'safe_to_prune', 'owner_source', 'path' ), $assoc_args, 'lock_key');
+		}
+
+		$guidance = (array) ( $fs['guidance'] ?? $status['recovery_guidance'] ?? array() );
+		if ( ! empty($guidance) ) {
+			WP_CLI::log(sprintf('Status: %s', (string) ( $guidance['status_command'] ?? 'wp datamachine-code workspace worktree locks --format=json' )));
+			WP_CLI::log(sprintf('Prune:  %s', (string) ( $guidance['dry_run_command'] ?? 'wp datamachine-code workspace worktree locks --prune-stale --dry-run --format=json' )));
+			WP_CLI::log((string) ( $guidance['safety'] ?? 'Active filesystem flocks are not pruned.' ));
+		}
+	}
+
 	private function render_workspace_error( \WP_Error $error ): void {
 		$data = (array) $error->get_error_data();
 		if ( 'workspace_repo_busy' !== $error->get_error_code() ) {
@@ -2793,6 +2869,30 @@ class WorkspaceCommand extends BaseCommand {
 			if ( '' !== $session_id ) {
 				WP_CLI::log(sprintf('Session:    %s', $session_id));
 			}
+		}
+
+		$filesystem_lock = is_array($data['filesystem_lock'] ?? null) ? (array) $data['filesystem_lock'] : array();
+		if ( ! empty($filesystem_lock) ) {
+			WP_CLI::warning(sprintf('Filesystem lock: %s (%s)', (string) ( $filesystem_lock['lock_key'] ?? $data['lock_key'] ?? '-' ), (string) ( $filesystem_lock['state'] ?? 'unknown' )));
+			WP_CLI::log(sprintf('Path:       %s', (string) ( $filesystem_lock['path'] ?? $data['lock_path'] ?? '-' )));
+			WP_CLI::log(sprintf('Age:        %ss', (string) ( $filesystem_lock['age_seconds'] ?? '-' )));
+			$owner_evidence = (array) ( $filesystem_lock['owner_evidence'] ?? array() );
+			if ( ! empty($owner_evidence['source']) ) {
+				WP_CLI::log(sprintf('Owner src:  %s', (string) $owner_evidence['source']));
+			}
+			if ( ! empty($owner_evidence['message']) ) {
+				WP_CLI::log(sprintf('Owner note: %s', (string) $owner_evidence['message']));
+			}
+			if ( ! empty($filesystem_lock['operator_guidance']) ) {
+				WP_CLI::log(sprintf('Guidance:   %s', (string) $filesystem_lock['operator_guidance']));
+			}
+		}
+
+		if ( ! empty($data['status_command']) ) {
+			WP_CLI::log(sprintf('Inspect:    %s', (string) $data['status_command']));
+		}
+		if ( ! empty($data['stale_prune_command']) ) {
+			WP_CLI::log(sprintf('Recover:    %s', (string) $data['stale_prune_command']));
 		}
 
 		WP_CLI::error($error->get_error_message());

--- a/inc/Workspace/WorkspaceMutationLock.php
+++ b/inc/Workspace/WorkspaceMutationLock.php
@@ -29,12 +29,9 @@ final class WorkspaceMutationLock {
 
 	private int $lock_id = 0;
 
-	private string $lock_path = '';
-
-	private function __construct( $handle, int $lock_id = 0, string $lock_path = '' ) {
-		$this->handle    = $handle;
-		$this->lock_id   = $lock_id;
-		$this->lock_path = $lock_path;
+	private function __construct( $handle, int $lock_id = 0 ) {
+		$this->handle  = $handle;
+		$this->lock_id = $lock_id;
 	}
 
 	/**
@@ -132,7 +129,7 @@ final class WorkspaceMutationLock {
 						return $lock_id;
 				}
 
-				return new self($handle, (int) $lock_id, $lock_path);
+				return new self($handle, (int) $lock_id);
 			}
 
 			if ( 0 === $timeout || ( microtime(true) - $started ) >= $timeout ) {
@@ -162,9 +159,8 @@ final class WorkspaceMutationLock {
 		WorkspaceLockStore::release($this->lock_id);
 		flock($this->handle, LOCK_UN); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock
 		fclose($this->handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
-		$this->handle    = null;
-		$this->lock_id   = 0;
-		$this->lock_path = '';
+		$this->handle  = null;
+		$this->lock_id = 0;
 	}
 
 	/**
@@ -304,11 +300,11 @@ final class WorkspaceMutationLock {
 	 */
 	private static function recovery_guidance(): array {
 		return array(
-			'status_command'      => 'wp datamachine-code workspace worktree locks --format=json',
-			'dry_run_command'     => 'wp datamachine-code workspace worktree locks --prune-stale --dry-run --format=json',
-			'apply_command'       => 'wp datamachine-code workspace worktree locks --prune-stale --format=json',
-			'safety'              => 'Only expired DB rows and old unlocked filesystem lock files are pruned. Active filesystem flocks are never removed by this command.',
-			'active_lock_note'    => 'If a filesystem lock is active without DB owner evidence, another process still holds the OS file descriptor or crashed without releasing an operator-visible DB row. Inspect running DMC/WP-CLI processes before retrying.',
+			'status_command'   => 'wp datamachine-code workspace worktree locks --format=json',
+			'dry_run_command'  => 'wp datamachine-code workspace worktree locks --prune-stale --dry-run --format=json',
+			'apply_command'    => 'wp datamachine-code workspace worktree locks --prune-stale --format=json',
+			'safety'           => 'Only expired DB rows and old unlocked filesystem lock files are pruned. Active filesystem flocks are never removed by this command.',
+			'active_lock_note' => 'If a filesystem lock is active without DB owner evidence, another process still holds the OS file descriptor or crashed without releasing an operator-visible DB row. Inspect running DMC/WP-CLI processes before retrying.',
 		);
 	}
 
@@ -386,22 +382,22 @@ final class WorkspaceMutationLock {
 		}
 
 		if ( ! flock($handle, LOCK_EX | LOCK_NB) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock
-			$entry['state']               = 'active';
-			$entry['reason']              = 'filesystem_flock_held';
-			$entry['owner_evidence']      = self::owner_evidence_for_lock($lock_key, $scope);
-			$entry['recovery_command']    = 'wp datamachine-code workspace worktree locks --format=json';
-			$entry['safe_to_prune']       = false;
-			$entry['operator_guidance']   = 'An active OS flock cannot be safely pruned. Inspect the owner evidence or running DMC/WP-CLI processes and retry after the holder exits.';
+			$entry['state']             = 'active';
+			$entry['reason']            = 'filesystem_flock_held';
+			$entry['owner_evidence']    = self::owner_evidence_for_lock($lock_key, $scope);
+			$entry['recovery_command']  = 'wp datamachine-code workspace worktree locks --format=json';
+			$entry['safe_to_prune']     = false;
+			$entry['operator_guidance'] = 'An active OS flock cannot be safely pruned. Inspect the owner evidence or running DMC/WP-CLI processes and retry after the holder exits.';
 			fclose($handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 			return $entry;
 		}
 
 		flock($handle, LOCK_UN); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock
 		fclose($handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
-		$stale                    = false !== $mtime && $mtime < $cutoff;
-		$entry['state']           = $stale ? 'stale' : 'recent';
-		$entry['reason']          = $stale ? 'unlocked_stale_file' : 'unlocked_recent_file';
-		$entry['safe_to_prune']   = $stale;
+		$stale                     = false !== $mtime && $mtime < $cutoff;
+		$entry['state']            = $stale ? 'stale' : 'recent';
+		$entry['reason']           = $stale ? 'unlocked_stale_file' : 'unlocked_recent_file';
+		$entry['safe_to_prune']    = $stale;
 		$entry['recovery_command'] = $stale
 			? 'wp datamachine-code workspace worktree locks --prune-stale --dry-run --format=json'
 			: 'wp datamachine-code workspace worktree locks --format=json';

--- a/inc/Workspace/WorkspaceMutationLock.php
+++ b/inc/Workspace/WorkspaceMutationLock.php
@@ -137,13 +137,16 @@ final class WorkspaceMutationLock {
 
 			if ( 0 === $timeout || ( microtime(true) - $started ) >= $timeout ) {
 				fclose($handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+				$error_data = self::busy_error_data($repo, $lock_path);
 				return new \WP_Error(
 					'workspace_repo_busy',
 					sprintf(
-						'Workspace repo "%s" is busy with another worktree lifecycle mutation. Retry after the current add/remove/cleanup/prune operation completes.',
-						$repo
+						'Workspace repo "%s" is busy with another worktree lifecycle mutation. Retry after the current add/remove/cleanup/prune operation completes. Inspect lock status with `%s`; prune stale/orphaned locks with `%s` after confirming no active holder remains.',
+						$repo,
+						(string) ( $error_data['status_command'] ?? 'wp datamachine-code workspace worktree locks --format=json' ),
+						(string) ( $error_data['stale_prune_command'] ?? 'wp datamachine-code workspace worktree locks --prune-stale --dry-run --format=json' )
 					),
-					self::busy_error_data($repo, $lock_path)
+					$error_data
 				);
 			}
 
@@ -259,13 +262,24 @@ final class WorkspaceMutationLock {
 	private static function busy_error_data( string $repo, string $lock_path ): array {
 		$lock_key = 'worktree-' . $repo;
 		$data     = array(
-			'status'    => 423,
-			'retryable' => true,
-			'repo'      => $repo,
-			'scope'     => $repo,
-			'lock_key'  => $lock_key,
-			'lock_path' => $lock_path,
+			'status'              => 423,
+			'retryable'           => true,
+			'repo'                => $repo,
+			'scope'               => $repo,
+			'lock_key'            => $lock_key,
+			'lock_path'           => $lock_path,
+			'status_command'      => 'wp datamachine-code workspace worktree locks --format=json',
+			'stale_prune_command' => 'wp datamachine-code workspace worktree locks --prune-stale --dry-run --format=json',
+			'recovery_guidance'   => self::recovery_guidance(),
 		);
+
+		$filesystem_lock = self::filesystem_lock_entry($lock_path);
+		if ( ! empty($filesystem_lock) ) {
+			$data['filesystem_lock'] = $filesystem_lock;
+			if ( isset($filesystem_lock['age_seconds']) ) {
+				$data['filesystem_age_seconds'] = (int) $filesystem_lock['age_seconds'];
+			}
+		}
 
 		$active_lock = WorkspaceLockStore::active_lock($lock_key, $repo);
 		if ( is_array($active_lock) ) {
@@ -284,39 +298,48 @@ final class WorkspaceMutationLock {
 	}
 
 	/**
+	 * Operator guidance shared by busy errors and status commands.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private static function recovery_guidance(): array {
+		return array(
+			'status_command'      => 'wp datamachine-code workspace worktree locks --format=json',
+			'dry_run_command'     => 'wp datamachine-code workspace worktree locks --prune-stale --dry-run --format=json',
+			'apply_command'       => 'wp datamachine-code workspace worktree locks --prune-stale --format=json',
+			'safety'              => 'Only expired DB rows and old unlocked filesystem lock files are pruned. Active filesystem flocks are never removed by this command.',
+			'active_lock_note'    => 'If a filesystem lock is active without DB owner evidence, another process still holds the OS file descriptor or crashed without releasing an operator-visible DB row. Inspect running DMC/WP-CLI processes before retrying.',
+		);
+	}
+
+	/**
 	 * @return array<string,mixed>
 	 */
 	private static function filesystem_status( string $workspace_path ): array {
 		$lock_dir    = rtrim($workspace_path, '/') . '/.locks';
 		$files       = is_dir($lock_dir) ? glob($lock_dir . '/*.lock') : array();
 		$files       = false === $files ? array() : $files;
-		$policy      = self::retention_policy();
-		$cutoff      = time() - (int) $policy['filesystem_stale_after_seconds'];
 		$active      = 0;
 		$stale       = 0;
 		$recent      = 0;
 		$active_keys = array();
 		$stale_keys  = array();
+		$locks       = array();
 
 		foreach ( $files as $file ) {
-			$handle = fopen($file, 'c'); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
-			if ( false === $handle ) {
+			$entry = self::filesystem_lock_entry($file);
+			if ( empty($entry) ) {
 				continue;
 			}
-
-			if ( ! flock($handle, LOCK_EX | LOCK_NB) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock
+			$locks[] = $entry;
+			if ( 'active' === (string) ( $entry['state'] ?? '' ) ) {
 				++$active;
-				$active_keys[] = self::lock_key_from_path($file);
-				fclose($handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+				$active_keys[] = (string) ( $entry['lock_key'] ?? '' );
 				continue;
 			}
-
-			flock($handle, LOCK_UN); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock
-			fclose($handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
-			$mtime = filemtime($file);
-			if ( false !== $mtime && $mtime < $cutoff ) {
+			if ( 'stale' === (string) ( $entry['state'] ?? '' ) ) {
 				++$stale;
-				$stale_keys[] = self::lock_key_from_path($file);
+				$stale_keys[] = (string) ( $entry['lock_key'] ?? '' );
 			} else {
 				++$recent;
 			}
@@ -330,6 +353,83 @@ final class WorkspaceMutationLock {
 			'stale'       => $stale,
 			'stale_keys'  => array_values(array_filter($stale_keys)),
 			'recent'      => $recent,
+			'locks'       => $locks,
+			'guidance'    => self::recovery_guidance(),
+		);
+	}
+
+	/**
+	 * Inspect one filesystem lock file without mutating it.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private static function filesystem_lock_entry( string $file ): array {
+		$policy   = self::retention_policy();
+		$cutoff   = time() - (int) $policy['filesystem_stale_after_seconds'];
+		$lock_key = self::lock_key_from_path($file);
+		$scope    = str_starts_with($lock_key, 'worktree-') ? substr($lock_key, strlen('worktree-')) : $lock_key;
+		$mtime    = filemtime($file);
+		$entry    = array(
+			'lock_key'            => $lock_key,
+			'scope'               => $scope,
+			'path'                => $file,
+			'mtime'               => false === $mtime ? null : gmdate('c', $mtime),
+			'age_seconds'         => false === $mtime ? null : max(0, time() - $mtime),
+			'stale_after_seconds' => (int) $policy['filesystem_stale_after_seconds'],
+		);
+
+		$handle = fopen($file, 'c'); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+		if ( false === $handle ) {
+			$entry['state']  = 'unknown';
+			$entry['reason'] = 'open_failed';
+			return $entry;
+		}
+
+		if ( ! flock($handle, LOCK_EX | LOCK_NB) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock
+			$entry['state']               = 'active';
+			$entry['reason']              = 'filesystem_flock_held';
+			$entry['owner_evidence']      = self::owner_evidence_for_lock($lock_key, $scope);
+			$entry['recovery_command']    = 'wp datamachine-code workspace worktree locks --format=json';
+			$entry['safe_to_prune']       = false;
+			$entry['operator_guidance']   = 'An active OS flock cannot be safely pruned. Inspect the owner evidence or running DMC/WP-CLI processes and retry after the holder exits.';
+			fclose($handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+			return $entry;
+		}
+
+		flock($handle, LOCK_UN); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock
+		fclose($handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+		$stale                    = false !== $mtime && $mtime < $cutoff;
+		$entry['state']           = $stale ? 'stale' : 'recent';
+		$entry['reason']          = $stale ? 'unlocked_stale_file' : 'unlocked_recent_file';
+		$entry['safe_to_prune']   = $stale;
+		$entry['recovery_command'] = $stale
+			? 'wp datamachine-code workspace worktree locks --prune-stale --dry-run --format=json'
+			: 'wp datamachine-code workspace worktree locks --format=json';
+
+		return $entry;
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	private static function owner_evidence_for_lock( string $lock_key, string $scope ): array {
+		$active_lock = WorkspaceLockStore::active_lock($lock_key, $scope);
+		if ( is_array($active_lock) ) {
+			return array(
+				'source' => 'database',
+				'lock'   => $active_lock,
+			);
+		}
+		if ( is_wp_error($active_lock) ) {
+			return array(
+				'source'  => 'database_error',
+				'message' => $active_lock->get_error_message(),
+			);
+		}
+
+		return array(
+			'source'  => 'filesystem_only',
+			'message' => 'No active DB lock row is visible for this held filesystem flock.',
 		);
 	}
 

--- a/tests/smoke-workspace-mutation-lock.php
+++ b/tests/smoke-workspace-mutation-lock.php
@@ -221,6 +221,18 @@ namespace {
 	$assert('workspace_repo_busy', is_wp_error($busy) ? $busy->get_error_code() : '', 'busy failure uses DMC-shaped retryable code');
 	$assert(true, is_wp_error($busy) ? (bool) ( $busy->get_error_data()['retryable'] ?? false ) : false, 'busy failure is marked retryable');
 	$assert('worktree-demo', is_wp_error($busy) ? (string) ( $busy->get_error_data()['lock_key'] ?? '' ) : '', 'busy failure includes lock key');
+	$busy_data = is_wp_error($busy) ? $busy->get_error_data() : array();
+	$assert('active', (string) ( $busy_data['filesystem_lock']['state'] ?? '' ), 'busy failure includes active filesystem lock state');
+	$assert('filesystem_only', (string) ( $busy_data['filesystem_lock']['owner_evidence']['source'] ?? '' ), 'busy failure explains filesystem-only owner evidence when DB row is unavailable');
+	$assert(true, isset($busy_data['filesystem_lock']['age_seconds']), 'busy failure includes filesystem lock age');
+	$assert(true, isset($busy_data['status_command']), 'busy failure includes lock status command');
+	$assert(true, isset($busy_data['stale_prune_command']), 'busy failure includes stale prune command');
+	$assert(true, isset($busy_data['recovery_guidance']['safety']), 'busy failure includes recovery safety guidance');
+	$filesystem_locks = (array) ( $status['filesystem']['locks'] ?? array() );
+	$assert(1, count($filesystem_locks), 'status includes per-filesystem-lock detail rows');
+	$assert('active', (string) ( $filesystem_locks[0]['state'] ?? '' ), 'status lock detail records active state');
+	$assert('filesystem_flock_held', (string) ( $filesystem_locks[0]['reason'] ?? '' ), 'status lock detail records active flock reason');
+	$assert(false, (bool) ( $filesystem_locks[0]['safe_to_prune'] ?? true ), 'active filesystem lock is not safe to prune');
 
     $other = \DataMachineCode\Workspace\WorkspaceMutationLock::acquire($tmp, 'other', 0);
     $assert(false, is_wp_error($other), 'different repo acquisition is independent');
@@ -249,9 +261,14 @@ namespace {
 
 	$stale_path = $tmp . '/.locks/worktree-stale.lock';
     touch($stale_path, time() - 172800);
-    $stale_status = \DataMachineCode\Workspace\WorkspaceMutationLock::status($tmp);
-    $assert(1, (int) $stale_status['stale'], 'old unlocked filesystem lock is counted stale');
-    $dry_prune = \DataMachineCode\Workspace\WorkspaceMutationLock::prune_stale($tmp, true);
+	$stale_status = \DataMachineCode\Workspace\WorkspaceMutationLock::status($tmp);
+	$assert(1, (int) $stale_status['stale'], 'old unlocked filesystem lock is counted stale');
+	$stale_locks = array_values(array_filter((array) ( $stale_status['filesystem']['locks'] ?? array() ), static fn( array $lock ): bool => 'worktree-stale' === (string) ( $lock['lock_key'] ?? '' )));
+	$assert(1, count($stale_locks), 'stale filesystem lock appears in detail rows');
+	$assert('stale', (string) ( $stale_locks[0]['state'] ?? '' ), 'stale lock detail records stale state');
+	$assert(true, (bool) ( $stale_locks[0]['safe_to_prune'] ?? false ), 'stale unlocked filesystem lock is safe to prune');
+	$assert('wp datamachine-code workspace worktree locks --prune-stale --dry-run --format=json', (string) ( $stale_locks[0]['recovery_command'] ?? '' ), 'stale lock detail points at dry-run prune command');
+	$dry_prune = \DataMachineCode\Workspace\WorkspaceMutationLock::prune_stale($tmp, true);
     $assert(true, is_file($stale_path), 'dry-run stale lock prune does not remove file');
     $assert(1, (int) $dry_prune['filesystem']['removed_count'], 'dry-run reports stale lock file candidate');
     $prune = \DataMachineCode\Workspace\WorkspaceMutationLock::prune_stale($tmp, false);


### PR DESCRIPTION
## Summary
- Adds actionable filesystem lock evidence to workspace repo-busy failures, including lock age, holder source, status command, stale-prune command, and safety guidance.
- Adds `workspace worktree locks` for operator-visible lock status and safe stale/orphan cleanup of expired DB rows plus old unlocked filesystem lock files.
- Extends the mutation-lock smoke test to cover filesystem-only busy evidence, per-lock status rows, and stale lock recovery guidance.

Fixes #506.

## Tests
- `php -l inc/Workspace/WorkspaceMutationLock.php`
- `php -l inc/Cli/Commands/WorkspaceCommand.php`
- `php -l tests/smoke-workspace-mutation-lock.php`
- `php tests/smoke-workspace-mutation-lock.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the workspace mutation lock recovery evidence path, the operator lock status/prune CLI, and focused smoke coverage. Chris remains responsible for review and testing.