### PR TITLE
Filter workspace list by checkout type

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -107,6 +107,11 @@ class WorkspaceAbilities {
 								'type'        => 'string',
 								'description' => 'Optional primary repository name to filter by. Includes the primary checkout and its worktrees.',
 							),
+							'type' => array(
+								'type'        => 'string',
+								'enum'        => array( 'primary', 'worktree' ),
+								'description' => 'Optional checkout type filter. Use "primary" for base checkouts or "worktree" for branch worktrees.',
+							),
 						),
 					),
 					'output_schema'       => array(
@@ -2306,7 +2311,8 @@ class WorkspaceAbilities {
 	public static function listRepos( array $input ): array|\WP_Error {
 		$workspace = new Workspace();
 		$repo      = isset($input['repo']) ? (string) $input['repo'] : null;
-		return $workspace->list_repos($repo);
+		$type      = isset($input['type']) ? (string) $input['type'] : null;
+		return $workspace->list_repos($repo, $type);
 	}
 
 	/**

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -96,6 +96,14 @@ class WorkspaceCommand extends BaseCommand {
 	 * [--repo=<repo>]
 	 * : Filter by primary repository name. Includes the primary checkout and its worktrees.
 	 *
+	 * [--type=<type>]
+	 * : Filter by checkout type.
+	 * ---
+	 * options:
+	 *   - primary
+	 *   - worktree
+	 * ---
+	 *
 	 * [--format=<format>]
 	 * : Output format.
 	 * ---
@@ -118,6 +126,9 @@ class WorkspaceCommand extends BaseCommand {
 	 *     # List one primary checkout and its worktrees
 	 *     wp datamachine-code workspace list --repo=my-plugin
 	 *
+	 *     # List only worktrees for one primary checkout
+	 *     wp datamachine-code workspace list --repo=my-plugin --type=worktree --format=json
+	 *
 	 * @subcommand list
 	 */
 	public function list_repos( array $args, array $assoc_args ): void {
@@ -130,6 +141,9 @@ class WorkspaceCommand extends BaseCommand {
 		$input = array();
 		if ( isset($assoc_args['repo']) ) {
 			$input['repo'] = (string) $assoc_args['repo'];
+		}
+		if ( isset($assoc_args['type']) ) {
+			$input['type'] = (string) $assoc_args['type'];
 		}
 
 		$result = $ability->execute($input);

--- a/inc/Tools/WorkspaceTools.php
+++ b/inc/Tools/WorkspaceTools.php
@@ -212,6 +212,9 @@ class WorkspaceTools extends BaseTool
         if (isset($parameters['repo']) ) {
             $input['repo'] = (string) $parameters['repo'];
         }
+        if (isset($parameters['type']) ) {
+            $input['type'] = (string) $parameters['type'];
+        }
 
         $result = $ability->execute($input);
 
@@ -1012,6 +1015,11 @@ class WorkspaceTools extends BaseTool
             'repo' => array(
             'type'        => 'string',
             'description' => 'Optional primary repository name to filter by. Includes the primary checkout and its worktrees.',
+                    ),
+                    'type' => array(
+                        'type'        => 'string',
+                        'enum'        => array( 'primary', 'worktree' ),
+                        'description' => 'Optional checkout type filter. Use "primary" for base checkouts or "worktree" for branch worktrees.',
                     ),
             ),
             'required'   => array(),

--- a/inc/Workspace/WorkspaceRepositoryLifecycle.php
+++ b/inc/Workspace/WorkspaceRepositoryLifecycle.php
@@ -19,9 +19,10 @@ trait WorkspaceRepositoryLifecycle {
 	 * List repositories in the workspace.
 	 *
 	 * @param  string|null $repo Optional primary repository name to include.
+	 * @param  string|null $type Optional checkout type filter: primary or worktree.
 	 * @return array{success: bool, repos: array, path: string}|\WP_Error
 	 */
-	public function list_repos( ?string $repo = null ): array|\WP_Error {
+	public function list_repos( ?string $repo = null, ?string $type = null ): array|\WP_Error {
 		$path    = $this->workspace_path;
 		$visible = $this->require_workspace_visible();
 		if ( null !== $visible ) {
@@ -29,6 +30,10 @@ trait WorkspaceRepositoryLifecycle {
 		}
 
 		$repo_filter = null !== $repo && '' !== trim($repo) ? $this->parse_handle($repo)['repo'] : null;
+		$type_filter = null !== $type && '' !== trim($type) ? strtolower(trim($type)) : null;
+		if ( null !== $type_filter && ! in_array($type_filter, array( 'primary', 'worktree' ), true) ) {
+			return new \WP_Error('invalid_workspace_type', 'Workspace list type must be "primary" or "worktree".', array( 'status' => 400 ));
+		}
 
 		if ( ! is_dir($path) ) {
 			return array(
@@ -60,11 +65,19 @@ trait WorkspaceRepositoryLifecycle {
 				continue;
 			}
 
+			$is_worktree = $is_wt || $parsed['is_worktree'];
+			if ( 'primary' === $type_filter && $is_worktree ) {
+				continue;
+			}
+			if ( 'worktree' === $type_filter && ! $is_worktree ) {
+				continue;
+			}
+
 			$repo_info = array(
 				'name'        => $entry,
 				'path'        => $entry_path,
 				'git'         => $is_git,
-				'is_worktree' => $is_wt || $parsed['is_worktree'],
+				'is_worktree' => $is_worktree,
 				'repo'        => $parsed['repo'],
 			);
 

--- a/tests/smoke-workspace-list-repo-filter.php
+++ b/tests/smoke-workspace-list-repo-filter.php
@@ -127,6 +127,23 @@ namespace {
     $missing = $workspace->list_repos('missing');
     $assert_same(array(), $repo_names($missing), 'missing repo filter returns no repos');
 
+    echo "\n[4] Type filter can return only primary checkouts\n";
+    $primaries = $workspace->list_repos(null, 'primary');
+	$assert_same(array( 'data-machine-code', 'my-plugin' ), $repo_names($primaries), 'primary type filter excludes worktree handles');
+
+    echo "\n[5] Type filter can return only worktrees\n";
+    $worktrees = $workspace->list_repos(null, 'worktree');
+	$assert_same(array( 'my-plugin@feature-one' ), $repo_names($worktrees), 'worktree type filter excludes primary handles');
+
+    echo "\n[6] Repo and type filters compose\n";
+	$plugin_worktrees = $workspace->list_repos('my-plugin', 'worktree');
+	$assert_same(array( 'my-plugin@feature-one' ), $repo_names($plugin_worktrees), 'repo plus worktree filter returns matching worktrees only');
+
+    echo "\n[7] Invalid type filter returns a structured error\n";
+    $invalid = $workspace->list_repos(null, 'dirty');
+    $assert_same(true, is_wp_error($invalid), 'invalid type returns WP_Error');
+    $assert_same('invalid_workspace_type', is_wp_error($invalid) ? $invalid->get_error_code() : '', 'invalid type error code is stable');
+
     echo "\nResult: " . ( $total - $failures ) . "/{$total} passed\n";
     exit($failures > 0 ? 1 : 0);
 }


### PR DESCRIPTION
## Summary
- Add a `type` filter to workspace listing so callers can request only primary checkouts or only worktrees.
- Expose the filter through the WP-CLI command, workspace ability schema, and workspace tool definition.
- Extend the workspace list smoke test for primary/worktree filtering, composed repo+type filtering, and invalid type diagnostics.

## Testing
- `php tests/smoke-workspace-list-repo-filter.php`
- `php -l inc/Workspace/WorkspaceRepositoryLifecycle.php && php -l inc/Abilities/WorkspaceAbilities.php && php -l inc/Cli/Commands/WorkspaceCommand.php && php -l inc/Tools/WorkspaceTools.php && php -l tests/smoke-workspace-list-repo-filter.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation and targeted smoke test updates; Chris requested the fix and remains responsible for review and merge.