### PR TITLE
Fix manage_github_issue comment routing

### DIFF
--- a/inc/Tools/GitHubTools.php
+++ b/inc/Tools/GitHubTools.php
@@ -28,7 +28,7 @@ class GitHubTools extends BaseTool
         $contexts = array( 'chat', 'pipeline' );
         $this->registerProjectedToolFallback('list_github_issues', array( $this, 'getListIssuesDefinition' ), $contexts, array( 'access_level' => 'editor', 'ability' => 'datamachine-code/list-github-issues' ));
         $this->registerProjectedToolFallback('get_github_issue', array( $this, 'getGetIssueDefinition' ), $contexts, array( 'access_level' => 'editor', 'ability' => 'datamachine-code/get-github-issue' ));
-        $this->registerTool('manage_github_issue', array( $this, 'getManageIssueDefinition' ), $contexts, array( 'access_level' => 'editor', 'ability' => 'datamachine-code/update-github-issue' ));
+        $this->registerTool('manage_github_issue', array( $this, 'getManageIssueDefinition' ), $contexts, array( 'access_level' => 'editor' ));
         $this->registerTool('add_label_to_issue', array( $this, 'getAddLabelToIssueDefinition' ), $contexts, array( 'access_level' => 'editor' ));
         $this->registerTool('remove_label_from_issue', array( $this, 'getRemoveLabelFromIssueDefinition' ), $contexts, array( 'access_level' => 'editor', 'ability' => 'datamachine-code/remove-github-label' ));
         $this->registerTool('comment_github_pull_request', array( $this, 'getCommentPullRequestDefinition' ), $contexts, array( 'access_level' => 'editor', 'ability' => 'datamachine-code/comment-github-pull-request' ));
@@ -346,7 +346,17 @@ class GitHubTools extends BaseTool
 		$action = $parameters['action'] ?? '';
 
 		if ('comment' === $action ) {
-			return $this->executeGitHubAbility('datamachine-code/comment-github-issue', 'manage_github_issue', $parameters);
+			$comment_parameters = array(
+				'repo'         => $parameters['repo'] ?? '',
+				'issue_number' => $parameters['issue_number'] ?? 0,
+				'body'         => $parameters['body'] ?? '',
+			);
+
+			if (array_key_exists('allow_repeat_automation_comment', $parameters) ) {
+				$comment_parameters['allow_repeat_automation_comment'] = $parameters['allow_repeat_automation_comment'];
+			}
+
+			return $this->executeGitHubAbility('datamachine-code/comment-github-issue', 'manage_github_issue', $comment_parameters);
 		} elseif ('close' === $action ) {
 			$parameters['state'] = 'closed';
 		}

--- a/tests/smoke-github-create-tools.php
+++ b/tests/smoke-github-create-tools.php
@@ -101,6 +101,16 @@ namespace {
 			'input' => $input,
 			);
 
+			if ('datamachine-code/comment-github-issue' === $this->name ) {
+				return array(
+				'success' => true,
+				'comment' => array(
+				'id'   => 562,
+				'body' => $input['body'] ?? '',
+				),
+				);
+			}
+
 			if ('datamachine-code/add-github-labels' === $this->name ) {
 				return \DataMachineCode\Abilities\GitHubAbilities::addLabels($input);
 			}
