### PR TITLE
Align active cleanup pagination assignments

### DIFF
--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -2028,8 +2028,8 @@ class Workspace {
 		$limit       = (int) ( $pagination['limit'] ?? 25 );
 		$next_offset = (int) $pagination['next_offset'];
 		if ( ! $dry_run && $written_count > 0 ) {
-			$current     = (int) ( $pagination['offset'] ?? 0 );
-			$next_offset = max( $current, $next_offset - $written_count );
+			$current                   = (int) ( $pagination['offset'] ?? 0 );
+			$next_offset               = max( $current, $next_offset - $written_count );
 			$pagination['next_offset'] = $next_offset;
 		}
 


### PR DESCRIPTION
## Summary
- Aligns the active/no-signal pagination assignment block introduced by PR #580 so PHPCS no longer flags the changed lines.

## Testing
- Not run; formatting-only follow-up to PR #580. Earlier functional coverage passed with `php tests/smoke-worktree-metadata-reconcile.php` and `php tests/smoke-worktree-cleanup-cli.php`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Reading the CI lint output and applying the formatting-only follow-up; Chris remains responsible for review and release decisions.