### PR TITLE
Drop vestigial test_backend setting

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -3,10 +3,7 @@
   "changelog_target": "docs/CHANGELOG.md",
   "extensions": {
     "wordpress": {
-      "release_latest_branch": "release-latest",
-      "settings": {
-        "test_backend": "host-smoke"
-      }
+      "release_latest_branch": "release-latest"
     }
   },
   "id": "data-machine-code",


### PR DESCRIPTION
## Summary
`data-machine-code` set `test_backend=host-smoke`, but its smoke scripts use the **`smoke-*.php` prefix** convention (97 files), not the **`*-smoke.php` suffix** the WordPress test dispatcher discovers. The host-smoke backend's `find -name '*-smoke.php'` matched **zero** files — the setting was a no-op.

With the `test_backend` toggle removed upstream (homeboy-extensions #1205: tests route by file type through WP Codebox), this drops the dead setting for hygiene.

## Note
DMC's 97 `smoke-*.php` scripts don't run through `homeboy test` at all (naming mismatch with the dispatcher's `*-smoke.php` contract). Wiring them into the pipeline is a separate follow-up, out of scope here.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Identified the setting as a no-op (prefix-vs-suffix naming) and removed it; Chris directed the cleanup.