### PR TITLE
Refuse worktrees behind the default branch

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -1194,7 +1194,7 @@ class WorkspaceAbilities {
 							),
 							'allow_stale'    => array(
 								'type'        => 'boolean',
-								'description' => 'Bypass the staleness gate. When false (default) and the new worktree would be more than `datamachine_worktree_stale_threshold` commits behind upstream, worktree creation is rolled back and a `worktree_stale` error is returned. Set true to opt in to a known-stale checkout.',
+								'description' => 'Bypass the staleness gate. When false (default), any branch/base behind the remote default branch is refused, and a new worktree more than `datamachine_worktree_stale_threshold` commits behind upstream is rolled back with a staleness error. Set true to opt in to a known-stale checkout.',
 							),
 							'rebase_base'    => array(
 								'type'        => 'boolean',
@@ -1259,6 +1259,14 @@ class WorkspaceAbilities {
 							'base_upstream'             => array(
 								'type'        => 'string',
 								'description' => 'Paired with base_stale_commits_behind: the origin ref the local base was compared against (e.g. `origin/main`).',
+							),
+							'default_branch_commits_behind' => array(
+								'type'        => 'integer',
+								'description' => 'How many commits the requested branch/base is behind the remote default branch. Any value greater than 0 is refused unless allow_stale=true.',
+							),
+							'default_branch_ref'        => array(
+								'type'        => 'string',
+								'description' => 'Remote default branch ref used for default-branch freshness checks (e.g. `refs/remotes/origin/main`).',
 							),
 							'gate_threshold'            => array(
 								'type'        => 'integer',

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -2111,11 +2111,15 @@ class WorkspaceCommand extends BaseCommand {
 	 *
 	 * [--allow-stale]
 	 * : Bypass the staleness gate (applies to `add` only). By default,
-	 *   `worktree add` refuses to return a worktree that would be more than
+	 *   `worktree add` refuses any branch/base that is behind the remote
+	 *   default branch after fetch, and refuses to return a worktree that
+	 *   would be more than
 	 *   `datamachine_worktree_stale_threshold` commits (default 50) behind
 	 *   upstream — the stale checkout is torn down and a `worktree_stale`
 	 *   error is returned with remediation options. Pass `--allow-stale` to
-	 *   opt in to a known-stale checkout. The ability-level input is
+	 *   opt in to a known-stale checkout. Default-branch freshness is
+	 *   zero-tolerance: one missing default-branch commit is stale. The
+	 *   ability-level input is
 	 *   `allow_stale=true`.
 	 *
 	 * [--rebase-base]
@@ -2365,7 +2369,7 @@ class WorkspaceCommand extends BaseCommand {
 	 *     # Create a bare worktree (skip the default bootstrap pass)
 	 *     wp datamachine-code workspace worktree add data-machine fix/foo --skip-bootstrap
 	 *
-	 *     # Proceed with a known-stale base (bypass the staleness gate)
+	 *     # Proceed with a known-stale base/branch (bypass the staleness gate)
 	 *     wp datamachine-code workspace worktree add data-machine fix/foo --allow-stale
 	 *
 	 *     # Auto-rebase onto upstream after creation

--- a/inc/Workspace/WorkspaceWorktreeLifecycle.php
+++ b/inc/Workspace/WorkspaceWorktreeLifecycle.php
@@ -210,8 +210,8 @@ trait WorkspaceWorktreeLifecycle {
 			}
 			$cmd = sprintf('worktree add %s %s', escapeshellarg($wt_path), escapeshellarg($branch));
 		} else {
-			$base           = $from && '' !== trim($from) ? trim($from) : $this->resolve_default_base($primary_path);
-			$resolved_base  = $base;
+			$base          = $from && '' !== trim($from) ? trim($from) : $this->resolve_default_base($primary_path);
+			$resolved_base = $base;
 			if ( ! $allow_stale && ! $rebase_base && ! $fetch_failed ) {
 				$default_guard = $this->assert_ref_current_with_default_branch($primary_path, $resolved_base, $repo, $branch, 'base');
 				if ( is_wp_error($default_guard) ) {

--- a/inc/Workspace/WorkspaceWorktreeLifecycle.php
+++ b/inc/Workspace/WorkspaceWorktreeLifecycle.php
@@ -41,6 +41,11 @@ trait WorkspaceWorktreeLifecycle {
 	 * Pass `$bootstrap = false` (or `--no-bootstrap` on the CLI) for a bare
 	 * checkout when you only need to read code on that branch.
 	 *
+	 * When the branch/base is behind the remote default branch, worktree
+	 * creation is refused unless `$allow_stale` is set. This check is
+	 * zero-tolerance: any default-branch commits missing from the requested
+	 * branch/base mean the worktree would start stale.
+	 *
 	 * When the materialized branch (or its local base) is more than
 	 * `datamachine_worktree_stale_threshold` commits behind upstream and
 	 * neither `$allow_stale` nor `$rebase_base` is set, the worktree is
@@ -59,7 +64,7 @@ trait WorkspaceWorktreeLifecycle {
 	 * @param  bool        $allow_stale    Bypass the staleness gate (default false).
 	 * @param  bool        $rebase_base    Rebase onto upstream after creation (default false).
 	 * @param  bool        $force          Bypass the disk-budget refusal threshold (default false).
-	 * @return array{success: bool, handle: string, path: string, branch: string, slug: string, created_branch: bool, message: string, disk_budget?: array, context_injected?: bool, context_files?: string[], context_skip_reason?: string, bootstrap?: array, fetch_failed?: bool, fetch_error?: string, stale_commits_behind?: int, upstream?: string, base_stale_commits_behind?: int, base_upstream?: string, gate_threshold?: int, rebase_attempted?: bool, rebase_succeeded?: bool, rebase_error?: string, rebase_target?: string}|\WP_Error
+	 * @return array{success: bool, handle: string, path: string, branch: string, slug: string, created_branch: bool, message: string, disk_budget?: array, context_injected?: bool, context_files?: string[], context_skip_reason?: string, bootstrap?: array, fetch_failed?: bool, fetch_error?: string, stale_commits_behind?: int, upstream?: string, base_stale_commits_behind?: int, base_upstream?: string, default_branch_commits_behind?: int, default_branch_ref?: string, gate_threshold?: int, rebase_attempted?: bool, rebase_succeeded?: bool, rebase_error?: string, rebase_target?: string}|\WP_Error
 	 */
 	public function worktree_add( string $repo, string $branch, ?string $from = null, bool $inject_context = true, bool $bootstrap = true, bool $allow_stale = false, bool $rebase_base = false, bool $force = false, array $task = array() ): array|\WP_Error {
 		$visible = $this->require_workspace_visible();
@@ -197,10 +202,22 @@ trait WorkspaceWorktreeLifecycle {
 		$resolved_base  = null;
 
 		if ( 0 === $exists_local ) {
+			if ( ! $allow_stale && ! $rebase_base && ! $fetch_failed ) {
+				$default_guard = $this->assert_ref_current_with_default_branch($primary_path, $branch, $repo, $branch, 'branch');
+				if ( is_wp_error($default_guard) ) {
+					return $default_guard;
+				}
+			}
 			$cmd = sprintf('worktree add %s %s', escapeshellarg($wt_path), escapeshellarg($branch));
 		} else {
 			$base           = $from && '' !== trim($from) ? trim($from) : $this->resolve_default_base($primary_path);
 			$resolved_base  = $base;
+			if ( ! $allow_stale && ! $rebase_base && ! $fetch_failed ) {
+				$default_guard = $this->assert_ref_current_with_default_branch($primary_path, $resolved_base, $repo, $branch, 'base');
+				if ( is_wp_error($default_guard) ) {
+					return $default_guard;
+				}
+			}
 			$cmd            = sprintf('worktree add -b %s %s %s', escapeshellarg($branch), escapeshellarg($wt_path), escapeshellarg($base));
 			$created_branch = true;
 		}
@@ -274,10 +291,26 @@ trait WorkspaceWorktreeLifecycle {
 			}
 		}
 
+		if ( ! $fetch_failed ) {
+			$this->populate_default_branch_behind_count($primary_path, $branch, $response);
+		}
+
 		// Staleness gate. Threshold filterable per-site / per-repo. Only fires
 		// when fetch succeeded (otherwise behind-counts are unreliable) and
 		// rebase didn't already zero out the staleness.
 		if ( ! $allow_stale && ! $fetch_failed ) {
+			if ( isset($response['default_branch_commits_behind']) && (int) $response['default_branch_commits_behind'] > 0 ) {
+				$this->run_git($primary_path, sprintf('worktree remove --force %s', escapeshellarg($wt_path)));
+
+				return $this->worktree_behind_default_branch_error(
+					(int) $response['default_branch_commits_behind'],
+					(string) ( $response['default_branch_ref'] ?? 'origin/HEAD' ),
+					$repo,
+					$branch,
+					'branch'
+				);
+			}
+
 			/**
 			 * Filters the staleness threshold above which `worktree_add` refuses
 			 * to return a stale worktree without explicit `--allow-stale` opt-in.
@@ -1113,6 +1146,102 @@ trait WorkspaceWorktreeLifecycle {
 			}
 		}
 		return 'HEAD';
+	}
+
+	/**
+	 * Resolve the fetched remote default branch ref, if one is configured.
+	 *
+	 * @param  string $repo_path Primary repo path.
+	 * @return string|null Fully-qualified remote default ref, or null when absent.
+	 */
+	private function resolve_remote_default_ref( string $repo_path ): ?string {
+		$result = $this->run_git($repo_path, 'symbolic-ref --quiet refs/remotes/origin/HEAD');
+		if ( is_wp_error($result) ) {
+			return null;
+		}
+
+		$ref = trim( (string) ( $result['output'] ?? '' ));
+		return '' !== $ref ? $ref : null;
+	}
+
+	/**
+	 * Refuse a branch/base that is behind the remote default branch.
+	 *
+	 * This is intentionally zero-tolerance. The older upstream staleness gate has
+	 * a threshold for large-drift cleanup, but default-branch freshness protects
+	 * the starting point for new agent work and should not silently allow lag.
+	 *
+	 * @param  string $primary_path Primary repo path.
+	 * @param  string $ref          Branch or base ref to compare.
+	 * @param  string $repo         Repository name.
+	 * @param  string $branch       Requested worktree branch.
+	 * @param  string $ref_role     Human-readable role: branch or base.
+	 * @return true|\WP_Error True when current/unknown, WP_Error when behind.
+	 */
+	private function assert_ref_current_with_default_branch( string $primary_path, string $ref, string $repo, string $branch, string $ref_role ): true|\WP_Error {
+		$default_ref = $this->resolve_remote_default_ref($primary_path);
+		if ( null === $default_ref ) {
+			return true;
+		}
+
+		$behind = WorktreeStalenessProbe::behind_count($primary_path, $ref, $default_ref);
+		if ( ! is_int($behind) || 0 === $behind ) {
+			return true;
+		}
+
+		return $this->worktree_behind_default_branch_error($behind, $default_ref, $repo, $branch, $ref_role);
+	}
+
+	/**
+	 * Add default-branch freshness fields for the materialized branch.
+	 *
+	 * @param  string $primary_path Primary repo path.
+	 * @param  string $branch       Requested worktree branch.
+	 * @param  array  $response     Worktree response payload, mutated in place.
+	 */
+	private function populate_default_branch_behind_count( string $primary_path, string $branch, array &$response ): void {
+		$default_ref = $this->resolve_remote_default_ref($primary_path);
+		if ( null === $default_ref ) {
+			return;
+		}
+
+		$behind = WorktreeStalenessProbe::behind_count($primary_path, $branch, $default_ref);
+		if ( is_int($behind) ) {
+			$response['default_branch_commits_behind'] = $behind;
+			$response['default_branch_ref']            = $default_ref;
+		}
+	}
+
+	/**
+	 * Build the default-branch staleness error used by preflight and rollback gates.
+	 *
+	 * @param  int    $behind     Commits behind the remote default branch.
+	 * @param  string $default_ref Remote default branch ref.
+	 * @param  string $repo       Repository name.
+	 * @param  string $branch     Requested worktree branch.
+	 * @param  string $ref_role   Human-readable role: branch or base.
+	 * @return \WP_Error
+	 */
+	private function worktree_behind_default_branch_error( int $behind, string $default_ref, string $repo, string $branch, string $ref_role ): \WP_Error {
+		return new \WP_Error(
+			'worktree_behind_default_branch',
+			sprintf(
+				'Worktree %s for branch "%s" is %d commits behind the remote default branch %s. Refusing to create a stale worktree. Refresh or rebase the branch first, create from the remote default ref directly, or pass --allow-stale to explicitly opt in to a known-stale checkout.',
+				$ref_role,
+				$branch,
+				$behind,
+				$default_ref
+			),
+			array(
+				'status'                        => 409,
+				'default_branch_commits_behind' => $behind,
+				'default_branch_ref'            => $default_ref,
+				'repo'                          => $repo,
+				'branch'                        => $branch,
+				'ref_role'                      => $ref_role,
+				'allow_stale'                   => false,
+			)
+		);
 	}
 
 	/**

--- a/tests/smoke-worktree-default-branch-guard.php
+++ b/tests/smoke-worktree-default-branch-guard.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * Smoke test for zero-tolerance worktree default-branch freshness guard.
+ *
+ * Run: php tests/smoke-worktree-default-branch-guard.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Core\FilesRepository {
+	if ( ! class_exists(__NAMESPACE__ . '\FilesystemHelper') ) {
+		class FilesystemHelper {
+			public static function get() {
+				return null;
+			}
+		}
+	}
+}
+
+namespace DataMachineCode\Abilities {
+	if ( ! class_exists(__NAMESPACE__ . '\GitHubAbilities') ) {
+		class GitHubAbilities {
+			public static function getPat(): string {
+				return '';
+			}
+		}
+	}
+}
+
+namespace {
+	if ( ! defined('ABSPATH') ) {
+		define('ABSPATH', __DIR__ . '/');
+	}
+
+	if ( ! defined('ARRAY_A') ) {
+		define('ARRAY_A', 'ARRAY_A');
+	}
+
+	if ( ! class_exists('WP_Error') ) {
+		class WP_Error {
+			public string $code;
+			public string $message;
+			public array $data;
+
+			public function __construct( $code = '', $message = '', $data = array() ) {
+				$this->code    = (string) $code;
+				$this->message = (string) $message;
+				$this->data    = (array) $data;
+			}
+
+			public function get_error_code(): string {
+				return $this->code;
+			}
+
+			public function get_error_message(): string {
+				return $this->message;
+			}
+
+			public function get_error_data(): array {
+				return $this->data;
+			}
+		}
+	}
+
+	if ( ! function_exists('is_wp_error') ) {
+		function is_wp_error( $thing ): bool {
+			return $thing instanceof \WP_Error;
+		}
+	}
+
+	if ( ! function_exists('wp_mkdir_p') ) {
+		function wp_mkdir_p( string $path ): bool {
+			return is_dir($path) || mkdir($path, 0755, true);
+		}
+	}
+
+	if ( ! function_exists('get_option') ) {
+		function get_option( string $_name, $default = false ) {
+			return $default;
+		}
+	}
+
+	if ( ! function_exists('update_option') ) {
+		function update_option( string $_name, $_value, $_autoload = null ): bool {
+			return true;
+		}
+	}
+
+	if ( ! function_exists('current_time') ) {
+		function current_time( string $_type, bool $_gmt = false ): string {
+			return gmdate('Y-m-d H:i:s');
+		}
+	}
+
+	if ( ! function_exists('wp_json_encode') ) {
+		function wp_json_encode( mixed $value, int $flags = 0, int $depth = 512 ): string|false {
+			return json_encode($value, $flags, $depth);
+		}
+	}
+
+	if ( ! function_exists('apply_filters') ) {
+		function apply_filters( string $_hook_name, $value, ...$_args ) {
+			return $value;
+		}
+	}
+
+	class DatamachineCodeDefaultGuardWpdb {
+		public string $prefix = 'wp_';
+		public array $rows = array();
+		public int $insert_id = 1;
+
+		public function replace( string $_table, array $data ): int {
+			$this->rows[ (string) $data['handle'] ] = $data;
+			return 1;
+		}
+
+		public function insert( string $_table, array $_data, ?array $_format = null ): int {
+			++$this->insert_id;
+			return 1;
+		}
+
+		public function update( string $_table, array $_data, array $_where ): int {
+			return 1;
+		}
+
+		public function get_var( string $sql ): ?string {
+			return str_contains($sql, 'datamachine_code_locks') ? $this->prefix . 'datamachine_code_locks' : null;
+		}
+
+		public function prepare( string $query, mixed ...$args ): string {
+			foreach ( $args as $arg ) {
+				$query = preg_replace('/%[sd]/', is_int($arg) ? (string) $arg : "'" . str_replace("'", "''", (string) $arg) . "'", $query, 1) ?? $query;
+			}
+			return $query;
+		}
+	}
+
+	include __DIR__ . '/../inc/Support/GitHubRemote.php';
+	include __DIR__ . '/../inc/Support/GitRunner.php';
+	include __DIR__ . '/../inc/Support/PathSecurity.php';
+	include __DIR__ . '/../inc/Storage/WorktreeInventoryRepository.php';
+	include __DIR__ . '/../inc/Workspace/WorkspaceMutationLock.php';
+	include __DIR__ . '/../inc/Workspace/WorktreeStalenessProbe.php';
+	include __DIR__ . '/../inc/Workspace/WorktreeDiskBudget.php';
+	include __DIR__ . '/../inc/Workspace/WorktreeContextInjector.php';
+	include __DIR__ . '/../inc/Workspace/Workspace.php';
+
+	exec('git --version 2>&1', $_git_version, $git_exit);
+	if ( 0 !== $git_exit ) {
+		echo "SKIP: git not available\n";
+		exit(0);
+	}
+
+	$failures = 0;
+	$total    = 0;
+	$assert   = function ( bool $condition, string $message ) use ( &$failures, &$total ): void {
+		++$total;
+		if ( $condition ) {
+			echo "  [PASS] {$message}\n";
+			return;
+		}
+		++$failures;
+		echo "  [FAIL] {$message}\n";
+	};
+
+	$run = function ( string $command, string $cwd ) use ( $assert ): string {
+		exec(sprintf('cd %s && %s 2>&1', escapeshellarg($cwd), $command), $output, $code);
+		$stdout = trim(implode("\n", $output));
+		$assert(0 === $code, 'command succeeds: ' . $command . ( '' !== $stdout ? "\n{$stdout}" : '' ));
+		return $stdout;
+	};
+
+	echo "=== smoke-worktree-default-branch-guard ===\n";
+
+	$tmp = sys_get_temp_dir() . '/dmc-worktree-default-guard-' . bin2hex(random_bytes(4));
+	mkdir($tmp, 0755, true);
+	$tmp = (string) realpath($tmp);
+	register_shutdown_function(
+		function () use ( $tmp ): void {
+			if ( is_dir($tmp) ) {
+				exec('rm -rf ' . escapeshellarg($tmp) . ' 2>&1');
+			}
+		}
+	);
+
+	define('DATAMACHINE_WORKSPACE_PATH', $tmp . '/workspace');
+	mkdir(DATAMACHINE_WORKSPACE_PATH, 0755, true);
+
+	$origin = $tmp . '/origin';
+	mkdir($origin, 0755, true);
+	$run('git init -q --initial-branch=main', $origin);
+	$run('git config user.email test@example.test', $origin);
+	$run('git config user.name Test', $origin);
+	file_put_contents($origin . '/README.md', "v1\n");
+	$run('git add README.md', $origin);
+	$run('git commit -q -m initial', $origin);
+
+	$primary = DATAMACHINE_WORKSPACE_PATH . '/demo';
+	exec(sprintf('git clone -q %s %s 2>&1', escapeshellarg($origin), escapeshellarg($primary)), $clone_output, $clone_code);
+	$assert(0 === $clone_code, 'primary clone succeeds');
+	$run('git config user.email test@example.test', $primary);
+	$run('git config user.name Test', $primary);
+
+	$old_sha = trim($run('git rev-parse HEAD', $primary));
+	file_put_contents($origin . '/README.md', "v2\n");
+	$run('git add README.md', $origin);
+	$run('git commit -q -m second', $origin);
+	$run('git fetch -q origin', $primary);
+	$run('git branch feature/stale ' . escapeshellarg($old_sha), $primary);
+	$run('git branch feature/rebase ' . escapeshellarg($old_sha), $primary);
+	$run('git branch --set-upstream-to origin/main feature/rebase', $primary);
+
+	$GLOBALS['wpdb'] = new DatamachineCodeDefaultGuardWpdb();
+	$workspace       = new \DataMachineCode\Workspace\Workspace();
+
+	$refused = $workspace->worktree_add('demo', 'feature/stale', null, false, false);
+	$assert(is_wp_error($refused), 'stale branch is refused');
+	$assert(is_wp_error($refused) && 'worktree_behind_default_branch' === $refused->get_error_code(), 'refusal uses default-branch error code');
+	$assert(! is_dir(DATAMACHINE_WORKSPACE_PATH . '/demo@feature-stale'), 'refused worktree directory is not created');
+
+	$rebased = $workspace->worktree_add('demo', 'feature/rebase', null, false, false, false, true);
+	$assert(! is_wp_error($rebased), '--rebase-base permits branch that can rebase onto origin/main');
+	$assert(0 === (int) ( $rebased['default_branch_commits_behind'] ?? -1 ), 'rebased result reports no default-branch lag');
+	$assert(true === ( $rebased['rebase_succeeded'] ?? false ), 'rebased result reports successful rebase');
+
+	$allowed = $workspace->worktree_add('demo', 'feature/stale', null, false, false, true);
+	$assert(! is_wp_error($allowed), '--allow-stale permits explicit stale worktree');
+	$assert(1 === (int) ( $allowed['default_branch_commits_behind'] ?? -1 ), 'allowed result reports default-branch behind count');
+
+	echo "\nResult: " . ( $total - $failures ) . "/{$total} passed\n";
+	exit($failures > 0 ? 1 : 0);
+}


### PR DESCRIPTION
## Summary
- Refuse `workspace worktree add` when the requested branch/base is behind the fetched remote default branch unless `allow_stale=true` is explicit.
- Report `default_branch_commits_behind` / `default_branch_ref` in the worktree response schema and update CLI/ability docs for the zero-tolerance default-branch guard.
- Add smoke coverage for refusal, `--allow-stale`, and `--rebase-base` behavior.

## Tests
- `php tests/smoke-worktree-default-branch-guard.php`
- `php tests/smoke-worktree-staleness.php`
- `php tests/smoke-worktree-base-branch-cli.php`
- `php -l inc/Workspace/WorkspaceWorktreeLifecycle.php`
- `php -l inc/Cli/Commands/WorkspaceCommand.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the default-branch freshness guard, smoke test, and PR description; Chris directed the behavior and remains responsible for review/testing.