### PR TITLE
fix: bind GitHub publish job context

### DIFF
--- a/inc/Handlers/GitHub/GitHubPullRequestPublish.php
+++ b/inc/Handlers/GitHub/GitHubPullRequestPublish.php
@@ -53,11 +53,12 @@ class GitHubPullRequestPublish extends PublishHandler {
 		}
 
 		$tools['github_pull_request_publish'] = array(
-			'class'       => self::class,
-			'method'      => 'handle_tool_call',
-			'handler'     => 'github_pull_request',
-			'description' => 'Publish generated files to a GitHub branch and open a pull request as the publish step for this pipeline item. Call exactly once when the item is ready to publish.',
-			'parameters'  => array(
+			'class'                   => self::class,
+			'client_context_bindings' => array( 'job_id' ),
+			'method'                  => 'handle_tool_call',
+			'handler'                 => 'github_pull_request',
+			'description'             => 'Publish generated files to a GitHub branch and open a pull request as the publish step for this pipeline item. Call exactly once when the item is ready to publish.',
+			'parameters'              => array(
 				'type'       => 'object',
 				'required'   => array( 'title', 'head' ),
 				'properties' => array(

--- a/tests/smoke-github-pr-publish-handler.php
+++ b/tests/smoke-github-pr-publish-handler.php
@@ -27,8 +27,9 @@ $assert = static function ( bool $condition, string $message ) use ( &$failures 
 };
 
 $assert(false !== strpos($handler, "registerHandler(\n\t\t\t'github_pull_request',\n\t\t\t'publish'"), 'github_pull_request registers as a publish handler');
-$assert(false !== strpos($handler, "'handler'     => 'github_pull_request'"), 'AI tool is marked as the github_pull_request handler tool');
+$assert(false !== strpos($handler, "'handler'                 => 'github_pull_request'"), 'AI tool is marked as the github_pull_request handler tool');
 $assert(false !== strpos($handler, "'github_pull_request_publish'"), 'handler exposes github_pull_request_publish tool');
+$assert(false !== strpos($handler, "'client_context_bindings' => array( 'job_id' )"), 'PR publish tool binds job_id from runtime context');
 $assert(false !== strpos($handler, "'required'   => array( 'title', 'head' )"), 'PR publish requires title and head');
 $assert(false !== strpos($handler, 'GitHubAbilities::createPullRequest'), 'handler delegates PR creation to GitHubAbilities');
 $assert(false !== strpos($handler, "'files'") && false !== strpos($handler, "'items'"), 'PR publish accepts a files array');


### PR DESCRIPTION
## Summary
- Bind `job_id` into the `github_pull_request_publish` handler tool from runtime context instead of relying on the model to provide it.
- Keep GitHub PR publishing aligned with Data Machine's WordPress and email publish handlers.
- Add smoke coverage so the PR publish tool keeps the runtime `job_id` binding.

## Verification
- `php tests/smoke-github-pr-publish-handler.php`
- `php tests/smoke-github-create-tools.php`
- `php -l inc/Handlers/GitHub/GitHubPullRequestPublish.php`

## Evidence
- Site Generation Loop run `27035430789` showed the static agent first called `github_pull_request_publish`, but it failed with `job_id parameter is required for publish operations`; the agent then fell back to lower-level GitHub tools, bypassing the semantic output recorder.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Diagnosed the Site Generation Loop artifact failure, drafted the binding fix, and added smoke coverage for Chris to review/test.