### PR TITLE
add workspace context repositories ability

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -429,6 +429,44 @@ class WorkspaceAbilities {
 			);
 
 			AbilityRegistry::register(
+				'datamachine-code/workspace-context-repositories',
+				array(
+					'label'               => 'Register Workspace Context Repositories',
+					'description'         => 'Register read-only context repositories for the current workspace run. Context repositories are exposed through workspace read/list/grep tools with path allowlists and are rejected by mutating workspace operations.',
+					'category'            => 'datamachine-code-workspace',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'target_repo'      => array( 'type' => 'string' ),
+							'target_workspace' => array( 'type' => 'string' ),
+							'access'           => array(
+								'type'        => 'string',
+								'enum'        => array( 'readonly', 'read_only' ),
+								'description' => 'Context repositories are currently read-only.',
+							),
+							'repositories'     => array(
+								'type'        => 'array',
+								'description' => 'Read-only context repository specs. Each entry is { repo, ref, alias, paths }.',
+							),
+						),
+						'required'   => array( 'repositories' ),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'      => array( 'type' => 'boolean' ),
+							'access'       => array( 'type' => 'string' ),
+							'count'        => array( 'type' => 'integer' ),
+							'repositories' => array( 'type' => 'array' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'registerContextRepositories' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			AbilityRegistry::register(
 				'datamachine-code/workspace-adopt',
 				array(
 					'label'               => 'Adopt Workspace Repo',
@@ -2641,6 +2679,79 @@ class WorkspaceAbilities {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Register read-only context repositories for workspace tools.
+	 *
+	 * @param  array $input Input parameters with repositories list.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public static function registerContextRepositories( array $input ): array|\WP_Error {
+		$repositories = self::normalizeContextRepositories($input['repositories'] ?? array());
+		if ( is_wp_error($repositories) ) {
+			return $repositories;
+		}
+
+		if ( ! function_exists('update_option') ) {
+			return new \WP_Error('context_repositories_storage_unavailable', 'Context repositories cannot be registered because option storage is unavailable.', array( 'status' => 500 ));
+		}
+
+		update_option('datamachine_code_context_repositories', $repositories, false);
+
+		return array(
+			'success'      => true,
+			'access'       => 'readonly',
+			'count'        => count($repositories),
+			'repositories' => array_values($repositories),
+		);
+	}
+
+	/**
+	 * @param mixed $repositories Raw repository specs.
+	 * @return array<string,array<string,mixed>>|\WP_Error
+	 */
+	private static function normalizeContextRepositories( mixed $repositories ): array|\WP_Error {
+		if ( ! is_array($repositories) ) {
+			return new \WP_Error('invalid_context_repositories', 'repositories must be an array.', array( 'status' => 400 ));
+		}
+
+		$normalized = array();
+		foreach ( $repositories as $repository ) {
+			if ( ! is_array($repository) ) {
+				continue;
+			}
+
+			$repo = trim( (string) ( $repository['repo'] ?? '' ));
+			if ( '' === $repo ) {
+				return new \WP_Error('invalid_context_repository', 'Each context repository requires a repo value.', array( 'status' => 400 ));
+			}
+
+			$alias = sanitize_key( (string) ( $repository['alias'] ?? basename($repo) ) );
+			if ( '' === $alias ) {
+				return new \WP_Error('invalid_context_repository_alias', sprintf('Could not derive a context repository alias for %s.', $repo), array( 'status' => 400 ));
+			}
+
+			$paths = array();
+			if ( is_array($repository['paths'] ?? null) ) {
+				foreach ( $repository['paths'] as $path ) {
+					$path = trim( (string) $path );
+					if ( '' !== $path ) {
+						$paths[] = $path;
+					}
+				}
+			}
+
+			$normalized[ $alias ] = array(
+				'alias'  => $alias,
+				'repo'   => $repo,
+				'ref'    => trim( (string) ( $repository['ref'] ?? '' )),
+				'target' => $alias,
+				'paths'  => array_values(array_unique($paths)),
+			);
+		}
+
+		return $normalized;
 	}
 
 	/**

--- a/tests/smoke-workspace-context-repositories-ability.php
+++ b/tests/smoke-workspace-context-repositories-ability.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Pure-PHP smoke for workspace context repository ability registration.
+ *
+ * Run: php tests/smoke-workspace-context-repositories-ability.php
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachineCode\Abilities {
+	class AbilityRegistry
+	{
+	}
+}
+
+namespace DataMachineCode\Support {
+	class RuntimeCapabilities
+	{
+	}
+}
+
+namespace {
+	if ( ! defined('ABSPATH') ) {
+		define('ABSPATH', __DIR__);
+	}
+
+	class WP_Error
+	{
+		public function __construct( private string $code, private string $message, private array $data = array() )
+		{
+		}
+
+		public function get_error_code(): string
+		{
+			return $this->code;
+		}
+
+		public function get_error_message(): string
+		{
+			return $this->message;
+		}
+
+		public function get_error_data(): array
+		{
+			return $this->data;
+		}
+	}
+
+	function is_wp_error( $value ): bool
+	{
+		return $value instanceof WP_Error;
+	}
+
+	function sanitize_key( string $key ): string
+	{
+		$key = strtolower($key);
+		return preg_replace('/[^a-z0-9_\-]/', '', $key) ?? '';
+	}
+
+	function update_option( string $name, $value, $autoload = null ): bool
+	{
+		$GLOBALS['dmc_context_repository_options'][ $name ] = $value;
+		$GLOBALS['dmc_context_repository_autoload'][ $name ] = $autoload;
+		return true;
+	}
+
+	function get_option( string $name, $default = false )
+	{
+		return $GLOBALS['dmc_context_repository_options'][ $name ] ?? $default;
+	}
+
+	function apply_filters( string $tag, $value )
+	{
+		return $value;
+	}
+
+	function wp_json_encode( $data, int $flags = 0 )
+	{
+		return json_encode($data, $flags);
+	}
+
+	require __DIR__ . '/../inc/Abilities/WorkspaceAbilities.php';
+	require __DIR__ . '/../inc/Workspace/WorkspaceAliasResolver.php';
+
+	$failures = array();
+	$assert   = function ( string $label, bool $condition ) use ( &$failures ): void {
+		if ( $condition ) {
+			echo "  ok {$label}\n";
+			return;
+		}
+
+		$failures[] = $label;
+		echo "  fail {$label}\n";
+	};
+
+	echo "Workspace context repositories ability - smoke\n";
+
+	$result = \DataMachineCode\Abilities\WorkspaceAbilities::registerContextRepositories(
+		array(
+			'target_repo'      => 'Automattic/build-with-wordpress',
+			'target_workspace' => 'build-with-wordpress@skills',
+			'access'           => 'readonly',
+			'repositories'     => array(
+				array(
+					'repo'  => 'Automattic/studio',
+					'ref'   => 'trunk',
+					'alias' => 'studio',
+					'paths' => array( 'apps/cli/ai/tools/**', 'apps/cli/ai/tools/**', 'README.md' ),
+				),
+			),
+		)
+	);
+
+	$stored = get_option('datamachine_code_context_repositories', array());
+	$policy = \DataMachineCode\Workspace\WorkspaceAliasResolver::policy_attestation('studio');
+
+	$assert('registers successfully', is_array($result) && true === ( $result['success'] ?? false ));
+	$assert('reports repository count', is_array($result) && 1 === ( $result['count'] ?? 0 ));
+	$assert('stores context repositories option', isset($stored['studio']));
+	$assert('stores option with autoload disabled', false === ( $GLOBALS['dmc_context_repository_autoload']['datamachine_code_context_repositories'] ?? null ));
+	$assert('deduplicates allowed paths', array( 'apps/cli/ai/tools/**', 'README.md' ) === ( $stored['studio']['paths'] ?? array() ));
+	$assert('resolver exposes read-only policy', false === ( $policy['writable'] ?? true ) && true === ( $policy['read_only'] ?? false ));
+	$assert('resolver keeps repo and ref', 'Automattic/studio' === ( $policy['repo'] ?? '' ) && 'trunk' === ( $policy['ref'] ?? '' ));
+
+	if ( $failures ) {
+		echo "\nFailures:\n";
+		foreach ( $failures as $failure ) {
+			echo " - {$failure}\n";
+		}
+		exit(1);
+	}
+
+	echo "\nOK\n";
+}


### PR DESCRIPTION
## Summary
- Register `datamachine-code/workspace-context-repositories` so runners can provision read-only context repository aliases through the canonical DMC ability surface.
- Persist normalized context specs into the existing `datamachine_code_context_repositories` option consumed by `WorkspaceAliasResolver` and `RemoteWorkspaceBackend`.
- Add smoke coverage proving the ability stores deduplicated allowed paths and exposes read-only resolver policy.

Unblocks the Homeboy runner path for Extra-Chill/data-machine-code#617.

## Verification
- `php tests/smoke-workspace-context-repositories-ability.php`
- `php tests/smoke-workspace-context-repositories.php`
- `php tests/smoke-remote-workspace-backend.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the missing DMC ability expected by Homeboy, drafted the ability implementation and smoke coverage, and ran focused verification. Chris remains responsible for review and merge.