### PR TITLE
Bound metadata reconciliation recommendations

### DIFF
--- a/inc/Cleanup/CleanupRemainingWorkSummary.php
+++ b/inc/Cleanup/CleanupRemainingWorkSummary.php
@@ -14,6 +14,7 @@ class CleanupRemainingWorkSummary {
 
 
 	private const EXAMPLE_LIMIT = 3;
+	private const METADATA_RECONCILE_COMMAND = 'studio wp datamachine-code workspace worktree reconcile-metadata --dry-run --limit=25 --offset=0 --until-budget=30s --format=json';
 
 	/**
 	 * Build a concise summary from DB-backed cleanup items.
@@ -218,7 +219,7 @@ class CleanupRemainingWorkSummary {
 
 	private static function command_for_reason( string $reason, string $bucket ): array {
 		$command = match ( $reason ) {
-			'needs_metadata_reconcile', 'lifecycle_reconciliation_candidate', 'repaired_metadata' => 'studio wp datamachine-code workspace worktree reconcile-metadata --dry-run --format=json',
+			'needs_metadata_reconcile', 'lifecycle_reconciliation_candidate', 'repaired_metadata' => self::METADATA_RECONCILE_COMMAND,
 			'dirty_worktree', 'unpushed_commits', 'probe_timeout', 'plan_mismatch' => 'studio wp datamachine-code workspace cleanup run --mode=retention --dry-run --format=json',
 			'artifact_already_removed', 'artifact_plan_mismatch' => 'studio wp datamachine-code workspace cleanup run --mode=artifacts --dry-run --format=json',
 			default => 'studio wp datamachine-code workspace cleanup run --mode=retention --dry-run --format=json',

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -33,6 +33,10 @@ class WorkspaceCommand extends BaseCommand {
 
 	private const CLEANUP_MODES = array( 'inventory', 'artifacts', 'retention', 'emergency' );
 
+	private const METADATA_RECONCILE_DEFAULT_LIMIT = 25;
+
+	private const METADATA_RECONCILE_DEFAULT_BUDGET = '30s';
+
 	private ?CleanupRunEvidenceStoreInterface $cleanup_run_evidence_store = null;
 
 	/**
@@ -2557,8 +2561,7 @@ class WorkspaceCommand extends BaseCommand {
 	 *     wp datamachine-code workspace worktree abandoned --apply --force --limit=100 --passes=5 --until-budget=120s --format=json
 	 *
 	 *     # Adopt/reconcile unmanaged worktree metadata before cleanup
-	 *     wp datamachine-code workspace worktree reconcile-metadata --dry-run --format=json
-	 *     wp datamachine-code workspace worktree reconcile-metadata --dry-run --limit=25 --offset=0 --format=json
+	 *     wp datamachine-code workspace worktree reconcile-metadata --dry-run --limit=25 --offset=0 --until-budget=30s --format=json
 	 *     wp datamachine-code workspace worktree reconcile-metadata --apply --limit=25 --offset=0 --format=json
 	 *     wp datamachine-code workspace worktree reconcile-metadata --apply --limit=50 --until-budget=60s --format=json
 	 *     wp datamachine-code workspace worktree active-no-signal-report --limit=25 --offset=0 --format=json
@@ -2839,6 +2842,13 @@ class WorkspaceCommand extends BaseCommand {
 				$input['apply']    = ! empty($assoc_args['apply']);
 				$input['via_jobs'] = ! empty($assoc_args['via-jobs']);
 				$input['source']   = self::CLEANUP_CLI_SOURCE;
+				$uses_plan         = ! empty($assoc_args['apply-plan']);
+				$has_bounds        = isset($assoc_args['limit']) || isset($assoc_args['offset']) || ( isset($assoc_args['until-budget']) && '' !== trim( (string) $assoc_args['until-budget']) );
+				if ( ! $uses_plan && ! $has_bounds && ( $input['dry_run'] || $input['apply'] ) ) {
+					$input['limit']        = self::METADATA_RECONCILE_DEFAULT_LIMIT;
+					$input['offset']       = 0;
+					$input['until_budget'] = self::METADATA_RECONCILE_DEFAULT_BUDGET;
+				}
 				if ( isset($assoc_args['limit']) ) {
 					$input['limit'] = (int) $assoc_args['limit'];
 				}
@@ -2848,7 +2858,7 @@ class WorkspaceCommand extends BaseCommand {
 				if ( isset($assoc_args['until-budget']) && '' !== trim( (string) $assoc_args['until-budget']) ) {
 					$input['until_budget'] = trim( (string) $assoc_args['until-budget']);
 				}
-				if ( ! empty($assoc_args['apply-plan']) ) {
+				if ( $uses_plan ) {
 					$input['apply_plan'] = $this->read_worktree_json_plan( (string) $assoc_args['apply-plan'], 'metadata reconciliation');
 				}
 				break;
@@ -4675,13 +4685,17 @@ class WorkspaceCommand extends BaseCommand {
 		WP_CLI::log('');
 		if ( ! empty($result['dry_run']) ) {
 			if ( isset($result['pagination']['next_offset']) ) {
-				WP_CLI::log(
-					sprintf(
-						'Next page: wp datamachine-code workspace worktree reconcile-metadata --dry-run --limit=%d --offset=%d --format=json',
-						(int) ( $result['pagination']['limit'] ?? 0 ),
-						(int) $result['pagination']['next_offset']
-					)
-				);
+				if ( ! empty($result['pagination']['next_command']) ) {
+					WP_CLI::log('Next page: ' . (string) $result['pagination']['next_command']);
+				} else {
+					WP_CLI::log(
+						sprintf(
+							'Next page: wp datamachine-code workspace worktree reconcile-metadata --dry-run --limit=%d --offset=%d --format=json',
+							(int) ( $result['pagination']['limit'] ?? 0 ),
+							(int) $result['pagination']['next_offset']
+						)
+					);
+				}
 			}
 			WP_CLI::success(sprintf('%d metadata reconciliation proposal(s). Review JSON output before applying; --apply-plan remains a low-level escape hatch until DB-backed cleanup runs land.', count($proposals)));
 			return;

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -79,6 +79,16 @@ class Workspace {
 	public const HYGIENE_DEFAULT_SIZE_LIMIT = 1000;
 
 	/**
+	 * Default page size for metadata reconciliation recommendations.
+	 */
+	public const METADATA_RECONCILE_DEFAULT_LIMIT = 25;
+
+	/**
+	 * Default wall-clock budget for metadata reconciliation recommendations.
+	 */
+	public const METADATA_RECONCILE_DEFAULT_BUDGET = '30s';
+
+	/**
 	 * @var string Resolved workspace path.
 	 */
 	private string $workspace_path;

--- a/inc/Workspace/WorkspaceCleanupPlan.php
+++ b/inc/Workspace/WorkspaceCleanupPlan.php
@@ -230,7 +230,7 @@ trait WorkspaceCleanupPlan {
 
 			$resolver_type = WorktreeCleanupClassifier::resolver_type($reason);
 			$next_action   = match ( $resolver_type ) {
-				'metadata_reconciliation'  => 'workspace worktree reconcile-metadata --dry-run --format=json',
+				'metadata_reconciliation'  => sprintf('workspace worktree reconcile-metadata --dry-run --limit=%d --offset=0 --until-budget=%s --format=json', self::METADATA_RECONCILE_DEFAULT_LIMIT, self::METADATA_RECONCILE_DEFAULT_BUDGET),
 				'lifecycle_reconciliation' => 'workspace worktree cleanup --dry-run --format=json',
 				default                    => 'workspace worktree cleanup --dry-run --skip-github --format=json',
 			};

--- a/inc/Workspace/WorkspaceMetadataReconciliation.php
+++ b/inc/Workspace/WorkspaceMetadataReconciliation.php
@@ -20,7 +20,7 @@ trait WorkspaceMetadataReconciliation {
 	 *
 	 * Dry-runs build a reviewed plan from the current git worktree listing.
 	 * Passing `limit` and/or `offset` bounds expensive per-worktree probes to
-	 * only that page; omitting both preserves the historical full scan.
+	 * only that page; CLI defaults provide a bounded first page for operators.
 	 * Applying a plan revalidates handle/path/repo/branch before writing metadata.
 	 *
 	 * @param  array $opts Options: dry_run bool, apply_plan array, limit int, offset int, until_budget string.
@@ -120,6 +120,9 @@ trait WorkspaceMetadataReconciliation {
 
 		$classified_skips = $this->classify_worktree_metadata_reconciliation_skips($skipped);
 		$pagination       = $paged ? $this->build_worktree_metadata_reconciliation_pagination($total_worktrees, count($page_worktrees), $limit, $offset) : null;
+		if ( null !== $pagination && null !== ( $pagination['next_offset'] ?? null ) ) {
+			$pagination['next_command'] = sprintf('studio wp datamachine-code workspace worktree reconcile-metadata --%s --limit=%d --offset=%d%s --format=json', $apply ? 'apply' : 'dry-run', $limit, (int) $pagination['next_offset'], null !== $budget_context ? ' --until-budget=' . (string) $budget_context['label'] : '');
+		}
 		if ( null !== $pagination && $budget_stopped ) {
 			$pagination['partial']      = true;
 			$pagination['complete']     = false;

--- a/inc/Workspace/WorkspaceWorktreeCleanupEngine.php
+++ b/inc/Workspace/WorkspaceWorktreeCleanupEngine.php
@@ -810,7 +810,7 @@ trait WorkspaceWorktreeCleanupEngine {
 			return array(
 				'reason_code'    => 'owner_repo_mismatch',
 				'reason'         => sprintf('worktree handle repo (%s) does not match inventory repo (%s) - %s: %s', $parsed['repo'], $repo, $safety_outcome, $message),
-				'hint'           => 'Run workspace worktree reconcile-metadata --dry-run to review stale registry ownership, then prune or repair the mismatched row.',
+				'hint'           => 'Run workspace worktree reconcile-metadata --dry-run --limit=25 --offset=0 --until-budget=30s --format=json to review stale registry ownership, then prune or repair the mismatched row.',
 				'handle_repo'    => $parsed['repo'],
 				'inventory_repo' => $repo,
 				'git_error_code' => $error_code,
@@ -1716,6 +1716,11 @@ trait WorkspaceWorktreeCleanupEngine {
 	 */
 	private function worktree_cleanup_skipped_next_commands( array $skipped_by_reason ): array {
 		$active_no_signal_commands = $this->build_active_no_signal_next_commands(25, 0);
+		$metadata_reconcile_command = sprintf(
+			'studio wp datamachine-code workspace worktree reconcile-metadata --dry-run --limit=%d --offset=0 --until-budget=%s --format=json',
+			self::METADATA_RECONCILE_DEFAULT_LIMIT,
+			self::METADATA_RECONCILE_DEFAULT_BUDGET
+		);
 		$templates                 = array(
 			'artifact_only_dirty_worktree'       => array(
 				'label'       => 'Review generated artifact cleanup separately',
@@ -1733,7 +1738,7 @@ trait WorkspaceWorktreeCleanupEngine {
 			),
 			'needs_metadata_reconcile'           => array(
 				'label'       => 'Repair missing lifecycle metadata in bounded batches',
-				'command'     => 'studio wp datamachine-code workspace worktree reconcile-metadata --dry-run --format=json',
+				'command'     => $metadata_reconcile_command,
 				'alternative' => 'Low-level apply still requires a reviewed --apply-plan=<file> until DB-backed cleanup runs land.',
 				'why'         => 'Reconciliation writes lifecycle metadata so future inventory cleanup can classify these rows without a full scan.',
 				'destructive' => false,
@@ -1799,7 +1804,7 @@ trait WorkspaceWorktreeCleanupEngine {
 			),
 			'requires_full_scan'                 => array(
 				'label'       => 'Repair missing lifecycle metadata in bounded batches',
-				'command'     => 'studio wp datamachine-code workspace worktree reconcile-metadata --dry-run --format=json',
+				'command'     => $metadata_reconcile_command,
 				'alternative' => 'Low-level apply still requires a reviewed --apply-plan=<file> until DB-backed cleanup runs land.',
 				'why'         => 'Reconciliation writes lifecycle metadata so future inventory cleanup no longer needs a full scan for those rows.',
 				'destructive' => false,

--- a/inc/Workspace/WorkspaceWorktreeInventoryCleanup.php
+++ b/inc/Workspace/WorkspaceWorktreeInventoryCleanup.php
@@ -78,7 +78,7 @@ trait WorkspaceWorktreeInventoryCleanup {
 					$base_row, array(
 						'reason_code' => 'needs_metadata_reconcile',
 						'reason'      => 'inventory row has no lifecycle metadata; metadata reconciliation is required before cleanup planning can classify it',
-						'hint'        => 'Run workspace worktree reconcile-metadata --dry-run --format=json to generate reviewed metadata reconciliation rows.',
+						'hint'        => 'Run workspace worktree reconcile-metadata --dry-run --limit=25 --offset=0 --until-budget=30s --format=json to generate reviewed metadata reconciliation rows.',
 					)
 				);
 				continue;

--- a/tests/smoke-cleanup-run-storage.php
+++ b/tests/smoke-cleanup-run-storage.php
@@ -241,7 +241,7 @@ datamachine_code_cleanup_run_assert(15 === (int) ( $evidence['remaining_work_sum
 datamachine_code_cleanup_run_assert(1 === (int) ( $evidence['remaining_work_summary']['skipped_by_reason']['plan_mismatch']['count'] ?? 0 ), 'evidence groups skipped plan mismatches');
 datamachine_code_cleanup_run_assert('demo@stale-artifact' === (string) ( $evidence['remaining_work_summary']['skipped_by_reason']['plan_mismatch']['examples'][0]['handle'] ?? '' ), 'skipped examples include representative handle');
 datamachine_code_cleanup_run_assert(4 === (int) ( $evidence['remaining_work_summary']['blocked_resolvers_by_reason']['needs_metadata_reconcile']['count'] ?? 0 ), 'evidence keeps blocked resolver bucket');
-datamachine_code_cleanup_run_assert(str_contains((string) wp_json_encode($evidence['remaining_work_summary']['recommended_commands']), 'workspace worktree reconcile-metadata'), 'summary recommends next DMC commands');
+datamachine_code_cleanup_run_assert(str_contains((string) wp_json_encode($evidence['remaining_work_summary']['recommended_commands']), 'workspace worktree reconcile-metadata --dry-run --limit=25 --offset=0 --until-budget=30s --format=json'), 'summary recommends bounded next DMC commands');
 datamachine_code_cleanup_run_assert(str_contains((string) wp_json_encode($evidence['remaining_work_summary']['recommended_commands']), 'apply_destructive'), 'summary labels destructive apply commands separately from review commands');
 
 $done = $service->resume($plan['run_id']);

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -107,7 +107,7 @@ namespace {
         'reason_code'         => 'needs_metadata_reconcile',
         'reason'              => 'inventory row has no lifecycle metadata; metadata reconciliation is required before cleanup planning can classify it',
         'missing_fields'      => array( 'repo', 'branch', 'path' ),
-        'hint'                => 'Run workspace worktree reconcile-metadata --dry-run --format=json to generate reviewed metadata reconciliation rows.',
+        'hint'                => 'Run workspace worktree reconcile-metadata --dry-run --limit=25 --offset=0 --until-budget=30s --format=json to generate reviewed metadata reconciliation rows.',
         'size_bytes'          => 0,
         'artifact_size_bytes' => 0,
         );
@@ -204,7 +204,7 @@ namespace {
         array(
          'reason_code' => 'needs_metadata_reconcile',
          'count'       => 2,
-         'command'     => 'studio wp datamachine-code workspace worktree reconcile-metadata --dry-run --format=json',
+         'command'     => 'studio wp datamachine-code workspace worktree reconcile-metadata --dry-run --limit=25 --offset=0 --until-budget=30s --format=json',
          'alternative' => 'Low-level apply still requires a reviewed --apply-plan=<file> until DB-backed cleanup runs land.',
          'destructive' => false,
         ),
@@ -1208,7 +1208,7 @@ namespace {
     datamachine_code_cleanup_assert(1 === (int) ( $decoded['summary']['liveness']['stale'] ?? 0 ), 'JSON summary includes liveness metadata counts');
     datamachine_code_cleanup_assert(5 === count($decoded['summary']['skipped_next_commands'] ?? array()), 'JSON summary includes actionable skipped next commands');
     datamachine_code_cleanup_assert(str_contains($decoded['summary']['skipped_next_commands'][0]['command'] ?? '', 'worktree cleanup --dry-run --format=json'), 'JSON lifecycle command runs DMC-owned cleanup signal detection');
-    datamachine_code_cleanup_assert(str_contains($decoded['summary']['skipped_next_commands'][1]['command'] ?? '', 'reconcile-metadata --dry-run --format=json'), 'JSON metadata command is metadata reconciliation');
+    datamachine_code_cleanup_assert(str_contains($decoded['summary']['skipped_next_commands'][1]['command'] ?? '', 'reconcile-metadata --dry-run --limit=25 --offset=0 --until-budget=30s --format=json'), 'JSON metadata command is bounded metadata reconciliation');
     datamachine_code_cleanup_assert(str_contains($decoded['summary']['skipped_next_commands'][2]['command'] ?? '', 'active-no-signal-report'), 'JSON active/no-signal command routes to evidence report');
     datamachine_code_cleanup_assert(str_contains($decoded['summary']['skipped_next_commands'][3]['alternative'] ?? '', 'active-no-signal-finalized-apply --dry-run'), 'JSON no-merge command routes finalized PR rows to dry-run apply');
 
@@ -1219,14 +1219,21 @@ namespace {
     datamachine_code_cleanup_assert(10 === (int) ( $ability->last_input['offset'] ?? 0 ), 'cleanup forwards dry-run offset');
     datamachine_code_cleanup_assert('30s' === ( $ability->last_input['until_budget'] ?? '' ), 'cleanup forwards dry-run time budget');
 
-    WP_CLI::$logs      = array();
-    WP_CLI::$successes = array();
-    $command->worktree(array( 'active-no-signal-report' ), array( 'limit' => 5, 'offset' => 10, 'until-budget' => '30s', 'format' => 'json' ));
-    datamachine_code_cleanup_assert('30s' === ( $active_report_ability->last_input['until_budget'] ?? '' ), 'active/no-signal report forwards time budget');
-    $active_report_json = json_decode(WP_CLI::$logs[0] ?? '', true);
-    datamachine_code_cleanup_assert(str_contains($active_report_json['pagination']['next_command'] ?? '', '--until-budget=30s'), 'active/no-signal report JSON continuation keeps time budget');
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->worktree(array( 'active-no-signal-report' ), array( 'limit' => 5, 'offset' => 10, 'until-budget' => '30s', 'format' => 'json' ));
+	datamachine_code_cleanup_assert('30s' === ( $active_report_ability->last_input['until_budget'] ?? '' ), 'active/no-signal report forwards time budget');
+	$active_report_json = json_decode(WP_CLI::$logs[0] ?? '', true);
+	datamachine_code_cleanup_assert(str_contains($active_report_json['pagination']['next_command'] ?? '', '--until-budget=30s'), 'active/no-signal report JSON continuation keeps time budget');
 
-    WP_CLI::$logs      = array();
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->worktree(array( 'reconcile-metadata' ), array( 'dry-run' => true, 'format' => 'json' ));
+	datamachine_code_cleanup_assert(25 === (int) ( $reconcile_metadata_ability->last_input['limit'] ?? 0 ), 'metadata reconciliation dry-run defaults to bounded limit');
+	datamachine_code_cleanup_assert(0 === (int) ( $reconcile_metadata_ability->last_input['offset'] ?? -1 ), 'metadata reconciliation dry-run defaults to first page');
+	datamachine_code_cleanup_assert('30s' === ( $reconcile_metadata_ability->last_input['until_budget'] ?? '' ), 'metadata reconciliation dry-run defaults to bounded time budget');
+
+	WP_CLI::$logs      = array();
     WP_CLI::$successes = array();
     $command->worktree(array( 'active-no-signal-finalized-apply' ), array( 'dry-run' => true, 'limit' => 5, 'offset' => 10, 'until-budget' => '30s', 'format' => 'json' ));
     datamachine_code_cleanup_assert('30s' === ( $active_finalized_ability->last_input['until_budget'] ?? '' ), 'finalized active/no-signal apply forwards time budget');


### PR DESCRIPTION
## Summary
- Bounds the default CLI `workspace worktree reconcile-metadata --dry-run --format=json` path to the first page with `--limit=25 --offset=0 --until-budget=30s` when no bounds are provided.
- Updates cleanup status/planning/inventory recommendations to point operators at the bounded metadata reconciliation form.
- Adds pagination continuation commands for metadata reconciliation JSON/human output and focused smoke coverage for the default bounded CLI path.

Closes https://github.com/Extra-Chill/data-machine-code/issues/644

## Verification
- `composer install`
- `php tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-cleanup-run-storage.php`
- `php tests/smoke-worktree-metadata-reconcile.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the bounded CLI/default recommendation fix, updated focused smoke coverage, and ran targeted verification for Chris to review.