### PR TITLE
Guard release tags against stale source

### DIFF
--- a/.github/scripts/verify-release-source.sh
+++ b/.github/scripts/verify-release-source.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+	cat <<'USAGE'
+Usage: verify-release-source.sh [--remote-ref=<ref>] [--tag=<tag>] [--expected-source=<sha>]
+
+Verifies release source freshness for the Data Machine Code release workflow.
+Without --tag, the current checkout must match the remote main ref exactly.
+With --tag, the tag commit must contain --expected-source or the remote main ref.
+USAGE
+}
+
+REMOTE_REF="origin/main"
+TAG_NAME=""
+EXPECTED_SOURCE=""
+
+for arg in "$@"; do
+	case "$arg" in
+		--remote-ref=*)
+			REMOTE_REF="${arg#--remote-ref=}"
+			;;
+		--tag=*)
+			TAG_NAME="${arg#--tag=}"
+			;;
+		--expected-source=*)
+			EXPECTED_SOURCE="${arg#--expected-source=}"
+			;;
+		-h|--help)
+			usage
+			exit 0
+			;;
+		*)
+			echo "Unknown argument: $arg" >&2
+			usage >&2
+			exit 2
+			;;
+	esac
+done
+
+REMOTE_NAME="${REMOTE_REF%%/*}"
+REMOTE_BRANCH="${REMOTE_REF#*/}"
+
+if [ -z "$REMOTE_NAME" ] || [ "$REMOTE_NAME" = "$REMOTE_REF" ] || [ -z "$REMOTE_BRANCH" ]; then
+	echo "::error::Remote ref must look like origin/main; got ${REMOTE_REF}" >&2
+	exit 2
+fi
+
+git fetch --tags "$REMOTE_NAME" "$REMOTE_BRANCH"
+
+REMOTE_SHA="$(git rev-parse "$REMOTE_REF")"
+HEAD_SHA="$(git rev-parse HEAD)"
+
+echo "Release source guard: checkout HEAD ${HEAD_SHA}"
+echo "Release source guard: ${REMOTE_REF} ${REMOTE_SHA}"
+
+if [ -z "$TAG_NAME" ]; then
+	read -r HEAD_ONLY REMOTE_ONLY < <(git rev-list --left-right --count "HEAD...${REMOTE_REF}")
+	echo "Release source guard: HEAD...${REMOTE_REF} ahead=${HEAD_ONLY} behind=${REMOTE_ONLY}"
+
+	if [ "$HEAD_SHA" != "$REMOTE_SHA" ]; then
+		echo "::error::Release checkout is not at ${REMOTE_REF}. HEAD=${HEAD_SHA} ${REMOTE_REF}=${REMOTE_SHA} ahead=${HEAD_ONLY} behind=${REMOTE_ONLY}. Fetch latest main and release from the current source before tagging." >&2
+		exit 1
+	fi
+
+	echo "Release source guard: checkout is current with ${REMOTE_REF}."
+	if [ -n "${GITHUB_OUTPUT:-}" ]; then
+		echo "source-sha=${REMOTE_SHA}" >> "$GITHUB_OUTPUT"
+	fi
+	exit 0
+fi
+
+if ! git rev-parse --verify --quiet "${TAG_NAME}^{commit}" >/dev/null; then
+	echo "::error::Release tag ${TAG_NAME} was not found after release. Expected tag to verify source ancestry." >&2
+	exit 1
+fi
+
+TAG_SHA="$(git rev-parse "${TAG_NAME}^{commit}")"
+SOURCE_SHA="${EXPECTED_SOURCE:-$REMOTE_SHA}"
+SOURCE_SUBJECT="$(git log -1 --format=%s "$SOURCE_SHA")"
+TAG_SUBJECT="$(git log -1 --format=%s "$TAG_SHA")"
+REMOTE_SUBJECT="$(git log -1 --format=%s "$REMOTE_SHA")"
+read -r TAG_ONLY REMOTE_ONLY < <(git rev-list --left-right --count "${TAG_NAME}...${REMOTE_REF}")
+read -r TAG_SOURCE_ONLY SOURCE_ONLY < <(git rev-list --left-right --count "${TAG_NAME}...${SOURCE_SHA}")
+
+echo "Release source guard: tag ${TAG_NAME} ${TAG_SHA}"
+echo "Release source guard: tag subject ${TAG_SUBJECT}"
+echo "Release source guard: expected source ${SOURCE_SHA}"
+echo "Release source guard: expected source subject ${SOURCE_SUBJECT}"
+echo "Release source guard: ${REMOTE_REF} subject ${REMOTE_SUBJECT}"
+echo "Release source guard: ${TAG_NAME}...${REMOTE_REF} ahead=${TAG_ONLY} behind=${REMOTE_ONLY}"
+echo "Release source guard: ${TAG_NAME}...${SOURCE_SHA} ahead=${TAG_SOURCE_ONLY} behind=${SOURCE_ONLY}"
+
+if ! git merge-base --is-ancestor "$SOURCE_SHA" "$TAG_SHA"; then
+	echo "::error::Release tag ${TAG_NAME} (${TAG_SHA}) does not contain expected source ${SOURCE_SHA}. Tag/source divergence: ahead=${TAG_SOURCE_ONLY} behind=${SOURCE_ONLY}. Latest ${REMOTE_REF}=${REMOTE_SHA}; tag/latest-main divergence: ahead=${TAG_ONLY} behind=${REMOTE_ONLY}. The tag may report a new version while missing merged fixes; fetch latest main and retag from current source." >&2
+	exit 1
+fi
+
+echo "Release source guard: tag ${TAG_NAME} contains expected source ${SOURCE_SHA}."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,12 +103,20 @@ jobs:
           persist-credentials: false
           token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
 
