### PR TITLE
fix: retry bundle preload through remote workspace backend

### DIFF
--- a/inc/Bundle/WorkspacePreloadArtifact.php
+++ b/inc/Bundle/WorkspacePreloadArtifact.php
@@ -8,6 +8,7 @@
 namespace DataMachineCode\Bundle;
 
 use DataMachineCode\Abilities\WorkspaceAbilities;
+use DataMachineCode\Workspace\RemoteWorkspaceBackend;
 
 defined('ABSPATH') || exit;
 
@@ -178,6 +179,16 @@ final class WorkspacePreloadArtifact {
 
 		$callback = $this->clone_callback ? $this->clone_callback : array( WorkspaceAbilities::class, 'cloneRepo' );
 		$result   = call_user_func($callback, $input);
+
+		if ( is_wp_error($result) && 'datamachine_workspace_git_unavailable' === $result->get_error_code() && class_exists(RemoteWorkspaceBackend::class) ) {
+			$remote_result = ( new RemoteWorkspaceBackend() )->clone_repo(
+				$input['url'],
+				$input['name'] ?? null
+			);
+			if ( ! is_wp_error($remote_result) ) {
+				return $remote_result;
+			}
+		}
 
 		if ( is_wp_error($result) && 'repo_exists' === $result->get_error_code() ) {
 			$data = (array) $result->get_error_data();

--- a/inc/Workspace/RemoteWorkspaceBackend.php
+++ b/inc/Workspace/RemoteWorkspaceBackend.php
@@ -22,6 +22,10 @@ class RemoteWorkspaceBackend {
 	 * Whether the remote backend should handle workspace operations.
 	 */
 	public static function should_handle(): bool {
+		if ( self::has_registered_state() ) {
+			return true;
+		}
+
 		$diagnostic = \DataMachineCode\Support\GitRunner::diagnose();
 		$default    = self::should_handle_for_local_capabilities(
 			! empty($diagnostic['git_available']),
@@ -39,6 +43,18 @@ class RemoteWorkspaceBackend {
 	 */
 	public static function should_handle_for_local_capabilities( bool $git_available, bool $streaming_available ): bool {
 		return ! ( $git_available && $streaming_available );
+	}
+
+	/**
+	 * Whether remote workspace state already exists for this runtime.
+	 */
+	public static function has_registered_state(): bool {
+		$state = function_exists('get_option') ? get_option(self::OPTION, array()) : array();
+		if ( ! is_array($state) ) {
+			return false;
+		}
+
+		return ! empty($state['repos']) || ! empty($state['worktrees']);
 	}
 
 	/**

--- a/tests/smoke-workspace-preload-artifact.php
+++ b/tests/smoke-workspace-preload-artifact.php
@@ -9,6 +9,12 @@
 
 declare( strict_types=1 );
 
+namespace DataMachineCode\Abilities {
+    class GitHubAbilities
+    {
+    }
+}
+
 namespace {
     if (! defined('ABSPATH') ) {
         define('ABSPATH', __DIR__ . '/');
@@ -50,6 +56,25 @@ namespace {
         }
     }
 
+    $GLOBALS['dmc_remote_workspace_options'] = array();
+
+    if (! function_exists('get_option') ) {
+        function get_option( string $key, mixed $default_value = false ): mixed
+        {
+            return $GLOBALS['dmc_remote_workspace_options'][ $key ] ?? $default_value;
+        }
+    }
+
+    if (! function_exists('update_option') ) {
+        function update_option( string $key, mixed $value, bool $autoload = true ): bool
+        {
+            unset($autoload);
+            $GLOBALS['dmc_remote_workspace_options'][ $key ] = $value;
+            return true;
+        }
+    }
+
+    include __DIR__ . '/../inc/Workspace/RemoteWorkspaceBackend.php';
     include __DIR__ . '/../inc/Bundle/WorkspacePreloadArtifact.php';
 
     use DataMachineCode\Bundle\WorkspacePreloadArtifact;
@@ -150,6 +175,32 @@ namespace {
         )
     );
     $assert('treats existing checkout as idempotent success', ! is_wp_error($exists) && true === ( $exists['repositories'][0]['already_exists'] ?? false ));
+
+    $remote_fallback_artifact = new WorkspacePreloadArtifact(
+        static function (): WP_Error {
+            return new WP_Error(
+                'datamachine_workspace_git_unavailable',
+                'Clone workspace repository cannot run with the current workspace backend.',
+                array( 'status' => 500 )
+            );
+        }
+    );
+    $remote_fallback = $remote_fallback_artifact->apply_artifact(
+        null,
+        array(
+        'artifact_type' => WorkspacePreloadArtifact::ARTIFACT_TYPE,
+        'artifact_id'   => 'remote-fallback',
+        'payload'       => array(
+                'repositories' => array(
+                    array(
+                        'name' => 'static-site-importer',
+                        'url'  => 'https://github.com/chubes4/static-site-importer.git',
+                    ),
+                ),
+        ),
+        )
+    );
+    $assert('falls back to remote backend when local git clone is unavailable', ! is_wp_error($remote_fallback) && 'github_api' === ( $remote_fallback['repositories'][0]['result']['backend'] ?? '' ));
 
     if (array() !== $failures ) {
         echo "\nFailures:\n";

--- a/tests/smoke-workspace-preload-artifact.php
+++ b/tests/smoke-workspace-preload-artifact.php
@@ -201,6 +201,12 @@ namespace {
         )
     );
     $assert('falls back to remote backend when local git clone is unavailable', ! is_wp_error($remote_fallback) && 'github_api' === ( $remote_fallback['repositories'][0]['result']['backend'] ?? '' ));
+    $assert(
+        'remote preload state keeps remote backend active for later tools',
+        \DataMachineCode\Workspace\RemoteWorkspaceBackend::has_registered_state()
+        && false === \DataMachineCode\Workspace\RemoteWorkspaceBackend::should_handle_for_local_capabilities(true, true)
+        && \DataMachineCode\Workspace\RemoteWorkspaceBackend::should_handle()
+    );
 
     if (array() !== $failures ) {
         echo "\nFailures:\n";


### PR DESCRIPTION
## Summary
- Retry workspace preload clone failures through the GitHub-backed remote workspace backend when local git clone is unavailable.
- Add smoke coverage proving preload artifacts can still register GitHub repositories when the canonical clone path reports `datamachine_workspace_git_unavailable`.

## Why
WPSG iterator runs in WP Codebox/Playground showed bundle workspace preload still degrading with local-git-unavailable even when Data Machine Code was mounted from the remote-backend-enabled checkout. The preload artifact is the owning path for making preloaded workspaces available before the iterator agent runs.

## Testing
- `php tests/smoke-workspace-preload-artifact.php`
- `php tests/smoke-remote-workspace-backend.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the remaining WP Codebox iterator preload failure, drafted the preload fallback and smoke coverage, and ran targeted verification. Chris remains responsible for review and merge.