### PR TITLE
Project write and git workspace tools for coding agents

### DIFF
--- a/inc/Tools/AbilityToolProjections.php
+++ b/inc/Tools/AbilityToolProjections.php
@@ -51,6 +51,23 @@ class AbilityToolProjections {
 			'workspace_read'                       => self::workspace('datamachine-code/workspace-read'),
 			'workspace_grep'                       => self::workspace('datamachine-code/workspace-grep'),
 
+			'workspace_write'                      => self::workspace_write('datamachine-code/workspace-write'),
+			'workspace_edit'                       => self::workspace_write('datamachine-code/workspace-edit'),
+			'workspace_apply_patch'                => self::workspace_write('datamachine-code/workspace-apply-patch'),
+			'workspace_delete'                     => self::workspace_write('datamachine-code/workspace-delete'),
+			'workspace_git_status'                 => self::workspace_write('datamachine-code/workspace-git-status'),
+			'workspace_git_log'                    => self::workspace_write('datamachine-code/workspace-git-log'),
+			'workspace_git_diff'                   => self::workspace_write('datamachine-code/workspace-git-diff'),
+			'workspace_git_pull'                   => self::workspace_write('datamachine-code/workspace-git-pull'),
+			'workspace_git_add'                    => self::workspace_write('datamachine-code/workspace-git-add'),
+			'workspace_git_commit'                 => self::workspace_write('datamachine-code/workspace-git-commit'),
+			'workspace_git_push'                   => self::workspace_write('datamachine-code/workspace-git-push'),
+			'workspace_git_rebase'                 => self::workspace_write('datamachine-code/workspace-git-rebase'),
+			'workspace_git_reset'                  => self::workspace_write('datamachine-code/workspace-git-reset'),
+			'workspace_worktree_add'               => self::workspace_write('datamachine-code/workspace-worktree-add'),
+			'workspace_pr_status'                  => self::workspace_write('datamachine-code/workspace-pr-status'),
+			'workspace_pr_rebase'                  => self::workspace_write('datamachine-code/workspace-pr-rebase'),
+
 			'list_github_issues'                   => self::github('datamachine-code/list-github-issues'),
 			'get_github_issue'                     => self::github('datamachine-code/get-github-issue'),
 			'list_github_pulls'                    => self::github('datamachine-code/list-github-pulls'),
@@ -77,6 +94,23 @@ class AbilityToolProjections {
 		return array(
 			'ability' => $ability,
 			'modes'   => array( 'chat', 'pipeline' ),
+		);
+	}
+
+	/**
+	 * Build a mutating workspace projection declaration.
+	 *
+	 * Write/git workspace tools require explicit opt-in (via `allow_only` or an
+	 * allow-mode tool policy) before they are exposed to a model request, so a
+	 * read-only inspection task never receives file-mutating tools by default.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private static function workspace_write( string $ability ): array {
+		return array(
+			'ability'         => $ability,
+			'modes'           => array( 'chat', 'pipeline' ),
+			'requires_opt_in' => true,
 		);
 	}
 

--- a/tests/smoke-ability-tool-projections.php
+++ b/tests/smoke-ability-tool-projections.php
@@ -133,6 +133,27 @@ namespace {
 		$assert("{$tool_name} does not duplicate parameter schema", ! array_key_exists('parameters', $declaration));
 	}
 
+	// Write/git workspace tools must be projected so coding agents can mutate
+	// files, but gated behind explicit opt-in so read-only tasks never receive
+	// file-mutating tools by default.
+	$expected_write = array(
+		'workspace_write'       => 'datamachine-code/workspace-write',
+		'workspace_edit'        => 'datamachine-code/workspace-edit',
+		'workspace_apply_patch' => 'datamachine-code/workspace-apply-patch',
+		'workspace_delete'      => 'datamachine-code/workspace-delete',
+		'workspace_git_add'     => 'datamachine-code/workspace-git-add',
+		'workspace_git_commit'  => 'datamachine-code/workspace-git-commit',
+		'workspace_git_push'    => 'datamachine-code/workspace-git-push',
+	);
+
+	foreach ( $expected_write as $tool_name => $ability_slug ) {
+		$declaration = $tools[ $tool_name ] ?? array();
+		$assert("{$tool_name} is projected", isset($tools[ $tool_name ]));
+		$assert("{$tool_name} points at canonical ability", $ability_slug === ( $declaration['ability'] ?? '' ));
+		$assert("{$tool_name} is available to chat", in_array('chat', $declaration['modes'] ?? array(), true));
+		$assert("{$tool_name} requires opt-in", true === ( $declaration['requires_opt_in'] ?? false ));
+	}
+
 	$workspace_result = dmc_projection_normalize_tool_result(
 		array(
 			'success' => true,


### PR DESCRIPTION
## Summary

`AbilityToolProjections::projected_tools()` only exposed **read-only** workspace tools (`workspace_ls`, `workspace_read`, `workspace_grep`, etc.) as model-facing Data Machine tools. The mutating workspace abilities exist and are registered (`datamachine-code/workspace-write`, `-edit`, `-apply-patch`, `-delete`, the git `add`/`commit`/`push`/etc., worktree, and PR abilities) but were never projected — so a coding agent in sandbox/chat runs never received a write tool. The model had nothing to call and would either fail or fabricate the edit.

This projects the mutating workspace tools, each gated behind `requires_opt_in` so a read-only task never receives file-mutating tools by default. They surface only when explicitly named via `allow_only` or an allow-mode tool policy.

## Why this matters

This is the final runtime gap that prevented WP Codebox coding agents from actually editing files. End-to-end trace:
- The sandbox correctly declares the writable tool policy (Extra-Chill/homeboy-extensions#1190).
- The Claude Code provider correctly does structured tool calling (Extra-Chill/wp-coding-agents#197).
- But `AbilityToolSource` → `datamachine_ability_tool_projections` only listed read tools, so `ToolPolicyResolver` gathered no write tools and the model was sent none.

## Changes

- Add `workspace_write`, `workspace_edit`, `workspace_apply_patch`, `workspace_delete`, `workspace_git_status/log/diff/pull/add/commit/push/rebase/reset`, `workspace_worktree_add`, `workspace_pr_status/rebase` to `projected_tools()`.
- New `workspace_write()` declaration helper sets `requires_opt_in => true`.
- Extend `tests/smoke-ability-tool-projections.php` to assert the write tools project with `requires_opt_in`.

## Testing

- `php -l inc/Tools/AbilityToolProjections.php`
- `php tests/smoke-ability-tool-projections.php` — all new write-tool projection assertions pass (`workspace_write/edit/apply_patch/delete/git_add/git_commit/git_push ... requires opt-in`).
  - Note: the test's optional trailing transcript-formatter section throws a pre-existing `wp_json_encode()` fatal when run standalone against a sibling data-machine checkout; this is unrelated to this change and reproduces on clean `main`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** End-to-end traced the missing tool-projection through wp-codebox → agents/chat → ToolPolicyResolver → AbilityToolSource, implemented the projection + opt-in gating, and added test coverage; Chris directs the work and remains responsible for review/testing.