### PR TITLE
Fix worktree base-ref alias

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -2500,8 +2500,8 @@ class WorkspaceCommand extends BaseCommand {
 					WP_CLI::error('Usage: worktree add <repo> <branch> [--from=<ref>|--base=<ref>|--base-ref=<ref>|--base-branch=<branch>] [--skip-context-injection] [--skip-bootstrap] [--allow-stale] [--rebase-base] [--force]');
 					return;
 				}
-				$input['repo']   = $args[1];
-				$input['branch'] = $args[2];
+				$input['repo']    = $args[1];
+				$input['branch']  = $args[2];
 				$exact_base       = $assoc_args['from'] ?? $assoc_args['base'] ?? $assoc_args['base-ref'] ?? '';
 				$exact_base_flags = array_filter(
 					array(

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -2098,9 +2098,13 @@ class WorkspaceCommand extends BaseCommand {
 	 * [--base=<ref>]
 	 * : Alias for `--from=<ref>`.
 	 *
+	 * [--base-ref=<ref>]
+	 * : Alias for `--from=<ref>`.
+	 *
 	 * [--base-branch=<branch>]
 	 * : Convenience alias for branch-shaped bases. `--base-branch=main`
-	 *   maps to `--from=origin/main`. Use `--from` or `--base` for exact refs.
+	 *   maps to `--from=origin/main`. Use `--from`, `--base`, or `--base-ref`
+	 *   for exact refs.
 	 *
 	 * [--skip-context-injection]
 	 * : Skip injecting the originating site's agent context into a new
@@ -2493,18 +2497,25 @@ class WorkspaceCommand extends BaseCommand {
 		switch ( $operation ) {
 			case 'add':
 				if ( empty($args[1]) || empty($args[2]) ) {
-					WP_CLI::error('Usage: worktree add <repo> <branch> [--from=<ref>|--base=<ref>|--base-branch=<branch>] [--skip-context-injection] [--skip-bootstrap] [--allow-stale] [--rebase-base] [--force]');
+					WP_CLI::error('Usage: worktree add <repo> <branch> [--from=<ref>|--base=<ref>|--base-ref=<ref>|--base-branch=<branch>] [--skip-context-injection] [--skip-bootstrap] [--allow-stale] [--rebase-base] [--force]');
 					return;
 				}
 				$input['repo']   = $args[1];
 				$input['branch'] = $args[2];
-				$exact_base      = $assoc_args['from'] ?? $assoc_args['base'] ?? '';
-				if ( ! empty($assoc_args['from']) && ! empty($assoc_args['base']) ) {
-					WP_CLI::error('Use either --from=<ref> or --base=<ref>, not both.');
+				$exact_base       = $assoc_args['from'] ?? $assoc_args['base'] ?? $assoc_args['base-ref'] ?? '';
+				$exact_base_flags = array_filter(
+					array(
+						'from'     => $assoc_args['from'] ?? '',
+						'base'     => $assoc_args['base'] ?? '',
+						'base-ref' => $assoc_args['base-ref'] ?? '',
+					)
+				);
+				if ( count($exact_base_flags) > 1 ) {
+					WP_CLI::error('Use only one of --from=<ref>, --base=<ref>, or --base-ref=<ref>.');
 					return;
 				}
 				if ( ! empty($exact_base) && ! empty($assoc_args['base-branch']) ) {
-					WP_CLI::error('Use either --from=<ref>/--base=<ref> or --base-branch=<branch>, not both.');
+					WP_CLI::error('Use either --from=<ref>/--base=<ref>/--base-ref=<ref> or --base-branch=<branch>, not both.');
 					return;
 				}
 				if ( ! empty($exact_base) ) {

--- a/tests/smoke-worktree-base-branch-cli.php
+++ b/tests/smoke-worktree-base-branch-cli.php
@@ -159,21 +159,39 @@ namespace {
         );
         datamachine_code_assert(false, 'ambiguous exact-base flags should throw');
     } catch ( RuntimeException $e ) {
-        datamachine_code_assert(str_contains($e->getMessage(), 'not both'), 'ambiguous exact-base flags fail clearly');
+        datamachine_code_assert(str_contains($e->getMessage(), 'only one'), 'ambiguous exact-base flags fail clearly');
     }
 
-    echo "\n[6] exact base flags reject ambiguous base-branch input\n";
+    echo "\n[6] --base-ref aliases exact --from refs\n";
+    $command->worktree(
+        array( 'add', 'data-machine', 'feat/test' ),
+        array( 'base-ref' => 'origin/trunk' )
+    );
+    datamachine_code_assert('origin/trunk' === $ability->last_input['from'], '--base-ref forwards exact refs as from');
+
+    echo "\n[7] --base-ref rejects other exact-base aliases\n";
     try {
         $command->worktree(
             array( 'add', 'data-machine', 'feat/test' ),
-            array( 'base' => 'origin/main', 'base-branch' => 'develop' )
+            array( 'base' => 'origin/main', 'base-ref' => 'upstream/develop' )
+        );
+        datamachine_code_assert(false, 'ambiguous base-ref flags should throw');
+    } catch ( RuntimeException $e ) {
+        datamachine_code_assert(str_contains($e->getMessage(), 'only one'), 'ambiguous base-ref flags fail clearly');
+    }
+
+    echo "\n[8] exact base flags reject ambiguous base-branch input\n";
+    try {
+        $command->worktree(
+            array( 'add', 'data-machine', 'feat/test' ),
+            array( 'base-ref' => 'origin/main', 'base-branch' => 'develop' )
         );
         datamachine_code_assert(false, 'ambiguous flags should throw');
     } catch ( RuntimeException $e ) {
         datamachine_code_assert(str_contains($e->getMessage(), 'not both'), 'ambiguous flags fail clearly');
     }
 
-    echo "\n[7] --force is forwarded for add and JSON output keeps disk budget\n";
+    echo "\n[9] --force is forwarded for add and JSON output keeps disk budget\n";
     \WP_CLI::reset_logs();
     $command->worktree(
         array( 'add', 'data-machine', 'feat/test' ),


### PR DESCRIPTION
## Summary
- Accept `--base-ref=<ref>` as an exact-ref alias for `workspace worktree add`.
- Keep `--from`, `--base`, and `--base-ref` mutually exclusive, and continue rejecting exact refs combined with `--base-branch`.
- Update the existing worktree base CLI smoke test to cover the new alias and conflict behavior.

## Verification
- `php tests/smoke-worktree-base-branch-cli.php`
- `php -l inc/Cli/Commands/WorkspaceCommand.php`
- `php -l tests/smoke-worktree-base-branch-cli.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the CLI alias, updated smoke coverage, and ran targeted verification for Chris to review.