### PR TITLE
Adopt AGENTS.md section provenance metadata

### DIFF
--- a/inc/Runtime/AgentsMdSections.php
+++ b/inc/Runtime/AgentsMdSections.php
@@ -71,6 +71,9 @@ MD;
 			}, array(
 				'label'       => 'Auto-generated marker',
 				'description' => 'HTML-comment header signalling that AGENTS.md is composed from registered sections.',
+				'owner'       => 'data-machine-code',
+				'freshness'   => 'generated',
+				'conditions'  => 'Always registered when Data Machine Code and composable memory section registration are available.',
 			)
 		);
 	}
@@ -138,6 +141,9 @@ MD;
 			}, array(
 				'label'       => 'Data Machine',
 				'description' => 'Memory, automation, workspace, and system operations.',
+				'owner'       => 'data-machine-code',
+				'freshness'   => 'snapshot',
+				'conditions'  => 'Always registered when Data Machine Code and composable memory section registration are available.',
 			)
 		);
 	}
@@ -149,6 +155,9 @@ MD;
 			}, array(
 				'label'       => 'Workspace Inventory',
 				'description' => 'Live snapshot of cloned repos + active worktrees in the workspace.',
+				'owner'       => 'data-machine-code',
+				'freshness'   => 'snapshot',
+				'conditions'  => 'Registered when Data Machine Code is active; content is omitted when no workspace inventory is available.',
 			)
 		);
 	}
@@ -166,6 +175,9 @@ MD;
 			}, array(
 				'label'       => 'Abilities',
 				'description' => 'WordPress Abilities API discovery.',
+				'owner'       => 'data-machine-code',
+				'freshness'   => 'static',
+				'conditions'  => 'Always registered when Data Machine Code and composable memory section registration are available.',
 			)
 		);
 	}
@@ -185,6 +197,9 @@ MD;
 			}, array(
 				'label'       => 'WordPress Source',
 				'description' => 'Pointers to WordPress source directories.',
+				'owner'       => 'data-machine-code',
+				'freshness'   => 'static',
+				'conditions'  => 'Always registered when Data Machine Code and composable memory section registration are available.',
 			)
 		);
 	}
@@ -208,6 +223,9 @@ MD;
 			}, array(
 				'label'       => 'Multisite',
 				'description' => 'Multisite-specific WP-CLI guidance.',
+				'owner'       => 'data-machine-code',
+				'freshness'   => 'static',
+				'conditions'  => 'Only registered on multisite installs.',
 			)
 		);
 	}

--- a/tests/smoke-agents-md-marker.php
+++ b/tests/smoke-agents-md-marker.php
@@ -53,6 +53,11 @@ $expected_inventory_truth   = 'workspace list` is the source of truth';
 $expected_inventory_refresh = 'datamachine memory compose AGENTS.md{$agent_suffix}';
 $expected_abilities_note    = 'does not currently register a WP-CLI abilities discovery command';
 $stale_abilities_cli        = 'help abilities';
+$expected_section_owner     = "'owner'       => 'data-machine-code'";
+$expected_snapshot_fresh    = "'freshness'   => 'snapshot'";
+$expected_static_fresh      = "'freshness'   => 'static'";
+$expected_generated_fresh   = "'freshness'   => 'generated'";
+$expected_multisite_cond    = "'conditions'  => 'Only registered on multisite installs.'";
 
 $assert(
     'auto-generated marker uses memory compose command',
@@ -109,6 +114,26 @@ $assert(
 $assert(
     'GitSync guidance distinguishes compact sync family',
     str_contains($source, $expected_gitsync_cli)
+);
+$assert(
+    'AGENTS.md sections declare Data Machine Code ownership',
+    6 === substr_count($source, $expected_section_owner)
+);
+$assert(
+    'AGENTS.md sections declare generated freshness for compose marker',
+    str_contains($source, $expected_generated_fresh)
+);
+$assert(
+    'AGENTS.md sections declare snapshot freshness for dynamic workspace guidance',
+    2 === substr_count($source, $expected_snapshot_fresh)
+);
+$assert(
+    'AGENTS.md sections declare static freshness for stable guidance',
+    3 === substr_count($source, $expected_static_fresh)
+);
+$assert(
+    'multisite section documents its registration condition',
+    str_contains($source, $expected_multisite_cond)
 );
 $assert(
     'plugin entrypoint delegates AGENTS.md section registration',


### PR DESCRIPTION
## Summary
- Adds `owner`, `freshness`, and `conditions` metadata to Data Machine Code's registered `AGENTS.md` sections.
- Extends the AGENTS.md marker smoke test to guard section provenance metadata for owner/freshness/conditions.

## Verification
- `php -l inc/Runtime/AgentsMdSections.php && php -l tests/smoke-agents-md-marker.php`
- `php tests/smoke-agents-md-marker.php`
- `phpcs inc/Runtime/AgentsMdSections.php tests/smoke-agents-md-marker.php` attempted, but PHPCS is not installed in this worktree or globally (`zsh:1: command not found: phpcs`).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the provenance metadata adoption, updated the targeted smoke test, and ran local verification. Chris remains responsible for review and merge.