### PR TITLE
Fix active cleanup branch identity

### DIFF
--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -2112,14 +2112,36 @@ class Workspace {
 		$handle       = (string) ( $row['handle'] ?? '' );
 		$repo         = (string) ( $row['repo'] ?? '' );
 		$branch       = (string) ( $row['branch'] ?? '' );
+		$branch_slug  = (string) ( $row['branch_slug'] ?? '' );
 		$path         = (string) ( $row['path'] ?? '' );
 		$primary_path = '' !== $repo ? $this->get_primary_path($repo) : '';
 		$metadata     = is_array($row['metadata'] ?? null) ? $row['metadata'] : array();
+		$branch_probe = null;
+		if ( '' !== $path && is_dir($path) ) {
+			$branch_probe = $this->run_git($path, 'branch --show-current', self::CLEANUP_GIT_PROBE_TIMEOUT);
+			if ( ! is_wp_error($branch_probe) && ! $this->is_git_timeout_error($branch_probe) ) {
+				$actual_branch = trim( (string) ( $branch_probe['output'] ?? '' ) );
+				if ( '' !== $actual_branch ) {
+					$branch = $actual_branch;
+				}
+			}
+		}
+		$metadata_branch = is_string($metadata['branch'] ?? null) ? (string) $metadata['branch'] : '';
+		$branch_identity = array(
+			'actual_branch'                 => $branch,
+			'branch_slug'                   => $branch_slug,
+			'metadata_branch'               => '' !== $metadata_branch ? $metadata_branch : null,
+			'branch_slug_matches_actual'    => '' === $branch_slug || $this->slugify_branch($branch) === $branch_slug,
+			'metadata_branch_matches_actual' => '' === $metadata_branch || $metadata_branch === $branch,
+		);
+		$branch_identity['mismatch'] = ! $branch_identity['branch_slug_matches_actual'] || ! $branch_identity['metadata_branch_matches_actual'];
 
 		$out = array(
 			'handle'                  => $handle,
 			'repo'                    => $repo,
 			'branch'                  => $branch,
+			'branch_slug'             => $branch_slug,
+			'branch_identity'         => $branch_identity,
 			'path'                    => $path,
 			'created_at'              => $row['created_at'] ?? null,
 			'lifecycle_state'         => $metadata['lifecycle_state'] ?? null,
@@ -2136,6 +2158,9 @@ class Workspace {
 			'suggested_action'        => 'insufficient_signal',
 			'reason'                  => 'not enough evidence gathered',
 		);
+		if ( is_wp_error($branch_probe) ) {
+			$out['branch_probe_error'] = $branch_probe->get_error_message();
+		}
 
 		if ( '' === $repo || '' === $branch || '' === $path || ! is_dir($path) || ! is_dir($primary_path . '/.git') ) {
 			$out['suggested_action'] = 'insufficient_signal';

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -2126,12 +2126,12 @@ class Workspace {
 				}
 			}
 		}
-		$metadata_branch = is_string($metadata['branch'] ?? null) ? (string) $metadata['branch'] : '';
-		$branch_identity = array(
-			'actual_branch'                 => $branch,
-			'branch_slug'                   => $branch_slug,
-			'metadata_branch'               => '' !== $metadata_branch ? $metadata_branch : null,
-			'branch_slug_matches_actual'    => '' === $branch_slug || $this->slugify_branch($branch) === $branch_slug,
+		$metadata_branch             = is_string($metadata['branch'] ?? null) ? (string) $metadata['branch'] : '';
+		$branch_identity             = array(
+			'actual_branch'                  => $branch,
+			'branch_slug'                    => $branch_slug,
+			'metadata_branch'                => '' !== $metadata_branch ? $metadata_branch : null,
+			'branch_slug_matches_actual'     => '' === $branch_slug || $this->slugify_branch($branch) === $branch_slug,
 			'metadata_branch_matches_actual' => '' === $metadata_branch || $metadata_branch === $branch,
 		);
 		$branch_identity['mismatch'] = ! $branch_identity['branch_slug_matches_actual'] || ! $branch_identity['metadata_branch_matches_actual'];

--- a/inc/Workspace/WorkspaceHygieneReport.php
+++ b/inc/Workspace/WorkspaceHygieneReport.php
@@ -375,7 +375,7 @@ trait WorkspaceHygieneReport {
 				'owner'                 => $owner,
 				'session'               => $session_view,
 				'task'                  => $task_view,
-				'missing_metadata'      => $is_worktree && ! is_array($metadata),
+				'missing_metadata'      => $is_worktree && ( ! is_array($metadata) || array() === $metadata ),
 				'metadata'              => $metadata,
 			);
 

--- a/inc/Workspace/WorkspaceWorktreeInventoryCleanup.php
+++ b/inc/Workspace/WorkspaceWorktreeInventoryCleanup.php
@@ -53,22 +53,27 @@ trait WorkspaceWorktreeInventoryCleanup {
 				continue;
 			}
 
-			$handle     = (string) ( $wt['handle'] ?? '?' );
-			$repo       = (string) ( $wt['repo'] ?? '' );
-			$branch     = (string) ( $wt['branch_slug'] ?? '' );
+			$handle      = (string) ( $wt['handle'] ?? '?' );
+			$repo        = (string) ( $wt['repo'] ?? '' );
+			$branch_slug = (string) ( $wt['branch_slug'] ?? '' );
+			$metadata    = $wt['metadata'] ?? null;
+			$branch      = (string) ( $wt['branch'] ?? ( is_array($metadata) ? ( $metadata['branch'] ?? '' ) : '' ) );
+			if ( '' === $branch ) {
+				$branch = $branch_slug;
+			}
 			$path       = (string) ( $wt['path'] ?? '' );
-			$metadata   = $wt['metadata'] ?? null;
 			$created_at = $wt['created_at'] ?? null;
 			$base_row   = array(
-				'handle'     => $handle,
-				'repo'       => $repo,
-				'branch'     => $branch,
-				'path'       => $path,
-				'created_at' => $created_at,
-				'metadata'   => $metadata,
+				'handle'      => $handle,
+				'repo'        => $repo,
+				'branch'      => $branch,
+				'branch_slug' => $branch_slug,
+				'path'        => $path,
+				'created_at'  => $created_at,
+				'metadata'    => $metadata,
 			);
 
-			if ( ! is_array($metadata) ) {
+			if ( ! is_array($metadata) || array() === $metadata ) {
 				$skipped[] = array_merge(
 					$base_row, array(
 						'reason_code' => 'needs_metadata_reconcile',

--- a/tests/smoke-worktree-metadata-reconcile.php
+++ b/tests/smoke-worktree-metadata-reconcile.php
@@ -782,21 +782,31 @@ namespace {
     $make_branch('dirty-default-merged');
     $make_branch('unpushed-default-merged');
     $make_branch('ambiguous-default');
-    foreach (array( 'default-merged', 'dirty-default-merged', 'unpushed-default-merged' ) as $merged_branch ) {
+    $make_branch('fix/foo');
+    foreach (array( 'default-merged', 'dirty-default-merged', 'unpushed-default-merged', 'fix/foo' ) as $merged_branch ) {
         $run('git checkout main', $primary);
         $run(sprintf('git merge --no-ff %s -m %s', escapeshellarg($merged_branch), escapeshellarg('merge ' . $merged_branch)), $primary);
         $run('git push origin main', $primary);
     }
     $run('git checkout main', $primary);
-    foreach (array( 'default-merged', 'dirty-default-merged', 'unpushed-default-merged', 'ambiguous-default' ) as $branch_name ) {
-        $run(sprintf('git worktree add %s %s', escapeshellarg($tmp . '/demo@' . $branch_name), escapeshellarg($branch_name)), $primary);
+    $merged_branch_worktrees = array(
+        'demo@default-merged'          => array( 'branch' => 'default-merged', 'metadata_branch' => 'default-merged' ),
+        'demo@dirty-default-merged'    => array( 'branch' => 'dirty-default-merged', 'metadata_branch' => 'dirty-default-merged' ),
+        'demo@unpushed-default-merged' => array( 'branch' => 'unpushed-default-merged', 'metadata_branch' => 'unpushed-default-merged' ),
+        'demo@ambiguous-default'       => array( 'branch' => 'ambiguous-default', 'metadata_branch' => 'ambiguous-default' ),
+        'demo@fix-foo'                 => array( 'branch' => 'fix/foo', 'metadata_branch' => 'fix-foo' ),
+    );
+    foreach ($merged_branch_worktrees as $handle => $branch_row ) {
+        $branch_name     = $branch_row['branch'];
+        $metadata_branch = $branch_row['metadata_branch'];
+        $run(sprintf('git worktree add %s %s', escapeshellarg($tmp . '/' . $handle), escapeshellarg($branch_name)), $primary);
         \DataMachineCode\Workspace\WorktreeContextInjector::store_lifecycle_metadata(
-            'demo@' . $branch_name,
+            $handle,
             array(
-            'handle'          => 'demo@' . $branch_name,
+            'handle'          => $handle,
             'repo'            => 'demo',
-            'branch'          => $branch_name,
-            'path'            => $tmp . '/demo@' . $branch_name,
+            'branch'          => $metadata_branch,
+            'path'            => $tmp . '/' . $handle,
             'created_at'      => '2026-04-06T00:00:00+00:00',
             'observed_at'     => '2026-04-06T00:00:00+00:00',
             'lifecycle_state' => \DataMachineCode\Workspace\WorktreeContextInjector::STATE_ACTIVE,
@@ -814,6 +824,10 @@ namespace {
         $merged_rows[ $row['handle'] ?? '' ] = $row;
     }
     $assert('merged_to_default', $merged_rows['demo@default-merged']['suggested_action'] ?? '', 'clean contained branch is classified merged_to_default');
+    $assert('fix/foo', $merged_rows['demo@fix-foo']['branch'] ?? '', 'active/no-signal report uses actual checked-out branch with slashes');
+    $assert('fix-foo', $merged_rows['demo@fix-foo']['branch_slug'] ?? '', 'active/no-signal report preserves handle branch slug');
+    $assert(true, (bool) ( $merged_rows['demo@fix-foo']['branch_identity']['mismatch'] ?? false ), 'active/no-signal report surfaces metadata branch mismatch');
+    $assert('merged_to_default', $merged_rows['demo@fix-foo']['suggested_action'] ?? '', 'clean contained slash branch is classified merged_to_default');
     $assert('unsafe_dirty_or_unpushed', $merged_rows['demo@dirty-default-merged']['suggested_action'] ?? '', 'dirty contained branch remains unsafe');
     $assert('unsafe_dirty_or_unpushed', $merged_rows['demo@unpushed-default-merged']['suggested_action'] ?? '', 'unpushed contained branch remains unsafe');
     $assert('no_pr_branch_review', $merged_rows['demo@ambiguous-default']['suggested_action'] ?? '', 'ambiguous unmerged branch remains manual review');
@@ -821,17 +835,20 @@ namespace {
     $merged_dry_run = $ws->worktree_active_no_signal_merged_apply(array( 'dry_run' => true, 'limit' => 100, 'offset' => 0 ));
     $assert(true, ! is_wp_error($merged_dry_run) && ( $merged_dry_run['success'] ?? false ), 'merged-to-default active/no-signal dry-run succeeds');
     $assert(true, (bool) ( $merged_dry_run['dry_run'] ?? false ), 'merged-to-default dry-run does not write');
-    $assert(1, (int) ( $merged_dry_run['summary']['planned'] ?? 0 ), 'merged-to-default dry-run plans only safe merged rows');
+    $assert(2, (int) ( $merged_dry_run['summary']['planned'] ?? 0 ), 'merged-to-default dry-run plans only safe merged rows');
     $assert('', \DataMachineCode\Workspace\WorktreeContextInjector::get_metadata('demo@default-merged')['cleanup_eligible_at'] ?? '', 'merged-to-default dry-run leaves metadata unchanged');
 
     $merged_apply = $ws->worktree_active_no_signal_merged_apply(array( 'limit' => 100, 'offset' => 0 ));
     $assert(true, ! is_wp_error($merged_apply) && ( $merged_apply['success'] ?? false ), 'merged-to-default active/no-signal apply succeeds');
-    $assert(1, (int) ( $merged_apply['summary']['written'] ?? 0 ), 'merged-to-default apply writes only safe merged row metadata');
+    $assert(2, (int) ( $merged_apply['summary']['written'] ?? 0 ), 'merged-to-default apply writes only safe merged row metadata');
     $stored_default_merged = \DataMachineCode\Workspace\WorktreeContextInjector::get_metadata('demo@default-merged');
     $assert('cleanup_eligible', $stored_default_merged['lifecycle_state'] ?? '', 'merged-to-default apply stores cleanup_eligible state');
     $assert('merged', $stored_default_merged['finalized_state'] ?? '', 'merged-to-default apply records merged finalizer state');
     $assert('merged-to-default', $stored_default_merged['cleanup_eligibility_evidence']['signal'] ?? '', 'merged-to-default apply records merge evidence signal');
     $assert(0, (int) ( $stored_default_merged['cleanup_eligibility_evidence']['commits_outside_default'] ?? -1 ), 'merged-to-default evidence records containment count');
+    $stored_fix_foo = \DataMachineCode\Workspace\WorktreeContextInjector::get_metadata('demo@fix-foo');
+    $assert('cleanup_eligible', $stored_fix_foo['lifecycle_state'] ?? '', 'merged-to-default apply stores cleanup_eligible state for slash branch');
+    $assert('fix/foo', $stored_fix_foo['branch'] ?? '', 'merged-to-default apply stores actual slash branch');
     $assert('', \DataMachineCode\Workspace\WorktreeContextInjector::get_metadata('demo@dirty-default-merged')['cleanup_eligible_at'] ?? '', 'dirty merged-to-default row remains active');
     $assert('', \DataMachineCode\Workspace\WorktreeContextInjector::get_metadata('demo@unpushed-default-merged')['cleanup_eligible_at'] ?? '', 'unpushed merged-to-default row remains active');
     $assert('', \DataMachineCode\Workspace\WorktreeContextInjector::get_metadata('demo@ambiguous-default')['cleanup_eligible_at'] ?? '', 'ambiguous row remains active');


### PR DESCRIPTION
## Summary
- Use the checked-out worktree branch as the active/no-signal evidence source of truth before Git ref and PR lookups.
- Preserve handle branch slugs as display/fallback data and expose `branch_identity` diagnostics when metadata/slug branch identity diverges.
- Treat empty metadata arrays as missing metadata for inventory/hygiene classification and add smoke coverage for `demo@fix-foo` on actual branch `fix/foo` classifying as `merged_to_default`.

Fixes #523.

## Tests
- `php tests/smoke-worktree-metadata-reconcile.php` passed: 172/172 assertions.
- `php tests/smoke-worktree-handles.php` passed: 32/32 assertions.
- `php -l inc/Workspace/Workspace.php && php -l inc/Workspace/WorkspaceWorktreeInventoryCleanup.php && php -l inc/Workspace/WorkspaceHygieneReport.php && php -l tests/smoke-worktree-metadata-reconcile.php` passed.
- `php tests/smoke-worktree-cleanup.php` has a pre-existing baseline failure: 134/137 assertions pass, with 3 full dry-run size/artifact summary assertions failing. The same failures reproduce on `main` at `ae19bee`, so they are not introduced by this branch.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the active/no-signal branch identity fix, updated smoke coverage, and ran targeted verification. Chris remains responsible for review and merge.