### PR TITLE
Compact abandoned cleanup pagination handles

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -3400,6 +3400,8 @@ class WorkspaceCommand extends BaseCommand {
 	 * @return array<string,mixed>
 	 */
 	private function compact_worktree_abandoned_result( array $result ): array {
+		$result['steps'] = $this->compact_worktree_abandoned_steps( (array) ( $result['steps'] ?? array() ) );
+
 		$blocked = (array) ( $result['blocked'] ?? array() );
 		if ( count($blocked) <= 25 ) {
 			return $result;
@@ -3433,6 +3435,38 @@ class WorkspaceCommand extends BaseCommand {
 		$result['blocked']                       = array();
 
 		return $result;
+	}
+
+	/**
+	 * Compact large nested step pagination handle lists.
+	 *
+	 * @param  array<string,mixed> $steps Abandoned cleanup step summaries.
+	 * @return array<string,mixed>
+	 */
+	private function compact_worktree_abandoned_steps( array $steps ): array {
+		foreach ( $steps as $step_key => $step ) {
+			if ( ! is_array($step) ) {
+				continue;
+			}
+
+			$pagination = (array) ( $step['pagination'] ?? array() );
+			foreach ( array( 'remaining_handles', 'handles' ) as $field ) {
+				$handles = (array) ( $pagination[ $field ] ?? array() );
+				if ( count($handles) <= 25 ) {
+					continue;
+				}
+
+				$pagination[ $field . '_examples' ]  = array_slice(array_values($handles), 0, 25);
+				$pagination[ $field . '_truncated' ] = true;
+				$pagination[ $field . '_count' ]     = count($handles);
+				unset($pagination[ $field ]);
+			}
+
+			$step['pagination']  = $pagination;
+			$steps[ $step_key ] = $step;
+		}
+
+		return $steps;
 	}
 
 	/**

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -3462,7 +3462,7 @@ class WorkspaceCommand extends BaseCommand {
 				unset($pagination[ $field ]);
 			}
 
-			$step['pagination']  = $pagination;
+			$step['pagination'] = $pagination;
 			$steps[ $step_key ] = $step;
 		}
 

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -577,6 +577,7 @@ namespace {
                 'reason'      => 'large blocked output fixture',
                 );
             }
+            $remaining_handles = array_map(fn( $row ) => (string) ( $row['handle'] ?? '' ), $skipped);
 
             return array(
             'success' => true,
@@ -590,6 +591,10 @@ namespace {
             'bytes_reclaimed'  => empty($input['dry_run']) ? 4096 : 0,
             ),
             'skipped' => $skipped,
+            'pagination' => array(
+            'remaining_total'   => count($remaining_handles),
+            'remaining_handles' => $remaining_handles,
+            ),
             );
         }
     }
@@ -1168,6 +1173,9 @@ namespace {
     datamachine_code_cleanup_assert(array() === ( $abandoned_compact_json['blocked'] ?? null ), 'abandoned compact JSON omits full blocked rows');
     datamachine_code_cleanup_assert(true === ( $abandoned_compact_json['evidence']['blocked_truncated'] ?? false ), 'abandoned compact JSON records blocked truncation evidence');
     datamachine_code_cleanup_assert(isset($abandoned_compact_json['blocked_examples']['active_no_signal'][0]['handle']), 'abandoned compact JSON includes grouped blocked examples');
+    datamachine_code_cleanup_assert(! isset($abandoned_compact_json['steps']['bounded_apply_initial']['pagination']['remaining_handles']), 'abandoned compact JSON omits full nested remaining handles');
+    datamachine_code_cleanup_assert(32 === (int) ( $abandoned_compact_json['steps']['bounded_apply_initial']['pagination']['remaining_handles_count'] ?? 0 ), 'abandoned compact JSON keeps nested remaining handle count');
+    datamachine_code_cleanup_assert(25 === count($abandoned_compact_json['steps']['bounded_apply_initial']['pagination']['remaining_handles_examples'] ?? array()), 'abandoned compact JSON keeps bounded nested handle examples');
 
     WP_CLI::$logs      = array();
     WP_CLI::$successes = array();
@@ -1175,6 +1183,7 @@ namespace {
     $abandoned_verbose_json = json_decode(WP_CLI::$logs[0] ?? '', true);
     datamachine_code_cleanup_assert(JSON_ERROR_NONE === json_last_error(), 'abandoned verbose JSON output parses cleanly');
     datamachine_code_cleanup_assert(32 === count($abandoned_verbose_json['blocked'] ?? array()), 'abandoned verbose JSON keeps full blocked rows');
+    datamachine_code_cleanup_assert(32 === count($abandoned_verbose_json['steps']['bounded_apply_initial']['pagination']['remaining_handles'] ?? array()), 'abandoned verbose JSON keeps full nested remaining handles');
     datamachine_code_cleanup_assert(! isset($abandoned_verbose_json['evidence']['blocked_truncated']), 'abandoned verbose JSON does not report truncation');
     $bounded_apply_ability->extra_skipped = 0;
 


### PR DESCRIPTION
## Summary
- Compact large nested pagination handle lists in abandoned cleanup JSON output.
- Preserve counts and bounded examples so output stays useful without dumping hundreds of handles.
- Keep full nested handle lists available with `--verbose --format=json`.

## Tests
- `php -l inc/Cli/Commands/WorkspaceCommand.php && php -l tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-worktree-cleanup-cli.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted nested pagination compaction and smoke coverage; Chris directed the behavior and remains responsible for review/testing.