### PR TITLE
Fix cleanup resume limit batching

### DIFF
--- a/inc/Workspace/CleanupRunService.php
+++ b/inc/Workspace/CleanupRunService.php
@@ -16,7 +16,6 @@ class CleanupRunService {
 
 	private const DEFAULT_APPLY_LIMIT        = 25;
 	private const MAX_APPLY_LIMIT            = 100;
-	private const WORKTREE_APPLY_BATCH_LIMIT = 1;
 
 
 
@@ -98,6 +97,8 @@ class CleanupRunService {
 		$worktree_rows  = $this->pending_rows_of_type($items, 'worktree_removal');
 		$batch_type     = '';
 		$processed_rows = 0;
+		$applied_rows   = 0;
+		$skipped_rows   = 0;
 		$remaining_rows = max(0, count($artifact_rows) + count($worktree_rows));
 		$results        = array();
 
@@ -114,11 +115,13 @@ class CleanupRunService {
 				)
 			);
 			$this->record_apply_result($artifact_batch, $results['artifact_cleanup'], 'removed');
+			$applied_rows += count((array) ( $results['artifact_cleanup']['removed'] ?? array() ));
+			$skipped_rows += count((array) ( $results['artifact_cleanup']['skipped'] ?? array() ));
 		}
 
 		$remaining_capacity = max(0, $limit - $processed_rows);
 		if ( $remaining_capacity > 0 && array() !== $worktree_rows ) {
-			$worktree_batch  = array_slice($worktree_rows, 0, min($remaining_capacity, self::WORKTREE_APPLY_BATCH_LIMIT));
+			$worktree_batch  = array_slice($worktree_rows, 0, $remaining_capacity);
 			$processed_rows += count($worktree_batch);
 			$batch_type      = '' === $batch_type ? 'worktree_removal' : 'mixed';
 			$this->mark_batch_applying($worktree_batch, $run_id, $batch_type, $limit, $remaining_rows);
@@ -130,6 +133,8 @@ class CleanupRunService {
 				)
 			);
 			$this->record_apply_result($worktree_batch, $results['worktree_removal'], 'removed');
+			$applied_rows += count((array) ( $results['worktree_removal']['removed'] ?? array() ));
+			$skipped_rows += count((array) ( $results['worktree_removal']['skipped'] ?? array() ));
 		}
 
 		$status          = $this->status($run_id);
@@ -151,11 +156,17 @@ class CleanupRunService {
 			return $status;
 		}
 
