### PR TITLE
Separate remote workspace backend guidance

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -2371,6 +2371,91 @@ class WorkspaceAbilities {
 	}
 
 	/**
+	 * Add model-facing next-tool guidance to remote workspace ability results.
+	 *
+	 * RemoteWorkspaceBackend returns domain state only; this adapter is the
+	 * explicitly agent-facing layer that preserves CLI/tool loop guidance.
+	 *
+	 * @param string                 $operation Remote backend operation name.
+	 * @param array<string,mixed>|\WP_Error $result Backend result.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private static function decorate_remote_workspace_result( string $operation, array|\WP_Error $result ): array|\WP_Error {
+		if ( is_wp_error($result) ) {
+			return $result;
+		}
+
+		$guidance = self::remote_workspace_guidance($operation, $result);
+		if ( empty($guidance) ) {
+			return $result;
+		}
+
+		return array_merge($result, $guidance);
+	}
+
+	/**
+	 * @param array<string,mixed> $result Backend result.
+	 * @return array<string,mixed>
+	 */
+	private static function remote_workspace_guidance( string $operation, array $result ): array {
+		$name   = (string) ( $result['name'] ?? '' );
+		$handle = (string) ( $result['handle'] ?? $name );
+
+		switch ( $operation ) {
+			case 'clone_repo':
+				return array(
+					'conversation_state' => 'incomplete',
+					'next_required_tool' => 'workspace_worktree_add',
+					'next_required_args' => array( 'repo' => $name ),
+				);
+
+			case 'worktree_add':
+				return array(
+					'conversation_state' => 'incomplete',
+					'next_required_tool' => 'workspace_read or workspace_edit or workspace_write',
+					'next_required_args' => array( 'repo' => $handle ),
+				);
+
+			case 'write_file':
+			case 'edit_file':
+				return array(
+					'conversation_state' => 'incomplete',
+					'next_required_tool' => 'workspace_git_status',
+					'next_required_args' => array( 'name' => $name ),
+				);
+
+			case 'git_status':
+				return array(
+					'conversation_state' => 'incomplete',
+					'next_required_tool' => (int) ( $result['dirty'] ?? 0 ) > 0 ? 'workspace_git_commit' : 'workspace_edit or workspace_write',
+					'next_required_args' => array( 'name' => $name ),
+				);
+
+			case 'git_commit':
+				return array(
+					'conversation_state' => 'incomplete',
+					'next_required_tool' => 'workspace_git_push',
+					'next_required_args' => array(
+						'name'   => $name,
+						'branch' => (string) ( $result['branch'] ?? '' ),
+					),
+				);
+
+			case 'git_push':
+				return array(
+					'conversation_state' => 'incomplete',
+					'next_required_tool' => 'create_github_pull_request',
+					'next_required_args' => array(
+						'repo' => (string) ( $result['repo'] ?? $result['github_repo'] ?? '' ),
+						'head' => (string) ( $result['branch'] ?? '' ),
+					),
+				);
+		}
+
+		return array();
+	}
+
+	/**
 	 * Clone a git repository into the workspace.
 	 *
 	 * @param  array $input Input parameters with 'url', optional 'name'.
@@ -2378,10 +2463,11 @@ class WorkspaceAbilities {
 	 */
 	public static function cloneRepo( array $input ): array|\WP_Error {
 		if ( RemoteWorkspaceBackend::should_handle() ) {
-			return ( new RemoteWorkspaceBackend() )->clone_repo(
+			$result = ( new RemoteWorkspaceBackend() )->clone_repo(
 				$input['url'] ?? '',
 				$input['name'] ?? null
 			);
+			return self::decorate_remote_workspace_result('clone_repo', $result);
 		}
 
 		$workspace = new Workspace();
@@ -2428,11 +2514,12 @@ class WorkspaceAbilities {
 	 */
 	public static function writeFile( array $input ): array|\WP_Error {
 		if ( RemoteWorkspaceBackend::should_handle() ) {
-			return ( new RemoteWorkspaceBackend() )->write_file(
+			$result = ( new RemoteWorkspaceBackend() )->write_file(
 				$input['repo'] ?? '',
 				$input['path'] ?? '',
 				$input['content'] ?? ''
 			);
+			return self::decorate_remote_workspace_result('write_file', $result);
 		}
 
 		$workspace = new Workspace();
@@ -2465,13 +2552,14 @@ class WorkspaceAbilities {
 		}
 
 		if ( RemoteWorkspaceBackend::should_handle() ) {
-			return ( new RemoteWorkspaceBackend() )->edit_file(
+			$result = ( new RemoteWorkspaceBackend() )->edit_file(
 				$input['repo'] ?? '',
 				$input['path'] ?? '',
 				$old_string,
 				$new_string,
 				! empty($input['replace_all'])
 			);
+			return self::decorate_remote_workspace_result('edit_file', $result);
 		}
 
 		$workspace = new Workspace();
@@ -2541,7 +2629,8 @@ class WorkspaceAbilities {
 	 */
 	public static function gitStatus( array $input ): array|\WP_Error {
 		if ( RemoteWorkspaceBackend::should_handle() ) {
-			return ( new RemoteWorkspaceBackend() )->git_status($input['name'] ?? '');
+			$result = ( new RemoteWorkspaceBackend() )->git_status($input['name'] ?? '');
+			return self::decorate_remote_workspace_result('git_status', $result);
 		}
 
 		$workspace = new Workspace();
@@ -2613,10 +2702,11 @@ class WorkspaceAbilities {
 	 */
 	public static function gitCommit( array $input ): array|\WP_Error {
 		if ( RemoteWorkspaceBackend::should_handle() ) {
-			return ( new RemoteWorkspaceBackend() )->git_commit(
+			$result = ( new RemoteWorkspaceBackend() )->git_commit(
 				$input['name'] ?? '',
 				$input['message'] ?? ''
 			);
+			return self::decorate_remote_workspace_result('git_commit', $result);
 		}
 
 		$workspace = new Workspace();
@@ -2635,11 +2725,12 @@ class WorkspaceAbilities {
 	 */
 	public static function gitPush( array $input ): array|\WP_Error {
 		if ( RemoteWorkspaceBackend::should_handle() ) {
-			return ( new RemoteWorkspaceBackend() )->git_push(
+			$result = ( new RemoteWorkspaceBackend() )->git_push(
 				$input['name'] ?? '',
 				$input['remote'] ?? 'origin',
 				$input['branch'] ?? null
 			);
+			return self::decorate_remote_workspace_result('git_push', $result);
 		}
 
 		$workspace = new Workspace();
@@ -2732,11 +2823,12 @@ class WorkspaceAbilities {
 	 */
 	public static function worktreeAdd( array $input ): array|\WP_Error {
 		if ( RemoteWorkspaceBackend::should_handle() ) {
-			return ( new RemoteWorkspaceBackend() )->worktree_add(
+			$result = ( new RemoteWorkspaceBackend() )->worktree_add(
 				$input['repo'] ?? '',
 				$input['branch'] ?? '',
 				$input['from'] ?? null
 			);
+			return self::decorate_remote_workspace_result('worktree_add', $result);
 		}
 
 		$workspace = new Workspace();

--- a/inc/Workspace/RemoteWorkspaceBackend.php
+++ b/inc/Workspace/RemoteWorkspaceBackend.php
@@ -60,9 +60,6 @@ class RemoteWorkspaceBackend {
 			'name'               => $name,
 			'path'               => 'github://' . $repo,
 			'message'            => sprintf('Registered %s as remote workspace "%s".', $repo, $name),
-			'conversation_state' => 'incomplete',
-			'next_required_tool' => 'workspace_worktree_add',
-			'next_required_args' => array( 'repo' => $name ),
 		);
 	}
 
@@ -105,9 +102,6 @@ class RemoteWorkspaceBackend {
 			'slug'               => $slug,
 			'created_branch'     => true,
 			'message'            => sprintf('Registered remote workspace %s for %s.', $handle, $repo),
-			'conversation_state' => 'incomplete',
-			'next_required_tool' => 'workspace_read or workspace_edit or workspace_write',
-			'next_required_args' => array( 'repo' => $handle ),
 		);
 	}
 
@@ -334,12 +328,10 @@ class RemoteWorkspaceBackend {
 		return array(
 			'success'            => true,
 			'backend'            => 'github_api',
+			'name'               => $context['handle'],
 			'path'               => $path,
 			'size'               => strlen($content),
 			'created'            => true,
-			'conversation_state' => 'incomplete',
-			'next_required_tool' => 'workspace_git_status',
-			'next_required_args' => array( 'name' => $context['handle'] ),
 		);
 	}
 
@@ -392,11 +384,9 @@ class RemoteWorkspaceBackend {
 		return array(
 			'success'            => true,
 			'backend'            => 'github_api',
+			'name'               => $context['handle'],
 			'path'               => $write['path'],
 			'replacements'       => $replace_all ? $count : 1,
-			'conversation_state' => 'incomplete',
-			'next_required_tool' => 'workspace_git_status',
-			'next_required_args' => array( 'name' => $context['handle'] ),
 		);
 	}
 
@@ -505,9 +495,6 @@ class RemoteWorkspaceBackend {
 			'commit'             => '' !== $context['last_commit_sha'] ? $context['last_commit_sha'] : null,
 			'dirty'              => count($files),
 			'files'              => $files,
-			'conversation_state' => 'incomplete',
-			'next_required_tool' => count($files) > 0 ? 'workspace_git_commit' : 'workspace_edit or workspace_write',
-			'next_required_args' => array( 'name' => $handle ),
 		);
 	}
 
@@ -586,14 +573,9 @@ class RemoteWorkspaceBackend {
 			'success'            => true,
 			'backend'            => 'github_api',
 			'name'               => $handle,
+			'branch'             => $context['branch'],
 			'commit'             => $last_sha,
 			'message'            => sprintf('Committed remote workspace changes to %s.', $context['branch']),
-			'conversation_state' => 'incomplete',
-			'next_required_tool' => 'workspace_git_push',
-			'next_required_args' => array(
-				'name'   => $handle,
-				'branch' => $context['branch'],
-			),
 		);
 	}
 
@@ -1055,12 +1037,6 @@ class RemoteWorkspaceBackend {
 			'url'                => $branch_url,
 			'html_url'           => $branch_url,
 			'message'            => 'Remote workspace branch already updated via GitHub API.',
-			'conversation_state' => 'incomplete',
-			'next_required_tool' => 'create_github_pull_request',
-			'next_required_args' => array(
-				'repo' => $context['repo'],
-				'head' => $push_branch,
-			),
 		);
 	}
 

--- a/inc/Workspace/RemoteWorkspaceBackend.php
+++ b/inc/Workspace/RemoteWorkspaceBackend.php
@@ -55,11 +55,11 @@ class RemoteWorkspaceBackend {
 		$this->save_state($state);
 
 		return array(
-			'success'            => true,
-			'backend'            => 'github_api',
-			'name'               => $name,
-			'path'               => 'github://' . $repo,
-			'message'            => sprintf('Registered %s as remote workspace "%s".', $repo, $name),
+			'success' => true,
+			'backend' => 'github_api',
+			'name'    => $name,
+			'path'    => 'github://' . $repo,
+			'message' => sprintf('Registered %s as remote workspace "%s".', $repo, $name),
 		);
 	}
 
@@ -94,14 +94,14 @@ class RemoteWorkspaceBackend {
 		$this->save_state($state);
 
 		return array(
-			'success'            => true,
-			'backend'            => 'github_api',
-			'handle'             => $handle,
-			'path'               => 'github://' . $repo . '#' . $branch,
-			'branch'             => $branch,
-			'slug'               => $slug,
-			'created_branch'     => true,
-			'message'            => sprintf('Registered remote workspace %s for %s.', $handle, $repo),
+			'success'        => true,
+			'backend'        => 'github_api',
+			'handle'         => $handle,
+			'path'           => 'github://' . $repo . '#' . $branch,
+			'branch'         => $branch,
+			'slug'           => $slug,
+			'created_branch' => true,
+			'message'        => sprintf('Registered remote workspace %s for %s.', $handle, $repo),
 		);
 	}
 
@@ -326,12 +326,12 @@ class RemoteWorkspaceBackend {
 		$this->save_state($state);
 
 		return array(
-			'success'            => true,
-			'backend'            => 'github_api',
-			'name'               => $context['handle'],
-			'path'               => $path,
-			'size'               => strlen($content),
-			'created'            => true,
+			'success' => true,
+			'backend' => 'github_api',
+			'name'    => $context['handle'],
+			'path'    => $path,
+			'size'    => strlen($content),
+			'created' => true,
 		);
 	}
 
@@ -382,11 +382,11 @@ class RemoteWorkspaceBackend {
 		}
 
 		return array(
-			'success'            => true,
-			'backend'            => 'github_api',
-			'name'               => $context['handle'],
-			'path'               => $write['path'],
-			'replacements'       => $replace_all ? $count : 1,
+			'success'      => true,
+			'backend'      => 'github_api',
+			'name'         => $context['handle'],
+			'path'         => $write['path'],
+			'replacements' => $replace_all ? $count : 1,
 		);
 	}
 
@@ -484,17 +484,17 @@ class RemoteWorkspaceBackend {
 
 		$files = array_values(array_unique(array_values( (array) $context['changed_files'])));
 		return array(
-			'success'            => true,
-			'backend'            => 'github_api',
-			'name'               => $handle,
-			'repo'               => $context['repo_name'],
-			'is_worktree'        => true,
-			'path'               => 'github://' . $context['repo'] . '#' . $context['branch'],
-			'branch'             => $context['branch'],
-			'remote'             => 'https://github.com/' . $context['repo'] . '.git',
-			'commit'             => '' !== $context['last_commit_sha'] ? $context['last_commit_sha'] : null,
-			'dirty'              => count($files),
-			'files'              => $files,
+			'success'     => true,
+			'backend'     => 'github_api',
+			'name'        => $handle,
+			'repo'        => $context['repo_name'],
+			'is_worktree' => true,
+			'path'        => 'github://' . $context['repo'] . '#' . $context['branch'],
+			'branch'      => $context['branch'],
+			'remote'      => 'https://github.com/' . $context['repo'] . '.git',
+			'commit'      => '' !== $context['last_commit_sha'] ? $context['last_commit_sha'] : null,
+			'dirty'       => count($files),
+			'files'       => $files,
 		);
 	}
 
@@ -570,12 +570,12 @@ class RemoteWorkspaceBackend {
 		$this->save_state($state);
 
 		return array(
-			'success'            => true,
-			'backend'            => 'github_api',
-			'name'               => $handle,
-			'branch'             => $context['branch'],
-			'commit'             => $last_sha,
-			'message'            => sprintf('Committed remote workspace changes to %s.', $context['branch']),
+			'success' => true,
+			'backend' => 'github_api',
+			'name'    => $handle,
+			'branch'  => $context['branch'],
+			'commit'  => $last_sha,
+			'message' => sprintf('Committed remote workspace changes to %s.', $context['branch']),
 		);
 	}
 
@@ -1025,18 +1025,18 @@ class RemoteWorkspaceBackend {
 		$branch_url  = '' !== $push_branch ? 'https://github.com/' . $context['repo'] . '/tree/' . rawurlencode($push_branch) : null;
 
 		return array(
-			'success'            => true,
-			'kind'               => 'branch_push',
-			'backend'            => 'github_api',
-			'name'               => $handle,
-			'repo'               => $context['repo'],
-			'workspace_repo'     => $context['repo_name'] ?? $handle,
-			'github_repo'        => $context['repo'],
-			'remote'             => $remote,
-			'branch'             => $push_branch,
-			'url'                => $branch_url,
-			'html_url'           => $branch_url,
-			'message'            => 'Remote workspace branch already updated via GitHub API.',
+			'success'        => true,
+			'kind'           => 'branch_push',
+			'backend'        => 'github_api',
+			'name'           => $handle,
+			'repo'           => $context['repo'],
+			'workspace_repo' => $context['repo_name'] ?? $handle,
+			'github_repo'    => $context['repo'],
+			'remote'         => $remote,
+			'branch'         => $push_branch,
+			'url'            => $branch_url,
+			'html_url'       => $branch_url,
+			'message'        => 'Remote workspace branch already updated via GitHub API.',
 		);
 	}
 

--- a/tests/smoke-remote-workspace-backend.php
+++ b/tests/smoke-remote-workspace-backend.php
@@ -165,9 +165,11 @@ namespace {
     $backend = new RemoteWorkspaceBackend();
     $clone = $backend->clone_repo('https://github.com/chubes4/example.git');
     $assert('clone registers remote repo', ! is_wp_error($clone) && 'example' === $clone['name'] && 'github_api' === $clone['backend']);
+    $assert('clone backend result omits model-facing guidance', ! is_wp_error($clone) && ! array_key_exists('next_required_tool', $clone) && ! array_key_exists('next_required_args', $clone));
 
     $worktree = $backend->worktree_add('example', 'fix/example');
     $assert('worktree add returns DMC handle', ! is_wp_error($worktree) && 'example@fix-example' === $worktree['handle']);
+    $assert('worktree add backend result omits model-facing guidance', ! is_wp_error($worktree) && ! array_key_exists('next_required_tool', $worktree) && ! array_key_exists('next_required_args', $worktree));
 
     update_option(
         'datamachine_code_workspace_aliases',
@@ -190,6 +192,7 @@ namespace {
 
     $edit = $backend->edit_file('example@fix-example', 'src/example.php', 'old', 'new');
     $assert('edit stages pending content', ! is_wp_error($edit) && 1 === $edit['replacements']);
+    $assert('edit backend result omits model-facing guidance', ! is_wp_error($edit) && ! array_key_exists('next_required_tool', $edit) && ! array_key_exists('next_required_args', $edit));
 
     $show = $backend->show('example@fix-example');
     $assert('show supports remote worktree handles', ! is_wp_error($show) && 'github_api' === $show['backend'] && 1 === $show['dirty'] && 'fix/example' === $show['branch']);
@@ -204,17 +207,20 @@ namespace {
 
     $status = $backend->git_status('example@fix-example');
     $assert('status reports pending file as dirty', ! is_wp_error($status) && 1 === $status['dirty'] && array( 'src/example.php' ) === $status['files']);
+    $assert('status backend result omits model-facing guidance', ! is_wp_error($status) && ! array_key_exists('next_required_tool', $status) && ! array_key_exists('next_required_args', $status));
 
     $alias_status = $backend->git_status('current-project');
     $assert('status resolves current-project alias to remote worktree', ! is_wp_error($alias_status) && 1 === $alias_status['dirty'] && array( 'src/example.php' ) === $alias_status['files']);
 
     $commit = $backend->git_commit('example@fix-example', 'fix: update example');
     $assert('commit writes via GitHub API', ! is_wp_error($commit) && 'commit-1' === $commit['commit']);
+    $assert('commit backend result omits model-facing guidance', ! is_wp_error($commit) && ! array_key_exists('next_required_tool', $commit) && ! array_key_exists('next_required_args', $commit));
     $assert('commit uses requested message', 'fix: update example' === GitHubAbilities::$commits[0]['message']);
     $assert('commit supplies current file sha', 'file-sha-main-example' === GitHubAbilities::$commits[0]['input_sha']);
 
     $push = $backend->git_push('example@fix-example');
     $assert('push is successful compatibility no-op', ! is_wp_error($push) && 'fix/example' === $push['branch']);
+    $assert('push backend result omits model-facing guidance', ! is_wp_error($push) && ! array_key_exists('next_required_tool', $push) && ! array_key_exists('next_required_args', $push));
 
     if (! empty($failures) ) {
         echo "\nFAIL: " . count($failures) . " assertion(s) failed out of {$total}\n";

--- a/tests/smoke-tool-result-contracts.php
+++ b/tests/smoke-tool-result-contracts.php
@@ -77,7 +77,7 @@ $assert('workspace_git_push identifies branch pushes', is_array($push) && 'branc
 $assert('workspace_git_push exposes repo slug', is_array($push) && 'Extra-Chill/data-machine-code' === ( $push['repo'] ?? '' ));
 $assert('workspace_git_push exposes branch URL', is_array($push) && 'https://github.com/Extra-Chill/data-machine-code/tree/fix%2Ftool-result-contracts' === ( $push['url'] ?? '' ));
 $assert('workspace_git_push URL is distinguishable from PR URL', is_array($push) && str_contains($push['url'] ?? '', '/tree/') && ! str_contains($push['url'] ?? '', '/pull/'));
-$assert('workspace_git_push next args point to PR creation', is_array($push) && 'create_github_pull_request' === ( $push['next_required_tool'] ?? '' ));
+$assert('remote backend push omits model-facing next-tool hints', is_array($push) && ! array_key_exists('next_required_tool', $push) && ! array_key_exists('next_required_args', $push));
 
 if (! empty($failures) ) {
     echo "\nFAIL: " . count($failures) . " assertion(s)\n";


### PR DESCRIPTION
## Summary
- Removes model-facing `conversation_state`, `next_required_tool`, and `next_required_args` fields from `RemoteWorkspaceBackend` domain results.
- Adds a clearly named ability-layer decorator to preserve remote workspace next-step guidance at the tool boundary.

Closes #513.

## Tests
- `php -l inc/Workspace/RemoteWorkspaceBackend.php`
- `php -l inc/Abilities/WorkspaceAbilities.php`
- `php tests/smoke-remote-workspace-backend.php`
- `php tests/smoke-tool-result-contracts.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the backend/tool boundary split and smoke-test updates; Chris remains responsible for review and testing.