### PR TITLE
Fix remote workspace backend selection without streaming git

### DIFF
--- a/inc/Workspace/RemoteWorkspaceBackend.php
+++ b/inc/Workspace/RemoteWorkspaceBackend.php
@@ -22,10 +22,23 @@ class RemoteWorkspaceBackend {
 	 * Whether the remote backend should handle workspace operations.
 	 */
 	public static function should_handle(): bool {
+		$diagnostic = \DataMachineCode\Support\GitRunner::diagnose();
+		$default    = self::should_handle_for_local_capabilities(
+			! empty($diagnostic['git_available']),
+			! empty($diagnostic['git_available']) && ! empty($diagnostic['proc_open_available'])
+		);
+
 		return (bool) apply_filters(
 			'datamachine_code_remote_workspace_backend_should_handle',
-			! \DataMachineCode\Support\GitRunner::is_available()
+			$default
 		);
+	}
+
+	/**
+	 * Decide whether constrained runtimes need the GitHub-backed backend.
+	 */
+	public static function should_handle_for_local_capabilities( bool $git_available, bool $streaming_available ): bool {
+		return ! ( $git_available && $streaming_available );
 	}
 
 	/**

--- a/tests/smoke-remote-workspace-backend.php
+++ b/tests/smoke-remote-workspace-backend.php
@@ -163,6 +163,10 @@ namespace {
     echo "Remote workspace backend - smoke\n";
 
     $backend = new RemoteWorkspaceBackend();
+    $assert('remote backend handles missing git runtime', RemoteWorkspaceBackend::should_handle_for_local_capabilities(false, false));
+    $assert('remote backend handles non-streaming git runtime', RemoteWorkspaceBackend::should_handle_for_local_capabilities(true, false));
+    $assert('remote backend leaves full local git runtime alone', ! RemoteWorkspaceBackend::should_handle_for_local_capabilities(true, true));
+
     $clone = $backend->clone_repo('https://github.com/chubes4/example.git');
     $assert('clone registers remote repo', ! is_wp_error($clone) && 'example' === $clone['name'] && 'github_api' === $clone['backend']);
     $assert('clone backend result omits model-facing guidance', ! is_wp_error($clone) && ! array_key_exists('next_required_tool', $clone) && ! array_key_exists('next_required_args', $clone));


### PR DESCRIPTION
## Summary
- route DMC workspace operations to the GitHub-backed remote backend when local streaming git is unavailable
- keep full local git runtimes on the existing local backend
- add smoke coverage for missing-git and non-streaming constrained runtime selection

## Verification
- `php tests/smoke-remote-workspace-backend.php`
- `php tests/smoke-workspace-preload-artifact.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the WPSG iterator workspace-preload failure, drafted the DMC backend-selection fix and smoke coverage; Chris reviews and owns the submitted changes.