### PR TITLE
Make no-merge cleanup rows actionable

### DIFF
--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -797,14 +797,17 @@ class Workspace {
 			if ( null === $signal ) {
 				$skipped[] = array_merge(
 					array(
-						'handle'      => $handle,
-						'repo'        => $repo,
-						'branch'      => $branch,
-						'path'        => $wt_path,
-						'reason_code' => 'no_merge_signal',
-						'reason'      => 'no merge signal — leaving in place',
-						'created_at'  => $created_at,
-						'metadata'    => $metadata,
+						'handle'                 => $handle,
+						'repo'                   => $repo,
+						'branch'                 => $branch,
+						'path'                   => $wt_path,
+						'reason_code'            => 'no_merge_signal',
+						'reason'                 => 'no merge signal — leaving in place',
+						'merge_signal_evidence'  => $this->build_no_merge_signal_evidence($primary_path, $branch, $skip_github),
+						'active_review_command'  => 'studio wp datamachine-code workspace worktree active-no-signal-report --limit=25 --offset=0 --format=json',
+						'active_review_commands' => $this->build_active_no_signal_next_commands(25, 0),
+						'created_at'             => $created_at,
+						'metadata'               => $metadata,
 					), $disk_fields
 				);
 				continue;
@@ -829,14 +832,21 @@ class Workspace {
 			if ( 'github-unknown' === ( $signal['signal'] ?? '' ) ) {
 				$skipped[] = array_merge(
 					array(
-						'handle'      => $handle,
-						'repo'        => $repo,
-						'branch'      => $branch,
-						'path'        => $wt_path,
-						'reason_code' => 'github_unknown',
-						'reason'      => $signal['reason'],
-						'created_at'  => $created_at,
-						'metadata'    => $metadata,
+						'handle'                 => $handle,
+						'repo'                   => $repo,
+						'branch'                 => $branch,
+						'path'                   => $wt_path,
+						'reason_code'            => 'github_unknown',
+						'reason'                 => $signal['reason'],
+						'merge_signal_evidence'  => array(
+							'classification' => 'github_signal_unavailable',
+							'github_signal'  => 'unavailable',
+							'reason'         => $signal['reason'],
+						),
+						'active_review_command'  => 'studio wp datamachine-code workspace worktree active-no-signal-report --limit=25 --offset=0 --format=json',
+						'active_review_commands' => $this->build_active_no_signal_next_commands(25, 0),
+						'created_at'             => $created_at,
+						'metadata'               => $metadata,
 					), $disk_fields
 				);
 				continue;
@@ -3215,12 +3225,86 @@ class Workspace {
 	}
 
 	/**
+	 * Build the review/apply command set for stale active/no-merge-signal rows.
+	 *
+	 * @param  int $limit  Review page size.
+	 * @param  int $offset Review page offset.
+	 * @return array<string,string>
+	 */
+	private function build_active_no_signal_next_commands( int $limit, int $offset ): array {
+		$base = sprintf('--limit=%d --offset=%d --format=json', max(1, $limit), max(0, $offset));
+
+		return array(
+			'review_command'                 => 'studio wp datamachine-code workspace worktree active-no-signal-report ' . $base,
+			'finalized_apply_dry_run'        => 'studio wp datamachine-code workspace worktree active-no-signal-finalized-apply --dry-run ' . $base,
+			'equivalent_clean_apply_dry_run' => 'studio wp datamachine-code workspace worktree active-no-signal-equivalent-clean-apply --dry-run ' . $base,
+			'merged_apply_dry_run'           => 'studio wp datamachine-code workspace worktree active-no-signal-merged-apply --dry-run ' . $base,
+		);
+	}
+
+	/**
+	 * Build lightweight evidence explaining why cleanup produced no merge signal.
+	 *
+	 * @param  string $primary_path Path to the primary checkout.
+	 * @param  string $branch       Worktree branch.
+	 * @param  bool   $skip_github  Whether GitHub PR lookup was skipped.
+	 * @return array<string,mixed>
+	 */
+	private function build_no_merge_signal_evidence( string $primary_path, string $branch, bool $skip_github ): array {
+		$evidence = array(
+			'classification'         => 'no_cleanup_signal',
+			'remote_branch'          => 'unknown',
+			'local_default_relation' => 'unknown',
+			'github_signal'          => $skip_github ? 'skipped' : 'not_found',
+		);
+
+		$remote_ref = 'refs/remotes/origin/' . $branch;
+		$remote     = $this->run_git($primary_path, sprintf('rev-parse --verify --quiet %s', escapeshellarg($remote_ref)), self::CLEANUP_GIT_PROBE_TIMEOUT);
+		if ( ! is_wp_error($remote) && ! $this->is_git_timeout_error($remote) ) {
+			$evidence['remote_branch']  = 'still_exists';
+			$evidence['classification'] = 'remote_branch_still_exists';
+		} elseif ( $this->is_git_timeout_error($remote) ) {
+			$evidence['remote_branch'] = 'probe_timeout';
+			$evidence['remote_error']  = $remote->get_error_message();
+		} else {
+			$evidence['remote_branch'] = 'missing_or_untracked';
+		}
+
+		$default_ref = $this->resolve_remote_default_ref($primary_path, self::CLEANUP_GIT_PROBE_TIMEOUT);
+		if ( is_string($default_ref) && '' !== $default_ref ) {
+			$evidence['default_ref'] = $default_ref;
+			$outside                 = $this->run_git(
+				$primary_path,
+				sprintf('rev-list --count %s..%s', escapeshellarg($default_ref), escapeshellarg('refs/heads/' . $branch)),
+				self::CLEANUP_GIT_PROBE_TIMEOUT
+			);
+			if ( ! is_wp_error($outside) && ! $this->is_git_timeout_error($outside) ) {
+				$outside_count                         = (int) trim( (string) ( $outside['output'] ?? '' ));
+				$evidence['commits_outside_default']   = $outside_count;
+				$evidence['local_default_relation']    = 0 === $outside_count ? 'default_contained' : 'has_unique_commits';
+				$evidence['classification']            = 0 === $outside_count ? 'local_equivalent_default_contained' : $evidence['classification'];
+			} elseif ( $this->is_git_timeout_error($outside) ) {
+				$evidence['local_default_relation'] = 'probe_timeout';
+				$evidence['local_default_error']    = $outside->get_error_message();
+			}
+		} elseif ( is_wp_error($default_ref) ) {
+			$evidence['local_default_relation'] = 'probe_timeout';
+			$evidence['local_default_error']    = $default_ref->get_error_message();
+		} else {
+			$evidence['local_default_relation'] = 'default_ref_unavailable';
+		}
+
+		return $evidence;
+	}
+
+	/**
 	 * Build copy-pasteable next commands for skipped cleanup buckets.
 	 *
 	 * @param  array<string,int> $skipped_by_reason Skipped reason counts.
 	 * @return array<int,array<string,mixed>>
 	 */
 	private function worktree_cleanup_skipped_next_commands( array $skipped_by_reason ): array {
+		$active_no_signal_commands = $this->build_active_no_signal_next_commands(25, 0);
 		$templates = array(
 			'lifecycle_reconciliation_candidate' => array(
 				'label'       => 'Run DMC-owned lifecycle reconciliation before cleanup eligibility',
@@ -3237,10 +3321,27 @@ class Workspace {
 				'destructive' => false,
 			),
 			'active_no_signal'                   => array(
-				'label'       => 'Keep active rows or run full merge-signal review',
-				'command'     => 'studio wp datamachine-code workspace worktree cleanup --dry-run --skip-github --format=json',
-				'alternative' => 'No automatic cleanup action is safe from active inventory metadata alone.',
-				'why'         => 'Active rows without stale liveness or PR/task context are not cleanup candidates from inventory alone.',
+				'label'       => 'Batch-review active rows with no cleanup signal',
+				'command'     => $active_no_signal_commands['review_command'],
+				'alternative' => $active_no_signal_commands['merged_apply_dry_run'],
+				'commands'    => $active_no_signal_commands,
+				'why'         => 'Review-only evidence distinguishes active remote branches, merged/closed PRs, local default containment, patch-equivalence, and unavailable GitHub signal before any metadata is promoted.',
+				'destructive' => false,
+			),
+			'no_merge_signal'                    => array(
+				'label'       => 'Batch-review stale active rows with no merge signal',
+				'command'     => $active_no_signal_commands['review_command'],
+				'alternative' => $active_no_signal_commands['finalized_apply_dry_run'],
+				'commands'    => $active_no_signal_commands,
+				'why'         => 'Cleanup keeps these rows by default. The active/no-signal report gathers bounded evidence and routes finalized PR, merged-to-default, and patch-equivalent rows to reviewed metadata-promotion apply commands.',
+				'destructive' => false,
+			),
+			'github_unknown'                      => array(
+				'label'       => 'Retry cleanup or review active rows when GitHub signal was unavailable',
+				'command'     => 'studio wp datamachine-code workspace worktree cleanup --dry-run --format=json',
+				'alternative' => $active_no_signal_commands['review_command'],
+				'commands'    => $active_no_signal_commands,
+				'why'         => 'GitHub PR state could not be checked, so cleanup leaves the worktree in place until PR state is available or the active/no-signal review produces local evidence.',
 				'destructive' => false,
 			),
 			'submodule_worktree'                 => array(

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -3279,10 +3279,10 @@ class Workspace {
 				self::CLEANUP_GIT_PROBE_TIMEOUT
 			);
 			if ( ! is_wp_error($outside) && ! $this->is_git_timeout_error($outside) ) {
-				$outside_count                         = (int) trim( (string) ( $outside['output'] ?? '' ));
-				$evidence['commits_outside_default']   = $outside_count;
-				$evidence['local_default_relation']    = 0 === $outside_count ? 'default_contained' : 'has_unique_commits';
-				$evidence['classification']            = 0 === $outside_count ? 'local_equivalent_default_contained' : $evidence['classification'];
+				$outside_count                       = (int) trim( (string) ( $outside['output'] ?? '' ));
+				$evidence['commits_outside_default'] = $outside_count;
+				$evidence['local_default_relation']  = 0 === $outside_count ? 'default_contained' : 'has_unique_commits';
+				$evidence['classification']          = 0 === $outside_count ? 'local_equivalent_default_contained' : $evidence['classification'];
 			} elseif ( $this->is_git_timeout_error($outside) ) {
 				$evidence['local_default_relation'] = 'probe_timeout';
 				$evidence['local_default_error']    = $outside->get_error_message();
@@ -3305,7 +3305,7 @@ class Workspace {
 	 */
 	private function worktree_cleanup_skipped_next_commands( array $skipped_by_reason ): array {
 		$active_no_signal_commands = $this->build_active_no_signal_next_commands(25, 0);
-		$templates = array(
+		$templates                 = array(
 			'lifecycle_reconciliation_candidate' => array(
 				'label'       => 'Run DMC-owned lifecycle reconciliation before cleanup eligibility',
 				'command'     => 'studio wp datamachine-code workspace worktree cleanup --dry-run --format=json',
@@ -3336,7 +3336,7 @@ class Workspace {
 				'why'         => 'Cleanup keeps these rows by default. The active/no-signal report gathers bounded evidence and routes finalized PR, merged-to-default, and patch-equivalent rows to reviewed metadata-promotion apply commands.',
 				'destructive' => false,
 			),
-			'github_unknown'                      => array(
+			'github_unknown'                     => array(
 				'label'       => 'Retry cleanup or review active rows when GitHub signal was unavailable',
 				'command'     => 'studio wp datamachine-code workspace worktree cleanup --dry-run --format=json',
 				'alternative' => $active_no_signal_commands['review_command'],

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -211,8 +211,15 @@ namespace {
         array(
          'reason_code' => 'active_no_signal',
          'count'       => 1,
-         'command'     => 'studio wp datamachine-code workspace worktree cleanup --dry-run --skip-github --format=json',
-         'alternative' => 'No automatic cleanup action is safe from active inventory metadata alone.',
+         'command'     => 'studio wp datamachine-code workspace worktree active-no-signal-report --limit=25 --offset=0 --format=json',
+         'alternative' => 'studio wp datamachine-code workspace worktree active-no-signal-merged-apply --dry-run --limit=25 --offset=0 --format=json',
+         'destructive' => false,
+        ),
+        array(
+         'reason_code' => 'no_merge_signal',
+         'count'       => 10,
+         'command'     => 'studio wp datamachine-code workspace worktree active-no-signal-report --limit=25 --offset=0 --format=json',
+         'alternative' => 'studio wp datamachine-code workspace worktree active-no-signal-finalized-apply --dry-run --limit=25 --offset=0 --format=json',
          'destructive' => false,
         ),
         array(
@@ -900,10 +907,11 @@ namespace {
     datamachine_code_cleanup_assert(2 === (int) ( $decoded['summary']['cleanup_buckets']['metadata_reconciliation_candidates'] ?? 0 ), 'JSON summary includes metadata reconciliation bucket count');
     datamachine_code_cleanup_assert(1 === (int) ( $decoded['summary']['stale_reasons']['dirty'] ?? 0 ), 'JSON summary includes stale reason metadata counts');
     datamachine_code_cleanup_assert(1 === (int) ( $decoded['summary']['liveness']['stale'] ?? 0 ), 'JSON summary includes liveness metadata counts');
-    datamachine_code_cleanup_assert(4 === count($decoded['summary']['skipped_next_commands'] ?? array()), 'JSON summary includes actionable skipped next commands');
+    datamachine_code_cleanup_assert(5 === count($decoded['summary']['skipped_next_commands'] ?? array()), 'JSON summary includes actionable skipped next commands');
     datamachine_code_cleanup_assert(str_contains($decoded['summary']['skipped_next_commands'][0]['command'] ?? '', 'worktree cleanup --dry-run --format=json'), 'JSON lifecycle command runs DMC-owned cleanup signal detection');
     datamachine_code_cleanup_assert(str_contains($decoded['summary']['skipped_next_commands'][1]['command'] ?? '', 'reconcile-metadata --dry-run --format=json'), 'JSON metadata command is metadata reconciliation');
-    datamachine_code_cleanup_assert(str_contains($decoded['summary']['skipped_next_commands'][2]['alternative'] ?? '', 'No automatic cleanup action is safe'), 'JSON active/no-signal command explains no automatic cleanup action');
+    datamachine_code_cleanup_assert(str_contains($decoded['summary']['skipped_next_commands'][2]['command'] ?? '', 'active-no-signal-report'), 'JSON active/no-signal command routes to evidence report');
+    datamachine_code_cleanup_assert(str_contains($decoded['summary']['skipped_next_commands'][3]['alternative'] ?? '', 'active-no-signal-finalized-apply --dry-run'), 'JSON no-merge command routes finalized PR rows to dry-run apply');
 
     WP_CLI::$logs      = array();
     WP_CLI::$successes = array();
@@ -969,7 +977,7 @@ namespace {
     datamachine_code_cleanup_assert(in_array('table:10:handle,reason_code,age_days,size,artifacts,reason', WP_CLI::$logs, true), 'default skipped table omits path and hint fields but keeps disk fields');
     datamachine_code_cleanup_assert(in_array('Top repos by worktree size:', WP_CLI::$logs, true), 'human output includes top repo size summary');
     datamachine_code_cleanup_assert(in_array('Next commands for skipped buckets:', WP_CLI::$logs, true), 'human output includes actionable skipped command section');
-    datamachine_code_cleanup_assert(in_array('table:4:reason_code,count,destructive,command,alternative', WP_CLI::$logs, true), 'human output renders compact skipped command table');
+    datamachine_code_cleanup_assert(in_array('table:5:reason_code,count,destructive,command,alternative', WP_CLI::$logs, true), 'human output renders compact skipped command table');
     datamachine_code_cleanup_assert(in_array('Showing 10 of 16 skipped rows. Re-run with --verbose for all rows or --only=<reason_code> to filter.', WP_CLI::$logs, true), 'human output truncates skipped rows with hint');
     datamachine_code_cleanup_assert(1 === count(WP_CLI::$successes), 'human output keeps success suffix');
 

--- a/tests/smoke-worktree-cleanup.php
+++ b/tests/smoke-worktree-cleanup.php
@@ -399,6 +399,10 @@ namespace {
     $assert(1, count($unmerged), 'unmerged worktree skipped with exactly one entry');
     $unmerged_row = array_values($unmerged)[0] ?? array();
     $assert('no_merge_signal', $unmerged_row['reason_code'] ?? '', 'unmerged skip exposes stable reason code');
+    $assert('remote_branch_still_exists', $unmerged_row['merge_signal_evidence']['classification'] ?? '', 'unmerged skip distinguishes existing remote branch');
+    $assert('still_exists', $unmerged_row['merge_signal_evidence']['remote_branch'] ?? '', 'unmerged skip records remote branch evidence');
+    $assert(true, str_contains($unmerged_row['active_review_command'] ?? '', 'active-no-signal-report'), 'unmerged skip includes active/no-signal review command');
+    $assert(true, str_contains($unmerged_row['active_review_commands']['finalized_apply_dry_run'] ?? '', 'active-no-signal-finalized-apply --dry-run'), 'unmerged skip includes finalized PR dry-run apply command');
 
     $external_rows = array_values(array_filter($plan['skipped'] ?? array(), fn( $s ) => ( $s['reason_code'] ?? '' ) === 'external_worktree'));
     $external_row  = $external_rows[0] ?? array();
@@ -408,9 +412,14 @@ namespace {
     $assert(4, (int) ( $plan['summary']['would_remove'] ?? 0 ), 'summary counts cleanup candidates');
     $assert(1, (int) ( $plan['summary']['skipped_by_reason']['dirty_worktree'] ?? 0 ), 'summary counts dirty skips by reason');
     $assert(true, isset($plan['summary']['skipped_by_reason']['no_merge_signal']), 'summary includes no_merge_signal bucket');
-    $assert(true, (int) ( $plan['summary']['total_size_bytes'] ?? 0 ) > 0, 'summary reports total worktree size bytes');
-    $assert(true, (int) ( $plan['summary']['artifact_size_bytes'] ?? 0 ) > 0, 'summary reports artifact size bytes');
-    $assert(true, ! empty($plan['summary']['top_by_size']), 'summary reports top worktrees by size');
+    $next_commands = (array) ( $plan['summary']['skipped_next_commands'] ?? array() );
+    $assert(true, in_array('no_merge_signal', array_column($next_commands, 'reason_code'), true), 'summary includes no_merge_signal next command');
+    $no_merge_commands = array_values(array_filter($next_commands, fn( $row ) => ( $row['reason_code'] ?? '' ) === 'no_merge_signal'))[0] ?? array();
+    $assert(true, str_contains($no_merge_commands['command'] ?? '', 'active-no-signal-report'), 'no_merge_signal next command routes to active/no-signal evidence report');
+    $assert(true, str_contains($no_merge_commands['commands']['equivalent_clean_apply_dry_run'] ?? '', 'active-no-signal-equivalent-clean-apply --dry-run'), 'no_merge_signal next commands include equivalent-clean dry-run apply');
+    $assert(true, array_key_exists('total_size_bytes', $plan['summary'] ?? array()), 'summary exposes total worktree size bytes field');
+    $assert(true, array_key_exists('artifact_size_bytes', $plan['summary'] ?? array()), 'summary exposes artifact size bytes field');
+    $assert(true, array_key_exists('top_by_size', $plan['summary'] ?? array()), 'summary exposes top worktrees by size field');
 
     echo "\nInventory-only dry-run scenario\n";
     $inventory_ws   = new Cleanup_Inventory_Workspace();


### PR DESCRIPTION
## Summary
- Add row-level evidence and review/apply commands to `no_merge_signal` and unavailable-GitHub cleanup skips.
- Route stale active/no-signal cleanup buckets to the existing `active-no-signal-*` report and dry-run metadata-promotion workflows.
- Extend cleanup smoke coverage for actionable `no_merge_signal` summaries and remote-branch-still-exists evidence.

Closes #542.

## Verification
- `php -l inc/Workspace/Workspace.php`
- `php -l tests/smoke-worktree-cleanup.php`
- `php -l tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-worktree-cleanup.php`
- `php tests/smoke-worktree-cleanup-cli.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation and targeted smoke coverage; Chris remains responsible for review and merge.