### PR TITLE
Keep active cleanup apply pagination symmetric

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -2635,7 +2635,7 @@ class WorkspaceCommand extends BaseCommand {
 				if ( isset($assoc_args['offset']) ) {
 					$input['offset'] = (int) $assoc_args['offset'];
 				}
-				if ( 'active-no-signal-report' === $operation && isset($assoc_args['until-budget']) && '' !== trim( (string) $assoc_args['until-budget']) ) {
+				if ( isset($assoc_args['until-budget']) && '' !== trim( (string) $assoc_args['until-budget']) ) {
 					$input['until_budget'] = trim( (string) $assoc_args['until-budget']);
 				}
 				break;

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -1528,7 +1528,7 @@ class Workspace {
 			'written'      => $written,
 			'skipped'      => $skipped,
 			'summary'      => $summary,
-			'pagination'   => $report['pagination'] ?? array(),
+			'pagination'   => $this->retarget_active_no_signal_pagination($report['pagination'] ?? array(), 'active-no-signal-finalized-apply', $dry_run),
 			'evidence'     => array(
 				'scope'  => 'promote finalized active_no_signal PR evidence into cleanup_eligible metadata',
 				'safety' => 'Revalidates dirty, unpushed, identity, and closed+merged PR evidence before writing metadata. Does not delete worktrees.',
@@ -1621,7 +1621,7 @@ class Workspace {
 			'written'      => $written,
 			'skipped'      => $skipped,
 			'summary'      => $summary,
-			'pagination'   => $report['pagination'] ?? array(),
+			'pagination'   => $this->retarget_active_no_signal_pagination($report['pagination'] ?? array(), 'active-no-signal-equivalent-clean-apply', $dry_run),
 			'evidence'     => array(
 				'scope'  => 'promote effectively clean upstream-equivalent active_no_signal rows into cleanup_eligible metadata',
 				'safety' => 'Revalidates upstream-equivalence evidence before writing metadata. Does not delete worktrees.',
@@ -1714,12 +1714,46 @@ class Workspace {
 			'written'      => $written,
 			'skipped'      => $skipped,
 			'summary'      => $summary,
-			'pagination'   => $report['pagination'] ?? array(),
+			'pagination'   => $this->retarget_active_no_signal_pagination($report['pagination'] ?? array(), 'active-no-signal-merged-apply', $dry_run),
 			'evidence'     => array(
 				'scope'  => 'promote clean active_no_signal rows contained in remote default into cleanup_eligible metadata',
 				'safety' => 'Revalidates clean worktree, no unpushed commits, containment, primary protection, branch identity, and merged-to-default evidence before writing metadata. Does not delete worktrees.',
 			),
 		);
+	}
+
+	/**
+	 * Retarget active/no-signal report pagination to the apply command in use.
+	 *
+	 * @param  array<string,mixed> $pagination Report pagination payload.
+	 * @param  string              $operation  Active/no-signal apply operation.
+	 * @param  bool                $dry_run    Whether the current apply is a dry-run.
+	 * @return array<string,mixed>
+	 */
+	private function retarget_active_no_signal_pagination( array $pagination, string $operation, bool $dry_run ): array {
+		if ( null === ( $pagination['next_offset'] ?? null ) ) {
+			$pagination['next_command'] = null;
+			return $pagination;
+		}
+
+		$limit       = (int) ( $pagination['limit'] ?? 25 );
+		$next_offset = (int) $pagination['next_offset'];
+		$dry_run_arg = $dry_run ? ' --dry-run' : '';
+		$budget_arg  = '';
+		if ( is_string($pagination['next_command'] ?? null) && preg_match('/ --until-budget=([^ ]+)/', (string) $pagination['next_command'], $matches) ) {
+			$budget_arg = ' --until-budget=' . $matches[1];
+		}
+
+		$pagination['next_command'] = sprintf(
+			'studio wp datamachine-code workspace worktree %s%s --limit=%d --offset=%d%s --format=json',
+			$operation,
+			$dry_run_arg,
+			$limit,
+			$next_offset,
+			$budget_arg
+		);
+
+		return $pagination;
 	}
 
 	/**

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -636,7 +636,15 @@ namespace {
     'datamachine-code/workspace-worktree-cleanup-artifacts' => $artifact_ability,
     'datamachine-code/workspace-worktree-emergency-cleanup' => $emergency_ability,
     'datamachine-code/workspace-worktree-list'              => $list_ability,
+    'datamachine-code/workspace-worktree-active-no-signal-finalized-apply' =>
+        $ability,
+    'datamachine-code/workspace-worktree-active-no-signal-equivalent-clean-apply' =>
+        $ability,
+    'datamachine-code/workspace-worktree-active-no-signal-merged-apply' =>
+        $ability,
     'datamachine/get-jobs'                             => $get_jobs_ability,
+    'datamachine-code/retry-job'                       => $retry_job_ability,
+    'datamachine-code/fail-job'                        => $fail_job_ability,
     'datamachine/retry-job'                            => $retry_job_ability,
     'datamachine/fail-job'                             => $fail_job_ability,
     );
@@ -914,6 +922,18 @@ namespace {
     datamachine_code_cleanup_assert(str_contains(WP_CLI::$successes[0] ?? '', 'Apply this bounded reviewed class with: studio wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --limit=1'), 'inventory-only human output prints bounded apply command');
     $command->worktree(array( 'cleanup' ), array( 'dry-run' => true, 'inventory-only' => true, 'include-repaired-metadata' => true, 'format' => 'json' ));
     datamachine_code_cleanup_assert(true === ( $ability->last_input['include_repaired_metadata'] ?? null ), '--include-repaired-metadata forwards to cleanup ability');
+
+    echo "\n[8a] active/no-signal apply forwards bounded continuation flags\n";
+    WP_CLI::$logs      = array();
+    WP_CLI::$successes = array();
+    $command->worktree(
+        array( 'active-no-signal-finalized-apply' ),
+        array( 'dry-run' => true, 'limit' => 5, 'offset' => 10, 'until-budget' => '60s', 'format' => 'json' )
+    );
+    datamachine_code_cleanup_assert(true === ( $ability->last_input['dry_run'] ?? null ), 'active/no-signal apply forwards dry-run flag');
+    datamachine_code_cleanup_assert(5 === (int) ( $ability->last_input['limit'] ?? 0 ), 'active/no-signal apply forwards limit');
+    datamachine_code_cleanup_assert(10 === (int) ( $ability->last_input['offset'] ?? 0 ), 'active/no-signal apply forwards offset');
+    datamachine_code_cleanup_assert('60s' === ( $ability->last_input['until_budget'] ?? '' ), 'active/no-signal apply forwards until-budget continuation');
 
     echo "\n[8b] emergency-cleanup keeps apply-plan as low-level escape hatch\n";
     WP_CLI::$logs      = array();

--- a/tests/smoke-worktree-metadata-reconcile.php
+++ b/tests/smoke-worktree-metadata-reconcile.php
@@ -578,6 +578,11 @@ namespace {
     $assert(true, (bool) ( $finalized_dry_run['dry_run'] ?? false ), 'finalized active/no-signal dry-run does not write');
     $assert(1, (int) ( $finalized_dry_run['summary']['planned'] ?? 0 ), 'finalized active/no-signal dry-run plans merged PR rows only');
     $assert('', \DataMachineCode\Workspace\WorktreeContextInjector::get_metadata('demo@head-merged')['cleanup_eligible_at'] ?? '', 'finalized active/no-signal dry-run leaves metadata unchanged');
+    $run('git remote set-url origin https://github.com/acme/demo.git', $primary);
+    $finalized_page_dry_run = $ws->worktree_active_no_signal_finalized_apply(array( 'dry_run' => true, 'limit' => 1, 'offset' => 0 ));
+    $run(sprintf('git remote set-url origin %s', escapeshellarg($remote)), $primary);
+    $assert(true, str_contains($finalized_page_dry_run['pagination']['next_command'] ?? '', 'active-no-signal-finalized-apply --dry-run --limit=1 --offset=1'), 'finalized active/no-signal dry-run continuation stays on finalized apply command');
+    $assert(false, str_contains($finalized_page_dry_run['pagination']['next_command'] ?? '', 'active-no-signal-report'), 'finalized active/no-signal dry-run continuation does not fall back to report command');
 
     echo "\nDry-run reconciliation\n";
     $plan = $ws->worktree_reconcile_metadata(array( 'dry_run' => true ));
@@ -724,6 +729,8 @@ namespace {
     $assert(true, ! is_wp_error($equivalent_clean_dry_run) && ( $equivalent_clean_dry_run['success'] ?? false ), 'equivalent-clean active/no-signal dry-run succeeds');
     $assert(1, (int) ( $equivalent_clean_dry_run['summary']['planned'] ?? 0 ), 'equivalent-clean dry-run plans only equivalent clean rows');
     $assert('', \DataMachineCode\Workspace\WorktreeContextInjector::get_metadata('demo@equivalent-clean')['cleanup_eligible_at'] ?? '', 'equivalent-clean dry-run leaves metadata unchanged');
+    $equivalent_clean_page = $ws->worktree_active_no_signal_equivalent_clean_apply(array( 'dry_run' => true, 'limit' => 1, 'offset' => 0 ));
+    $assert(true, str_contains($equivalent_clean_page['pagination']['next_command'] ?? '', 'active-no-signal-equivalent-clean-apply --dry-run --limit=1 --offset=1'), 'equivalent-clean dry-run continuation stays on equivalent-clean apply command');
     $equivalent_clean_apply = $ws->worktree_active_no_signal_equivalent_clean_apply(array( 'limit' => 50, 'offset' => 0 ));
     $assert(true, ! is_wp_error($equivalent_clean_apply) && ( $equivalent_clean_apply['success'] ?? false ), 'equivalent-clean active/no-signal apply succeeds');
     $assert(1, (int) ( $equivalent_clean_apply['summary']['written'] ?? 0 ), 'equivalent-clean active/no-signal apply writes metadata');
@@ -871,6 +878,8 @@ namespace {
     $assert(true, (bool) ( $merged_dry_run['dry_run'] ?? false ), 'merged-to-default dry-run does not write');
     $assert(2, (int) ( $merged_dry_run['summary']['planned'] ?? 0 ), 'merged-to-default dry-run plans only safe merged rows');
     $assert('', \DataMachineCode\Workspace\WorktreeContextInjector::get_metadata('demo@default-merged')['cleanup_eligible_at'] ?? '', 'merged-to-default dry-run leaves metadata unchanged');
+    $merged_page_dry_run = $ws->worktree_active_no_signal_merged_apply(array( 'dry_run' => true, 'limit' => 1, 'offset' => 0 ));
+    $assert(true, str_contains($merged_page_dry_run['pagination']['next_command'] ?? '', 'active-no-signal-merged-apply --dry-run --limit=1 --offset=1'), 'merged-to-default dry-run continuation stays on merged apply command');
 
     $merged_apply = $ws->worktree_active_no_signal_merged_apply(array( 'limit' => 100, 'offset' => 0 ));
     $assert(true, ! is_wp_error($merged_apply) && ( $merged_apply['success'] ?? false ), 'merged-to-default active/no-signal apply succeeds');


### PR DESCRIPTION
## Summary
- Retarget active/no-signal apply pagination so `next_command` stays on the same apply operation instead of falling back to `active-no-signal-report`.
- Preserve `--dry-run`, limit/offset, and budget continuation flags for bounded active/no-signal apply paging.
- Refresh smoke coverage for finalized, equivalent-clean, and merged active/no-signal apply continuations.

Part of #271.

## Testing
- `php tests/smoke-worktree-metadata-reconcile.php`
- `php tests/smoke-worktree-cleanup-cli.php`
- `php -l inc/Workspace/Workspace.php`
- `php -l inc/Cli/Commands/WorkspaceCommand.php`
- `php -l tests/smoke-worktree-metadata-reconcile.php`
- `php -l tests/smoke-worktree-cleanup-cli.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Identified the narrow UX slice, implemented the pagination/CLI fix, and added smoke coverage. Chris remains responsible for review and merge.