### PR TITLE
refactor: centralize site-scoped agent-context default in MaintenanceTask base

### DIFF
--- a/inc/Tasks/MaintenanceTask.php
+++ b/inc/Tasks/MaintenanceTask.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Base class for site-scoped workspace-maintenance system tasks.
+ *
+ * @package DataMachineCode\Tasks
+ */
+
+namespace DataMachineCode\Tasks;
+
+defined( 'ABSPATH' ) || exit;
+
+use DataMachine\Engine\AI\System\Tasks\SystemTask;
+
+/**
+ * Thin base that centralizes the agent-context default for this plugin.
+ *
+ * Every Data Machine Code task is site-scoped workspace maintenance —
+ * disk/file/git cleanup driven by the Workspace service and gated by
+ * PluginSettings. None of them act as an agent or invoke an agent-scoped
+ * ability, so the core SystemTask default of `requiresAgentContext() === true`
+ * (the safe default for content-mutating agent tasks in data-machine core) is
+ * wrong for this domain.
+ *
+ * Forgetting to override that default fails quietly: an agent-less recurring
+ * schedule (`per_agent => false`) is rejected at TaskScheduler::schedule()'s
+ * agent-context gate and the cleanup silently stops running (see #564 / #566).
+ * Making the correct-for-DMC choice the default here means that failure mode
+ * cannot recur by omission.
+ *
+ * This mirrors core's `DataMachine\Engine\AI\System\Tasks\Retention\RetentionTask`,
+ * which performs the same opt-out for retention cleanup. Unlike RetentionTask,
+ * this base intentionally stays a pure default — it does not finalize
+ * executeTask() or add any other behavior; we only want the agent-context
+ * default centralized.
+ *
+ * A task that genuinely needs agent context can override
+ * `requiresAgentContext()` back to true.
+ */
+abstract class MaintenanceTask extends SystemTask {
+
+	/**
+	 * DMC tasks are site-scoped workspace maintenance with no agent owner.
+	 *
+	 * @return bool
+	 */
+	public function requiresAgentContext(): bool {
+		return false;
+	}
+}

--- a/inc/Tasks/WorkspaceDiskEmergencyCleanupTask.php
+++ b/inc/Tasks/WorkspaceDiskEmergencyCleanupTask.php
@@ -8,13 +8,12 @@
 namespace DataMachineCode\Tasks;
 
 use DataMachine\Core\PluginSettings;
-use DataMachine\Engine\AI\System\Tasks\SystemTask;
 use DataMachine\Engine\Tasks\TaskScheduler;
 use DataMachineCode\Workspace\Workspace;
 
 defined('ABSPATH') || exit;
 
