### PR TITLE
Fail GitHub fetches on API errors

### DIFF
--- a/inc/Handlers/GitHub/GitHub.php
+++ b/inc/Handlers/GitHub/GitHub.php
@@ -60,13 +60,11 @@ class GitHub extends FetchHandler {
 		}
 
 		if ( empty($repo) ) {
-			$context->log('error', 'GitHub: No repository configured and no default repo set.');
-			return array();
+			throw new \RuntimeException('GitHub: No repository configured and no default repo set.');
 		}
 
 		if ( ! GitHubAbilities::isConfigured() ) {
-			$context->log('error', 'GitHub: Personal Access Token not configured.');
-			return array();
+			throw new \RuntimeException('GitHub: Authentication is not configured.');
 		}
 
 		$context->log(
@@ -144,8 +142,7 @@ class GitHub extends FetchHandler {
 		);
 
 		if ( is_wp_error($result) ) {
-			$context->log('error', 'GitHub: PR review context error — ' . $result->get_error_message());
-			return array();
+			throw new \RuntimeException('GitHub: PR review context error — ' . $result->get_error_message());
 		}
 
 		$packet = $result['context'] ?? array();
@@ -179,8 +176,7 @@ class GitHub extends FetchHandler {
 		);
 
 		if ( is_wp_error($result) ) {
-			$context->log('error', 'GitHub: Repo review profile error — ' . $result->get_error_message());
-			return array();
+			throw new \RuntimeException('GitHub: Repo review profile error — ' . $result->get_error_message());
 		}
 
 		$profile = $result['profile'] ?? array();
@@ -235,8 +231,7 @@ class GitHub extends FetchHandler {
 		);
 
 		if ( is_wp_error($result) ) {
-			$context->log('error', 'GitHub: PR documentation impact error — ' . $result->get_error_message());
-			return array();
+			throw new \RuntimeException('GitHub: PR documentation impact error — ' . $result->get_error_message());
 		}
 
 		$packet = $result['packet'] ?? array();
@@ -286,8 +281,7 @@ class GitHub extends FetchHandler {
 		);
 
 		if ( is_wp_error($result) ) {
-			$context->log('error', 'GitHub: Check runs error — ' . $result->get_error_message());
-			return array();
+			throw new \RuntimeException('GitHub: Check runs error — ' . $result->get_error_message());
 		}
 
 		return array( 'items' => array( $this->buildStatusPacket($repo, $sha, 'check_runs', $result) ) );
@@ -311,8 +305,7 @@ class GitHub extends FetchHandler {
 		);
 
 		if ( is_wp_error($result) ) {
-			$context->log('error', 'GitHub: Commit statuses error — ' . $result->get_error_message());
-			return array();
+			throw new \RuntimeException('GitHub: Commit statuses error — ' . $result->get_error_message());
 		}
 
 		return array( 'items' => array( $this->buildStatusPacket($repo, $sha, 'commit_statuses', $result) ) );
@@ -342,8 +335,7 @@ class GitHub extends FetchHandler {
 		);
 
 		if ( is_wp_error($result) ) {
-			$context->log('error', 'GitHub: Actions artifact error — ' . $result->get_error_message());
-			return array();
+			throw new \RuntimeException('GitHub: Actions artifact error — ' . $result->get_error_message());
 		}
 
 		$json_files = is_array($result['json_files'] ?? null) ? $result['json_files'] : array();
@@ -489,8 +481,7 @@ class GitHub extends FetchHandler {
 		);
 
 		if ( is_wp_error($result) ) {
-			$context->log('error', 'GitHub: Tree API error — ' . $result->get_error_message());
-			return array();
+			throw new \RuntimeException('GitHub: Tree API error — ' . $result->get_error_message());
 		}
 
 		$files = $result['files'] ?? array();
@@ -614,8 +605,7 @@ class GitHub extends FetchHandler {
 		}
 
 		if ( is_wp_error($result) ) {
-			$context->log('error', 'GitHub: API error — ' . $result->get_error_message());
-			return array();
+			throw new \RuntimeException('GitHub: API error — ' . $result->get_error_message());
 		}
 
 		if ( empty($items) ) {
@@ -794,8 +784,7 @@ class GitHub extends FetchHandler {
 		}
 
 		if ( is_wp_error($result) ) {
-			$context->log('error', 'GitHub: API error — ' . $result->get_error_message());
-			return array();
+			throw new \RuntimeException('GitHub: API error — ' . $result->get_error_message());
 		}
 
 		$item = 'pulls' === $data_source ? ( $result['pull'] ?? array() ) : ( $result['issue'] ?? array() );

--- a/inc/Handlers/GitHub/GitHub.php
+++ b/inc/Handlers/GitHub/GitHub.php
@@ -142,7 +142,7 @@ class GitHub extends FetchHandler {
 		);
 
 		if ( is_wp_error($result) ) {
-			throw new \RuntimeException('GitHub: PR review context error — ' . $result->get_error_message());
+			throw new \RuntimeException('GitHub: PR review context error — ' . esc_html($result->get_error_message()));
 		}
 
 		$packet = $result['context'] ?? array();
@@ -176,7 +176,7 @@ class GitHub extends FetchHandler {
 		);
 
 		if ( is_wp_error($result) ) {
-			throw new \RuntimeException('GitHub: Repo review profile error — ' . $result->get_error_message());
+			throw new \RuntimeException('GitHub: Repo review profile error — ' . esc_html($result->get_error_message()));
 		}
 
 		$profile = $result['profile'] ?? array();
@@ -231,7 +231,7 @@ class GitHub extends FetchHandler {
 		);
 
 		if ( is_wp_error($result) ) {
-			throw new \RuntimeException('GitHub: PR documentation impact error — ' . $result->get_error_message());
+			throw new \RuntimeException('GitHub: PR documentation impact error — ' . esc_html($result->get_error_message()));
 		}
 
 		$packet = $result['packet'] ?? array();
@@ -281,7 +281,7 @@ class GitHub extends FetchHandler {
 		);
 
 		if ( is_wp_error($result) ) {
-			throw new \RuntimeException('GitHub: Check runs error — ' . $result->get_error_message());
+			throw new \RuntimeException('GitHub: Check runs error — ' . esc_html($result->get_error_message()));
 		}
 
 		return array( 'items' => array( $this->buildStatusPacket($repo, $sha, 'check_runs', $result) ) );
@@ -305,7 +305,7 @@ class GitHub extends FetchHandler {
 		);
 
 		if ( is_wp_error($result) ) {
-			throw new \RuntimeException('GitHub: Commit statuses error — ' . $result->get_error_message());
+			throw new \RuntimeException('GitHub: Commit statuses error — ' . esc_html($result->get_error_message()));
 		}
 
 		return array( 'items' => array( $this->buildStatusPacket($repo, $sha, 'commit_statuses', $result) ) );
@@ -335,7 +335,7 @@ class GitHub extends FetchHandler {
 		);
 
 		if ( is_wp_error($result) ) {
-			throw new \RuntimeException('GitHub: Actions artifact error — ' . $result->get_error_message());
+			throw new \RuntimeException('GitHub: Actions artifact error — ' . esc_html($result->get_error_message()));
 		}
 
 		$json_files = is_array($result['json_files'] ?? null) ? $result['json_files'] : array();
@@ -481,7 +481,7 @@ class GitHub extends FetchHandler {
 		);
 
 		if ( is_wp_error($result) ) {
-			throw new \RuntimeException('GitHub: Tree API error — ' . $result->get_error_message());
+			throw new \RuntimeException('GitHub: Tree API error — ' . esc_html($result->get_error_message()));
 		}
 
 		$files = $result['files'] ?? array();
@@ -605,7 +605,7 @@ class GitHub extends FetchHandler {
 		}
 
 		if ( is_wp_error($result) ) {
-			throw new \RuntimeException('GitHub: API error — ' . $result->get_error_message());
+			throw new \RuntimeException('GitHub: API error — ' . esc_html($result->get_error_message()));
 		}
 
 		if ( empty($items) ) {
@@ -784,7 +784,7 @@ class GitHub extends FetchHandler {
 		}
 
 		if ( is_wp_error($result) ) {
-			throw new \RuntimeException('GitHub: API error — ' . $result->get_error_message());
+			throw new \RuntimeException('GitHub: API error — ' . esc_html($result->get_error_message()));
 		}
 
 		$item = 'pulls' === $data_source ? ( $result['pull'] ?? array() ) : ( $result['issue'] ?? array() );

--- a/tests/smoke-github-fetch-errors-fail.php
+++ b/tests/smoke-github-fetch-errors-fail.php
@@ -25,8 +25,8 @@ $assert = static function ( bool $condition, string $message ) use ( &$failures 
 };
 
 $assert(false !== strpos($handler, "throw new \\RuntimeException('GitHub: Authentication is not configured.')"), 'missing GitHub auth throws');
-$assert(false !== strpos($handler, "throw new \\RuntimeException('GitHub: API error — ' . \$result->get_error_message())"), 'issues and pulls API errors throw');
-$assert(false !== strpos($handler, "throw new \\RuntimeException('GitHub: Tree API error — ' . \$result->get_error_message())"), 'file tree API errors throw');
+$assert(false !== strpos($handler, "throw new \\RuntimeException('GitHub: API error — ' . esc_html(\$result->get_error_message()))"), 'issues and pulls API errors throw');
+$assert(false !== strpos($handler, "throw new \\RuntimeException('GitHub: Tree API error — ' . esc_html(\$result->get_error_message()))"), 'file tree API errors throw');
 $assert(false !== strpos($handler, 'GitHub: No items found.') && false !== strpos($handler, 'return array();'), 'true empty issue/pull lists remain no-item results');
 
 echo "\n";

--- a/tests/smoke-github-fetch-errors-fail.php
+++ b/tests/smoke-github-fetch-errors-fail.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Smoke tests for GitHub fetch handler API/auth error propagation.
+ *
+ * Run with: php tests/smoke-github-fetch-errors-fail.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+declare(strict_types=1);
+
+$root    = dirname(__DIR__);
+$handler = file_get_contents($root . '/inc/Handlers/GitHub/GitHub.php') ?: '';
+
+$failures = array();
+
+$assert = static function ( bool $condition, string $message ) use ( &$failures ): void {
+    if ($condition ) {
+        echo "PASS: {$message}\n";
+        return;
+    }
+
+    echo "FAIL: {$message}\n";
+    $failures[] = $message;
+};
+
+$assert(false !== strpos($handler, "throw new \\RuntimeException('GitHub: Authentication is not configured.')"), 'missing GitHub auth throws');
+$assert(false !== strpos($handler, "throw new \\RuntimeException('GitHub: API error — ' . \$result->get_error_message())"), 'issues and pulls API errors throw');
+$assert(false !== strpos($handler, "throw new \\RuntimeException('GitHub: Tree API error — ' . \$result->get_error_message())"), 'file tree API errors throw');
+$assert(false !== strpos($handler, 'GitHub: No items found.') && false !== strpos($handler, 'return array();'), 'true empty issue/pull lists remain no-item results');
+
+echo "\n";
+if (empty($failures) ) {
+    echo "OK: GitHub fetch error propagation smoke assertions passed.\n";
+    exit(0);
+}
+
+echo sprintf("FAILED: %d assertion(s) failed.\n", count($failures));
+exit(1);


### PR DESCRIPTION
## Summary
- Throw on GitHub fetch auth/API failures so Data Machine can distinguish handler failures from legitimate empty queries.
- Keep true empty GitHub list/artifact/file results as no-item fetches.
- Add smoke coverage for GitHub fetch error propagation while preserving targeted fetch coverage.

## Testing
- `php -l inc/Handlers/GitHub/GitHub.php`
- `php tests/smoke-github-fetch-errors-fail.php`
- `php tests/smoke-github-fetch-by-number.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the swallowed GitHub fetch error path, drafted the handler change, and added focused smoke coverage for Chris to review and verify.