### PR TITLE
Fix cleanup planning triage

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -113,6 +113,9 @@ class WorkspaceCommand extends BaseCommand {
 	 *   - worktree
 	 * ---
 	 *
+	 * [--summary]
+	 * : Show compact workspace triage counts instead of one row per checkout.
+	 *
 	 * [--format=<format>]
 	 * : Output format.
 	 * ---
@@ -173,6 +176,11 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 
+		if ( ! empty($assoc_args['summary']) ) {
+			$this->render_workspace_list_summary($result, $assoc_args);
+			return;
+		}
+
 		$items = array_map(
 			function ( $repo ) {
 				$freshness = is_array($repo['primary_freshness'] ?? null) ? $repo['primary_freshness'] : null;
@@ -197,6 +205,77 @@ class WorkspaceCommand extends BaseCommand {
 			$assoc_args,
 			'name'
 		);
+	}
+
+	/**
+	 * Render compact workspace list counts for cleanup triage.
+	 *
+	 * @param  array<string,mixed> $result     Workspace list ability result.
+	 * @param  array<string,mixed> $assoc_args CLI assoc args.
+	 * @return void
+	 */
+	private function render_workspace_list_summary( array $result, array $assoc_args ): void {
+		$repos   = (array) ( $result['repos'] ?? array() );
+		$summary = array(
+			'total'       => count($repos),
+			'primary'     => 0,
+			'worktree'    => 0,
+			'context'     => 0,
+			'non_git'     => 0,
+			'repos'       => array(),
+			'workspace'   => (string) ( $result['path'] ?? '' ),
+		);
+
+		foreach ( $repos as $row ) {
+			if ( ! is_array($row) ) {
+				continue;
+			}
+			$kind = ! empty($row['is_context']) ? 'context' : ( ! empty($row['is_worktree']) ? 'worktree' : 'primary' );
+			++$summary[ $kind ];
+			if ( empty($row['git']) ) {
+				++$summary['non_git'];
+			}
+			$repo = (string) ( $row['repo'] ?? $row['name'] ?? 'unknown' );
+			if ( ! isset($summary['repos'][ $repo ]) ) {
+				$summary['repos'][ $repo ] = array(
+					'repo'      => $repo,
+					'primary'   => 0,
+					'worktree'  => 0,
+					'context'   => 0,
+					'total'     => 0,
+				);
+			}
+			++$summary['repos'][ $repo ][ $kind ];
+			++$summary['repos'][ $repo ]['total'];
+		}
+
+		ksort($summary['repos']);
+		$summary['repos'] = array_values($summary['repos']);
+
+		$format = (string) ( $assoc_args['format'] ?? 'table' );
+		if ( 'json' === $format ) {
+			WP_CLI::log( (string) wp_json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+			return;
+		}
+
+		WP_CLI::log(sprintf('Workspace: %s', $summary['workspace']));
+		$this->format_items(
+			array(
+				array( 'metric' => 'total', 'count' => $summary['total'] ),
+				array( 'metric' => 'primary', 'count' => $summary['primary'] ),
+				array( 'metric' => 'worktree', 'count' => $summary['worktree'] ),
+				array( 'metric' => 'context', 'count' => $summary['context'] ),
+				array( 'metric' => 'non_git', 'count' => $summary['non_git'] ),
+			),
+			array( 'metric', 'count' ),
+			array( 'format' => 'table' ),
+			'metric'
+		);
+
+		if ( array() !== $summary['repos'] ) {
+			WP_CLI::log('Repos:');
+			$this->format_items($summary['repos'], array( 'repo', 'primary', 'worktree', 'context', 'total' ), array( 'format' => 'table' ), 'repo');
+		}
 	}
 
 	/**
@@ -339,6 +418,11 @@ class WorkspaceCommand extends BaseCommand {
 	 *
 	 * [--force]
 	 * : Pass force=true into the cleanup task params for modes that support it.
+	 *
+	 * [--include-artifacts]
+	 * : For `plan --mode=retention`, also include the exhaustive artifact cleanup
+	 *   scan. Omitted by default so safe retention planning stays bounded on large
+	 *   workspaces; use `--mode=artifacts` for an artifact-only plan.
 	 *
 	 * [--older-than=<duration>]
 	 * : Pass an age gate such as 7d or 24h into cleanup task params.
@@ -529,8 +613,18 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 
+		$mode = strtolower(preg_replace('/[^a-z0-9_\-]/', '', (string) ( $assoc_args['mode'] ?? 'retention' )));
+		if ( ! in_array($mode, self::CLEANUP_MODES, true) ) {
+			WP_CLI::error(sprintf('Unknown cleanup mode: %s. Expected one of: %s.', $mode, implode(', ', self::CLEANUP_MODES)));
+			return;
+		}
+
+		$include_artifacts = 'artifacts' === $mode || ! empty($assoc_args['include-artifacts']);
+		$include_worktrees = 'artifacts' !== $mode;
 		$input = array(
-			'mode'              => strtolower(preg_replace('/[^a-z0-9_\-]/', '', (string) ( $assoc_args['mode'] ?? 'retention' ))),
+			'mode'              => $mode,
+			'include_artifacts' => $include_artifacts,
+			'include_worktrees' => $include_worktrees,
 			'include_resolvers' => true,
 		);
 		if ( isset($assoc_args['older-than']) && '' !== trim( (string) $assoc_args['older-than']) ) {
@@ -538,6 +632,10 @@ class WorkspaceCommand extends BaseCommand {
 		}
 		if ( isset($assoc_args['force']) ) {
 			$input['force_artifact_cleanup'] = (bool) $assoc_args['force'];
+		}
+		if ( 'json' !== (string) ( $assoc_args['format'] ?? 'table' ) ) {
+			$profile = $include_artifacts ? 'includes artifact scan' : 'worktree inventory only';
+			WP_CLI::log(sprintf('Planning cleanup (%s; %s)...', $mode, $profile));
 		}
 
 		$result = $ability->execute($input);
@@ -912,6 +1010,10 @@ class WorkspaceCommand extends BaseCommand {
 		WP_CLI::log(sprintf('Rows:   %d', (int) ( $summary['total_rows'] ?? 0 )));
 		WP_CLI::log(sprintf('Bytes:  %s', $this->format_bytes($summary['total_size_bytes'] ?? 0)));
 		WP_CLI::log(sprintf('Apply:  wp datamachine-code workspace cleanup apply %s', (string) ( $result['run_id'] ?? '' )));
+		$inputs = (array) ( $result['inputs'] ?? array() );
+		if ( empty($inputs['include_artifacts']) ) {
+			WP_CLI::log('Artifacts: skipped for bounded retention planning; run `wp datamachine-code workspace cleanup plan --mode=artifacts` when you want artifact rows.');
+		}
 	}
 
 	private function cleanup_run_id( int $job_id ): string {

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -217,13 +217,13 @@ class WorkspaceCommand extends BaseCommand {
 	private function render_workspace_list_summary( array $result, array $assoc_args ): void {
 		$repos   = (array) ( $result['repos'] ?? array() );
 		$summary = array(
-			'total'       => count($repos),
-			'primary'     => 0,
-			'worktree'    => 0,
-			'context'     => 0,
-			'non_git'     => 0,
-			'repos'       => array(),
-			'workspace'   => (string) ( $result['path'] ?? '' ),
+			'total'     => count($repos),
+			'primary'   => 0,
+			'worktree'  => 0,
+			'context'   => 0,
+			'non_git'   => 0,
+			'repos'     => array(),
+			'workspace' => (string) ( $result['path'] ?? '' ),
 		);
 
 		foreach ( $repos as $row ) {
@@ -238,11 +238,11 @@ class WorkspaceCommand extends BaseCommand {
 			$repo = (string) ( $row['repo'] ?? $row['name'] ?? 'unknown' );
 			if ( ! isset($summary['repos'][ $repo ]) ) {
 				$summary['repos'][ $repo ] = array(
-					'repo'      => $repo,
-					'primary'   => 0,
-					'worktree'  => 0,
-					'context'   => 0,
-					'total'     => 0,
+					'repo'     => $repo,
+					'primary'  => 0,
+					'worktree' => 0,
+					'context'  => 0,
+					'total'    => 0,
 				);
 			}
 			++$summary['repos'][ $repo ][ $kind ];
@@ -261,11 +261,26 @@ class WorkspaceCommand extends BaseCommand {
 		WP_CLI::log(sprintf('Workspace: %s', $summary['workspace']));
 		$this->format_items(
 			array(
-				array( 'metric' => 'total', 'count' => $summary['total'] ),
-				array( 'metric' => 'primary', 'count' => $summary['primary'] ),
-				array( 'metric' => 'worktree', 'count' => $summary['worktree'] ),
-				array( 'metric' => 'context', 'count' => $summary['context'] ),
-				array( 'metric' => 'non_git', 'count' => $summary['non_git'] ),
+				array(
+					'metric' => 'total',
+					'count'  => $summary['total'],
+				),
+				array(
+					'metric' => 'primary',
+					'count'  => $summary['primary'],
+				),
+				array(
+					'metric' => 'worktree',
+					'count'  => $summary['worktree'],
+				),
+				array(
+					'metric' => 'context',
+					'count'  => $summary['context'],
+				),
+				array(
+					'metric' => 'non_git',
+					'count'  => $summary['non_git'],
+				),
 			),
 			array( 'metric', 'count' ),
 			array( 'format' => 'table' ),
@@ -621,7 +636,7 @@ class WorkspaceCommand extends BaseCommand {
 
 		$include_artifacts = 'artifacts' === $mode || ! empty($assoc_args['include-artifacts']);
 		$include_worktrees = 'artifacts' !== $mode;
-		$input = array(
+		$input             = array(
 			'mode'              => $mode,
 			'include_artifacts' => $include_artifacts,
 			'include_worktrees' => $include_worktrees,

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -626,8 +626,8 @@ namespace {
         }
     }
 
-    class FakeListAbility
-    {
+	class FakeListAbility
+	{
         public function execute( array $input ): array  // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
         {
             return array(
@@ -673,12 +673,57 @@ namespace {
             ),
             ),
             );
-        }
-    }
+		}
+	}
 
-    class FakeCleanupRunAbility
-    {
-        public array $last_input = array();
+	class FakeWorkspaceListAbility
+	{
+		public function execute( array $input ): array  // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+		{
+			return array(
+			'success' => true,
+			'path'    => '/workspace',
+			'repos'   => array(
+			array(
+			'name'        => 'repo',
+			'repo'        => 'repo',
+			'branch'      => 'main',
+			'remote'      => 'https://example.com/repo.git',
+			'git'         => true,
+			'is_worktree' => false,
+			'path'        => '/workspace/repo',
+			),
+			array(
+			'name'        => 'repo@feature-one',
+			'repo'        => 'repo',
+			'branch'      => 'feature/one',
+			'git'         => true,
+			'is_worktree' => true,
+			'path'        => '/workspace/repo@feature-one',
+			),
+			array(
+			'name'        => 'docs@cleanup',
+			'repo'        => 'docs',
+			'branch'      => 'cleanup',
+			'git'         => false,
+			'is_worktree' => true,
+			'path'        => '/workspace/docs@cleanup',
+			),
+			array(
+			'name'       => 'context-docs',
+			'repo'       => 'docs',
+			'git'        => true,
+			'is_context' => true,
+			'path'       => '/workspace/docs',
+			),
+			),
+			);
+		}
+	}
+
+	class FakeCleanupRunAbility
+	{
+		public array $last_input = array();
 
         public function execute( array $input ): array
         {
@@ -691,11 +736,31 @@ namespace {
             'mode'      => (string) ( $input['mode'] ?? '' ),
             'task_type' => 'workspace_retention_cleanup',
             );
-        }
-    }
+		}
+	}
 
-    class FakeCleanupStatusAbility
-    {
+	class FakeCleanupPlanAbility
+	{
+		public array $last_input = array();
+
+		public function execute( array $input ): array
+		{
+			$this->last_input = $input;
+			return array(
+			'success' => true,
+			'run_id'  => 'cleanup-run-20260612000000-test',
+			'plan_id' => 'cleanup-plan-test',
+			'inputs'  => $input,
+			'summary' => array(
+			'total_rows'       => 2,
+			'total_size_bytes' => 4096,
+			),
+			);
+		}
+	}
+
+	class FakeCleanupStatusAbility
+	{
         public array $last_input = array();
 
         public function execute( array $input ): array
@@ -887,17 +952,21 @@ namespace {
     $active_merged_ability = new FakeActiveNoSignalAbility('merged-apply');
     $active_remote_clean_ability = new FakeActiveNoSignalAbility('remote-clean-apply');
     $reconcile_metadata_ability = new FakeReconcileMetadataAbility();
-    $bounded_apply_ability = new FakeBoundedCleanupEligibleApplyAbility();
-    $prune_ability = new FakePruneAbility();
-    $list_ability = new FakeListAbility();
-    $cleanup_run_ability = new FakeCleanupRunAbility();
-    $cleanup_status_ability = new FakeCleanupStatusAbility();
+	$bounded_apply_ability = new FakeBoundedCleanupEligibleApplyAbility();
+	$prune_ability = new FakePruneAbility();
+	$list_ability = new FakeListAbility();
+	$workspace_list_ability = new FakeWorkspaceListAbility();
+	$cleanup_run_ability = new FakeCleanupRunAbility();
+	$cleanup_plan_ability = new FakeCleanupPlanAbility();
+	$cleanup_status_ability = new FakeCleanupStatusAbility();
     $hygiene_ability = new FakeHygieneAbility();
     $get_jobs_ability = new FakeGetJobsAbility();
     $retry_job_ability = new FakeRetryJobAbility();
     $fail_job_ability = new FakeFailJobAbility();
-    $GLOBALS['__abilities'] = array(
-    'datamachine-code/workspace-cleanup-run'                 => $cleanup_run_ability,
+	$GLOBALS['__abilities'] = array(
+	'datamachine-code/workspace-list'                        => $workspace_list_ability,
+	'datamachine-code/workspace-cleanup-plan'                => $cleanup_plan_ability,
+	'datamachine-code/workspace-cleanup-run'                 => $cleanup_run_ability,
     'datamachine-code/workspace-cleanup-apply'               => $cleanup_status_ability,
     'datamachine-code/workspace-cleanup-status'              => $cleanup_status_ability,
     'datamachine-code/workspace-cleanup-resume'              => $cleanup_status_ability,
@@ -943,14 +1012,51 @@ namespace {
     datamachine_code_cleanup_assert(str_contains($doc_comment, 'workspace cleanup plan --mode=retention'), 'worktree examples include DB-backed cleanup plan');
     datamachine_code_cleanup_assert(str_contains($doc_comment, 'workspace cleanup run --mode=retention'), 'worktree examples include task-backed cleanup run');
     datamachine_code_cleanup_assert(! str_contains($doc_comment, '> cleanup-plan.json'), 'worktree examples do not normalize cleanup-plan file redirection');
-    datamachine_code_cleanup_assert(! str_contains($doc_comment, '> artifact-plan.json'), 'worktree examples do not normalize artifact-plan file redirection');
-    datamachine_code_cleanup_assert(! str_contains($doc_comment, '> emergency-plan.json'), 'worktree examples do not normalize emergency-plan file redirection');
-    datamachine_code_cleanup_assert(! str_contains($doc_comment, '> reconcile-plan.json'), 'worktree examples do not normalize reconcile-plan file redirection');
+	datamachine_code_cleanup_assert(! str_contains($doc_comment, '> artifact-plan.json'), 'worktree examples do not normalize artifact-plan file redirection');
+	datamachine_code_cleanup_assert(! str_contains($doc_comment, '> emergency-plan.json'), 'worktree examples do not normalize emergency-plan file redirection');
+	datamachine_code_cleanup_assert(! str_contains($doc_comment, '> reconcile-plan.json'), 'worktree examples do not normalize reconcile-plan file redirection');
 
-    echo "\n[0b] task-backed workspace cleanup run/status/control output\n";
-    WP_CLI::$logs      = array();
-    WP_CLI::$successes = array();
-    $command->cleanup(array( 'run' ), array( 'mode' => 'retention', 'format' => 'json' ));
+	echo "\n[0a2] workspace list compact triage output\n";
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->list_repos(array(), array( 'summary' => true ));
+	datamachine_code_cleanup_assert(in_array('Workspace: /workspace', WP_CLI::$logs, true), 'workspace list --summary prints workspace path');
+	datamachine_code_cleanup_assert(in_array('table:5:metric,count', WP_CLI::$logs, true), 'workspace list --summary prints compact metric counts');
+	datamachine_code_cleanup_assert(in_array('table:2:repo,primary,worktree,context,total', WP_CLI::$logs, true), 'workspace list --summary groups counts by repo');
+
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->list_repos(array(), array( 'summary' => true, 'format' => 'json' ));
+	$list_summary_json = json_decode(WP_CLI::$logs[0] ?? '', true);
+	datamachine_code_cleanup_assert(4 === (int) ( $list_summary_json['total'] ?? 0 ), 'workspace list --summary JSON keeps total count');
+	datamachine_code_cleanup_assert(2 === (int) ( $list_summary_json['worktree'] ?? 0 ), 'workspace list --summary JSON counts worktrees');
+	datamachine_code_cleanup_assert(1 === (int) ( $list_summary_json['non_git'] ?? 0 ), 'workspace list --summary JSON counts non-git rows');
+
+	echo "\n[0b] task-backed workspace cleanup run/status/control output\n";
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->cleanup(array( 'plan' ), array( 'mode' => 'retention' ));
+	datamachine_code_cleanup_assert('retention' === ( $cleanup_plan_ability->last_input['mode'] ?? '' ), 'cleanup plan receives retention mode');
+	datamachine_code_cleanup_assert(false === ( $cleanup_plan_ability->last_input['include_artifacts'] ?? true ), 'retention cleanup plan skips exhaustive artifact scan by default');
+	datamachine_code_cleanup_assert(true === ( $cleanup_plan_ability->last_input['include_worktrees'] ?? false ), 'retention cleanup plan keeps inventory worktree planning enabled');
+	datamachine_code_cleanup_assert(in_array('Planning cleanup (retention; worktree inventory only)...', WP_CLI::$logs, true), 'human cleanup plan reports bounded scan profile before planning');
+	datamachine_code_cleanup_assert(in_array('Artifacts: skipped for bounded retention planning; run `wp datamachine-code workspace cleanup plan --mode=artifacts` when you want artifact rows.', WP_CLI::$logs, true), 'human cleanup plan shows explicit artifact follow-up command');
+
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->cleanup(array( 'plan' ), array( 'mode' => 'retention', 'include-artifacts' => true, 'format' => 'json' ));
+	datamachine_code_cleanup_assert(true === ( $cleanup_plan_ability->last_input['include_artifacts'] ?? false ), 'retention cleanup plan can explicitly include artifacts');
+	datamachine_code_cleanup_assert('{' === substr(WP_CLI::$logs[0] ?? '', 0, 1), 'json cleanup plan output is not prefixed by progress text');
+
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->cleanup(array( 'plan' ), array( 'mode' => 'artifacts', 'format' => 'json' ));
+	datamachine_code_cleanup_assert(true === ( $cleanup_plan_ability->last_input['include_artifacts'] ?? false ), 'artifact cleanup plan includes artifact scan');
+	datamachine_code_cleanup_assert(false === ( $cleanup_plan_ability->last_input['include_worktrees'] ?? true ), 'artifact cleanup plan skips worktree removal rows');
+
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->cleanup(array( 'run' ), array( 'mode' => 'retention', 'format' => 'json' ));
     $run_json = json_decode(WP_CLI::$logs[0] ?? '', true);
     datamachine_code_cleanup_assert('jobs_queued' === ( $run_json['state'] ?? '' ), 'cleanup run queues a system task');
     datamachine_code_cleanup_assert('cleanup-run-123' === ( $run_json['run_id'] ?? '' ), 'cleanup run returns stable run id');


### PR DESCRIPTION
## Summary
- Make `workspace cleanup plan --mode=retention` freeze a bounded worktree-inventory plan by default instead of starting with an exhaustive artifact scan.
- Keep artifact cleanup planning explicit through `--mode=artifacts` or `--include-artifacts` for retention plans.
- Add `workspace list --summary` for compact cleanup triage counts on large workspaces.

Fixes #631.
Fixes #632.
Fixes #633.

## Verification
- `php -l inc/Cli/Commands/WorkspaceCommand.php`
- `php -l tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-cleanup-run-storage.php`
- `php tests/smoke-workspace-list-repo-filter.php`

## Note
- `php tests/smoke-worktree-cleanup-chunks.php` still fails one repaired-metadata expectation (`expected no_merge_signal`, actual `plan_mismatch`). This appears unrelated to the CLI planning/list changes in this PR.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigating the cleanup/list CLI path, drafting the implementation and focused smoke coverage, and running targeted verification. Chris remains responsible for review and merge.