### PR TITLE
Fix workspace hygiene and cleanup resume

### DIFF
--- a/inc/Workspace/CleanupRunService.php
+++ b/inc/Workspace/CleanupRunService.php
@@ -124,8 +124,9 @@ class CleanupRunService {
 			$this->mark_batch_applying($worktree_batch, $run_id, $batch_type, $limit, $remaining_rows);
 			$results['worktree_removal'] = $this->workspace->worktree_cleanup_merged(
 				array(
-					'apply_plan'  => array( 'candidates' => array_map(fn( $item ) => $item['evidence'], $worktree_batch) ),
-					'skip_github' => true,
+					'apply_plan'        => array( 'candidates' => array_map(fn( $item ) => $item['evidence'], $worktree_batch) ),
+					'direct_apply_plan' => true,
+					'skip_github'       => true,
 				)
 			);
 			$this->record_apply_result($worktree_batch, $results['worktree_removal'], 'removed');

--- a/inc/Workspace/WorkspaceHygieneReport.php
+++ b/inc/Workspace/WorkspaceHygieneReport.php
@@ -59,6 +59,7 @@ trait WorkspaceHygieneReport {
 		$cleanup       = null;
 		$cleanup_error = null;
 		$locks         = WorkspaceMutationLock::status($this->workspace_path);
+		$remote_backend = $this->build_remote_workspace_backend_report();
 
 		if ( $include_cleanup ) {
 			$cleanup = $this->worktree_cleanup_merged(
@@ -92,6 +93,7 @@ trait WorkspaceHygieneReport {
 			),
 			'worktrees'                 => $worktree_summary,
 			'worktree_status_mode'      => $worktree_status_mode,
+			'remote_backend'            => $remote_backend,
 			'top_repos_by_worktrees'    => $this->top_repos_by_worktree_count($worktrees, 10),
 			'top_repos_by_size'         => $this->top_repos_by_size( (array) ( $size_report['entries'] ?? array() ), 10),
 			'locks'                     => $locks,
@@ -105,9 +107,37 @@ trait WorkspaceHygieneReport {
 						$include_cleanup ? 'Cleanup summary uses inventory-only dry-run detection (--inventory-only --skip-github); no per-worktree git probes or GitHub API lookups are required.' : 'Cleanup dry-run disabled by request.',
 						! empty($worktree_summary['stale_primaries']) ? 'One or more primary checkouts are behind their configured upstream according to local remote refs; refresh before using a primary for verification.' : '',
 						! empty($worktree_summary['base_branch_worktree_count']) ? 'One or more non-primary worktrees have a base branch checked out; gh pr merge --delete-branch can merge remotely but fail local cleanup.' : '',
+						! empty($remote_backend['registered_state']) ? 'Remote workspace state is registered; local checkout commands should fall back to local workspace discovery when the remote backend misses a handle.' : '',
 					)
 				)
 			),
+		);
+	}
+
+	/**
+	 * Summarize the GitHub API remote workspace backend state for diagnostics.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function build_remote_workspace_backend_report(): array {
+		$available = class_exists(RemoteWorkspaceBackend::class);
+		if ( ! $available ) {
+			return array(
+				'available'        => false,
+				'active'           => false,
+				'registered_state' => false,
+				'mode'             => 'local_git',
+			);
+		}
+
+		$registered_state = RemoteWorkspaceBackend::has_registered_state();
+		$active           = $registered_state ? true : RemoteWorkspaceBackend::should_handle();
+
+		return array(
+			'available'        => true,
+			'active'           => $active,
+			'registered_state' => $registered_state,
+			'mode'             => $active ? 'remote_or_fallback' : 'local_git',
 		);
 	}
 

--- a/inc/Workspace/WorkspaceHygieneReport.php
+++ b/inc/Workspace/WorkspaceHygieneReport.php
@@ -55,10 +55,10 @@ trait WorkspaceHygieneReport {
 			$worktree_status_mode = 'top_level_inventory';
 		}
 
-		$size_report   = $include_sizes ? $this->build_workspace_size_report($size_limit) : $this->empty_workspace_size_report($size_limit, false);
-		$cleanup       = null;
-		$cleanup_error = null;
-		$locks         = WorkspaceMutationLock::status($this->workspace_path);
+		$size_report    = $include_sizes ? $this->build_workspace_size_report($size_limit) : $this->empty_workspace_size_report($size_limit, false);
+		$cleanup        = null;
+		$cleanup_error  = null;
+		$locks          = WorkspaceMutationLock::status($this->workspace_path);
 		$remote_backend = $this->build_remote_workspace_backend_report();
 
 		if ( $include_cleanup ) {
@@ -570,27 +570,27 @@ trait WorkspaceHygieneReport {
 	 */
 	private function summarize_workspace_worktrees( array $worktrees, ?array $cleanup ): array {
 		$summary = array(
-			'total'                      => count($worktrees),
-			'primaries'                  => 0,
-			'worktrees'                  => 0,
-			'artifacts'                  => 0,
-			'external'                   => 0,
-			'dirty'                      => 0,
-			'protected_dirty'            => 0,
-			'protected_unpushed'         => 0,
-			'missing_metadata'           => 0,
-			'stale_primaries'            => 0,
+			'total'                       => count($worktrees),
+			'primaries'                   => 0,
+			'worktrees'                   => 0,
+			'artifacts'                   => 0,
+			'external'                    => 0,
+			'dirty'                       => 0,
+			'protected_dirty'             => 0,
+			'protected_unpushed'          => 0,
+			'missing_metadata'            => 0,
+			'stale_primaries'             => 0,
 			'primary_freshness_by_status' => array(),
 			'primary_freshness_attention' => array(),
-			'base_branch_worktree_count' => 0,
-			'base_branch_worktrees'      => array(),
-			'by_liveness'                => array(
+			'base_branch_worktree_count'  => 0,
+			'base_branch_worktrees'       => array(),
+			'by_liveness'                 => array(
 				WorktreeContextInjector::LIVENESS_LIVE    => 0,
 				WorktreeContextInjector::LIVENESS_STOPPED => 0,
 				WorktreeContextInjector::LIVENESS_STALE   => 0,
 				WorktreeContextInjector::LIVENESS_UNKNOWN => 0,
 			),
-			'duplicate_task_groups'      => 0,
+			'duplicate_task_groups'       => 0,
 		);
 
 		foreach ( $worktrees as $row ) {

--- a/inc/Workspace/WorkspaceWorktreeCleanupEngine.php
+++ b/inc/Workspace/WorkspaceWorktreeCleanupEngine.php
@@ -1072,7 +1072,7 @@ trait WorkspaceWorktreeCleanupEngine {
 			),
 			'continuation'   => $continuation,
 			'evidence'       => array(
-				'elapsed_ms'        => (int) round(( microtime(true) - $started_at ) * 1000),
+				'elapsed_ms'      => (int) round(( microtime(true) - $started_at ) * 1000),
 				'inventory_total' => count($all_candidates),
 				'removed_handles' => array_values(array_filter(array_map(fn( $row ) => (string) $row['handle'], $removed))),
 				'skipped_handles' => array_values(array_filter(array_map(fn( $row ) => (string) ( $row['handle'] ?? '' ), $skipped))),

--- a/inc/Workspace/WorkspaceWorktreeCleanupEngine.php
+++ b/inc/Workspace/WorkspaceWorktreeCleanupEngine.php
@@ -51,6 +51,7 @@ trait WorkspaceWorktreeCleanupEngine {
 		$dry_run                   = ! empty($opts['dry_run']);
 		$force                     = ! empty($opts['force']);
 		$skip_github               = ! empty($opts['skip_github']);
+		$direct_apply_plan         = ! empty($opts['direct_apply_plan']);
 		$inventory_only            = ! empty($opts['inventory_only']);
 		$include_repaired_metadata = ! empty($opts['include_repaired_metadata']);
 		$apply_plan                = isset($opts['apply_plan']) && is_array($opts['apply_plan']) ? $opts['apply_plan'] : null;
@@ -104,6 +105,10 @@ trait WorkspaceWorktreeCleanupEngine {
 			// Applying a stale plan must never use the dirty override. The current
 			// workspace state is re-evaluated below and dirty rows stay skipped.
 			$force = false;
+
+			if ( $direct_apply_plan && ! $dry_run ) {
+				return $this->apply_worktree_cleanup_plan_candidates($planned_candidates, $force, $started_at);
+			}
 		}
 
 		$age_filter = null;
@@ -631,7 +636,7 @@ trait WorkspaceWorktreeCleanupEngine {
 					// Delete the now-detached local branch while the repo lock still covers
 					// shared git metadata.
 					$primary_path = $this->get_primary_path($cand['repo']);
-					$branch       = $this->run_git($primary_path, sprintf('branch -D %s', escapeshellarg($cand['branch'])));
+					$branch       = $this->run_git($primary_path, sprintf('branch -D %s', escapeshellarg($cand['branch'])), self::CLEANUP_GIT_PROBE_TIMEOUT);
 					return is_wp_error($branch) ? $branch : $remove;
 				}
 			);
@@ -1006,7 +1011,7 @@ trait WorkspaceWorktreeCleanupEngine {
 
 					$primary_path = $this->get_primary_path($repo);
 					if ( '' !== $branch ) {
-						$delete = $this->run_git($primary_path, sprintf('branch -D %s', escapeshellarg($branch)));
+						$delete = $this->run_git($primary_path, sprintf('branch -D %s', escapeshellarg($branch)), self::CLEANUP_GIT_PROBE_TIMEOUT);
 						if ( is_wp_error($delete) ) {
 							// Branch deletion failure is non-fatal: the worktree is
 							// gone, the local branch may still be useful or may have
@@ -1067,11 +1072,100 @@ trait WorkspaceWorktreeCleanupEngine {
 			),
 			'continuation'   => $continuation,
 			'evidence'       => array(
-				'elapsed_ms'      => (int) round(( microtime(true) - $started_at ) * 1000),
+				'elapsed_ms'        => (int) round(( microtime(true) - $started_at ) * 1000),
 				'inventory_total' => count($all_candidates),
 				'removed_handles' => array_values(array_filter(array_map(fn( $row ) => (string) $row['handle'], $removed))),
 				'skipped_handles' => array_values(array_filter(array_map(fn( $row ) => (string) ( $row['handle'] ?? '' ), $skipped))),
 				'source'          => $source,
+			),
+		);
+	}
+
+	/**
+	 * Apply DB-backed cleanup rows without rebuilding a full workspace scan.
+	 *
+	 * @param  array<int,array<string,mixed>> $candidates Reviewed cleanup rows.
+	 * @param  bool                           $force      Whether dirty worktrees may be removed.
+	 * @param  float                          $started_at Start timestamp.
+	 * @return array<string,mixed>
+	 */
+	private function apply_worktree_cleanup_plan_candidates( array $candidates, bool $force, float $started_at ): array {
+		$processed       = 0;
+		$removed         = array();
+		$skipped         = array();
+		$bytes_reclaimed = 0;
+
+		foreach ( $candidates as $candidate ) {
+			++$processed;
+			$revalidated = $this->revalidate_bounded_cleanup_eligible_candidate($candidate, $force);
+			if ( isset($revalidated['skipped']) ) {
+				$skipped[] = $revalidated['skipped'];
+				continue;
+			}
+
+			$validated = $revalidated;
+			$repo      = (string) ( $validated['repo'] ?? '' );
+			$branch    = (string) ( $validated['branch'] ?? '' );
+			$wt_path   = (string) ( $validated['path'] ?? '' );
+			$size      = (int) ( $validated['size_bytes'] ?? 0 );
+			if ( $size <= 0 ) {
+				$measured = $this->estimate_path_size_bytes($wt_path);
+				$size     = null === $measured ? 0 : (int) $measured;
+			}
+
+			$remove = WorkspaceMutationLock::with_repo(
+				$this->workspace_path,
+				$repo,
+				function () use ( $repo, $branch, $wt_path, $force ) {
+					$result = $this->remove_worktree_by_path($repo, $branch, $wt_path, $force);
+					if ( is_wp_error($result) ) {
+						return $result;
+					}
+
+					$primary_path = $this->get_primary_path($repo);
+					if ( '' !== $branch ) {
+						$delete = $this->run_git($primary_path, sprintf('branch -D %s', escapeshellarg($branch)), self::CLEANUP_GIT_PROBE_TIMEOUT);
+						if ( is_wp_error($delete) ) {
+							return $result;
+						}
+					}
+
+					return $result;
+				}
+			);
+
+			if ( is_wp_error($remove) ) {
+				$skipped[] = array(
+					'handle'      => (string) ( $candidate['handle'] ?? '' ),
+					'repo'        => $repo,
+					'branch'      => $branch,
+					'path'        => $wt_path,
+					'reason_code' => 'remove_failed',
+					'reason'      => 'remove failed: ' . $remove->get_error_message(),
+					'size_bytes'  => $size,
+				);
+				continue;
+			}
+
+			$removed[]        = array_merge($validated, array( 'size_bytes' => $size ));
+			$bytes_reclaimed += max(0, $size);
+		}
+
+		return array(
+			'success'    => true,
+			'dry_run'    => false,
+			'candidates' => $candidates,
+			'removed'    => $removed,
+			'skipped'    => $skipped,
+			'summary'    => array(
+				'processed'       => $processed,
+				'removed'         => count($removed),
+				'skipped'         => count($skipped),
+				'bytes_reclaimed' => $bytes_reclaimed,
+			),
+			'evidence'   => array(
+				'elapsed_ms'        => (int) round(( microtime(true) - $started_at ) * 1000),
+				'direct_apply_plan' => true,
 			),
 		);
 	}

--- a/tests/smoke-workspace-hygiene-report.php
+++ b/tests/smoke-workspace-hygiene-report.php
@@ -66,14 +66,31 @@ namespace {
         return $value instanceof \WP_Error;
     }
 
-    function get_option( string $name, $default = false )  // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+    function get_option( string $name, $default = false )
     {
+        if ('datamachine_code_remote_workspace_state' === $name ) {
+            return array(
+            'repos'     => array(
+            'github-only' => array(
+            'repo' => 'Extra-Chill/github-only',
+            'url'  => 'https://github.com/Extra-Chill/github-only.git',
+            ),
+            ),
+            'worktrees' => array(),
+            );
+        }
+
+        if ('datamachine_worktree_metadata' !== $name ) {
+            return $default;
+        }
+
         return $GLOBALS['__dmc_hygiene_metadata'];
     }
 
     include __DIR__ . '/../inc/Workspace/WorkspaceLockStore.php';
     include __DIR__ . '/../inc/Workspace/WorkspaceMutationLock.php';
     include __DIR__ . '/../inc/Workspace/WorktreeContextInjector.php';
+    include __DIR__ . '/../inc/Workspace/RemoteWorkspaceBackend.php';
     include __DIR__ . '/../inc/Workspace/Workspace.php';
 
     function datamachine_code_hygiene_report_assert( bool $condition, string $message ): void
@@ -157,6 +174,9 @@ namespace {
         datamachine_code_hygiene_report_assert(1 === (int) ( $minimal['worktrees']['missing_metadata'] ?? 0 ), 'inventory counts missing metadata from registry only');
         datamachine_code_hygiene_report_assert('alpha' === ( $minimal['top_repos_by_worktrees'][0]['repo'] ?? '' ), 'inventory builds repo count leaders');
         datamachine_code_hygiene_report_assert(1 === (int) ( $minimal['top_repos_by_worktrees'][0]['worktree_count'] ?? 0 ), 'repo count leaders ignore primaries and missing-metadata repo still sorts after alpha');
+        datamachine_code_hygiene_report_assert(true === ( $minimal['remote_backend']['registered_state'] ?? false ), 'hygiene reports registered remote workspace state');
+        datamachine_code_hygiene_report_assert('remote_or_fallback' === ( $minimal['remote_backend']['mode'] ?? '' ), 'hygiene reports remote backend fallback mode');
+        datamachine_code_hygiene_report_assert(in_array('Remote workspace state is registered; local checkout commands should fall back to local workspace discovery when the remote backend misses a handle.', $minimal['notes'] ?? array(), true), 'hygiene notes remote backend local fallback expectation');
 
         echo "\n[1a] Size report exposes top offenders and kind grouping\n";
         $with_sizes = $workspace->workspace_hygiene_report(

--- a/tests/smoke-worktree-cleanup-remove-guard.php
+++ b/tests/smoke-worktree-cleanup-remove-guard.php
@@ -7,11 +7,13 @@
 
 declare( strict_types=1 );
 
-$source_path = __DIR__ . '/../inc/Workspace/WorkspaceWorktreeCleanupEngine.php';
-$source      = file_get_contents($source_path);
+$source_path  = __DIR__ . '/../inc/Workspace/WorkspaceWorktreeCleanupEngine.php';
+$service_path = __DIR__ . '/../inc/Workspace/CleanupRunService.php';
+$source       = file_get_contents($source_path);
+$service      = file_get_contents($service_path);
 
-if ( false === $source ) {
-	fwrite(STDERR, "Could not read cleanup engine source.\n");
+if ( false === $source || false === $service ) {
+	fwrite(STDERR, "Could not read cleanup source.\n");
 	exit(1);
 }
 
@@ -33,6 +35,14 @@ if ( str_contains($function, 'rm -rf') ) {
 
 if ( ! str_contains($function, 'worktree_remove_incomplete') ) {
 	$failures[] = 'surviving worktree directory must return a row-level failure';
+}
+
+if ( ! str_contains($source, 'apply_worktree_cleanup_plan_candidates') || ! str_contains($source, '$direct_apply_plan && ! $dry_run') ) {
+	$failures[] = 'DB-backed cleanup apply must have a direct plan path';
+}
+
+if ( ! str_contains($service, "'direct_apply_plan' => true") ) {
+	$failures[] = 'CleanupRunService must request direct plan apply for worktree rows';
 }
 
 if ( $failures ) {


### PR DESCRIPTION
## Summary
- Adds workspace hygiene diagnostics for remote backend/local resolver state.
- Makes DB-backed cleanup resume apply reviewed worktree rows directly, avoiding a full workspace scan before each single-row removal.
- Bounds cleanup branch deletion calls and extends the cleanup removal guard so resume cannot regress into full-scan or unbounded removal behavior.
- Fixes PHPCS alignment in the hygiene report changes.

Fixes #640.

## Tests
- `php -l inc/Workspace/CleanupRunService.php`
- `php -l inc/Workspace/WorkspaceWorktreeCleanupEngine.php`
- `php -l inc/Workspace/WorkspaceHygieneReport.php`
- `php -l tests/smoke-worktree-cleanup-remove-guard.php`
- `php tests/smoke-worktree-cleanup-remove-guard.php`
- `php tests/smoke-workspace-local-fallback.php`
- `homeboy --force-hot --allow-local-hot lint data-machine-code --path /Users/chubes/Developer/data-machine-code@fix-issue-637-638-worktree-resolution --changed-since b8a41834c3a05e9015790dc355fa695748596d9b`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the cleanup resume hang, drafted the direct-apply fix and guard updates, and ran local verification commands; Chris remains responsible for review and merge.