### PR TITLE
fix: route workspace clone CLI through ability

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -223,17 +223,18 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 
-		$workspace = new Workspace();
-		$result    = $workspace->clone_repo(
-			$args[0],
-			$assoc_args['name'] ?? null,
+		$ability = wp_get_ability('datamachine-code/workspace-clone');
+		if ( ! $ability ) {
+			WP_CLI::error('Workspace clone ability not available.');
+			return;
+		}
+
+		$result = $ability->execute(
 			array(
+				'url'                    => $args[0],
+				'name'                   => $assoc_args['name'] ?? null,
 				'full'                   => isset($assoc_args['full']),
 				'allow_duplicate_remote' => isset($assoc_args['allow-duplicate-remote']),
-				'progress_callback'      => static function ( array $event ): void {
-					$elapsed = number_format( (float) ( $event['elapsed'] ?? 0 ), 1);
-					WP_CLI::log(sprintf('[clone %ss] %s', $elapsed, (string) ( $event['message'] ?? '' )));
-				},
 			)
 		);
 

--- a/tests/smoke-workspace-clone-cli.php
+++ b/tests/smoke-workspace-clone-cli.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Pure-PHP smoke for workspace clone CLI routing.
+ *
+ * Run: php tests/smoke-workspace-clone-cli.php
+ */
+
+declare( strict_types=1 );
+
+namespace {
+	if ( ! defined('ABSPATH') ) {
+		define('ABSPATH', __DIR__);
+	}
+
+	class WP_CLI
+	{
+		public static array $logs = array();
+		public static array $successes = array();
+
+		public static function error( string $message ): void
+		{
+			throw new RuntimeException($message);
+		}
+
+		public static function success( string $message ): void
+		{
+			self::$successes[] = $message;
+		}
+
+		public static function log( string $message ): void
+		{
+			self::$logs[] = $message;
+		}
+	}
+
+	class WP_Error
+	{
+		public function __construct( private string $code, private string $message, private array $data = array() )
+		{
+		}
+
+		public function get_error_code(): string
+		{
+			return $this->code;
+		}
+
+		public function get_error_message(): string
+		{
+			return $this->message;
+		}
+
+		public function get_error_data(): array
+		{
+			return $this->data;
+		}
+	}
+
+	function is_wp_error( $value ): bool
+	{
+		return $value instanceof WP_Error;
+	}
+
+	function wp_get_ability( string $name )
+	{
+		return $GLOBALS['__abilities'][ $name ] ?? null;
+	}
+}
+
+namespace DataMachine\Cli {
+	class BaseCommand
+	{
+	}
+}
+
+namespace {
+	include_once dirname(__DIR__) . '/inc/Cli/Commands/WorkspaceCommand.php';
+
+	final class WorkspaceCloneTestAbility
+	{
+		public array $input = array();
+
+		public function execute( array $input ): array
+		{
+			$this->input = $input;
+			return array(
+				'success' => true,
+				'backend' => 'github_api',
+				'name'    => (string) $input['name'],
+				'path'    => 'github://Extra-Chill/data-machine-code',
+				'message' => 'Registered remote workspace.',
+			);
+		}
+	}
+
+	$failures = array();
+	$assert   = function ( string $label, bool $condition ) use ( &$failures ): void {
+		if ( $condition ) {
+			echo "  ok {$label}\n";
+			return;
+		}
+
+		$failures[] = $label;
+		echo "  fail {$label}\n";
+	};
+
+	echo "Workspace clone CLI - smoke\n";
+
+	$ability                                     = new WorkspaceCloneTestAbility();
+	$GLOBALS['__abilities']['datamachine-code/workspace-clone'] = $ability;
+
+	$command = new \DataMachineCode\Cli\Commands\WorkspaceCommand();
+	$command->clone_repo(
+		array( 'https://github.com/Extra-Chill/data-machine-code.git' ),
+		array(
+			'name'                   => 'data-machine-code',
+			'allow-duplicate-remote' => true,
+		)
+	);
+
+	$assert('uses workspace clone ability', 'https://github.com/Extra-Chill/data-machine-code.git' === ( $ability->input['url'] ?? '' ));
+	$assert('passes explicit clone name', 'data-machine-code' === ( $ability->input['name'] ?? '' ));
+	$assert('passes duplicate remote opt-in', true === ( $ability->input['allow_duplicate_remote'] ?? false ));
+	$assert('does not force full clone by default', false === ( $ability->input['full'] ?? true ));
+	$assert('prints ability success message', in_array('Registered remote workspace.', WP_CLI::$successes, true));
+	$assert('prints returned workspace path', in_array('Path: github://Extra-Chill/data-machine-code', WP_CLI::$logs, true));
+
+	if ( $failures ) {
+		echo "\nFailures:\n";
+		foreach ( $failures as $failure ) {
+			echo " - {$failure}\n";
+		}
+		exit(1);
+	}
+
+	echo "\nOK\n";
+}


### PR DESCRIPTION
## Summary
- Route `wp datamachine-code workspace clone` through the registered workspace clone ability instead of directly instantiating the local `Workspace` service.
- Keeps WP-CLI clone behavior aligned with ability backend selection so constrained WP Codebox runtimes can use the `github_api` remote workspace backend.
- Adds a focused smoke test proving CLI clone passes arguments through to the ability and renders the returned workspace path.

Fixes #620.

## Verification
- `php tests/smoke-workspace-clone-cli.php`
- `php tests/smoke-remote-workspace-backend.php`
- `php tests/smoke-remote-workspace-backend-filter.php`
- `php tests/smoke-workspace-git-capabilities.php`
- `php tests/smoke-workspace-preload-artifact.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the CLI bypass, drafted the minimal routing fix and smoke coverage, and ran focused verification. Chris remains responsible for review and merge.