@@ -136,7 +146,7 @@ namespace {
 
     function wp_get_ability( string $name ): ?DMC_Test_Ability
     {
-		if (in_array($name, array( 'datamachine-code/create-github-issue', 'datamachine-code/create-github-pull-request', 'datamachine-code/add-github-labels', 'datamachine-code/remove-github-label' ), true) ) {
+		if (in_array($name, array( 'datamachine-code/create-github-issue', 'datamachine-code/create-github-pull-request', 'datamachine-code/comment-github-issue', 'datamachine-code/update-github-issue', 'datamachine-code/add-github-labels', 'datamachine-code/remove-github-label' ), true) ) {
             return new DMC_Test_Ability($name);
         }
 
@@ -223,6 +233,7 @@ namespace {
     $assert('add_label_to_issue is available in chat', in_array('chat', $github_tools->registered['add_label_to_issue']['contexts'] ?? array(), true));
     $assert('add_label_to_issue is available in pipeline', in_array('pipeline', $github_tools->registered['add_label_to_issue']['contexts'] ?? array(), true));
     $assert('add_label_to_issue uses wrapper input normalization instead of direct ability projection', ! isset($github_tools->registered['add_label_to_issue']['options']['ability']));
+    $assert('manage_github_issue uses wrapper routing instead of direct ability projection', ! isset($github_tools->registered['manage_github_issue']['options']['ability']));
     $assert('remove_label_from_issue tool is registered', isset($github_tools->registered['remove_label_from_issue']));
     $assert('remove_label_from_issue is available in chat', in_array('chat', $github_tools->registered['remove_label_from_issue']['contexts'] ?? array(), true));
     $assert('remove_label_from_issue is available in pipeline', in_array('pipeline', $github_tools->registered['remove_label_from_issue']['contexts'] ?? array(), true));
@@ -303,6 +314,27 @@ namespace {
     $assert('remove_label_from_issue requires repo issue_number label', array( 'repo', 'issue_number', 'label' ) === ( $remove_label_definition['parameters']['required'] ?? array() ));
     $assert('manage_github_issue warns update labels replace full set', str_contains($manage_issue_definition['parameters']['properties']['labels']['description'] ?? '', 'REPLACES the entire existing label set'));
     $assert('manage_github_issue points to surgical label tools', str_contains($manage_issue_definition['description'] ?? '', 'add_label_to_issue') && str_contains($manage_issue_definition['description'] ?? '', 'remove_label_from_issue'));
+
+    $manage_comment_result = $github_tools->handleManageIssue(
+        array(
+        'repo'                            => 'Extra-Chill/data-machine-code',
+        'issue_number'                    => 562,
+        'action'                          => 'comment',
+        'title'                           => 'Must not update title',
+        'body'                            => 'Comment body',
+        'labels'                          => array( 'must-not-replace-labels' ),
+        'allow_repeat_automation_comment' => true,
+        )
+    );
+    $manage_comment_call = $GLOBALS['dmc_tool_ability_calls'][2] ?? array();
+    $assert('manage_github_issue comment returns standard success envelope', true === ( $manage_comment_result['success'] ?? false ) && 'manage_github_issue' === ( $manage_comment_result['tool_name'] ?? '' ));
+    $assert('manage_github_issue comment dispatches to comment ability', 'datamachine-code/comment-github-issue' === ( $manage_comment_call['name'] ?? '' ));
+    $assert('manage_github_issue comment does not dispatch to update ability', 'datamachine-code/update-github-issue' !== ( $manage_comment_call['name'] ?? '' ));
+    $assert('manage_github_issue comment forwards comment body', 'Comment body' === ( $manage_comment_call['input']['body'] ?? '' ));
+    $assert('manage_github_issue comment forwards repeat guard opt-in', true === ( $manage_comment_call['input']['allow_repeat_automation_comment'] ?? null ));
+    $assert('manage_github_issue comment strips update title', ! array_key_exists('title', $manage_comment_call['input'] ?? array() ));
+    $assert('manage_github_issue comment strips update labels', ! array_key_exists('labels', $manage_comment_call['input'] ?? array() ));
+    $assert('manage_github_issue comment strips action before ability execution', ! array_key_exists('action', $manage_comment_call['input'] ?? array() ));
 
     $add_label_result = $github_tools->handleAddLabelToIssue(
         array(


### PR DESCRIPTION
## Summary
- Removes the direct `update-github-issue` ability projection from `manage_github_issue` so composite wrapper routing cannot be bypassed.
- Routes `action=comment` through `comment-github-issue` with comment-only inputs, ignoring update-only fields such as `title` and `labels`.
- Adds smoke coverage proving comment calls create issue comments instead of mutating issue metadata even when update fields are present.

Closes #562.

## Tests
- `php tests/smoke-github-create-tools.php`
- `php -l inc/Tools/GitHubTools.php && php -l tests/smoke-github-create-tools.php`
- `php tests/smoke-ability-tool-projections.php`
- `php tests/smoke-tool-schemas.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigating the issue, drafting the minimal code change and smoke coverage, and running targeted verification. Chris remains responsible for review and merge.