### PR TITLE
fix: discover worktree-backed workspace primaries

### DIFF
--- a/inc/Workspace/WorkspaceWorktreeLifecycle.php
+++ b/inc/Workspace/WorkspaceWorktreeLifecycle.php
@@ -720,7 +720,7 @@ trait WorkspaceWorktreeLifecycle {
 				continue;
 			}
 			$entry_path = $this->workspace_path . '/' . $entry;
-			if ( ! is_dir($entry_path . '/.git') ) {
+			if ( ! file_exists($entry_path . '/.git') ) {
 				continue;
 			}
 			$primaries[] = $entry;

--- a/tests/smoke-worktree-lifecycle-metadata.php
+++ b/tests/smoke-worktree-lifecycle-metadata.php
@@ -321,6 +321,9 @@ namespace {
     $run('git add README.md', $primary);
     $run('git commit -m initial', $primary);
     $run('git remote add origin https://github.com/acme/demo.git', $primary);
+    $linked_primary = DATAMACHINE_WORKSPACE_PATH . '/linked-primary';
+    $run('git worktree add ../linked-primary -b linked-primary HEAD', $primary);
+    $assert(true, is_file($linked_primary . '/.git'), 'linked primary fixture uses a .git file');
     // Synthetic runtime registration so the env-driven session capture has a
     // runtime to scan. DMC enumerates no runtime IDs itself — the integration
     // layer (here, the test) declares them via the public filter.
@@ -334,6 +337,9 @@ namespace {
 
     $ws = new \DataMachineCode\Workspace\Workspace();
     $GLOBALS['wpdb'] = new DatamachineCodeLifecycleInventoryWpdb();
+    $linked_list = $ws->worktree_list('linked-primary', null, array( 'include_status' => false, 'include_disk' => false ));
+    $linked_items = array_values(array_filter($linked_list['worktrees'] ?? array(), fn( $wt ) => ( $wt['handle'] ?? '' ) === 'linked-primary'));
+    $assert(1, count($linked_items), 'worktree_list discovers primary checkouts whose .git is a file');
 
     $GLOBALS['datamachine_code_test_filters']['datamachine_worktree_disk_budget_thresholds'] = function ( array $thresholds ): array {
         $thresholds['refuse_free_bytes'] = PHP_INT_MAX;


### PR DESCRIPTION
## Summary
- Treat primary workspace checkouts with a `.git` file as valid git repositories during worktree inventory scans.
- Add smoke coverage for linked primary checkouts so inventory refresh does not mark existing paths missing.

## Testing
- `php tests/smoke-worktree-lifecycle-metadata.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the workspace inventory regression, drafted the minimal fix and smoke-test coverage, and ran targeted verification. Chris remains responsible for review and merge.