### PR TITLE
fix: fall back when workspace clone lacks git

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -2622,7 +2622,7 @@ class WorkspaceAbilities {
 		}
 
 		$workspace = new Workspace();
-		return $workspace->clone_repo(
+		$result    = $workspace->clone_repo(
 			$input['url'] ?? '',
 			$input['name'] ?? null,
 			array(
@@ -2631,6 +2631,16 @@ class WorkspaceAbilities {
 				'allow_duplicate_remote' => ! empty($input['allow_duplicate_remote']),
 			)
 		);
+
+		if ( is_wp_error($result) && 'datamachine_workspace_git_unavailable' === $result->get_error_code() ) {
+			$remote_result = ( new RemoteWorkspaceBackend() )->clone_repo(
+				$input['url'] ?? '',
+				$input['name'] ?? null
+			);
+			return self::decorate_remote_workspace_result('clone_repo', $remote_result);
+		}
+
+		return $result;
 	}
 
 	/**

--- a/tests/smoke-workspace-clone-ability-fallback.php
+++ b/tests/smoke-workspace-clone-ability-fallback.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Pure-PHP smoke for workspace clone ability fallback routing.
+ *
+ * Run: php tests/smoke-workspace-clone-ability-fallback.php
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachineCode\Abilities {
+	class AbilityRegistry
+	{
+	}
+}
+
+namespace DataMachineCode\Workspace {
+	class RemoteWorkspaceBackend
+	{
+		public static array $clone_input = array();
+
+		public static function should_handle(): bool
+		{
+			return false;
+		}
+
+		public function clone_repo( string $url, ?string $name = null ): array
+		{
+			self::$clone_input = compact('url', 'name');
+			return array(
+				'success' => true,
+				'backend' => 'github_api',
+				'name'    => (string) $name,
+				'path'    => 'github://Extra-Chill/data-machine-code',
+				'message' => 'Registered remote workspace.',
+			);
+		}
+	}
+
+	class Workspace
+	{
+		public static array $clone_input = array();
+
+		public function clone_repo( string $url, ?string $name = null, array $options = array() ): \WP_Error
+		{
+			self::$clone_input = compact('url', 'name', 'options');
+			return new \WP_Error(
+				'datamachine_workspace_git_unavailable',
+				'Clone workspace repository cannot run with the current workspace backend.'
+			);
+		}
+	}
+}
+
+namespace DataMachineCode\Support {
+	class RuntimeCapabilities
+	{
+	}
+
+	class GitRunner
+	{
+	}
+}
+
+namespace {
+	if ( ! defined('ABSPATH') ) {
+		define('ABSPATH', __DIR__);
+	}
+
+	class WP_Error
+	{
+		public function __construct( private string $code, private string $message, private array $data = array() )
+		{
+		}
+
+		public function get_error_code(): string
+		{
+			return $this->code;
+		}
+
+		public function get_error_message(): string
+		{
+			return $this->message;
+		}
+
+		public function get_error_data(): array
+		{
+			return $this->data;
+		}
+	}
+
+	function is_wp_error( $value ): bool
+	{
+		return $value instanceof WP_Error;
+	}
+
+	require __DIR__ . '/../inc/Abilities/WorkspaceAbilities.php';
+
+	$failures = array();
+	$assert   = function ( string $label, bool $condition ) use ( &$failures ): void {
+		if ( $condition ) {
+			echo "  ok {$label}\n";
+			return;
+		}
+
+		$failures[] = $label;
+		echo "  fail {$label}\n";
+	};
+
+	echo "Workspace clone ability fallback - smoke\n";
+
+	$result = \DataMachineCode\Abilities\WorkspaceAbilities::cloneRepo(
+		array(
+			'url'                    => 'https://github.com/Extra-Chill/data-machine-code.git',
+			'name'                   => 'data-machine-code',
+			'allow_duplicate_remote' => true,
+		)
+	);
+
+	$assert('local clone path was attempted first', 'https://github.com/Extra-Chill/data-machine-code.git' === ( \DataMachineCode\Workspace\Workspace::$clone_input['url'] ?? '' ));
+	$assert('local clone receives duplicate remote option', true === ( \DataMachineCode\Workspace\Workspace::$clone_input['options']['allow_duplicate_remote'] ?? false ));
+	$assert('remote fallback receives clone URL', 'https://github.com/Extra-Chill/data-machine-code.git' === ( \DataMachineCode\Workspace\RemoteWorkspaceBackend::$clone_input['url'] ?? '' ));
+	$assert('remote fallback receives clone name', 'data-machine-code' === ( \DataMachineCode\Workspace\RemoteWorkspaceBackend::$clone_input['name'] ?? '' ));
+	$assert('fallback returns remote backend result', is_array($result) && 'github_api' === ( $result['backend'] ?? '' ));
+	$assert('fallback keeps clone guidance', is_array($result) && 'workspace_worktree_add' === ( $result['next_required_tool'] ?? '' ));
+
+	if ( $failures ) {
+		echo "\nFailures:\n";
+		foreach ( $failures as $failure ) {
+			echo " - {$failure}\n";
+		}
+		exit(1);
+	}
+
+	echo "\nOK\n";
+}


### PR DESCRIPTION
## Summary
- Add an ability-level fallback for `datamachine-code/workspace-clone` when the local workspace clone path reports `datamachine_workspace_git_unavailable`.
- Routes that constrained-runtime failure through the existing `github_api` remote workspace backend, matching the preload artifact fallback behavior.
- Adds a focused smoke test that forces local clone unavailability through `WorkspaceAbilities::cloneRepo()` and verifies the remote backend result plus next-tool guidance.

Follow-up for #620 after the runner confirmed it calls the ability path directly.

## Verification
- `php tests/smoke-workspace-clone-ability-fallback.php`
- `php tests/smoke-workspace-clone-cli.php`
- `php tests/smoke-remote-workspace-backend.php`
- `php tests/smoke-workspace-preload-artifact.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the remaining ability-level constrained-runtime failure, drafted the fallback and smoke coverage, and ran focused verification. Chris remains responsible for review and merge.