### PR TITLE
fix: normalize mounted workspace writes

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -194,17 +194,17 @@ class WorkspaceAbilities {
 					'output_schema'       => array(
 						'type'       => 'object',
 						'properties' => array(
-							'success'     => array( 'type' => 'boolean' ),
-							'name'        => array( 'type' => 'string' ),
-							'repo'        => array( 'type' => 'string' ),
-							'is_worktree' => array( 'type' => 'boolean' ),
-							'path'        => array( 'type' => 'string' ),
+							'success'           => array( 'type' => 'boolean' ),
+							'name'              => array( 'type' => 'string' ),
+							'repo'              => array( 'type' => 'string' ),
+							'is_worktree'       => array( 'type' => 'boolean' ),
+							'path'              => array( 'type' => 'string' ),
 							// Nullable: detached HEAD has no branch; local-only repos
 							// have no remote; freshly-init'd repos have no commit yet.
-							'branch'      => array( 'type' => array( 'string', 'null' ) ),
-							'remote'      => array( 'type' => array( 'string', 'null' ) ),
-							'commit'      => array( 'type' => array( 'string', 'null' ) ),
-							'dirty'       => array( 'type' => 'integer' ),
+							'branch'            => array( 'type' => array( 'string', 'null' ) ),
+							'remote'            => array( 'type' => array( 'string', 'null' ) ),
+							'commit'            => array( 'type' => array( 'string', 'null' ) ),
+							'dirty'             => array( 'type' => 'integer' ),
 							'primary_freshness' => self::primaryFreshnessSchema(),
 						),
 					),
@@ -390,19 +390,19 @@ class WorkspaceAbilities {
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
-							'url'            => array(
+							'url'                    => array(
 								'type'        => 'string',
 								'description' => 'Git repository URL to clone.',
 							),
-							'name'           => array(
+							'name'                   => array(
 								'type'        => 'string',
 								'description' => 'Directory name override (derived from URL if omitted).',
 							),
-							'full'           => array(
+							'full'                   => array(
 								'type'        => 'boolean',
 								'description' => 'Disable the default blobless partial clone for remote repositories.',
 							),
-							'auth_token_env' => array(
+							'auth_token_env'         => array(
 								'type'        => 'string',
 								'description' => 'Optional environment variable name containing a bearer token for HTTPS clone authentication.',
 							),

--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -2665,6 +2665,7 @@ class WorkspaceAbilities {
 	 * @return array Result.
 	 */
 	public static function writeFile( array $input ): array|\WP_Error {
+		$input = self::normalize_mounted_workspace_path_input($input, array( 'repo' ));
 		if ( RemoteWorkspaceBackend::should_handle() ) {
 			$result = ( new RemoteWorkspaceBackend() )->write_file(
 				$input['repo'] ?? '',

--- a/tests/smoke-workspace-alias-tools.php
+++ b/tests/smoke-workspace-alias-tools.php
@@ -19,6 +19,7 @@ namespace {
     $GLOBALS['dmc_workspace_alias_ability'] = null;
     $GLOBALS['dmc_workspace_alias_registered_abilities'] = array();
     $GLOBALS['dmc_workspace_alias_remote_edit_input'] = array();
+    $GLOBALS['dmc_workspace_alias_remote_write_input'] = array();
 
     function add_filter( string $tag, callable $callback, int $priority = 10, int $accepted_args = 1 ): void
     {
@@ -125,6 +126,16 @@ namespace DataMachineCode\Workspace {
             'name'         => $handle,
             'path'         => $path,
             'replacements' => 1,
+            );
+        }
+
+        public function write_file( string $handle, string $path, string $content ): array
+        {
+            $GLOBALS['dmc_workspace_alias_remote_write_input'] = compact('handle', 'path', 'content');
+            return array(
+            'success' => true,
+            'name'    => $handle,
+            'path'    => $path,
             );
         }
     }
@@ -272,6 +283,17 @@ namespace {
     $assert('workspace_edit ability converts mounted path to relative path', 'wordpress/scripts/build/build.sh' === ( $GLOBALS['dmc_workspace_alias_remote_edit_input']['path'] ?? '' ));
     $assert('workspace_edit ability maps old alias to old_string', 'npm install --silent' === ( $GLOBALS['dmc_workspace_alias_remote_edit_input']['old_string'] ?? '' ));
     $assert('workspace_edit ability maps new alias to new_string', 'npm install --legacy-peer-deps' === ( $GLOBALS['dmc_workspace_alias_remote_edit_input']['new_string'] ?? '' ));
+
+    $ability_mounted_write = \DataMachineCode\Abilities\WorkspaceAbilities::writeFile(
+        array(
+			'path'    => '/workspace/example-plugin/wordpress/scripts/build/generated.sh',
+            'content' => '#!/bin/sh',
+        )
+    );
+    $assert('workspace_write ability accepts mounted absolute path', ! is_wp_error($ability_mounted_write) && true === ( $ability_mounted_write['success'] ?? false ));
+	$assert('workspace_write ability infers repo from mounted path', 'example-plugin' === ( $GLOBALS['dmc_workspace_alias_remote_write_input']['handle'] ?? '' ));
+    $assert('workspace_write ability converts mounted path to relative path', 'wordpress/scripts/build/generated.sh' === ( $GLOBALS['dmc_workspace_alias_remote_write_input']['path'] ?? '' ));
+    $assert('workspace_write ability preserves content', '#!/bin/sh' === ( $GLOBALS['dmc_workspace_alias_remote_write_input']['content'] ?? '' ));
 
     $unsupported_alias = \DataMachineCode\Abilities\WorkspaceAbilities::editFile(
         array(

--- a/tests/smoke-workspace-alias-tools.php
+++ b/tests/smoke-workspace-alias-tools.php
@@ -284,16 +284,16 @@ namespace {
     $assert('workspace_edit ability maps old alias to old_string', 'npm install --silent' === ( $GLOBALS['dmc_workspace_alias_remote_edit_input']['old_string'] ?? '' ));
     $assert('workspace_edit ability maps new alias to new_string', 'npm install --legacy-peer-deps' === ( $GLOBALS['dmc_workspace_alias_remote_edit_input']['new_string'] ?? '' ));
 
-    $ability_mounted_write = \DataMachineCode\Abilities\WorkspaceAbilities::writeFile(
-        array(
+	$ability_mounted_write = \DataMachineCode\Abilities\WorkspaceAbilities::writeFile(
+		array(
 			'path'    => '/workspace/example-plugin/wordpress/scripts/build/generated.sh',
-            'content' => '#!/bin/sh',
-        )
-    );
-    $assert('workspace_write ability accepts mounted absolute path', ! is_wp_error($ability_mounted_write) && true === ( $ability_mounted_write['success'] ?? false ));
+			'content' => '#!/bin/sh',
+		)
+	);
+	$assert('workspace_write ability accepts mounted absolute path', ! is_wp_error($ability_mounted_write) && true === ( $ability_mounted_write['success'] ?? false ));
 	$assert('workspace_write ability infers repo from mounted path', 'example-plugin' === ( $GLOBALS['dmc_workspace_alias_remote_write_input']['handle'] ?? '' ));
-    $assert('workspace_write ability converts mounted path to relative path', 'wordpress/scripts/build/generated.sh' === ( $GLOBALS['dmc_workspace_alias_remote_write_input']['path'] ?? '' ));
-    $assert('workspace_write ability preserves content', '#!/bin/sh' === ( $GLOBALS['dmc_workspace_alias_remote_write_input']['content'] ?? '' ));
+	$assert('workspace_write ability converts mounted path to relative path', 'wordpress/scripts/build/generated.sh' === ( $GLOBALS['dmc_workspace_alias_remote_write_input']['path'] ?? '' ));
+	$assert('workspace_write ability preserves content', '#!/bin/sh' === ( $GLOBALS['dmc_workspace_alias_remote_write_input']['content'] ?? '' ));
 
     $unsupported_alias = \DataMachineCode\Abilities\WorkspaceAbilities::editFile(
         array(


### PR DESCRIPTION
## Summary
- Normalize `workspace_write` ability inputs when callers pass mounted absolute workspace paths like `/workspace/<repo>/<path>`.
- Extend the workspace alias smoke to prove mounted absolute write paths are converted to repo handles plus relative paths.

## Testing
- `php tests/smoke-workspace-alias-tools.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the mounted workspace write path gap, drafted the normalization fix and smoke coverage, and ran targeted verification. Chris remains responsible for review and merge.