### PR TITLE
Use repo-scoped GitHub auth for fetches

### DIFF
--- a/inc/Handlers/GitHub/GitHub.php
+++ b/inc/Handlers/GitHub/GitHub.php
@@ -63,8 +63,9 @@ class GitHub extends FetchHandler {
 			throw new \RuntimeException('GitHub: No repository configured and no default repo set.');
 		}
 
-		if ( ! GitHubAbilities::isConfigured() ) {
-			throw new \RuntimeException('GitHub: Authentication is not configured.');
+		$credential = GitHubAbilities::getCredential(array( 'repo' => $repo ));
+		if ( is_wp_error($credential) ) {
+			throw new \RuntimeException('GitHub: Authentication is not configured — ' . $credential->get_error_message());
 		}
 
 		$context->log(

--- a/inc/Handlers/GitHub/GitHub.php
+++ b/inc/Handlers/GitHub/GitHub.php
@@ -65,7 +65,7 @@ class GitHub extends FetchHandler {
 
 		$credential = GitHubAbilities::getCredential(array( 'repo' => $repo ));
 		if ( is_wp_error($credential) ) {
-			throw new \RuntimeException('GitHub: Authentication is not configured — ' . $credential->get_error_message());
+			throw new \RuntimeException('GitHub: Authentication is not configured — ' . esc_html($credential->get_error_message()));
 		}
 
 		$context->log(

--- a/tests/smoke-github-fetch-errors-fail.php
+++ b/tests/smoke-github-fetch-errors-fail.php
@@ -24,7 +24,8 @@ $assert = static function ( bool $condition, string $message ) use ( &$failures 
     $failures[] = $message;
 };
 
-$assert(false !== strpos($handler, "throw new \\RuntimeException('GitHub: Authentication is not configured.')"), 'missing GitHub auth throws');
+$assert(false !== strpos($handler, "GitHubAbilities::getCredential(array( 'repo' => \$repo ))"), 'GitHub fetch resolves credentials for the requested repo');
+$assert(false !== strpos($handler, "throw new \\RuntimeException('GitHub: Authentication is not configured — ' . \$credential->get_error_message())"), 'missing GitHub auth throws with resolver error');
 $assert(false !== strpos($handler, "throw new \\RuntimeException('GitHub: API error — ' . esc_html(\$result->get_error_message()))"), 'issues and pulls API errors throw');
 $assert(false !== strpos($handler, "throw new \\RuntimeException('GitHub: Tree API error — ' . esc_html(\$result->get_error_message()))"), 'file tree API errors throw');
 $assert(false !== strpos($handler, 'GitHub: No items found.') && false !== strpos($handler, 'return array();'), 'true empty issue/pull lists remain no-item results');

--- a/tests/smoke-github-fetch-errors-fail.php
+++ b/tests/smoke-github-fetch-errors-fail.php
@@ -25,7 +25,7 @@ $assert = static function ( bool $condition, string $message ) use ( &$failures 
 };
 
 $assert(false !== strpos($handler, "GitHubAbilities::getCredential(array( 'repo' => \$repo ))"), 'GitHub fetch resolves credentials for the requested repo');
-$assert(false !== strpos($handler, "throw new \\RuntimeException('GitHub: Authentication is not configured — ' . \$credential->get_error_message())"), 'missing GitHub auth throws with resolver error');
+$assert(false !== strpos($handler, "throw new \\RuntimeException('GitHub: Authentication is not configured — ' . esc_html(\$credential->get_error_message()))"), 'missing GitHub auth throws with resolver error');
 $assert(false !== strpos($handler, "throw new \\RuntimeException('GitHub: API error — ' . esc_html(\$result->get_error_message()))"), 'issues and pulls API errors throw');
 $assert(false !== strpos($handler, "throw new \\RuntimeException('GitHub: Tree API error — ' . esc_html(\$result->get_error_message()))"), 'file tree API errors throw');
 $assert(false !== strpos($handler, 'GitHub: No items found.') && false !== strpos($handler, 'return array();'), 'true empty issue/pull lists remain no-item results');


### PR DESCRIPTION
## Summary
- Resolve GitHub fetch credentials with the requested repo before fetching.
- Avoid rejecting repo-scoped credential profiles because the default profile is not configured.
- Keep auth failures explicit by including the resolver error in the thrown fetch failure.

## Verification
- `php tests/smoke-github-fetch-errors-fail.php`
- `php tests/smoke-github-fetch-by-number.php`
- `php -l inc/Handlers/GitHub/GitHub.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the repo-scoped GitHub fetch auth failure, drafting the minimal handler change and smoke update, and running focused verification. Chris remains responsible for review and testing.