### PR TITLE
Add runner workspace command ability

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -1065,6 +1065,20 @@ class WorkspaceAbilities {
 			);
 
 			AbilityRegistry::register(
+				'datamachine-code/run-runner-workspace-command',
+				array(
+					'label'               => 'Run Runner Workspace Command',
+					'description'         => 'Run a bounded verification or drift command against a runner-owned workspace handle without exposing DMC local paths to callers.',
+					'category'            => 'datamachine-code-workspace',
+					'input_schema'        => self::runnerWorkspaceCommandInputSchema(),
+					'output_schema'       => self::runnerWorkspaceCommandOutputSchema(),
+					'execute_callback'    => array( self::class, 'runRunnerWorkspaceCommand' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			AbilityRegistry::register(
 				'datamachine-code/workspace-git-rebase',
 				array(
 					'label'               => 'Workspace Git Rebase',
@@ -3047,6 +3061,121 @@ class WorkspaceAbilities {
 	 */
 	public static function publishRunnerWorkspace( array $input ): array|\WP_Error {
 		return ( new RunnerWorkspacePublisher() )->publish($input);
+	}
+
+	/**
+	 * Run a bounded command against a runner-owned workspace.
+	 *
+	 * @param  array<string,mixed> $input Command input.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public static function runRunnerWorkspaceCommand( array $input ): array|\WP_Error {
+		$handle = trim( (string) ( $input['workspace_handle'] ?? $input['name'] ?? $input['repo'] ?? '' ) );
+		$command = trim( (string) ( $input['command'] ?? '' ) );
+		$timeout = isset($input['timeout']) ? (int) $input['timeout'] : (int) ( $input['timeout_seconds'] ?? 300 );
+		$env     = isset($input['env']) && is_array($input['env']) ? $input['env'] : array();
+
+		if ( RemoteWorkspaceBackend::should_handle() ) {
+			$result = ( new RemoteWorkspaceBackend() )->run_command(
+				$handle,
+				$command,
+				(string) ( $input['description'] ?? '' ),
+				$timeout,
+				$env,
+				isset($input['cwd']) ? (string) $input['cwd'] : null
+			);
+			return self::decorate_remote_workspace_result('run_runner_workspace_command', $result);
+		}
+
+		$workspace = new Workspace();
+		return $workspace->run_runner_workspace_command(
+			$handle,
+			$command,
+			(string) ( $input['description'] ?? '' ),
+			$timeout,
+			$env,
+			isset($input['cwd']) ? (string) $input['cwd'] : null
+		);
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	private static function runnerWorkspaceCommandInputSchema(): array {
+		return array(
+			'type'       => 'object',
+			'required'   => array( 'workspace_handle', 'command' ),
+			'properties' => array(
+				'workspace_handle' => array(
+					'type'        => 'string',
+					'description' => 'Workspace handle: <repo>, <repo>@<branch-slug>, or a runner-provided alias.',
+				),
+				'name'             => array(
+					'type'        => 'string',
+					'description' => 'Alias for workspace_handle.',
+				),
+				'repo'             => array(
+					'type'        => 'string',
+					'description' => 'Alias for workspace_handle.',
+				),
+				'command'          => array(
+					'type'        => 'string',
+					'description' => 'Shell command to run inside the workspace.',
+				),
+				'description'      => array(
+					'type'        => 'string',
+					'description' => 'Human-readable reason for the command.',
+				),
+				'timeout'          => array(
+					'type'        => 'integer',
+					'description' => 'Timeout in seconds. Defaults to 300 and is capped at 1800.',
+				),
+				'timeout_seconds'  => array(
+					'type'        => 'integer',
+					'description' => 'Alias for timeout.',
+				),
+				'cwd'              => array(
+					'type'        => 'string',
+					'description' => 'Optional relative working directory inside the workspace.',
+				),
+				'env'              => array(
+					'type'                 => 'object',
+					'description'          => 'Optional string environment variables for the command.',
+					'additionalProperties' => array( 'type' => 'string' ),
+				),
+				'context'          => array(
+					'type'        => 'object',
+					'description' => 'Optional caller context carried for observability.',
+				),
+			),
+		);
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	private static function runnerWorkspaceCommandOutputSchema(): array {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'success'       => array( 'type' => 'boolean' ),
+				'kind'          => array( 'type' => 'string' ),
+				'backend'       => array( 'type' => 'string' ),
+				'failure_type'  => array( 'type' => array( 'string', 'null' ) ),
+				'name'          => array( 'type' => 'string' ),
+				'repo'          => array( 'type' => 'string' ),
+				'path'          => array( 'type' => array( 'string', 'null' ) ),
+				'command'       => array( 'type' => 'string' ),
+				'description'   => array( 'type' => 'string' ),
+				'exit_code'     => array( 'type' => array( 'integer', 'null' ) ),
+				'stdout'        => array( 'type' => 'string' ),
+				'stderr'        => array( 'type' => 'string' ),
+				'elapsed_ms'    => array( 'type' => 'integer' ),
+				'timed_out'     => array( 'type' => 'boolean' ),
+				'workspace'     => array( 'type' => 'object' ),
+				'message'       => array( 'type' => 'string' ),
+			),
+		);
 	}
 
 	/**

--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -3070,7 +3070,7 @@ class WorkspaceAbilities {
 	 * @return array<string,mixed>|\WP_Error
 	 */
 	public static function runRunnerWorkspaceCommand( array $input ): array|\WP_Error {
-		$handle = trim( (string) ( $input['workspace_handle'] ?? $input['name'] ?? $input['repo'] ?? '' ) );
+		$handle  = trim( (string) ( $input['workspace_handle'] ?? $input['name'] ?? $input['repo'] ?? '' ) );
 		$command = trim( (string) ( $input['command'] ?? '' ) );
 		$timeout = isset($input['timeout']) ? (int) $input['timeout'] : (int) ( $input['timeout_seconds'] ?? 300 );
 		$env     = isset($input['env']) && is_array($input['env']) ? $input['env'] : array();
@@ -3158,22 +3158,22 @@ class WorkspaceAbilities {
 		return array(
 			'type'       => 'object',
 			'properties' => array(
-				'success'       => array( 'type' => 'boolean' ),
-				'kind'          => array( 'type' => 'string' ),
-				'backend'       => array( 'type' => 'string' ),
-				'failure_type'  => array( 'type' => array( 'string', 'null' ) ),
-				'name'          => array( 'type' => 'string' ),
-				'repo'          => array( 'type' => 'string' ),
-				'path'          => array( 'type' => array( 'string', 'null' ) ),
-				'command'       => array( 'type' => 'string' ),
-				'description'   => array( 'type' => 'string' ),
-				'exit_code'     => array( 'type' => array( 'integer', 'null' ) ),
-				'stdout'        => array( 'type' => 'string' ),
-				'stderr'        => array( 'type' => 'string' ),
-				'elapsed_ms'    => array( 'type' => 'integer' ),
-				'timed_out'     => array( 'type' => 'boolean' ),
-				'workspace'     => array( 'type' => 'object' ),
-				'message'       => array( 'type' => 'string' ),
+				'success'      => array( 'type' => 'boolean' ),
+				'kind'         => array( 'type' => 'string' ),
+				'backend'      => array( 'type' => 'string' ),
+				'failure_type' => array( 'type' => array( 'string', 'null' ) ),
+				'name'         => array( 'type' => 'string' ),
+				'repo'         => array( 'type' => 'string' ),
+				'path'         => array( 'type' => array( 'string', 'null' ) ),
+				'command'      => array( 'type' => 'string' ),
+				'description'  => array( 'type' => 'string' ),
+				'exit_code'    => array( 'type' => array( 'integer', 'null' ) ),
+				'stdout'       => array( 'type' => 'string' ),
+				'stderr'       => array( 'type' => 'string' ),
+				'elapsed_ms'   => array( 'type' => 'integer' ),
+				'timed_out'    => array( 'type' => 'boolean' ),
+				'workspace'    => array( 'type' => 'object' ),
+				'message'      => array( 'type' => 'string' ),
 			),
 		);
 	}

--- a/inc/Support/ProcessRunner.php
+++ b/inc/Support/ProcessRunner.php
@@ -104,13 +104,20 @@ final class ProcessRunner {
 		stream_set_blocking($pipes[1], false);
 		stream_set_blocking($pipes[2], false);
 
-		$output    = '';
+		$separate_streams = ! empty($options['separate_streams']);
+		$stdout           = '';
+		$stderr           = '';
+		$output           = '';
 		$deadline  = $timeout_seconds > 0 ? microtime(true) + $timeout_seconds : null;
 		$exit_code = null;
 
 		while ( true ) {
-			$chunk = (string) stream_get_contents($pipes[1]) . (string) stream_get_contents($pipes[2]);
+			$stdout_chunk = (string) stream_get_contents($pipes[1]);
+			$stderr_chunk = (string) stream_get_contents($pipes[2]);
+			$chunk        = $stdout_chunk . $stderr_chunk;
 			if ( '' !== $chunk ) {
+				$stdout .= $stdout_chunk;
+				$stderr .= $stderr_chunk;
 				$output .= $chunk;
 				if ( null !== $on_output ) {
 					$on_output($chunk);
@@ -124,13 +131,15 @@ final class ProcessRunner {
 			}
 
 			if ( null !== $deadline && microtime(true) >= $deadline ) {
-				$output = self::terminate_timed_out_process($process, $pipes, $output);
+				$remaining = self::terminate_timed_out_process($process, $pipes, $output, $stdout, $stderr);
 				return self::error(
 					$options,
 					sprintf('Process command timed out after %d second(s).', $timeout_seconds),
 					array(
 						'timeout' => $timeout_seconds,
-						'output'  => self::cap_output(trim($output), $output_cap),
+						'output'  => self::cap_output(trim($remaining['output']), $output_cap),
+						'stdout'  => self::cap_output(trim($remaining['stdout']), $output_cap),
+						'stderr'  => self::cap_output(trim($remaining['stderr']), $output_cap),
 					)
 				);
 			}
@@ -138,7 +147,11 @@ final class ProcessRunner {
 			usleep( (int) ( $options['poll_interval_microseconds'] ?? 50000 ) );
 		}
 
-		$output .= (string) stream_get_contents($pipes[1]) . (string) stream_get_contents($pipes[2]);
+		$stdout_tail = (string) stream_get_contents($pipes[1]);
+		$stderr_tail = (string) stream_get_contents($pipes[2]);
+		$stdout     .= $stdout_tail;
+		$stderr     .= $stderr_tail;
+		$output     .= $stdout_tail . $stderr_tail;
 		foreach ( $pipes as $pipe ) {
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Process pipes are not WordPress filesystem paths.
 			fclose($pipe);
@@ -150,29 +163,43 @@ final class ProcessRunner {
 		}
 
 		$output = self::cap_output(trim(str_replace("\r", "\n", $output)), $output_cap);
+		$stdout = self::cap_output(trim(str_replace("\r", "\n", $stdout)), $output_cap);
+		$stderr = self::cap_output(trim(str_replace("\r", "\n", $stderr)), $output_cap);
 		if ( 0 !== $exit_code ) {
+			$data = array(
+				'exit_code' => $exit_code,
+				'output'    => $output,
+			);
+			if ( $separate_streams ) {
+				$data['stdout'] = $stdout;
+				$data['stderr'] = $stderr;
+			}
+
 			return self::error(
 				$options,
 				sprintf('Process command failed (exit %d): %s', $exit_code, $output),
-				array(
-					'exit_code' => $exit_code,
-					'output'    => $output,
-				)
+				$data
 			);
 		}
 
-		return array(
+		$result = array(
 			'success'   => true,
 			'output'    => $output,
 			'exit_code' => 0,
 		);
+		if ( $separate_streams ) {
+			$result['stdout'] = $stdout;
+			$result['stderr'] = $stderr;
+		}
+
+		return $result;
 	}
 
 	/**
 	 * @param resource $process
 	 * @param array<int,resource> $pipes
 	 */
-	private static function terminate_timed_out_process( $process, array $pipes, string $output ): string {
+	private static function terminate_timed_out_process( $process, array $pipes, string $output, string $stdout = '', string $stderr = '' ): array {
 		proc_terminate($process);
 		usleep(100000);
 		$status = proc_get_status($process);
@@ -180,14 +207,22 @@ final class ProcessRunner {
 			proc_terminate($process, 9);
 		}
 
-		$output .= (string) stream_get_contents($pipes[1]) . (string) stream_get_contents($pipes[2]);
+		$stdout_tail = (string) stream_get_contents($pipes[1]);
+		$stderr_tail = (string) stream_get_contents($pipes[2]);
+		$stdout     .= $stdout_tail;
+		$stderr     .= $stderr_tail;
+		$output     .= $stdout_tail . $stderr_tail;
 		foreach ( $pipes as $pipe ) {
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Process pipes are not WordPress filesystem paths.
 			fclose($pipe);
 		}
 		proc_close($process);
 
-		return $output;
+		return array(
+			'output' => $output,
+			'stdout' => $stdout,
+			'stderr' => $stderr,
+		);
 	}
 
 	private static function cap_output( string $output, int $output_cap ): string {
@@ -204,11 +239,19 @@ final class ProcessRunner {
 	 */
 	private static function error( array $options, string $message, array $data = array() ): array|\WP_Error {
 		if ( ! empty($options['error_as_result']) ) {
-			return array(
+			$result = array(
 				'success'   => false,
 				'output'    => (string) ( $data['output'] ?? $message ),
 				'exit_code' => (int) ( $data['exit_code'] ?? 1 ),
 			);
+			if ( array_key_exists('stdout', $data) ) {
+				$result['stdout'] = (string) $data['stdout'];
+			}
+			if ( array_key_exists('stderr', $data) ) {
+				$result['stderr'] = (string) $data['stderr'];
+			}
+
+			return $result;
 		}
 
 		$code = isset($options['error_code']) && is_string($options['error_code']) && '' !== $options['error_code'] ? $options['error_code'] : 'process_command_failed';

--- a/inc/Support/ProcessRunner.php
+++ b/inc/Support/ProcessRunner.php
@@ -26,7 +26,7 @@ final class ProcessRunner {
 	 *
 	 * @param  string              $command Shell command to execute.
 	 * @param  array<string,mixed> $options Execution options.
-	 * @return array{success: bool, output: string, exit_code: int}|\WP_Error
+	 * @return array<string,mixed>|\WP_Error
 	 */
 	public static function run( string $command, array $options = array() ): array|\WP_Error {
 		$timeout_seconds = max(0, (int) ( $options['timeout_seconds'] ?? 0 ));
@@ -53,7 +53,7 @@ final class ProcessRunner {
 
 	/**
 	 * @param  array<string,mixed> $options
-	 * @return array{success: bool, output: string, exit_code: int}|\WP_Error
+	 * @return array<string,mixed>|\WP_Error
 	 */
 	private static function run_via_exec( string $command, array $options, int $output_cap ): array|\WP_Error {
 		$shell = RuntimeCapabilities::shell_diagnostic();
@@ -87,7 +87,7 @@ final class ProcessRunner {
 	 * @param  array<string,mixed> $options
 	 * @param  callable|null       $on_output
 	 * @param  array<string,mixed>|null $env
-	 * @return array{success: bool, output: string, exit_code: int}|\WP_Error
+	 * @return array<string,mixed>|\WP_Error
 	 */
 	private static function run_via_proc_open( string $command, array $options, int $timeout_seconds, int $output_cap, ?callable $on_output, ?string $cwd, ?array $env ): array|\WP_Error {
 		$descriptor_spec = array(
@@ -108,8 +108,8 @@ final class ProcessRunner {
 		$stdout           = '';
 		$stderr           = '';
 		$output           = '';
-		$deadline  = $timeout_seconds > 0 ? microtime(true) + $timeout_seconds : null;
-		$exit_code = null;
+		$deadline         = $timeout_seconds > 0 ? microtime(true) + $timeout_seconds : null;
+		$exit_code        = 0;
 
 		while ( true ) {
 			$stdout_chunk = (string) stream_get_contents($pipes[1]);
@@ -126,7 +126,7 @@ final class ProcessRunner {
 
 			$status = proc_get_status($process);
 			if ( empty($status['running']) ) {
-				$exit_code = isset($status['exitcode']) ? (int) $status['exitcode'] : null;
+				$exit_code = (int) $status['exitcode'];
 				break;
 			}
 
@@ -158,7 +158,7 @@ final class ProcessRunner {
 		}
 
 		$close_code = proc_close($process);
-		if ( null === $exit_code ) {
+		if ( -1 === $exit_code ) {
 			$exit_code = $close_code;
 		}
 
@@ -236,6 +236,7 @@ final class ProcessRunner {
 	/**
 	 * @param array<string,mixed> $options
 	 * @param array<string,mixed> $data
+	 * @return array<string,mixed>|\WP_Error
 	 */
 	private static function error( array $options, string $message, array $data = array() ): array|\WP_Error {
 		if ( ! empty($options['error_as_result']) ) {

--- a/inc/Tools/AbilityToolProjections.php
+++ b/inc/Tools/AbilityToolProjections.php
@@ -62,6 +62,7 @@ class AbilityToolProjections {
 			'workspace_git_add'                    => self::workspace_write('datamachine-code/workspace-git-add'),
 			'workspace_git_commit'                 => self::workspace_write('datamachine-code/workspace-git-commit'),
 			'workspace_git_push'                   => self::workspace_write('datamachine-code/workspace-git-push'),
+			'workspace_run_runner_command'          => self::workspace_write('datamachine-code/run-runner-workspace-command'),
 			'workspace_git_rebase'                 => self::workspace_write('datamachine-code/workspace-git-rebase'),
 			'workspace_git_reset'                  => self::workspace_write('datamachine-code/workspace-git-reset'),
 			'workspace_worktree_add'               => self::workspace_write('datamachine-code/workspace-worktree-add'),

--- a/inc/Tools/WorkspaceTools.php
+++ b/inc/Tools/WorkspaceTools.php
@@ -58,6 +58,7 @@ class WorkspaceTools extends BaseTool
         'workspace_git_add',
         'workspace_git_commit',
         'workspace_git_push',
+        'workspace_run_runner_command',
         'workspace_git_rebase',
         'workspace_git_reset',
         'workspace_pr_status',
@@ -99,6 +100,7 @@ class WorkspaceTools extends BaseTool
         $this->registerTool('workspace_git_commit', array( $this, 'getGitCommitDefinition' ), $policy_contexts, $policy_meta + array( 'ability' => 'datamachine-code/workspace-git-commit' ));
         $this->registerTool('workspace_git_push', array( $this, 'getGitPushDefinition' ), $policy_contexts, $policy_meta + array( 'ability' => 'datamachine-code/workspace-git-push' ));
         $this->registerTool('workspace_publish_runner', array( $this, 'getPublishRunnerDefinition' ), $policy_contexts, $policy_meta + array( 'ability' => 'datamachine-code/publish-runner-workspace' ));
+        $this->registerTool('workspace_run_runner_command', array( $this, 'getRunRunnerCommandDefinition' ), $policy_contexts, $policy_meta + array( 'ability' => 'datamachine-code/run-runner-workspace-command' ));
         $this->registerTool('workspace_git_rebase', array( $this, 'getGitRebaseDefinition' ), $policy_contexts, $policy_meta + array( 'ability' => 'datamachine-code/workspace-git-rebase' ));
         $this->registerTool('workspace_git_reset', array( $this, 'getGitResetDefinition' ), $policy_contexts, $policy_meta + array( 'ability' => 'datamachine-code/workspace-git-reset' ));
         $this->registerTool('workspace_pr_status', array( $this, 'getPrStatusDefinition' ), $policy_contexts, $policy_meta + array( 'ability' => 'datamachine-code/workspace-pr-status' ));
@@ -623,6 +625,22 @@ class WorkspaceTools extends BaseTool
         }
 
         return $this->executeAbility('datamachine-code/publish-runner-workspace', 'workspace_publish_runner', $input, array( 'workspace_handle' ));
+    }
+
+    /**
+     * @param array<string,mixed> $parameters Tool parameters. @return array<string,mixed>
+     */
+    public function handleRunRunnerCommand( array $parameters ): array
+    {
+        $input = $parameters;
+        if (isset($parameters['name']) && ! isset($input['workspace_handle']) ) {
+            $input['workspace_handle'] = $parameters['name'];
+        }
+        if (isset($parameters['repo']) && ! isset($input['workspace_handle']) ) {
+            $input['workspace_handle'] = $parameters['repo'];
+        }
+
+        return $this->executeAbility('datamachine-code/run-runner-workspace-command', 'workspace_run_runner_command', $input, array( 'workspace_handle', 'command' ));
     }
 
     /**
@@ -1531,7 +1549,37 @@ class WorkspaceTools extends BaseTool
     }
 
     /**
-     * @return array<string,mixed> 
+     * @return array<string,mixed>
+     */
+    public function getRunRunnerCommandDefinition(): array
+    {
+        return $this->withRuntime(
+            array(
+            'class'       => __CLASS__,
+            'method'      => 'handleRunRunnerCommand',
+            'description' => 'Run a bounded verification or drift command against a runner-owned workspace handle through the canonical DMC backend API.',
+            'parameters'  => array(
+            'type'       => 'object',
+            'required'   => array( 'workspace_handle', 'command' ),
+            'properties' => array(
+                'workspace_handle' => array( 'type' => 'string', 'description' => 'Workspace handle: <repo>, <repo>@<branch-slug>, or runner alias.' ),
+                'name'             => array( 'type' => 'string', 'description' => 'Alias for workspace_handle.' ),
+                'repo'             => array( 'type' => 'string', 'description' => 'Alias for workspace_handle.' ),
+                'command'          => array( 'type' => 'string', 'description' => 'Shell command to run inside the workspace.' ),
+                'description'      => array( 'type' => 'string', 'description' => 'Human-readable reason for the command.' ),
+                'timeout'          => array( 'type' => 'integer', 'description' => 'Timeout in seconds. Defaults to 300 and is capped at 1800.' ),
+                'timeout_seconds'  => array( 'type' => 'integer', 'description' => 'Alias for timeout.' ),
+                'cwd'              => array( 'type' => 'string', 'description' => 'Optional relative working directory inside the workspace.' ),
+                'env'              => array( 'type' => 'object', 'description' => 'Optional string environment variables.' ),
+                'context'          => array( 'type' => 'object', 'description' => 'Optional caller context carried for observability.' ),
+            ),
+            ),
+            ), array( 'completion_signal' => 'complete' )
+        );
+    }
+
+	/**
+	 * @return array<string,mixed>
      */
     public function getGitRebaseDefinition(): array
     {

--- a/inc/Workspace/RemoteWorkspaceBackend.php
+++ b/inc/Workspace/RemoteWorkspaceBackend.php
@@ -651,6 +651,62 @@ class RemoteWorkspaceBackend {
 	}
 
 	/**
+	 * Remote/GitHub workspaces do not expose shell command execution.
+	 *
+	 * @param  string              $handle          Workspace handle.
+	 * @param  string              $command         Shell command requested by caller.
+	 * @param  string              $description     Human-readable reason for the command.
+	 * @param  int                 $timeout_seconds Timeout in seconds.
+	 * @param  array<string,mixed> $env             Environment variables, accepted for API symmetry.
+	 * @param  string|null         $cwd             Optional relative cwd, accepted for API symmetry.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function run_command( string $handle, string $command, string $description = '', int $timeout_seconds = 300, array $env = array(), ?string $cwd = null ): array|\WP_Error {
+		unset($timeout_seconds, $env, $cwd);
+
+		if ( '' === trim($command) ) {
+			return new \WP_Error('runner_workspace_command_missing_command', 'command is required.', array( 'status' => 400 ));
+		}
+
+		$context = $this->resolve_handle($handle);
+		if ( is_wp_error($context) ) {
+			return $context;
+		}
+
+		$result = array(
+			'success'      => false,
+			'kind'         => 'runner_workspace_command',
+			'backend'      => 'github_api',
+			'failure_type' => 'unavailable',
+			'name'         => $handle,
+			'repo'         => $context['repo_name'],
+			'path'         => 'github://' . $context['repo'] . ( '' !== (string) $context['branch'] ? '#' . $context['branch'] : '' ),
+			'command'      => trim($command),
+			'description'  => $description,
+			'exit_code'    => null,
+			'stdout'       => '',
+			'stderr'       => '',
+			'elapsed_ms'   => 0,
+			'timed_out'    => false,
+			'workspace'    => array(
+				'handle'     => $handle,
+				'repo'       => $context['repo_name'],
+				'github_repo'=> $context['repo'],
+				'branch'     => $context['branch'],
+				'backend'    => 'github_api',
+				'is_context' => ! empty($context['read_only_context']),
+			),
+			'message'      => 'Runner workspace command execution is unavailable for GitHub API remote workspaces; use a local runner workspace backend for shell commands.',
+		);
+
+		if ( WorkspaceAliasResolver::is_context_repository($handle) ) {
+			$result['workspace_policy'] = WorkspaceAliasResolver::policy_attestation($handle);
+		}
+
+		return $result;
+	}
+
+	/**
 	 * Compatibility no-op: files are tracked by pending remote workspace state.
 	 *
 	 * @return array<string,mixed>|\WP_Error

--- a/inc/Workspace/RemoteWorkspaceBackend.php
+++ b/inc/Workspace/RemoteWorkspaceBackend.php
@@ -689,12 +689,12 @@ class RemoteWorkspaceBackend {
 			'elapsed_ms'   => 0,
 			'timed_out'    => false,
 			'workspace'    => array(
-				'handle'     => $handle,
-				'repo'       => $context['repo_name'],
-				'github_repo'=> $context['repo'],
-				'branch'     => $context['branch'],
-				'backend'    => 'github_api',
-				'is_context' => ! empty($context['read_only_context']),
+				'handle'      => $handle,
+				'repo'        => $context['repo_name'],
+				'github_repo' => $context['repo'],
+				'branch'      => $context['branch'],
+				'backend'     => 'github_api',
+				'is_context'  => ! empty($context['read_only_context']),
 			),
 			'message'      => 'Runner workspace command execution is unavailable for GitHub API remote workspaces; use a local runner workspace backend for shell commands.',
 		);

--- a/inc/Workspace/WorkspaceGitOperations.php
+++ b/inc/Workspace/WorkspaceGitOperations.php
@@ -182,7 +182,7 @@ trait WorkspaceGitOperations {
 			$base_env = $_ENV;
 		}
 
-		$result          = ProcessRunner::run(
+		$result     = ProcessRunner::run(
 			$command,
 			array(
 				'cwd'              => $workdir,
@@ -193,7 +193,7 @@ trait WorkspaceGitOperations {
 				'separate_streams' => true,
 			)
 		);
-		$elapsed_ms      = max(0, (int) round(( microtime(true) - $started ) * 1000));
+		$elapsed_ms = max(0, (int) round(( microtime(true) - $started ) * 1000));
 
 		if ( is_wp_error($result) ) {
 			return $result;

--- a/inc/Workspace/WorkspaceGitOperations.php
+++ b/inc/Workspace/WorkspaceGitOperations.php
@@ -9,6 +9,7 @@ namespace DataMachineCode\Workspace;
 
 use DataMachineCode\Support\GitHubRemote;
 use DataMachineCode\Support\PathSecurity;
+use DataMachineCode\Support\ProcessRunner;
 
 defined('ABSPATH') || exit;
 
@@ -116,6 +117,116 @@ trait WorkspaceGitOperations {
 			'success' => true,
 			'message' => trim( (string) $result['output']),
 			'name'    => $parsed['dir_name'],
+		);
+	}
+
+	/**
+	 * Run a bounded shell command in a runner workspace.
+	 *
+	 * @param  string              $handle          Workspace handle.
+	 * @param  string              $command         Shell command to execute.
+	 * @param  string              $description     Human-readable reason for the command.
+	 * @param  int                 $timeout_seconds Timeout in seconds.
+	 * @param  array<string,mixed> $env             Extra environment variables.
+	 * @param  string|null         $cwd             Optional relative working directory.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function run_runner_workspace_command( string $handle, string $command, string $description = '', int $timeout_seconds = 300, array $env = array(), ?string $cwd = null ): array|\WP_Error {
+		if ( WorkspaceAliasResolver::is_context_repository($handle) ) {
+			return WorkspaceAliasResolver::mutation_error($handle, 'command execution');
+		}
+
+		$command = trim($command);
+		if ( '' === $command ) {
+			return new \WP_Error('runner_workspace_command_missing_command', 'command is required.', array( 'status' => 400 ));
+		}
+
+		$parsed    = $this->parse_handle($handle);
+		$repo_path = $this->resolve_repo_path($handle);
+		if ( is_wp_error($repo_path) ) {
+			return $repo_path;
+		}
+
+		$workdir = $repo_path;
+		if ( null !== $cwd && '' !== trim($cwd) ) {
+			$relative = trim(str_replace('\\', '/', $cwd), '/');
+			if ( '' === $relative || str_contains($relative, '..') ) {
+				return new \WP_Error('runner_workspace_command_invalid_cwd', 'cwd must be a relative path inside the workspace.', array( 'status' => 400 ));
+			}
+
+			$target = $repo_path . '/' . $relative;
+			if ( ! is_dir($target) ) {
+				return new \WP_Error('runner_workspace_command_cwd_not_found', sprintf('cwd "%s" was not found inside the workspace.', $relative), array( 'status' => 404 ));
+			}
+
+			$validation = $this->validate_containment($target, $repo_path);
+			if ( ! $validation['valid'] ) {
+				return new \WP_Error('path_traversal', $validation['message'], array( 'status' => 403 ));
+			}
+			$workdir = $validation['real_path'];
+		}
+
+		$clean_env = array();
+		foreach ( $env as $key => $value ) {
+			$key = trim( (string) $key );
+			if ( '' === $key || ! preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $key) ) {
+				return new \WP_Error('runner_workspace_command_invalid_env', sprintf('Invalid environment variable name "%s".', $key), array( 'status' => 400 ));
+			}
+			$clean_env[ $key ] = (string) $value;
+		}
+
+		$timeout_seconds = max(1, min(1800, $timeout_seconds));
+		$started         = microtime(true);
+		$base_env        = getenv();
+		if ( ! is_array($base_env) ) {
+			$base_env = $_ENV;
+		}
+
+		$result          = ProcessRunner::run(
+			$command,
+			array(
+				'cwd'              => $workdir,
+				'env'              => empty($clean_env) ? null : array_merge($base_env, $clean_env),
+				'timeout_seconds'  => $timeout_seconds,
+				'output_cap_bytes' => 1048576,
+				'error_as_result'  => true,
+				'separate_streams' => true,
+			)
+		);
+		$elapsed_ms      = max(0, (int) round(( microtime(true) - $started ) * 1000));
+
+		if ( is_wp_error($result) ) {
+			return $result;
+		}
+
+		$stdout    = (string) ( $result['stdout'] ?? ( $result['output'] ?? '' ) );
+		$stderr    = (string) ( $result['stderr'] ?? '' );
+		$exit_code = (int) ( $result['exit_code'] ?? 1 );
+		$success   = 0 === $exit_code;
+
+		return array(
+			'success'      => $success,
+			'kind'         => 'runner_workspace_command',
+			'backend'      => 'local_git',
+			'failure_type' => $success ? null : 'command_failed',
+			'name'         => $parsed['dir_name'],
+			'repo'         => $parsed['repo'],
+			'path'         => $repo_path,
+			'cwd'          => $workdir,
+			'command'      => $command,
+			'description'  => $description,
+			'exit_code'    => $exit_code,
+			'stdout'       => $stdout,
+			'stderr'       => $stderr,
+			'elapsed_ms'   => $elapsed_ms,
+			'timed_out'    => false,
+			'workspace'    => array(
+				'handle'      => $parsed['dir_name'],
+				'repo'        => $parsed['repo'],
+				'is_worktree' => $parsed['is_worktree'],
+				'backend'     => 'local_git',
+			),
+			'message'      => $success ? 'Runner workspace command completed successfully.' : 'Runner workspace command failed.',
 		);
 	}
 

--- a/tests/smoke-ability-tool-projections.php
+++ b/tests/smoke-ability-tool-projections.php
@@ -49,6 +49,10 @@ namespace {
 		return true;
 	}
 
+	function wp_json_encode( mixed $value, int $flags = 0 ): string|false {
+		return json_encode($value, $flags);
+	}
+
 	function dmc_projection_normalize_tool_result( array $ability_result, string $tool_name, string $ability_slug ): array {
 		$result              = $ability_result;
 		$result['tool_name'] = $result['tool_name'] ?? $tool_name;
@@ -144,6 +148,7 @@ namespace {
 		'workspace_git_add'     => 'datamachine-code/workspace-git-add',
 		'workspace_git_commit'  => 'datamachine-code/workspace-git-commit',
 		'workspace_git_push'    => 'datamachine-code/workspace-git-push',
+		'workspace_run_runner_command' => 'datamachine-code/run-runner-workspace-command',
 	);
 
 	foreach ( $expected_write as $tool_name => $ability_slug ) {

--- a/tests/smoke-runner-workspace-command.php
+++ b/tests/smoke-runner-workspace-command.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Smoke coverage for runner workspace command execution ability.
+ *
+ * Run: php tests/smoke-runner-workspace-command.php
+ */
+
+declare( strict_types=1 );
+
+namespace {
+	if ( ! defined('ABSPATH') ) {
+		define('ABSPATH', __DIR__ . '/');
+	}
+	if ( ! defined('DATAMACHINE_WORKSPACE_PATH') ) {
+		define('DATAMACHINE_WORKSPACE_PATH', sys_get_temp_dir() . '/dmc-runner-command-workspace');
+	}
+
+	$GLOBALS['dmc_runner_command_registered_abilities'] = array();
+	$GLOBALS['dmc_runner_command_options'] = array();
+	$GLOBALS['dmc_runner_command_filters'] = array();
+
+	function wp_register_ability( string $name, array $definition ): void {
+		$GLOBALS['dmc_runner_command_registered_abilities'][ $name ] = $definition;
+	}
+
+	function add_action( string $hook, callable $callback, int $priority = 10 ): void {
+		unset($hook, $callback, $priority);
+	}
+
+	function doing_action( string $hook ): bool {
+		return 'wp_abilities_api_init' === $hook;
+	}
+
+	function get_option( string $name, mixed $default = false ): mixed {
+		return $GLOBALS['dmc_runner_command_options'][ $name ] ?? $default;
+	}
+
+	function update_option( string $name, mixed $value, bool $autoload = true ): bool {
+		unset($autoload);
+		$GLOBALS['dmc_runner_command_options'][ $name ] = $value;
+		return true;
+	}
+
+	function add_filter( string $tag, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		unset($accepted_args);
+		$GLOBALS['dmc_runner_command_filters'][ $tag ][ $priority ][] = $callback;
+	}
+
+	function apply_filters( string $tag, mixed $value ): mixed {
+		if ( empty($GLOBALS['dmc_runner_command_filters'][ $tag ]) ) {
+			return $value;
+		}
+
+		ksort($GLOBALS['dmc_runner_command_filters'][ $tag ]);
+		foreach ( $GLOBALS['dmc_runner_command_filters'][ $tag ] as $callbacks ) {
+			foreach ( $callbacks as $callback ) {
+				$value = $callback($value);
+			}
+		}
+
+		return $value;
+	}
+
+	function is_wp_error( mixed $value ): bool {
+		return $value instanceof WP_Error;
+	}
+
+	class WP_Error {
+		public function __construct( private string $code, private string $message, private mixed $data = array() ) {}
+		public function get_error_code(): string { return $this->code; }
+		public function get_error_message(): string { return $this->message; }
+		public function get_error_data(): mixed { return $this->data; }
+	}
+}
+
+namespace DataMachineCode\Abilities {
+	class GitHubAbilities {}
+}
+
+namespace DataMachineCode\Support {
+	class PermissionHelper {
+		public static function can_manage(): bool { return true; }
+	}
+}
+
+namespace DataMachine\Core\FilesRepository {
+	class FilesystemHelper {
+		public static function get(): ?self { return new self(); }
+		public function is_writable( string $path ): bool { return is_writable($path); }
+		public function put_contents( string $path, string $content ): bool { return false !== file_put_contents($path, $content); }
+	}
+}
+
+namespace {
+	include __DIR__ . '/../inc/Support/RuntimeCapabilities.php';
+	include __DIR__ . '/../inc/Support/ProcessRunner.php';
+	include __DIR__ . '/../inc/Support/GitRunner.php';
+	include __DIR__ . '/../inc/Support/PathSecurity.php';
+	include __DIR__ . '/../inc/Workspace/WorkspaceAliasResolver.php';
+	include __DIR__ . '/../inc/Workspace/RemoteWorkspaceBackend.php';
+	include __DIR__ . '/../inc/Workspace/Workspace.php';
+	include __DIR__ . '/../inc/Abilities/WorkspaceAbilities.php';
+	include __DIR__ . '/../inc/Tools/AbilityToolProjections.php';
+
+	use DataMachineCode\Abilities\WorkspaceAbilities;
+	use DataMachineCode\Tools\AbilityToolProjections;
+
+	$failures = array();
+	$total    = 0;
+	$assert   = function ( string $label, bool $condition ) use ( &$failures, &$total ): void {
+		++$total;
+		if ( $condition ) {
+			echo "  ok {$label}\n";
+			return;
+		}
+
+		$failures[] = $label;
+		echo "  fail {$label}\n";
+	};
+
+	echo "Runner workspace command - smoke\n";
+
+	new WorkspaceAbilities();
+	$assert('canonical ability is registered', isset($GLOBALS['dmc_runner_command_registered_abilities']['datamachine-code/run-runner-workspace-command']));
+	$assert('tool projection exposes runner command', 'datamachine-code/run-runner-workspace-command' === ( AbilityToolProjections::projected_tools()['workspace_run_runner_command']['ability'] ?? null ));
+
+	$workspace_root = DATAMACHINE_WORKSPACE_PATH;
+	$repo_path      = $workspace_root . '/example@runner-command';
+	if ( ! is_dir($repo_path) ) {
+		mkdir($repo_path, 0777, true);
+	}
+	if ( ! is_dir($repo_path . '/.git') ) {
+		exec(sprintf('git -C %s init --quiet 2>&1', escapeshellarg($repo_path)));
+	}
+	if ( ! is_dir($repo_path . '/subdir') ) {
+		mkdir($repo_path . '/subdir');
+	}
+
+	$local = WorkspaceAbilities::runRunnerWorkspaceCommand(
+		array(
+			'workspace_handle' => 'example@runner-command',
+			'command'          => 'printf "%s" "$DMC_SMOKE"',
+			'description'      => 'verify env forwarding',
+			'timeout'          => 10,
+			'env'              => array( 'DMC_SMOKE' => 'runner-ok' ),
+		)
+	);
+	$assert('local command succeeds', is_array($local) && true === ( $local['success'] ?? false ));
+	$assert('local command uses local backend', is_array($local) && 'local_git' === ( $local['backend'] ?? null ));
+	$assert('local command captures stdout', is_array($local) && 'runner-ok' === ( $local['stdout'] ?? null ));
+
+	$cwd = WorkspaceAbilities::runRunnerWorkspaceCommand(
+		array(
+			'workspace_handle' => 'example@runner-command',
+			'command'          => 'pwd',
+			'cwd'              => 'subdir',
+		)
+	);
+	$assert('relative cwd is honored', is_array($cwd) && str_ends_with(trim((string) ( $cwd['stdout'] ?? '' )), '/subdir'));
+
+	$failed = WorkspaceAbilities::runRunnerWorkspaceCommand(
+		array(
+			'workspace_handle' => 'example@runner-command',
+			'command'          => 'printf "nope" && printf "bad" >&2 && exit 7',
+		)
+	);
+	$assert('non-zero command is typed result', is_array($failed) && false === ( $failed['success'] ?? true ) && 7 === ( $failed['exit_code'] ?? null ) && 'command_failed' === ( $failed['failure_type'] ?? null ));
+	$assert('non-zero command separates stderr', is_array($failed) && 'nope' === ( $failed['stdout'] ?? null ) && 'bad' === ( $failed['stderr'] ?? null ));
+
+	update_option(
+		'datamachine_code_remote_workspace_state',
+		array(
+			'repos'      => array( 'example' => array( 'repo' => 'Extra-Chill/example', 'url' => 'https://github.com/Extra-Chill/example.git' ) ),
+			'repo_names' => array( 'Extra-Chill/example' => 'example' ),
+			'worktrees' => array(
+				'example@runner-command' => array(
+					'repo_name'       => 'example',
+					'repo'            => 'Extra-Chill/example',
+					'branch'          => 'runner/command',
+					'base_ref'        => 'main',
+					'pending_files'   => array(),
+					'changed_files'   => array(),
+					'last_commit_sha' => '',
+				),
+			),
+		)
+	);
+
+	$remote = WorkspaceAbilities::runRunnerWorkspaceCommand(
+		array(
+			'workspace_handle' => 'example@runner-command',
+			'command'          => 'npm test',
+		)
+	);
+	$assert('remote backend returns typed unavailable result', is_array($remote) && false === ( $remote['success'] ?? true ) && 'github_api' === ( $remote['backend'] ?? null ) && 'unavailable' === ( $remote['failure_type'] ?? null ));
+	$assert('remote result does not leak local path', is_array($remote) && str_starts_with((string) ( $remote['path'] ?? '' ), 'github://'));
+
+	if ( $failures ) {
+		echo "\n" . count($failures) . " of {$total} assertions failed.\n";
+		exit(1);
+	}
+
+	echo "\nAll {$total} runner command assertions passed.\n";
+}


### PR DESCRIPTION
## Summary
- Adds the canonical `datamachine-code/run-runner-workspace-command` backend ability so WP Codebox can delegate runner workspace verification/drift commands without knowing DMC local paths.
- Runs bounded local workspace commands with typed `stdout`/`stderr`, exit code, elapsed time, backend/workspace metadata, and non-zero command results instead of throwing path assumptions at callers.
- Returns typed `unavailable` metadata for GitHub API remote workspaces where shell command execution is not available.

## Coordination
- Closes Extra-Chill/data-machine-code#628.
- Coordinates with Automattic/wp-codebox#878, which exposes `wp-codebox/run-runner-workspace-command` as the product-level boundary.
- Unblocks Extra-Chill/homeboy-extensions#1259 by giving WP Codebox a DMC backend for runner workspace command delegation.

## Tests
- `php tests/smoke-runner-workspace-command.php`
- `php tests/smoke-ability-tool-projections.php`
- `php tests/smoke-runner-workspace-publication.php`
- `php tests/smoke-remote-workspace-backend.php`
- `php tests/smoke-worktree-bootstrap.php`
- `php -l inc/Support/ProcessRunner.php && php -l inc/Workspace/WorkspaceGitOperations.php && php -l tests/smoke-runner-workspace-command.php`
- `php -l inc/Abilities/WorkspaceAbilities.php && php -l inc/Workspace/RemoteWorkspaceBackend.php && php -l inc/Tools/WorkspaceTools.php && php -l inc/Tools/AbilityToolProjections.php && php -l tests/smoke-ability-tool-projections.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the backend ability, smoke coverage, targeted verification, and PR drafting under Chris's direction.