### PR TITLE
fix: register workspace preload artifacts early

### DIFF
--- a/data-machine-code.php
+++ b/data-machine-code.php
@@ -66,6 +66,25 @@ function datamachine_code_has_datamachine_integration(): bool {
 }
 
 /**
+ * Register DMC-owned bundle artifact hooks.
+ *
+ * Bundle artifact type discovery can run before the rest of DMC's Data Machine
+ * integrations are available. Keep these hooks registered independently so
+ * imported agent bundles can materialize DMC-owned artifacts during install.
+ */
+function datamachine_code_register_bundle_artifacts(): void {
+	static $registered = false;
+
+	if ( $registered ) {
+		return;
+	}
+
+	$registered = true;
+	( new \DataMachineCode\Bundle\WorkspacePreloadArtifact() )->register();
+}
+datamachine_code_register_bundle_artifacts();
+
+/**
  * Register optional Data Machine integrations.
  */
 function datamachine_code_register_datamachine_integrations(): void {
@@ -76,10 +95,6 @@ function datamachine_code_register_datamachine_integrations(): void {
 	}
 
 	$registered = true;
-
-	// Bundle artifact types are Data Machine-specific and are only registered
-	// when the bundle importer substrate is present.
-	( new \DataMachineCode\Bundle\WorkspacePreloadArtifact() )->register();
 
 	// Project active workspace identity into Data Machine's engine_data snapshot.
 	\DataMachineCode\Runtime\ActiveWorkspaceProjector::register();


### PR DESCRIPTION
## Summary
- Register DMC-owned bundle artifact hooks during plugin load instead of waiting for the optional Data Machine integration bootstrap.
- Keeps workspace preload artifacts available when agent bundle import discovers and applies extension artifacts.

## Tests
- `php tests/smoke-bundle-artifact-early-registration.php`
- `php tests/smoke-workspace-preload-artifact.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the missing workspace preload registration path, drafted the patch, and ran local smoke tests; Chris remains responsible for review and merge.