### PR TITLE
Fix bootstrap after late plugin activation

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -119,6 +119,9 @@ function datamachine_code_bootstrap() {
 	add_action('wp_abilities_api_categories_init', 'datamachine_code_register_ability_categories');
 }
 add_action('plugins_loaded', 'datamachine_code_bootstrap', 20);
+if ( function_exists('did_action') && did_action('plugins_loaded') ) {
+	datamachine_code_bootstrap();
+}
 
 /**
  * Register DMC-owned webhook verifier modes with Data Machine core.

--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -119,6 +119,13 @@ function datamachine_code_bootstrap() {
 	add_action('wp_abilities_api_categories_init', 'datamachine_code_register_ability_categories');
 }
 add_action('plugins_loaded', 'datamachine_code_bootstrap', 20);
+add_action(
+	'activated_plugin',
+	static function (): void {
+		datamachine_code_bootstrap();
+	},
+	20
+);
 if ( function_exists('did_action') && did_action('plugins_loaded') ) {
 	datamachine_code_bootstrap();
 }

--- a/tests/smoke-github-issue-publish-handler.php
+++ b/tests/smoke-github-issue-publish-handler.php
@@ -33,6 +33,7 @@ $assert(false !== strpos($handler, "'items'       => array( 'type' => 'string' )
 $assert(false !== strpos($handler, 'GitHubAbilities::createIssue'), 'handler delegates issue creation to GitHubAbilities');
 $assert(false !== strpos($settings, "'labels'") && false !== strpos($settings, "'assignees'"), 'settings expose labels and assignees defaults');
 $assert(false !== strpos($plugin, 'new \\DataMachineCode\\Handlers\\GitHub\\GitHubIssuePublish();'), 'plugin bootstraps GitHub issue publish handler');
+$assert(false !== strpos($plugin, "did_action('plugins_loaded')") && false !== strpos($plugin, 'datamachine_code_bootstrap();'), 'plugin bootstraps immediately when loaded after plugins_loaded');
 
 echo "\n";
 if (empty($failures) ) {

--- a/tests/smoke-github-issue-publish-handler.php
+++ b/tests/smoke-github-issue-publish-handler.php
@@ -34,6 +34,7 @@ $assert(false !== strpos($handler, 'GitHubAbilities::createIssue'), 'handler del
 $assert(false !== strpos($settings, "'labels'") && false !== strpos($settings, "'assignees'"), 'settings expose labels and assignees defaults');
 $assert(false !== strpos($plugin, 'new \\DataMachineCode\\Handlers\\GitHub\\GitHubIssuePublish();'), 'plugin bootstraps GitHub issue publish handler');
 $assert(false !== strpos($plugin, "did_action('plugins_loaded')") && false !== strpos($plugin, 'datamachine_code_bootstrap();'), 'plugin bootstraps immediately when loaded after plugins_loaded');
+$assert(false !== strpos($plugin, "'activated_plugin'") && false !== strpos($plugin, 'datamachine_code_bootstrap();'), 'plugin retries bootstrap after late activation completes');
 
 echo "\n";
 if (empty($failures) ) {


### PR DESCRIPTION
## Summary
- Bootstrap Data Machine Code immediately when the plugin file is loaded after `plugins_loaded` has already fired.
- Covers WP Codebox/Playground activation flows where the plugin constants load but `datamachine_code_bootstrap()` would otherwise never run.
- Adds smoke coverage so `github_issue_publish` handler registration remains protected for late activation contexts.

## Why
The `wp-site-generator` fanout fails in WP Codebox with `required_handler_tool_unavailable` because Data Machine Code is activated inside an already-loaded runtime. The plugin file loads, but the `plugins_loaded` callback is registered too late, so GitHub publish handlers never register on `datamachine_tools`.

## Verification
- `php tests/smoke-github-issue-publish-handler.php`
- `php -l data-machine-code.php && php -l tests/smoke-github-issue-publish-handler.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the WP Codebox late-activation failure, drafting the bootstrap fix, updating smoke coverage, and running focused verification. Chris remains responsible for review and merge.