### PR TITLE
Add GitHub credential profile migration

### DIFF
--- a/inc/Cli/Commands/GitHubCommand.php
+++ b/inc/Cli/Commands/GitHubCommand.php
@@ -715,18 +715,30 @@ class GitHubCommand extends BaseCommand {
 	 * @subcommand migrate-credentials
 	 */
 	public function migrate_credentials( array $args, array $assoc_args ): void {
-		$result = GitHubCredentialSettingsMigration::migrate(! empty($assoc_args['apply']), ! empty($assoc_args['force']));
+		$result = GitHubCredentialSettingsMigration::migrate( ! empty($assoc_args['apply']), ! empty($assoc_args['force']) );
 
 		if ( 'json' === (string) ( $assoc_args['format'] ?? '' ) ) {
-			WP_CLI::line((string) wp_json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+			WP_CLI::line( (string) wp_json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) );
 			return;
 		}
 
 		$items = array(
-			array( 'field' => 'Applied', 'value' => ! empty($result['applied']) ? 'yes' : 'no' ),
-			array( 'field' => 'Legacy keys present', 'value' => ! empty($result['legacy_keys_present']) ? 'yes' : 'no' ),
-			array( 'field' => 'Profiles present', 'value' => ! empty($result['profiles_present']) ? 'yes' : 'no' ),
-			array( 'field' => 'Message', 'value' => (string) ( $result['message'] ?? '' ) ),
+			array(
+				'field' => 'Applied',
+				'value' => ! empty($result['applied']) ? 'yes' : 'no',
+			),
+			array(
+				'field' => 'Legacy keys present',
+				'value' => ! empty($result['legacy_keys_present']) ? 'yes' : 'no',
+			),
+			array(
+				'field' => 'Profiles present',
+				'value' => ! empty($result['profiles_present']) ? 'yes' : 'no',
+			),
+			array(
+				'field' => 'Message',
+				'value' => (string) ( $result['message'] ?? '' ),
+			),
 		);
 		$this->format_items($items, array( 'field', 'value' ), $assoc_args);
 

--- a/inc/Cli/Commands/GitHubCommand.php
+++ b/inc/Cli/Commands/GitHubCommand.php
@@ -16,6 +16,7 @@ use DataMachine\Cli\BaseCommand;
 use DataMachineCode\Abilities\GitHubAbilities;
 use DataMachineCode\GitHub\PrReviewFlowInstaller;
 use DataMachineCode\GitHub\PrReviewFlowScaffold;
+use DataMachineCode\Support\GitHubCredentialSettingsMigration;
 
 defined('ABSPATH') || exit;
 
@@ -682,6 +683,57 @@ class GitHubCommand extends BaseCommand {
 			}
 
 			$this->format_items($repo_items, array( 'repo', 'label' ), $assoc_args);
+		}
+
+		$legacy = $auth_status['legacy_migration'] ?? array();
+		if ( ! empty($legacy['legacy_keys_present']) ) {
+			WP_CLI::log('');
+			WP_CLI::warning('Legacy GitHub credential settings are still present. Run `wp datamachine-code github migrate-credentials --apply` after reviewing the dry run.');
+		}
+	}
+
+	/**
+	 * Migrate legacy single GitHub credential settings into profiles.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--apply]
+	 * : Write github_credential_profiles and github_default_profile_id. Omit for dry run.
+	 *
+	 * [--force]
+	 * : Overwrite existing profile settings from legacy settings.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 *
+	 * @subcommand migrate-credentials
+	 */
+	public function migrate_credentials( array $args, array $assoc_args ): void {
+		$result = GitHubCredentialSettingsMigration::migrate(! empty($assoc_args['apply']), ! empty($assoc_args['force']));
+
+		if ( 'json' === (string) ( $assoc_args['format'] ?? '' ) ) {
+			WP_CLI::line((string) wp_json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+			return;
+		}
+
+		$items = array(
+			array( 'field' => 'Applied', 'value' => ! empty($result['applied']) ? 'yes' : 'no' ),
+			array( 'field' => 'Legacy keys present', 'value' => ! empty($result['legacy_keys_present']) ? 'yes' : 'no' ),
+			array( 'field' => 'Profiles present', 'value' => ! empty($result['profiles_present']) ? 'yes' : 'no' ),
+			array( 'field' => 'Message', 'value' => (string) ( $result['message'] ?? '' ) ),
+		);
+		$this->format_items($items, array( 'field', 'value' ), $assoc_args);
+
+		if ( ! empty($result['applied']) ) {
+			WP_CLI::success('GitHub credential profiles migrated.');
+		} else {
+			WP_CLI::log('Dry run complete; pass --apply to write changes.');
 		}
 	}
 

--- a/inc/Support/GitHubCredentialResolver.php
+++ b/inc/Support/GitHubCredentialResolver.php
@@ -106,7 +106,7 @@ final class GitHubCredentialResolver {
 			$profile_summaries[] = self::summarizeProfile($profile);
 		}
 
-		return array(
+		$status = array(
 			// Top-level fields preserve the historical surface for back-compat with existing CLI/status callers.
 			'mode'                        => $mode,
 			'pat_configured'              => '' !== trim( (string) ( $default['pat'] ?? '' )),
@@ -121,6 +121,12 @@ final class GitHubCredentialResolver {
 			'default_profile_id'          => (string) $default['id'],
 			'profiles'                    => $profile_summaries,
 		);
+
+		if ( class_exists(GitHubCredentialSettingsMigration::class) ) {
+			$status['legacy_migration'] = GitHubCredentialSettingsMigration::status();
+		}
+
+		return $status;
 	}
 
 	public static function isConfigured(): bool {

--- a/inc/Support/GitHubCredentialSettingsMigration.php
+++ b/inc/Support/GitHubCredentialSettingsMigration.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Legacy GitHub credential settings migration.
+ *
+ * @package DataMachineCode\Support
+ */
+
+namespace DataMachineCode\Support;
+
+use DataMachine\Core\PluginSettings;
+
+defined('ABSPATH') || exit;
+
+final class GitHubCredentialSettingsMigration {
+
+	public const MIGRATED_OPTION = 'datamachine_code_github_legacy_credentials_migrated_v1';
+
+	private const LEGACY_KEYS = array(
+		'github_pat',
+		'github_auth_mode',
+		'github_app_id',
+		'github_app_installation_id',
+		'github_app_private_key',
+		'github_default_repo',
+	);
+
+	/**
+	 * Report non-secret migration state for operators.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public static function status(): array {
+		$legacy_present = self::legacy_keys_present();
+		$profiles       = PluginSettings::get('github_credential_profiles', array());
+
+		return array(
+			'legacy_keys_present' => ! empty($legacy_present),
+			'legacy_keys'         => $legacy_present,
+			'profiles_present'    => is_array($profiles) && ! empty($profiles),
+			'migrated'            => (bool) get_option(self::MIGRATED_OPTION, false),
+			'removal_target'      => 'Remove legacy writes and implicit synthesis after live installs report migrated=true.',
+		);
+	}
+
+	/**
+	 * Migrate the legacy single-credential shape into credential profiles.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public static function migrate( bool $apply = false, bool $force = false ): array {
+		$legacy_present = self::legacy_keys_present();
+		$existing       = PluginSettings::get('github_credential_profiles', array());
+		$has_profiles   = is_array($existing) && ! empty($existing);
+
+		if ( empty($legacy_present) ) {
+			return array(
+				'success'             => true,
+				'applied'             => false,
+				'legacy_keys_present' => false,
+				'profiles_present'    => $has_profiles,
+				'message'             => 'No legacy GitHub credential settings found.',
+			);
+		}
+
+		if ( $has_profiles && ! $force ) {
+			return array(
+				'success'             => true,
+				'applied'             => false,
+				'legacy_keys_present' => true,
+				'legacy_keys'         => $legacy_present,
+				'profiles_present'    => true,
+				'message'             => 'Credential profiles already exist; pass force to overwrite from legacy settings.',
+			);
+		}
+
+		$profile = self::legacy_profile();
+		$preview = self::redact_profile($profile);
+
+		if ( ! $apply ) {
+			return array(
+				'success'             => true,
+				'applied'             => false,
+				'legacy_keys_present' => true,
+				'legacy_keys'         => $legacy_present,
+				'profiles_present'    => $has_profiles,
+				'profile'             => $preview,
+				'message'             => 'Dry run only; pass apply to write github_credential_profiles.',
+			);
+		}
+
+		self::write_setting('github_credential_profiles', array( $profile ));
+		self::write_setting('github_default_profile_id', GitHubCredentialResolver::DEFAULT_PROFILE_ID);
+		update_option(self::MIGRATED_OPTION, true, false);
+
+		return array(
+			'success'             => true,
+			'applied'             => true,
+			'legacy_keys_present' => true,
+			'legacy_keys'         => $legacy_present,
+			'profiles_present'    => true,
+			'profile'             => $preview,
+			'message'             => 'Migrated legacy GitHub credential settings to github_credential_profiles.',
+		);
+	}
+
+	/**
+	 * @return array<int,string>
+	 */
+	private static function legacy_keys_present(): array {
+		$present = array();
+		foreach ( self::LEGACY_KEYS as $key ) {
+			$value = PluginSettings::get($key, '');
+			if ( is_string($value) && '' !== trim($value) ) {
+				$present[] = $key;
+			}
+		}
+
+		return $present;
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	private static function legacy_profile(): array {
+		$mode = strtolower(trim((string) PluginSettings::get('github_auth_mode', '')));
+		if ( ! in_array($mode, array( 'pat', 'app' ), true) ) {
+			$mode = 'pat';
+		}
+
+		return GitHubProfileSanitizer::sanitize(
+			array(
+				array(
+					'id'                  => GitHubCredentialResolver::DEFAULT_PROFILE_ID,
+					'label'               => 'Default',
+					'mode'                => $mode,
+					'pat'                 => (string) PluginSettings::get('github_pat', ''),
+					'app_id'              => (string) PluginSettings::get('github_app_id', ''),
+					'app_installation_id' => (string) PluginSettings::get('github_app_installation_id', ''),
+					'app_private_key'     => (string) PluginSettings::get('github_app_private_key', ''),
+					'default_repo'        => (string) PluginSettings::get('github_default_repo', ''),
+				)
+			)
+		)[0];
+	}
+
+	/**
+	 * @param array<string,mixed> $profile
+	 * @return array<string,mixed>
+	 */
+	private static function redact_profile( array $profile ): array {
+		$profile['pat_configured']             = '' !== trim((string) ( $profile['pat'] ?? '' ));
+		$profile['app_private_key_configured'] = '' !== trim((string) ( $profile['app_private_key'] ?? '' ));
+		unset($profile['pat'], $profile['app_private_key']);
+		return $profile;
+	}
+
+	private static function write_setting( string $key, mixed $value ): void {
+		$settings = get_option('datamachine_settings', array());
+		if ( ! is_array($settings) ) {
+			$settings = array();
+		}
+		$settings[ $key ] = $value;
+		update_option('datamachine_settings', $settings, false);
+	}
+}

--- a/inc/Support/GitHubCredentialSettingsMigration.php
+++ b/inc/Support/GitHubCredentialSettingsMigration.php
@@ -122,7 +122,7 @@ final class GitHubCredentialSettingsMigration {
 	 * @return array<string,mixed>
 	 */
 	private static function legacy_profile(): array {
-		$mode = strtolower(trim((string) PluginSettings::get('github_auth_mode', '')));
+		$mode = strtolower(trim( (string) PluginSettings::get('github_auth_mode', '') ));
 		if ( ! in_array($mode, array( 'pat', 'app' ), true) ) {
 			$mode = 'pat';
 		}
@@ -138,7 +138,7 @@ final class GitHubCredentialSettingsMigration {
 					'app_installation_id' => (string) PluginSettings::get('github_app_installation_id', ''),
 					'app_private_key'     => (string) PluginSettings::get('github_app_private_key', ''),
 					'default_repo'        => (string) PluginSettings::get('github_default_repo', ''),
-				)
+				),
 			)
 		)[0];
 	}
@@ -148,8 +148,8 @@ final class GitHubCredentialSettingsMigration {
 	 * @return array<string,mixed>
 	 */
 	private static function redact_profile( array $profile ): array {
-		$profile['pat_configured']             = '' !== trim((string) ( $profile['pat'] ?? '' ));
-		$profile['app_private_key_configured'] = '' !== trim((string) ( $profile['app_private_key'] ?? '' ));
+		$profile['pat_configured']             = '' !== trim( (string) ( $profile['pat'] ?? '' ) );
+		$profile['app_private_key_configured'] = '' !== trim( (string) ( $profile['app_private_key'] ?? '' ) );
 		unset($profile['pat'], $profile['app_private_key']);
 		return $profile;
 	}

--- a/tests/smoke-github-credential-profiles.php
+++ b/tests/smoke-github-credential-profiles.php
@@ -81,6 +81,24 @@ namespace {
         return true;
     }
 
+    function get_option( string $key, $default = false )
+    {
+        if ('datamachine_settings' === $key ) {
+            return $GLOBALS['dmc_settings'] ?? $default;
+        }
+        return $GLOBALS['dmc_options'][ $key ] ?? $default;
+    }
+
+    function update_option( string $key, $value, $autoload = null ): bool
+    {
+        if ('datamachine_settings' === $key ) {
+            $GLOBALS['dmc_settings'] = $value;
+            return true;
+        }
+        $GLOBALS['dmc_options'][ $key ] = $value;
+        return true;
+    }
+
     function wp_remote_retrieve_response_code( $response ): int
     {
         return (int) ( $response['response']['code'] ?? 0 );
@@ -108,8 +126,10 @@ namespace {
 
     include __DIR__ . '/../inc/Support/GitHubCredentialResolver.php';
     include __DIR__ . '/../inc/Support/GitHubProfileSanitizer.php';
+    include __DIR__ . '/../inc/Support/GitHubCredentialSettingsMigration.php';
 
     use DataMachineCode\Support\GitHubCredentialResolver;
+    use DataMachineCode\Support\GitHubCredentialSettingsMigration;
     use DataMachineCode\Support\GitHubProfileSanitizer;
 
     $failures = array();
@@ -125,6 +145,7 @@ namespace {
     $reset = function ( array $settings = array() ): void {
         $GLOBALS['dmc_settings']   = $settings;
         $GLOBALS['dmc_transients'] = array();
+        $GLOBALS['dmc_options']    = array();
     };
 
     echo "GitHub credential profiles — smoke\n";
@@ -334,6 +355,25 @@ namespace {
     $assert('sanitizer preserves PAT', 'marketing-secret' === $sanitized[0]['pat']);
     $assert('sanitizer trims allowed_repos entries', $sanitized[0]['allowed_repos'] === array( 'team/marketing', 'team/sub' ));
     $assert('sanitizer normalizes capabilities', $sanitized[0]['capabilities'] === array( 'pull_request_create', 'issues_write' ));
+
+    // 11. Legacy settings migration dry-runs without leaking secrets, then applies profiles.
+    $reset(
+        array(
+        'github_pat'         => 'legacy-secret-token',
+        'github_default_repo' => 'team/legacy',
+        )
+    );
+    $migration_status = GitHubCredentialSettingsMigration::status();
+    $assert('migration status detects legacy keys', true === $migration_status['legacy_keys_present'] && in_array('github_pat', $migration_status['legacy_keys'], true));
+    $dry_run = GitHubCredentialSettingsMigration::migrate(false);
+    $dry_json = wp_json_encode($dry_run);
+    $assert('migration dry run does not expose PAT body', is_string($dry_json) && ! str_contains($dry_json, 'legacy-secret-token'));
+    $assert('migration dry run reports redacted PAT configured flag', true === ( $dry_run['profile']['pat_configured'] ?? false ));
+    $applied = GitHubCredentialSettingsMigration::migrate(true);
+    $assert('migration apply writes profiles', true === ( $applied['applied'] ?? false ) && isset($GLOBALS['dmc_settings']['github_credential_profiles'][0]));
+    $migrated = GitHubCredentialResolver::resolve();
+    $assert('resolver uses migrated profile after apply', ! is_wp_error($migrated) && 'legacy-secret-token' === $migrated['token']);
+    $assert('migration apply marks migrated option', true === ( $GLOBALS['dmc_options'][GitHubCredentialSettingsMigration::MIGRATED_OPTION] ?? false ));
 
     if ($failures ) {
         echo "\nFailures:\n";


### PR DESCRIPTION
## Summary
- Adds a legacy GitHub credential migration helper and `github migrate-credentials` CLI command to move single-credential settings into profile settings.
- Adds non-secret migration diagnostics to GitHub auth status while keeping legacy reads available for the removal follow-up.

Closes #514.

## Tests
- `php -l inc/Support/GitHubCredentialSettingsMigration.php`
- `php -l inc/Support/GitHubCredentialResolver.php`
- `php -l inc/Cli/Commands/GitHubCommand.php`
- `php tests/smoke-github-credential-profiles.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the migration helper, CLI command, and smoke coverage; Chris remains responsible for review and testing.