### PR TITLE
fix: opt workspace-maintenance tasks out of the agent-context gate

### DIFF
--- a/inc/Tasks/WorkspaceDiskEmergencyCleanupTask.php
+++ b/inc/Tasks/WorkspaceDiskEmergencyCleanupTask.php
@@ -33,6 +33,23 @@ class WorkspaceDiskEmergencyCleanupTask extends SystemTask {
 	}
 
 	/**
+	 * Pure workspace/disk maintenance — runs without agent ownership context.
+	 *
+	 * This task cleans disk under pressure via the Workspace service (disk/file/
+	 * git ops gated by PluginSettings). It never acts as an agent or invokes an
+	 * agent-scoped ability; the only agent_id it touches is read from task params
+	 * (defaulting to 0) to forward into child cleanup chunk jobs. It is registered
+	 * as an agent-less hourly recurring schedule, so it must opt out of the
+	 * SystemTask agent-context gate or TaskScheduler::schedule() rejects it before
+	 * it runs.
+	 *
+	 * @return bool
+	 */
+	public function requiresAgentContext(): bool {
+		return false;
+	}
+
+	/**
 	 * Task metadata for Data Machine system-task surfaces.
 	 *
 	 * @return array<string,mixed>

--- a/inc/Tasks/WorkspaceHygieneReportTask.php
+++ b/inc/Tasks/WorkspaceHygieneReportTask.php
@@ -36,6 +36,21 @@ class WorkspaceHygieneReportTask extends SystemTask {
 	}
 
 	/**
+	 * Pure workspace/disk maintenance — runs without agent ownership context.
+	 *
+	 * This task produces a non-destructive disk/worktree hygiene report via the
+	 * Workspace service. It never acts as an agent or invokes an agent-scoped
+	 * ability. It is registered as an agent-less weekly recurring schedule, so it
+	 * must opt out of the SystemTask agent-context gate or
+	 * TaskScheduler::schedule() rejects it before it runs.
+	 *
+	 * @return bool
+	 */
+	public function requiresAgentContext(): bool {
+		return false;
+	}
+
+	/**
 	 * Task metadata for Data Machine system-task surfaces.
 	 *
 	 * @return array<string,mixed>

--- a/inc/Tasks/WorkspaceRetentionCleanupTask.php
+++ b/inc/Tasks/WorkspaceRetentionCleanupTask.php
@@ -33,6 +33,23 @@ class WorkspaceRetentionCleanupTask extends SystemTask {
 	}
 
 	/**
+	 * Pure workspace/disk maintenance — runs without agent ownership context.
+	 *
+	 * This task applies age-gated worktree and reconstructable-artifact cleanup
+	 * via the Workspace service (disk/file/git ops gated by PluginSettings). It
+	 * never acts as an agent or invokes an agent-scoped ability; the only agent_id
+	 * it touches is read from task params (defaulting to 0) to forward into child
+	 * cleanup chunk jobs. It is registered as an agent-less daily recurring
+	 * schedule, so it must opt out of the SystemTask agent-context gate or
+	 * TaskScheduler::schedule() rejects it before it runs.
+	 *
+	 * @return bool
+	 */
+	public function requiresAgentContext(): bool {
+		return false;
+	}
+
+	/**
 	 * Task metadata for Data Machine system-task surfaces.
 	 *
 	 * @return array<string,mixed>

--- a/inc/Tasks/WorktreeCleanupChunkTask.php
+++ b/inc/Tasks/WorktreeCleanupChunkTask.php
@@ -26,6 +26,23 @@ class WorktreeCleanupChunkTask extends SystemTask {
 	}
 
 	/**
+	 * Pure workspace/disk maintenance — runs without agent ownership context.
+	 *
+	 * This task applies one reviewed cleanup chunk (artifact deletion or worktree
+	 * removal) via the Workspace service. It is fanned out by the recurring
+	 * workspace-maintenance parent tasks, which forward agent_id from their own
+	 * params (0 under an agent-less recurring schedule). Without opting out, every
+	 * child chunk scheduled by an agent-less parent would be rejected by the
+	 * SystemTask agent-context gate in TaskScheduler::schedule(), so the actual
+	 * destructive cleanup would never run even after the parents are fixed.
+	 *
+	 * @return bool
+	 */
+	public function requiresAgentContext(): bool {
+		return false;
+	}
+
+	/**
 	 * Task metadata for Data Machine job surfaces.
 	 *
 	 * @return array<string,mixed>

--- a/inc/Tasks/WorktreeCleanupTask.php
+++ b/inc/Tasks/WorktreeCleanupTask.php
@@ -73,6 +73,21 @@ class WorktreeCleanupTask extends SystemTask {
 	}
 
 	/**
+	 * Pure workspace/git maintenance — runs without agent ownership context.
+	 *
+	 * This task removes merged worktrees via the Workspace service (git/disk ops
+	 * gated by PluginSettings). It never acts as an agent or invokes an
+	 * agent-scoped ability. It is registered as an agent-less recurring schedule,
+	 * so it must opt out of the SystemTask agent-context gate or
+	 * TaskScheduler::schedule() rejects it before it runs.
+	 *
+	 * @return bool
+	 */
+	public function requiresAgentContext(): bool {
+		return false;
+	}
+
+	/**
 	 * Task metadata for the Data Machine system surface.
 	 *
 	 * `setting_key` wires this task into the standard DM settings plumbing:


### PR DESCRIPTION
Fixes #564

## Root cause

The recurring workspace-maintenance system tasks are registered in `data-machine-code.php` (`datamachine_recurring_schedules` filter, ~lines 339–383) as **agent-less** schedules — no `agent_id`/`agent_slug`, not `per_agent`. But every one of them `extends SystemTask` **without overriding `requiresAgentContext()`**, so they inherited the base-class default of `true`.

In `data-machine` core `TaskScheduler::schedule()` (inc/Engine/Tasks/TaskScheduler.php ~161), when there is no agent context (`empty($context['agent_slug']) && empty($context['agent_id'])`) **and** `requiresAgentContext() === true`, it logs `TaskScheduler: queued task requires agent context` (`error_code: task_scheduler_agent_context_required`) and `return false` — the task is rejected before it runs.

On the live extrachill.com install, `workspace_disk_emergency_cleanup` fired hourly and logged **213 identical errors** (2026-05-30 → 2026-06-06, 100% of the DM error log); the emergency disk cleanup **never executed**.

## Tasks changed and why

All fixed by overriding `public function requiresAgentContext(): bool { return false; }` — the opt-out the `SystemTask` docblock explicitly documents for *"pure internal maintenance tasks."* **Not** `per_agent` — disk cleanup is site-scoped; you do not want N cleanups fanned out per agent. No agent identity is fabricated.

| Task | Schedule | Default | Status before fix |
|------|----------|---------|-------------------|
| `workspace_disk_emergency_cleanup` | hourly | enabled | **actively failing hourly** (the 213 logged errors) |
| `workspace_retention_cleanup` | daily | enabled | **actively failing daily** (same gate, less log volume) |
| `worktree_cleanup` | daily | disabled | would fail the moment an operator enables it |
| `workspace_hygiene_report` | weekly | disabled | would fail the moment an operator enables it |
| `worktree_cleanup_chunk` | child (fan-out) | n/a | see below |

### Sibling tasks affected and fixed in this PR

`workspace_retention_cleanup` is `default_enabled => true` and was silently failing on the same gate daily. `worktree_cleanup` and `workspace_hygiene_report` are disabled by default but are registered the identical agent-less way and would fail immediately on enable. All three are fixed here.

### Why `worktree_cleanup_chunk` is also fixed

`worktree_cleanup_chunk` is the child task that performs the **actual destructive cleanup** (artifact deletion / worktree removal). The recurring parents schedule it via `TaskScheduler::scheduleBatch()`, forwarding `'agent_id' => (int)($params['agent_id'] ?? 0)`. Under an agent-less recurring run that is `agent_id = 0`, which is `empty()` — so `scheduleBatch` → `schedule()` would hit the **same gate** and reject every chunk. Without this override the fix would only move the failure one layer down and the real cleanup still would never run.

## Evidence that `executeTask()` is pure maintenance (no agent-scoped calls)

Read each `executeTask()` end-to-end. Every one:
- gates on `PluginSettings::get(SETTING_KEY, ...)`,
- delegates to the `DataMachineCode\Workspace\Workspace` service (disk/file/git operations),
- logs via the `datamachine_log` action and calls `completeJob()`/`failJob()`.

None read `agent_id` from the engine snapshot and none invoke an agent-scoped ability. The only `agent_id` reference is `(int)($params['agent_id'] ?? 0)` forwarded into `scheduleBatch()` for child-job linkage — it is never used as an ownership/authorization input.

## Verification

- **`php -l` clean** on all five touched files.
- **Runtime check**: loaded the five worktree task classes against core's `SystemTask` and reflected `requiresAgentContext()` — all return `false`, each declared on its own class:

```
WorkspaceDiskEmergencyCleanupTask    requiresAgentContext()=false (declared in DataMachineCode\Tasks\WorkspaceDiskEmergencyCleanupTask)
WorktreeCleanupTask                  requiresAgentContext()=false (declared in DataMachineCode\Tasks\WorktreeCleanupTask)
WorkspaceRetentionCleanupTask        requiresAgentContext()=false (declared in DataMachineCode\Tasks\WorkspaceRetentionCleanupTask)
WorkspaceHygieneReportTask           requiresAgentContext()=false (declared in DataMachineCode\Tasks\WorkspaceHygieneReportTask)
WorktreeCleanupChunkTask             requiresAgentContext()=false (declared in DataMachineCode\Tasks\WorktreeCleanupChunkTask)
```

Per the `TaskScheduler::schedule()` gate logic (lines 161–175), `requiresAgentContext() === false` means an agent-less recurring run no longer takes the error branch — it builds the system job snapshot and enqueues the workflow. Full end-to-end "completed job row" verification on prod requires the deployed plugin to carry this code (deploy is out of scope for this PR).