### PR TITLE
Use wrapper for GitHub add-label tool

### DIFF
--- a/inc/Tools/GitHubTools.php
+++ b/inc/Tools/GitHubTools.php
@@ -29,7 +29,7 @@ class GitHubTools extends BaseTool
         $this->registerProjectedToolFallback('list_github_issues', array( $this, 'getListIssuesDefinition' ), $contexts, array( 'access_level' => 'editor', 'ability' => 'datamachine-code/list-github-issues' ));
         $this->registerProjectedToolFallback('get_github_issue', array( $this, 'getGetIssueDefinition' ), $contexts, array( 'access_level' => 'editor', 'ability' => 'datamachine-code/get-github-issue' ));
         $this->registerTool('manage_github_issue', array( $this, 'getManageIssueDefinition' ), $contexts, array( 'access_level' => 'editor', 'ability' => 'datamachine-code/update-github-issue' ));
-        $this->registerTool('add_label_to_issue', array( $this, 'getAddLabelToIssueDefinition' ), $contexts, array( 'access_level' => 'editor', 'ability' => 'datamachine-code/add-github-labels' ));
+        $this->registerTool('add_label_to_issue', array( $this, 'getAddLabelToIssueDefinition' ), $contexts, array( 'access_level' => 'editor' ));
         $this->registerTool('remove_label_from_issue', array( $this, 'getRemoveLabelFromIssueDefinition' ), $contexts, array( 'access_level' => 'editor', 'ability' => 'datamachine-code/remove-github-label' ));
         $this->registerTool('comment_github_pull_request', array( $this, 'getCommentPullRequestDefinition' ), $contexts, array( 'access_level' => 'editor', 'ability' => 'datamachine-code/comment-github-pull-request' ));
         $this->registerTool(

--- a/tests/smoke-github-create-tools.php
+++ b/tests/smoke-github-create-tools.php
@@ -222,6 +222,7 @@ namespace {
     $assert('add_label_to_issue tool is registered', isset($github_tools->registered['add_label_to_issue']));
     $assert('add_label_to_issue is available in chat', in_array('chat', $github_tools->registered['add_label_to_issue']['contexts'] ?? array(), true));
     $assert('add_label_to_issue is available in pipeline', in_array('pipeline', $github_tools->registered['add_label_to_issue']['contexts'] ?? array(), true));
+    $assert('add_label_to_issue uses wrapper input normalization instead of direct ability projection', ! isset($github_tools->registered['add_label_to_issue']['options']['ability']));
     $assert('remove_label_from_issue tool is registered', isset($github_tools->registered['remove_label_from_issue']));
     $assert('remove_label_from_issue is available in chat', in_array('chat', $github_tools->registered['remove_label_from_issue']['contexts'] ?? array(), true));
     $assert('remove_label_from_issue is available in pipeline', in_array('pipeline', $github_tools->registered['remove_label_from_issue']['contexts'] ?? array(), true));


### PR DESCRIPTION
## Summary
- Stop direct-projecting `add_label_to_issue` to the lower-level `datamachine-code/add-github-labels` ability.
- Keep the existing wrapper path so the AI-facing singular `label` argument is normalized to the ability's required `labels` array.
- Add smoke coverage proving `add_label_to_issue` uses wrapper normalization instead of direct ability projection.

## Context
The `wp-site-generator` Site Generation Loop proof run failed in design-agent label promotion: `add_label_to_issue` sent `{ label: "status:design-ready" }` directly to `datamachine-code/add-github-labels`, which requires `labels`.

## Verification
- `php -l inc/Tools/GitHubTools.php`
- `php tests/smoke-github-create-tools.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing proof-run artifacts, identifying the DMC tool registration boundary, and drafting the focused fix and smoke assertion.