### PR TITLE
Fix disk budget for bounded workspaces

### DIFF
--- a/inc/Workspace/WorktreeDiskBudget.php
+++ b/inc/Workspace/WorktreeDiskBudget.php
@@ -93,8 +93,16 @@ final class WorktreeDiskBudget {
 		$effective_refuse_bytes = $thresholds['refuse_free_bytes'];
 		$effective_warn_bytes   = $thresholds['warn_free_bytes'];
 		if ( null !== $total_bytes && $total_bytes > 0 ) {
-			$effective_refuse_bytes = max($effective_refuse_bytes, (int) ceil($total_bytes * ( $thresholds['refuse_free_percent'] / 100 )));
-			$effective_warn_bytes   = max($effective_warn_bytes, (int) ceil($total_bytes * ( $thresholds['warn_free_percent'] / 100 )));
+			$effective_refuse_bytes = self::effective_free_bytes_threshold(
+				$thresholds['refuse_free_bytes'],
+				$thresholds['refuse_free_percent'],
+				$total_bytes
+			);
+			$effective_warn_bytes   = self::effective_free_bytes_threshold(
+				$thresholds['warn_free_bytes'],
+				$thresholds['warn_free_percent'],
+				$total_bytes
+			);
 		}
 
 		if ( null !== $free_bytes ) {
@@ -293,6 +301,28 @@ final class WorktreeDiskBudget {
 		}
 
 		return $count;
+	}
+
+	/**
+	 * Calculate the free-space threshold for the measured filesystem.
+	 *
+	 * The absolute GiB floor protects normal workspaces, but bounded ephemeral
+	 * filesystems can be smaller than that floor. In that case, the percentage
+	 * threshold is the only attainable safety signal.
+	 *
+	 * @param  int   $absolute_bytes Absolute free-space threshold.
+	 * @param  float $percent        Percentage free-space threshold.
+	 * @param  int   $total_bytes    Measured filesystem size.
+	 * @return int
+	 */
+	private static function effective_free_bytes_threshold( int $absolute_bytes, float $percent, int $total_bytes ): int {
+		$percent_bytes = (int) ceil($total_bytes * ( $percent / 100 ));
+
+		if ( $total_bytes < $absolute_bytes ) {
+			return $percent_bytes;
+		}
+
+		return max($absolute_bytes, $percent_bytes);
 	}
 
 	/**

--- a/inc/Workspace/WorktreeDiskBudget.php
+++ b/inc/Workspace/WorktreeDiskBudget.php
@@ -94,12 +94,12 @@ final class WorktreeDiskBudget {
 		$effective_warn_bytes   = $thresholds['warn_free_bytes'];
 		if ( null !== $total_bytes && $total_bytes > 0 ) {
 			$effective_refuse_bytes = self::effective_free_bytes_threshold(
-				$thresholds['refuse_free_bytes'],
+				(int) $thresholds['refuse_free_bytes'],
 				$thresholds['refuse_free_percent'],
 				$total_bytes
 			);
 			$effective_warn_bytes   = self::effective_free_bytes_threshold(
-				$thresholds['warn_free_bytes'],
+				(int) $thresholds['warn_free_bytes'],
 				$thresholds['warn_free_percent'],
 				$total_bytes
 			);
@@ -112,7 +112,7 @@ final class WorktreeDiskBudget {
 					'Free disk space is %.1f GiB%s, below the refusal threshold of %.1f GiB or %.1f%% free, whichever is stricter.',
 					self::bytes_to_gib($free_bytes),
 					null === $free_percent ? '' : sprintf(' (%.1f%%)', $free_percent),
-					self::bytes_to_gib($thresholds['refuse_free_bytes']),
+					self::bytes_to_gib( (int) $thresholds['refuse_free_bytes'] ),
 					$thresholds['refuse_free_percent']
 				);
 			} elseif ( $free_bytes < $effective_warn_bytes ) {
@@ -120,7 +120,7 @@ final class WorktreeDiskBudget {
 					'Free disk space is %.1f GiB%s, below the warning threshold of %.1f GiB or %.1f%% free, whichever is stricter.',
 					self::bytes_to_gib($free_bytes),
 					null === $free_percent ? '' : sprintf(' (%.1f%%)', $free_percent),
-					self::bytes_to_gib($thresholds['warn_free_bytes']),
+					self::bytes_to_gib( (int) $thresholds['warn_free_bytes'] ),
 					$thresholds['warn_free_percent']
 				);
 			}
@@ -158,10 +158,10 @@ final class WorktreeDiskBudget {
 			'workspace_size_exact'      => false,
 			'worktree_count'            => $count,
 			'warn_free_bytes'           => $thresholds['warn_free_bytes'],
-			'warn_free_gib'             => round(self::bytes_to_gib($thresholds['warn_free_bytes']), 2),
+			'warn_free_gib'             => round(self::bytes_to_gib( (int) $thresholds['warn_free_bytes'] ), 2),
 			'warn_free_percent'         => $thresholds['warn_free_percent'],
 			'refuse_free_bytes'         => $thresholds['refuse_free_bytes'],
-			'refuse_free_gib'           => round(self::bytes_to_gib($thresholds['refuse_free_bytes']), 2),
+			'refuse_free_gib'           => round(self::bytes_to_gib( (int) $thresholds['refuse_free_bytes'] ), 2),
 			'refuse_free_percent'       => $thresholds['refuse_free_percent'],
 			'effective_refuse_bytes'    => $effective_refuse_bytes,
 			'effective_refuse_gib'      => round(self::bytes_to_gib($effective_refuse_bytes), 2),

--- a/tests/smoke-worktree-disk-budget.php
+++ b/tests/smoke-worktree-disk-budget.php
@@ -127,7 +127,32 @@ datamachine_code_budget_assert('warning' === $budget['status'], 'high worktree c
 datamachine_code_budget_assert(true === $budget['emergency_triggered'], 'worktree count warning triggers emergency cleanup');
 datamachine_code_budget_assert(str_contains($budget['warnings'][0], '101 worktree-like directories'), 'worktree-count warning is descriptive');
 
-echo "\n[7] inspect counts only worktree-like directories\n";
+echo "\n[7] small ephemeral filesystems use percentage thresholds\n";
+$budget = WorktreeDiskBudget::evaluate(
+    array(
+        'workspace_path' => '/workspace',
+        'free_bytes'     => 2 * $gib,
+        'total_bytes'    => 4 * $gib,
+        'worktree_count' => 0,
+    ),
+    $thresholds
+);
+datamachine_code_budget_assert('ok' === $budget['status'], 'small workspace with 50 percent free is ok');
+datamachine_code_budget_assert(0.4 === $budget['effective_refuse_gib'], 'small workspace refusal floor uses percentage threshold');
+datamachine_code_budget_assert(0.6 === $budget['effective_warn_gib'], 'small workspace warning floor uses percentage threshold');
+
+$budget = WorktreeDiskBudget::evaluate(
+    array(
+        'workspace_path' => '/workspace',
+        'free_bytes'     => (int) ( 0.2 * $gib ),
+        'total_bytes'    => 4 * $gib,
+        'worktree_count' => 0,
+    ),
+    $thresholds
+);
+datamachine_code_budget_assert('refused' === $budget['status'], 'small workspace still refuses below percentage threshold');
+
+echo "\n[8] inspect counts only worktree-like directories\n";
 $tmp = sys_get_temp_dir() . '/dmc-budget-' . uniqid('', true);
 mkdir($tmp);
 mkdir($tmp . '/repo');


### PR DESCRIPTION
## Summary
- Treat absolute GiB disk-budget floors as unattainable on bounded ephemeral filesystems smaller than the floor.
- Keep percentage-based refusal/warning thresholds active so small runner workspaces are still protected from real pressure.
- Add smoke coverage for a WP Codebox-style 4 GiB workspace.

## Verification
- `php tests/smoke-worktree-disk-budget.php`
- `php -l inc/Workspace/WorktreeDiskBudget.php`
- `php -l tests/smoke-worktree-disk-budget.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Docs Agent runner failure, implemented the disk-budget threshold fix, and ran targeted verification for human review.