+		$next_command = $pending_or_fail > 0 ? sprintf('studio wp datamachine-code workspace cleanup resume %s --limit=%d', $run_id, $limit) : null;
+
 		return array(
 			'success'                => true,
 			'state'                  => $next_status,
 			'run_id'                 => $run_id,
 			'status'                 => $next_status,
+			'processed'              => $processed_rows,
+			'applied'                => $applied_rows,
+			'skipped'                => $skipped_rows,
+			'next_command'           => $next_command,
 			'batch'                  => array(
 				'type'             => $batch_type,
 				'limit'            => $limit,
@@ -167,7 +178,7 @@ class CleanupRunService {
 			'summary'                => $status['summary'] ?? array(),
 			'remaining_work_summary' => $status['remaining_work_summary'] ?? array(),
 			'next'                   => $pending_or_fail > 0 ? array(
-				'resume_command' => sprintf('studio wp datamachine-code workspace cleanup resume %s --limit=%d', $run_id, $limit),
+				'resume_command' => $next_command,
 				'pending_rows'   => $pending_or_fail,
 			) : null,
 		);

--- a/tests/smoke-cleanup-run-storage.php
+++ b/tests/smoke-cleanup-run-storage.php
@@ -230,11 +230,15 @@ datamachine_code_cleanup_run_assert(false === (bool) ( $status['progress']['resu
 
 $apply = $service->apply($plan['run_id']);
 datamachine_code_cleanup_run_assert(! is_wp_error($apply), 'apply succeeds');
-datamachine_code_cleanup_run_assert('needs_resume' === (string) ( $apply['status'] ?? '' ), 'apply pauses after bounded worktree-removal batch');
+datamachine_code_cleanup_run_assert('completed' === (string) ( $apply['status'] ?? '' ), 'apply drains worktree rows up to the default limit');
+datamachine_code_cleanup_run_assert(4 === (int) ( $apply['processed'] ?? 0 ), 'apply reports processed row count');
+datamachine_code_cleanup_run_assert(2 === (int) ( $apply['applied'] ?? 0 ), 'apply reports applied row count');
+datamachine_code_cleanup_run_assert(2 === (int) ( $apply['skipped'] ?? 0 ), 'apply reports skipped row count');
+datamachine_code_cleanup_run_assert(null === ( $apply['next_command'] ?? null ), 'completed apply omits next command');
 
 $evidence = $service->evidence($plan['run_id']);
 datamachine_code_cleanup_run_assert(2 === (int) ( $evidence['summary']['items_by_status']['applied'] ?? 0 ), 'evidence reflects applied rows');
-datamachine_code_cleanup_run_assert(1 === (int) ( $evidence['summary']['items_by_status']['skipped'] ?? 0 ), 'evidence reflects skipped rows from first bounded batch');
+datamachine_code_cleanup_run_assert(2 === (int) ( $evidence['summary']['items_by_status']['skipped'] ?? 0 ), 'evidence reflects skipped rows from bounded batch');
 datamachine_code_cleanup_run_assert(35 === (int) ( $evidence['summary']['bytes_reclaimed'] ?? 0 ), 'evidence aggregates reclaimed bytes');
 datamachine_code_cleanup_run_assert(1 === (int) ( $evidence['remaining_work_summary']['applied_by_type']['artifact_cleanup']['count'] ?? 0 ), 'evidence groups applied artifact rows');
 datamachine_code_cleanup_run_assert(15 === (int) ( $evidence['remaining_work_summary']['applied_by_type']['artifact_cleanup']['bytes_reclaimed'] ?? 0 ), 'evidence reports artifact bytes reclaimed');
@@ -243,9 +247,6 @@ datamachine_code_cleanup_run_assert('demo@stale-artifact' === (string) ( $eviden
 datamachine_code_cleanup_run_assert(4 === (int) ( $evidence['remaining_work_summary']['blocked_resolvers_by_reason']['needs_metadata_reconcile']['count'] ?? 0 ), 'evidence keeps blocked resolver bucket');
 datamachine_code_cleanup_run_assert(str_contains((string) wp_json_encode($evidence['remaining_work_summary']['recommended_commands']), 'workspace worktree reconcile-metadata'), 'summary recommends next DMC commands');
 datamachine_code_cleanup_run_assert(str_contains((string) wp_json_encode($evidence['remaining_work_summary']['recommended_commands']), 'apply_destructive'), 'summary labels destructive apply commands separately from review commands');
-
-$done = $service->resume($plan['run_id']);
-datamachine_code_cleanup_run_assert('completed' === (string) ( $done['status'] ?? '' ), 'resume completes final bounded worktree-removal batch');
 
 $bounded_workspace = new DataMachineCodeCleanupRunFakeWorkspace();
 $bounded_service = new \DataMachineCode\Workspace\CleanupRunService($repo, $bounded_workspace);
@@ -259,6 +260,24 @@ datamachine_code_cleanup_run_assert(str_contains((string) ( $bounded_apply['next
 datamachine_code_cleanup_run_assert(str_contains((string) wp_json_encode($bounded_apply['remaining_work_summary']['recommended_commands'] ?? array()), 'current_run_resume'), 'bounded apply recommends resuming the current reviewed run');
 datamachine_code_cleanup_run_assert(1 === count($bounded_workspace->artifact_calls), 'bounded apply only runs artifact cleanup first');
 datamachine_code_cleanup_run_assert(0 === count($bounded_workspace->worktree_calls), 'bounded apply defers worktree cleanup until artifacts drain');
+
+$multi_workspace = new DataMachineCodeCleanupRunFakeWorkspace();
+$multi_service = new \DataMachineCode\Workspace\CleanupRunService($repo, $multi_workspace);
+$multi_plan = $multi_service->plan(array( 'mode' => 'retention' ));
+datamachine_code_cleanup_run_assert(! is_wp_error($multi_plan), 'multi-row resume plan succeeds');
+$multi_apply = $multi_service->apply($multi_plan['run_id'], array( 'limit' => 2 ));
+datamachine_code_cleanup_run_assert('needs_resume' === (string) ( $multi_apply['status'] ?? '' ), 'multi-row apply pauses after artifact rows when worktrees remain');
+datamachine_code_cleanup_run_assert(2 === (int) ( $multi_apply['processed'] ?? 0 ), 'multi-row apply reports processed artifact rows');
+datamachine_code_cleanup_run_assert(str_contains((string) ( $multi_apply['next_command'] ?? '' ), 'workspace cleanup resume'), 'multi-row apply exposes top-level next command');
+$multi_resume = $multi_service->resume($multi_plan['run_id'], array( 'limit' => 2 ));
+datamachine_code_cleanup_run_assert('completed' === (string) ( $multi_resume['status'] ?? '' ), 'resume drains multiple worktree rows up to the requested limit');
+datamachine_code_cleanup_run_assert('worktree_removal' === (string) ( $multi_resume['batch']['type'] ?? '' ), 'multi-row resume reports worktree batch type');
+datamachine_code_cleanup_run_assert(2 === (int) ( $multi_resume['processed'] ?? 0 ), 'multi-row resume reports processed worktree rows');
+datamachine_code_cleanup_run_assert(1 === (int) ( $multi_resume['applied'] ?? 0 ), 'multi-row resume reports applied worktree rows');
+datamachine_code_cleanup_run_assert(1 === (int) ( $multi_resume['skipped'] ?? 0 ), 'multi-row resume reports skipped worktree rows');
+datamachine_code_cleanup_run_assert(null === ( $multi_resume['next_command'] ?? null ), 'multi-row resume omits next command when no rows remain');
+datamachine_code_cleanup_run_assert(1 === count($multi_workspace->worktree_calls), 'multi-row resume applies worktree rows in one safety-revalidated call');
+datamachine_code_cleanup_run_assert(2 === count($multi_workspace->worktree_calls[0]['apply_plan']['candidates'] ?? array()), 'multi-row resume sends both eligible worktree candidates');
 
 $applying_repo = new \DataMachineCode\Storage\CleanupRunRepository();
 $applying_plan = ( new \DataMachineCode\Workspace\CleanupRunService($applying_repo, new DataMachineCodeCleanupRunFakeWorkspace()) )->plan(array( 'mode' => 'retention' ));


### PR DESCRIPTION
## Summary
- Fixes #645.
- Lets DB-backed cleanup apply/resume pass the full remaining `--limit` capacity to worktree-removal direct apply instead of hard-capping each invocation to one row.
- Adds explicit JSON evidence fields: `processed`, `applied`, `skipped`, and `next_command`.
- Updates focused cleanup-run smoke coverage for multi-row resume while preserving `limit=1` behavior.

## Verification
- `composer install`
- `php -l inc/Workspace/CleanupRunService.php`
- `php -l tests/smoke-cleanup-run-storage.php`
- `php tests/smoke-cleanup-run-storage.php`
- `php tests/smoke-worktree-cleanup-remove-guard.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the cleanup resume batching fix, updated focused smoke coverage, and ran targeted verification. Chris remains responsible for review and merge.