### PR TITLE
Fix GitHub issue publish job context

### DIFF
--- a/inc/Handlers/GitHub/GitHubIssuePublish.php
+++ b/inc/Handlers/GitHub/GitHubIssuePublish.php
@@ -51,11 +51,12 @@ class GitHubIssuePublish extends PublishHandler {
 		}
 
 		$tools['github_issue_publish'] = array(
-			'class'       => self::class,
-			'method'      => 'handle_tool_call',
-			'handler'     => 'github_issue',
-			'description' => 'Create a GitHub issue as the publish step for this pipeline item. Call exactly once with the final issue title and body.',
-			'parameters'  => array(
+			'class'                   => self::class,
+			'method'                  => 'handle_tool_call',
+			'handler'                 => 'github_issue',
+			'client_context_bindings' => array( 'job_id' ),
+			'description'             => 'Create a GitHub issue as the publish step for this pipeline item. Call exactly once with the final issue title and body.',
+			'parameters'              => array(
 				'type'       => 'object',
 				'required'   => array( 'title', 'body' ),
 				'properties' => array(

--- a/tests/smoke-github-issue-publish-handler.php
+++ b/tests/smoke-github-issue-publish-handler.php
@@ -27,8 +27,9 @@ $assert = static function ( bool $condition, string $message ) use ( &$failures 
 };
 
 $assert(false !== strpos($handler, "registerHandler(\n\t\t\t'github_issue',\n\t\t\t'publish'"), 'github_issue registers as a publish handler');
-$assert(false !== strpos($handler, "'handler'     => 'github_issue'"), 'AI tool is marked as the github_issue handler tool');
+$assert(false !== strpos($handler, "'handler'                 => 'github_issue'"), 'AI tool is marked as the github_issue handler tool');
 $assert(false !== strpos($handler, "'github_issue_publish'"), 'handler exposes github_issue_publish tool');
+$assert(false !== strpos($handler, "'client_context_bindings' => array( 'job_id' )"), 'publish tool binds job_id from runtime context');
 $assert(false !== strpos($handler, "'items'       => array( 'type' => 'string' )"), 'array parameters include item schemas');
 $assert(false !== strpos($handler, 'GitHubAbilities::createIssue'), 'handler delegates issue creation to GitHubAbilities');
 $assert(false !== strpos($settings, "'labels'") && false !== strpos($settings, "'assignees'"), 'settings expose labels and assignees defaults');


### PR DESCRIPTION
## Summary
- Bind the `github_issue_publish` handler tool's `job_id` from trusted runtime context so publish handlers can resolve engine data without asking the model to provide job IDs.
- Extend the GitHub issue publish smoke test to assert the runtime-context binding contract.

## Verification
- `php -l inc/Handlers/GitHub/GitHubIssuePublish.php && php -l tests/smoke-github-issue-publish-handler.php`
- `php tests/smoke-github-issue-publish-handler.php`
- `git diff --check`

## Evidence
- Downstream wp-site-generator run `26983939207` reached `github_issue_publish` but failed repeatedly with `job_id parameter is required for publish operations` despite the runtime job snapshot containing `job_id: 1`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Traced the failed runtime-tool evidence, drafted the minimal binding fix, and ran focused validation. Chris remains responsible for review and merge.