### PR TITLE
Fix Data Machine handler integration gate

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -84,7 +84,7 @@ function datamachine_code_register_datamachine_integrations(): void {
 	// Project active workspace identity into Data Machine's engine_data snapshot.
 	\DataMachineCode\Runtime\ActiveWorkspaceProjector::register();
 
-	if ( class_exists('DataMachine\Core\Steps\HandlerRegistrationTrait') ) {
+	if ( trait_exists('DataMachine\Core\Steps\HandlerRegistrationTrait') ) {
 		new \DataMachineCode\Handlers\GitHub\GitHub();
 		new \DataMachineCode\Handlers\GitHub\GitHubIssuePublish();
 		new \DataMachineCode\Handlers\GitHub\GitHubPullRequestPublish();

--- a/tests/smoke-github-issue-publish-handler.php
+++ b/tests/smoke-github-issue-publish-handler.php
@@ -33,6 +33,8 @@ $assert(false !== strpos($handler, "'client_context_bindings' => array( 'job_id'
 $assert(false !== strpos($handler, "'items'       => array( 'type' => 'string' )"), 'array parameters include item schemas');
 $assert(false !== strpos($handler, 'GitHubAbilities::createIssue'), 'handler delegates issue creation to GitHubAbilities');
 $assert(false !== strpos($settings, "'labels'") && false !== strpos($settings, "'assignees'"), 'settings expose labels and assignees defaults');
+$assert(false !== strpos($plugin, "trait_exists('DataMachine\\Core\\Steps\\HandlerRegistrationTrait')"), 'plugin detects Data Machine handler registration trait with trait_exists');
+$assert(false === strpos($plugin, "class_exists('DataMachine\\Core\\Steps\\HandlerRegistrationTrait')"), 'plugin does not gate trait detection with class_exists');
 $assert(false !== strpos($plugin, 'new \\DataMachineCode\\Handlers\\GitHub\\GitHubIssuePublish();'), 'plugin bootstraps GitHub issue publish handler');
 $assert(false !== strpos($plugin, "did_action('plugins_loaded')") && false !== strpos($plugin, 'datamachine_code_bootstrap();'), 'plugin bootstraps immediately when loaded after plugins_loaded');
 $assert(false !== strpos($plugin, "'activated_plugin'") && false !== strpos($plugin, 'datamachine_code_bootstrap();'), 'plugin retries bootstrap after late activation completes');


### PR DESCRIPTION
## Summary
- Switches the Data Machine handler integration gate from `class_exists()` to `trait_exists()` for `HandlerRegistrationTrait`.
- Adds smoke coverage proving the GitHub issue publish handler bootstrap checks for the trait correctly.

Fixes #591.

## Testing
- `php tests/smoke-github-issue-publish-handler.php`
- `php tests/smoke-github-pr-publish-handler.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the wp-site-generator loop failure, implementing the trait-gate fix, and drafting the PR text. Chris remains responsible for review and testing.