-class WorkspaceDiskEmergencyCleanupTask extends SystemTask {
+class WorkspaceDiskEmergencyCleanupTask extends MaintenanceTask {
 
 
 
@@ -30,23 +29,6 @@ class WorkspaceDiskEmergencyCleanupTask extends SystemTask {
 	 */
 	public function getTaskType(): string {
 		return 'workspace_disk_emergency_cleanup';
-	}
-
-	/**
-	 * Pure workspace/disk maintenance — runs without agent ownership context.
-	 *
-	 * This task cleans disk under pressure via the Workspace service (disk/file/
-	 * git ops gated by PluginSettings). It never acts as an agent or invokes an
-	 * agent-scoped ability; the only agent_id it touches is read from task params
-	 * (defaulting to 0) to forward into child cleanup chunk jobs. It is registered
-	 * as an agent-less hourly recurring schedule, so it must opt out of the
-	 * SystemTask agent-context gate or TaskScheduler::schedule() rejects it before
-	 * it runs.
-	 *
-	 * @return bool
-	 */
-	public function requiresAgentContext(): bool {
-		return false;
 	}
 
 	/**

--- a/inc/Tasks/WorkspaceHygieneReportTask.php
+++ b/inc/Tasks/WorkspaceHygieneReportTask.php
@@ -12,12 +12,11 @@
 namespace DataMachineCode\Tasks;
 
 use DataMachine\Core\PluginSettings;
-use DataMachine\Engine\AI\System\Tasks\SystemTask;
 use DataMachineCode\Workspace\Workspace;
 
 defined('ABSPATH') || exit;
 
-class WorkspaceHygieneReportTask extends SystemTask {
+class WorkspaceHygieneReportTask extends MaintenanceTask {
 
 
 
@@ -33,21 +32,6 @@ class WorkspaceHygieneReportTask extends SystemTask {
 	 */
 	public function getTaskType(): string {
 		return 'workspace_hygiene_report';
-	}
-
-	/**
-	 * Pure workspace/disk maintenance — runs without agent ownership context.
-	 *
-	 * This task produces a non-destructive disk/worktree hygiene report via the
-	 * Workspace service. It never acts as an agent or invokes an agent-scoped
-	 * ability. It is registered as an agent-less weekly recurring schedule, so it
-	 * must opt out of the SystemTask agent-context gate or
-	 * TaskScheduler::schedule() rejects it before it runs.
-	 *
-	 * @return bool
-	 */
-	public function requiresAgentContext(): bool {
-		return false;
 	}
 
 	/**

--- a/inc/Tasks/WorkspaceRetentionCleanupTask.php
+++ b/inc/Tasks/WorkspaceRetentionCleanupTask.php
@@ -8,13 +8,12 @@
 namespace DataMachineCode\Tasks;
 
 use DataMachine\Core\PluginSettings;
-use DataMachine\Engine\AI\System\Tasks\SystemTask;
 use DataMachine\Engine\Tasks\TaskScheduler;
 use DataMachineCode\Workspace\Workspace;
 
 defined('ABSPATH') || exit;
 
-class WorkspaceRetentionCleanupTask extends SystemTask {
+class WorkspaceRetentionCleanupTask extends MaintenanceTask {
 
 
 
@@ -30,23 +29,6 @@ class WorkspaceRetentionCleanupTask extends SystemTask {
 	 */
 	public function getTaskType(): string {
 		return 'workspace_retention_cleanup';
-	}
-
-	/**
-	 * Pure workspace/disk maintenance — runs without agent ownership context.
-	 *
-	 * This task applies age-gated worktree and reconstructable-artifact cleanup
-	 * via the Workspace service (disk/file/git ops gated by PluginSettings). It
-	 * never acts as an agent or invokes an agent-scoped ability; the only agent_id
-	 * it touches is read from task params (defaulting to 0) to forward into child
-	 * cleanup chunk jobs. It is registered as an agent-less daily recurring
-	 * schedule, so it must opt out of the SystemTask agent-context gate or
-	 * TaskScheduler::schedule() rejects it before it runs.
-	 *
-	 * @return bool
-	 */
-	public function requiresAgentContext(): bool {
-		return false;
 	}
 
 	/**

--- a/inc/Tasks/WorktreeCleanupChunkTask.php
+++ b/inc/Tasks/WorktreeCleanupChunkTask.php
@@ -7,12 +7,11 @@
 
 namespace DataMachineCode\Tasks;
 
-use DataMachine\Engine\AI\System\Tasks\SystemTask;
 use DataMachineCode\Workspace\Workspace;
 
 defined('ABSPATH') || exit;
 
-class WorktreeCleanupChunkTask extends SystemTask {
+class WorktreeCleanupChunkTask extends MaintenanceTask {
 
 
 
@@ -23,23 +22,6 @@ class WorktreeCleanupChunkTask extends SystemTask {
 	 */
 	public function getTaskType(): string {
 		return 'worktree_cleanup_chunk';
-	}
-
-	/**
-	 * Pure workspace/disk maintenance — runs without agent ownership context.
-	 *
-	 * This task applies one reviewed cleanup chunk (artifact deletion or worktree
-	 * removal) via the Workspace service. It is fanned out by the recurring
-	 * workspace-maintenance parent tasks, which forward agent_id from their own
-	 * params (0 under an agent-less recurring schedule). Without opting out, every
-	 * child chunk scheduled by an agent-less parent would be rejected by the
-	 * SystemTask agent-context gate in TaskScheduler::schedule(), so the actual
-	 * destructive cleanup would never run even after the parents are fixed.
-	 *
-	 * @return bool
-	 */
-	public function requiresAgentContext(): bool {
-		return false;
 	}
 
 	/**

--- a/inc/Tasks/WorktreeCleanupTask.php
+++ b/inc/Tasks/WorktreeCleanupTask.php
@@ -37,7 +37,6 @@
 namespace DataMachineCode\Tasks;
 
 use DataMachine\Core\PluginSettings;
-use DataMachine\Engine\AI\System\Tasks\SystemTask;
 use DataMachineCode\Workspace\Workspace;
 
 defined('ABSPATH') || exit;
@@ -52,7 +51,7 @@ defined('ABSPATH') || exit;
  * $default_enabled )`.
  */
 
-class WorktreeCleanupTask extends SystemTask {
+class WorktreeCleanupTask extends MaintenanceTask {
 
 
 
@@ -70,21 +69,6 @@ class WorktreeCleanupTask extends SystemTask {
 	 */
 	public function getTaskType(): string {
 		return 'worktree_cleanup';
-	}
-
-	/**
-	 * Pure workspace/git maintenance — runs without agent ownership context.
-	 *
-	 * This task removes merged worktrees via the Workspace service (git/disk ops
-	 * gated by PluginSettings). It never acts as an agent or invokes an
-	 * agent-scoped ability. It is registered as an agent-less recurring schedule,
-	 * so it must opt out of the SystemTask agent-context gate or
-	 * TaskScheduler::schedule() rejects it before it runs.
-	 *
-	 * @return bool
-	 */
-	public function requiresAgentContext(): bool {
-		return false;
 	}
 
 	/**


### PR DESCRIPTION
Closes #566

## What

Introduce a thin `MaintenanceTask` abstract base class in `inc/Tasks/` that sets the site-scoped agent-context default **once**, then reparent the five workspace-maintenance tasks to it and delete their five hand-copied `requiresAgentContext()` overrides (the ones PR #565 added as the symptom fix).

```php
namespace DataMachineCode\Tasks;

use DataMachine\Engine\AI\System\Tasks\SystemTask;

abstract class MaintenanceTask extends SystemTask {
    public function requiresAgentContext(): bool {
        return false;
    }
}
```

Reparented (and override deleted) in:
- `inc/Tasks/WorkspaceDiskEmergencyCleanupTask.php`
- `inc/Tasks/WorktreeCleanupTask.php`
- `inc/Tasks/WorkspaceRetentionCleanupTask.php`
- `inc/Tasks/WorkspaceHygieneReportTask.php`
- `inc/Tasks/WorktreeCleanupChunkTask.php`

Now-unused `use DataMachine\Engine\AI\System\Tasks\SystemTask;` was removed from the two files that no longer reference `SystemTask` directly (`WorktreeCleanupTask`, `WorktreeCleanupChunkTask`); `MaintenanceTask` is same-namespace so needs no `use`. No change to the schedule registration in `data-machine-code.php` (already `per_agent => false`).

## Why this shape

Every DMC task is **site-scoped workspace maintenance** with no agent owner. Core `SystemTask` defaults `requiresAgentContext()` to `true` (the safe default for content-mutating agent tasks in `data-machine` core), so each DMC task author must remember to override it — and forgetting fails quietly: the agent-less recurring schedule is rejected at `TaskScheduler::schedule()`'s agent-context gate and the cleanup silently stops (the #564 failure: 213 identical hourly errors, disk never cleaned). Centralizing the correct-for-DMC default makes that failure mode impossible by omission, and gives one obvious place to document the site-scoped contract.

### Core precedent

This mirrors core's `DataMachine\Engine\AI\System\Tasks\Retention\RetentionTask`, which already does the identical opt-out in its base:

```php
abstract class RetentionTask extends SystemTask {
    public function requiresAgentContext(): bool {
        return false;
    }
    // ... plus a final executeTask() finalizer
}
```

Unlike `RetentionTask`, `MaintenanceTask` is kept a **pure default base** — no `executeTask()` finalizer, no abstract wrapper, no other behavior — because we only want the agent-context default centralized. A task that genuinely needs agent context can still override back to `true`.

## No behavior change vs #565

All five tasks still report `requiresAgentContext() === false` — now inherited from `MaintenanceTask` rather than declared per-class.

### Evidence

**`php -l` clean** on `MaintenanceTask.php` and all five reparented files:
```
No syntax errors detected in MaintenanceTask.php
No syntax errors detected in WorkspaceDiskEmergencyCleanupTask.php
No syntax errors detected in WorktreeCleanupTask.php
No syntax errors detected in WorkspaceRetentionCleanupTask.php
No syntax errors detected in WorkspaceHygieneReportTask.php
No syntax errors detected in WorktreeCleanupChunkTask.php
```

**Reflection harness** (loads core `SystemTask`, then `MaintenanceTask` + the five tasks, reflects `requiresAgentContext()` on each):
```
WorkspaceDiskEmergencyCleanupTask    requiresAgentContext()=false (declared in DataMachineCode\Tasks\MaintenanceTask)
WorktreeCleanupTask                  requiresAgentContext()=false (declared in DataMachineCode\Tasks\MaintenanceTask)
WorkspaceRetentionCleanupTask        requiresAgentContext()=false (declared in DataMachineCode\Tasks\MaintenanceTask)
WorkspaceHygieneReportTask           requiresAgentContext()=false (declared in DataMachineCode\Tasks\MaintenanceTask)
WorktreeCleanupChunkTask             requiresAgentContext()=false (declared in DataMachineCode\Tasks\MaintenanceTask)

PASS: all five return false
PASS: all five inherit the override from MaintenanceTask
```

`getDeclaringClass()` is now `DataMachineCode\Tasks\MaintenanceTask` for all five — proving the override is inherited from the base, not duplicated.

**`homeboy lint`** (PHPCS + PHPStan) on the 6 changed files: PHPCS passed, PHPStan passed. (The command's overall exit was non-zero only due to a pre-existing CI-parity meta-warning that the local `data-machine` validation-dependency checkout is behind origin/main — unrelated to these changes; the actual lint and static analysis ran clean.)

## Target branch note

This PR targets **`fix-disk-cleanup-agent-context`** (the #565 branch), **not `main`**, because #565 is unmerged and this refactor builds on its override methods. **Once #565 merges, retarget this PR to `main` (or rebase onto main).**