+      - name: Verify release checkout is current
+        id: source-guard
+        run: bash .github/scripts/verify-release-source.sh
+
       - uses: Extra-Chill/homeboy-action@v2
         id: release
         with:
           commands: release
           release-dry-run: ${{ inputs.dry-run || 'false' }}
           app-token: ${{ steps.app-token.outputs.token || '' }}
+
+      - name: Verify release tag contains current source
+        if: ${{ steps.release.outputs.release-version != '' && (github.event_name != 'workflow_dispatch' || inputs.dry-run != true) }}
+        run: bash .github/scripts/verify-release-source.sh --tag="v${{ steps.release.outputs.release-version }}" --expected-source="${{ steps.source-guard.outputs.source-sha }}"
 
   # ── Record failed SHA to prevent retry loops ──
   record-failure:

--- a/tests/smoke-release-source-guard.sh
+++ b/tests/smoke-release-source-guard.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GUARD="${ROOT_DIR}/.github/scripts/verify-release-source.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+pass_count=0
+fail() {
+	echo "not ok - $1" >&2
+	exit 1
+}
+
+pass() {
+	pass_count=$((pass_count + 1))
+	echo "ok ${pass_count} - $1"
+}
+
+git_init_repo() {
+	local repo="$1"
+	git -C "$repo" config user.email smoke@example.com
+	git -C "$repo" config user.name "Smoke Test"
+}
+
+REMOTE="${TMP_DIR}/remote.git"
+WORK="${TMP_DIR}/work"
+STALE="${TMP_DIR}/stale"
+
+git init -q --bare -b main "$REMOTE"
+git clone -q "$REMOTE" "$WORK" 2>/dev/null
+git_init_repo "$WORK"
+
+printf 'first\n' > "${WORK}/source.txt"
+git -C "$WORK" add source.txt
+git -C "$WORK" commit -q -m 'fix: first releasable change'
+git -C "$WORK" push -q origin main
+FIRST_SHA="$(git -C "$WORK" rev-parse HEAD)"
+
+git clone -q "$REMOTE" "$STALE"
+
+printf 'second\n' > "${WORK}/source.txt"
+git -C "$WORK" commit -q -am 'fix: intended merged change'
+git -C "$WORK" push -q origin main
+SECOND_SHA="$(git -C "$WORK" rev-parse HEAD)"
+
+if ( cd "$STALE" && bash "$GUARD" --remote-ref=origin/main ) >"${TMP_DIR}/stale-checkout.out" 2>"${TMP_DIR}/stale-checkout.err"; then
+	fail 'stale checkout guard should fail'
+fi
+
+if ! grep -q "HEAD=${FIRST_SHA}" "${TMP_DIR}/stale-checkout.err"; then
+	fail 'stale checkout error includes HEAD SHA'
+fi
+
+if ! grep -q "origin/main=${SECOND_SHA}" "${TMP_DIR}/stale-checkout.err"; then
+	fail 'stale checkout error includes origin/main SHA'
+fi
+
+if ! grep -q 'behind=1' "${TMP_DIR}/stale-checkout.err"; then
+	fail 'stale checkout error includes behind count'
+fi
+
+pass 'stale checkout fails with actionable SHA and behind evidence'
+
+git -C "$STALE" fetch -q origin main --tags
+git -C "$STALE" reset -q --hard origin/main
+git -C "$STALE" tag v1.0.0
+
+( cd "$STALE" && bash "$GUARD" --remote-ref=origin/main --tag=v1.0.0 --expected-source="$SECOND_SHA" ) >"${TMP_DIR}/fresh-tag.out" 2>"${TMP_DIR}/fresh-tag.err"
+
+if ! grep -q "tag v1.0.0 ${SECOND_SHA}" "${TMP_DIR}/fresh-tag.out"; then
+	fail 'fresh tag output includes tag SHA'
+fi
+
+pass 'fresh tag containing origin/main passes with tag SHA evidence'
+
+git -C "$STALE" tag -f v0.9.0 "$FIRST_SHA" >/dev/null
+
+if ( cd "$STALE" && bash "$GUARD" --remote-ref=origin/main --tag=v0.9.0 --expected-source="$SECOND_SHA" ) >"${TMP_DIR}/stale-tag.out" 2>"${TMP_DIR}/stale-tag.err"; then
+	fail 'stale tag guard should fail'
+fi
+
+if ! grep -q "v0.9.0 (${FIRST_SHA})" "${TMP_DIR}/stale-tag.err"; then
+	fail 'stale tag error includes tag SHA'
+fi
+
+if ! grep -q "expected source ${SECOND_SHA}" "${TMP_DIR}/stale-tag.err"; then
+	fail 'stale tag error includes expected source SHA'
+fi
+
+if ! grep -q 'behind=1' "${TMP_DIR}/stale-tag.err"; then
+	fail 'stale tag error includes behind count'
+fi
+
+pass 'stale tag fails with tag SHA, origin/main SHA, and behind evidence'
+
+echo "${pass_count}/${pass_count} passed"


### PR DESCRIPTION
## Summary
- Add a release source guard that fails before tagging when the release checkout is not at `origin/main`.
- Verify the created release tag contains the exact preflight `origin/main` source SHA, while printing tag SHA, expected source SHA, latest `origin/main`, and ahead/behind ancestry evidence.
- Add a focused git-backed smoke test for stale checkout, fresh tag, and stale tag cases.

Closes #647.

## Verification
- `bash tests/smoke-release-source-guard.sh`
- `bash -n .github/scripts/verify-release-source.sh && bash -n tests/smoke-release-source-guard.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'`
- `git diff --check -- .github/workflows/release.yml .github/scripts/verify-release-source.sh tests/smoke-release-source-guard.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementing the release-source guard, focused smoke coverage, targeted verification, and PR drafting. Chris remains responsible for review and merge.