### PR TITLE
Add worktree origin session backfill

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -20,6 +20,7 @@ use DataMachine\Cli\BaseCommand;
 use DataMachineCode\Cleanup\CleanupRunEvidenceStoreInterface;
 use DataMachineCode\Cleanup\DataMachineJobCleanupRunEvidenceStore;
 use DataMachineCode\Workspace\Workspace;
+use DataMachineCode\Workspace\WorktreeContextInjector;
 use DataMachineCode\Workspace\WorkspaceMutationLock;
 
 defined('ABSPATH') || exit;
@@ -2297,7 +2298,7 @@ class WorkspaceCommand extends BaseCommand {
 		$operation = $args[0] ?? '';
 
 		if ( '' === $operation ) {
-			WP_CLI::error('Usage: wp datamachine-code workspace worktree <add|list|remove|prune|locks|cleanup|cleanup-artifacts|bounded-cleanup-eligible-apply|emergency-cleanup|reconcile-metadata|active-no-signal-report|active-no-signal-finalized-apply|active-no-signal-equivalent-clean-apply|refresh-context|finalize|mark-cleanup-eligible> [<repo>] [<branch>] [--flags]');
+			WP_CLI::error('Usage: wp datamachine-code workspace worktree <add|list|remove|prune|locks|cleanup|cleanup-artifacts|bounded-cleanup-eligible-apply|emergency-cleanup|reconcile-metadata|backfill-origin-session|active-no-signal-report|active-no-signal-finalized-apply|active-no-signal-equivalent-clean-apply|refresh-context|finalize|mark-cleanup-eligible> [<repo>] [<branch>] [--flags]');
 			return;
 		}
 
@@ -2309,6 +2310,28 @@ class WorkspaceCommand extends BaseCommand {
 				? WorkspaceMutationLock::prune_stale($workspace_path, $dry_run)
 				: WorkspaceMutationLock::status($workspace_path);
 			$this->render_workspace_lock_result($result, $assoc_args, ! empty($assoc_args['prune-stale']));
+			return;
+		}
+
+		if ( 'backfill-origin-session' === $operation ) {
+			$result = WorktreeContextInjector::backfill_legacy_origin_sessions(! empty($assoc_args['apply']));
+			if ( 'json' === (string) ( $assoc_args['format'] ?? '' ) ) {
+				WP_CLI::line((string) wp_json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+				return;
+			}
+
+			$items = array(
+				array( 'field' => 'Applied', 'value' => ! empty($result['applied']) ? 'yes' : 'no' ),
+				array( 'field' => 'Planned', 'value' => (string) ( $result['planned_count'] ?? 0 ) ),
+				array( 'field' => 'Migrated option', 'value' => ! empty($result['migrated']) ? 'yes' : 'no' ),
+				array( 'field' => 'Message', 'value' => (string) ( $result['message'] ?? '' ) ),
+			);
+			$this->format_items($items, array( 'field', 'value' ), $assoc_args);
+			if ( ! empty($result['applied']) ) {
+				WP_CLI::success('Backfilled legacy origin_session metadata.');
+			} else {
+				WP_CLI::log('Dry run complete; pass --apply to rewrite metadata.');
+			}
 			return;
 		}
 

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -2314,17 +2314,29 @@ class WorkspaceCommand extends BaseCommand {
 		}
 
 		if ( 'backfill-origin-session' === $operation ) {
-			$result = WorktreeContextInjector::backfill_legacy_origin_sessions(! empty($assoc_args['apply']));
+			$result = WorktreeContextInjector::backfill_legacy_origin_sessions( ! empty($assoc_args['apply']) );
 			if ( 'json' === (string) ( $assoc_args['format'] ?? '' ) ) {
-				WP_CLI::line((string) wp_json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+				WP_CLI::line( (string) wp_json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) );
 				return;
 			}
 
 			$items = array(
-				array( 'field' => 'Applied', 'value' => ! empty($result['applied']) ? 'yes' : 'no' ),
-				array( 'field' => 'Planned', 'value' => (string) ( $result['planned_count'] ?? 0 ) ),
-				array( 'field' => 'Migrated option', 'value' => ! empty($result['migrated']) ? 'yes' : 'no' ),
-				array( 'field' => 'Message', 'value' => (string) ( $result['message'] ?? '' ) ),
+				array(
+					'field' => 'Applied',
+					'value' => ! empty($result['applied']) ? 'yes' : 'no',
+				),
+				array(
+					'field' => 'Planned',
+					'value' => (string) ( $result['planned_count'] ?? 0 ),
+				),
+				array(
+					'field' => 'Migrated option',
+					'value' => ! empty($result['migrated']) ? 'yes' : 'no',
+				),
+				array(
+					'field' => 'Message',
+					'value' => (string) ( $result['message'] ?? '' ),
+				),
 			);
 			$this->format_items($items, array( 'field', 'value' ), $assoc_args);
 			if ( ! empty($result['applied']) ) {

--- a/inc/Workspace/WorktreeContextInjector.php
+++ b/inc/Workspace/WorktreeContextInjector.php
@@ -125,6 +125,8 @@ class WorktreeContextInjector {
 	 */
 	public const METADATA_OPTION = 'datamachine_worktree_metadata';
 
+	public const ORIGIN_SESSION_LEGACY_MIGRATED_OPTION = 'datamachine_code_worktree_attribution_legacy_migrated_v2';
+
 	/**
 	 * Files injected into the worktree, relative to the worktree root.
 	 */
@@ -483,6 +485,62 @@ class WorktreeContextInjector {
 	}
 
 	/**
+	 * Backfill legacy origin_session metadata into the canonical ids envelope.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public static function backfill_legacy_origin_sessions( bool $apply = false ): array {
+		if ( ! function_exists('get_option') ) {
+			return array(
+				'success' => false,
+				'applied' => false,
+				'message' => 'Options API is unavailable; cannot backfill worktree metadata.',
+			);
+		}
+
+		$all = get_option(self::METADATA_OPTION, array());
+		if ( ! is_array($all) ) {
+			$all = array();
+		}
+
+		$planned = array();
+		foreach ( $all as $handle => $metadata ) {
+			if ( ! is_string($handle) || ! is_array($metadata) || ! is_array($metadata['origin_session'] ?? null) ) {
+				continue;
+			}
+			$session = (array) $metadata['origin_session'];
+			if ( ! self::origin_session_has_legacy_keys($session) ) {
+				continue;
+			}
+
+			$canonical = self::summarize_session($metadata);
+			$planned[] = array(
+				'handle'         => $handle,
+				'primary_id'     => $canonical['primary_id'],
+				'runtime_ids'    => array_keys($canonical['ids']),
+				'origin_session' => $canonical,
+			);
+
+			if ( $apply ) {
+				self::store_lifecycle_metadata($handle, array( 'origin_session' => $canonical ));
+			}
+		}
+
+		if ( $apply && function_exists('update_option') ) {
+			update_option(self::ORIGIN_SESSION_LEGACY_MIGRATED_OPTION, true, false);
+		}
+
+		return array(
+			'success'       => true,
+			'applied'       => $apply,
+			'planned_count' => count($planned),
+			'planned'       => $planned,
+			'migrated'      => $apply ? (bool) get_option(self::ORIGIN_SESSION_LEGACY_MIGRATED_OPTION, false) : (bool) get_option(self::ORIGIN_SESSION_LEGACY_MIGRATED_OPTION, false),
+			'message'       => $apply ? 'Backfilled legacy worktree origin_session metadata.' : 'Dry run only; pass apply to rewrite worktree metadata.',
+		);
+	}
+
+	/**
 	 * Resolve the renderer-friendly primary identifier from a normalized
 	 * session envelope.
 	 *
@@ -611,6 +669,25 @@ class WorktreeContextInjector {
 
 		$session['ids'] = $ids;
 		return $session;
+	}
+
+	private static function origin_session_has_legacy_keys( array $session ): bool {
+		$canonical_top_level = array(
+			'primary_id' => true,
+			'ids'        => true,
+		);
+		foreach ( $session as $key => $value ) {
+			unset($value);
+			if ( ! is_string($key) || isset($canonical_top_level[ $key ]) ) {
+				continue;
+			}
+			$underscore = strpos($key, '_');
+			if ( false !== $underscore && 0 !== $underscore && strlen($key) - 1 !== $underscore ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/tests/smoke-worktree-agent-session-lifecycle.php
+++ b/tests/smoke-worktree-agent-session-lifecycle.php
@@ -368,6 +368,24 @@ namespace {
     $assert('legacy-beta-run', $legacy_view['ids']['beta-runtime']['run_id'] ?? null, 'legacy migration projects <runtime>_run_id into ids envelope');
     $assert('legacy-alpha-ses', $legacy_view['primary_id'], 'legacy-migrated rows still resolve a primary_id via runtime precedence');
 
+    $GLOBALS['datamachine_code_test_options'][\DataMachineCode\Workspace\WorktreeContextInjector::METADATA_OPTION] = array(
+    'demo@legacy-session' => array(
+    'origin_session' => array(
+    'alpha-runtime_session_id' => 'legacy-alpha-ses',
+    'alpha-runtime_thread_id'  => 'legacy-alpha-thr',
+    ),
+    ),
+    );
+    $backfill_dry_run = \DataMachineCode\Workspace\WorktreeContextInjector::backfill_legacy_origin_sessions(false);
+    $assert(1, $backfill_dry_run['planned_count'] ?? null, 'legacy origin_session backfill dry run plans legacy row');
+    $assert(false, $GLOBALS['datamachine_code_test_options'][\DataMachineCode\Workspace\WorktreeContextInjector::ORIGIN_SESSION_LEGACY_MIGRATED_OPTION] ?? false, 'dry run does not set migrated option');
+    $backfill_apply = \DataMachineCode\Workspace\WorktreeContextInjector::backfill_legacy_origin_sessions(true);
+    $rewritten = $GLOBALS['datamachine_code_test_options'][\DataMachineCode\Workspace\WorktreeContextInjector::METADATA_OPTION]['demo@legacy-session']['origin_session'] ?? array();
+    $assert(true, $backfill_apply['applied'] ?? false, 'legacy origin_session backfill apply reports applied');
+    $assert('legacy-alpha-ses', $rewritten['ids']['alpha-runtime']['session_id'] ?? null, 'legacy origin_session backfill rewrites ids envelope');
+    $assert(false, array_key_exists('alpha-runtime_session_id', $rewritten), 'legacy origin_session backfill removes top-level legacy key');
+    $assert(true, $GLOBALS['datamachine_code_test_options'][\DataMachineCode\Workspace\WorktreeContextInjector::ORIGIN_SESSION_LEGACY_MIGRATED_OPTION] ?? false, 'backfill apply sets migrated option');
+
     // Mixed envelope: explicit primary_id wins over runtime-derived precedence.
     $mixed_view = \DataMachineCode\Workspace\WorktreeContextInjector::summarize_session(
         array(


### PR DESCRIPTION
## Summary
- Adds a backfill path for legacy top-level runtime keys in worktree `origin_session` metadata.
- Adds `workspace worktree backfill-origin-session` with dry-run/apply behavior and sets the legacy migration gate option on apply.

Closes #515.

## Tests
- `php -l inc/Workspace/WorktreeContextInjector.php`
- `php -l inc/Cli/Commands/WorkspaceCommand.php`
- `php tests/smoke-worktree-agent-session-lifecycle.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the metadata backfill path, CLI wiring, and smoke coverage; Chris remains responsible for review and testing.