### PR TITLE
Add workspace row triage flow

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -208,6 +208,153 @@ class WorkspaceCommand extends BaseCommand {
 	}
 
 	/**
+	 * Triage external, noncanonical, and non-git workspace rows without cleanup.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <operation>
+	 * : Operation to run.
+	 * ---
+	 * options:
+	 *   - list
+	 *   - ignore
+	 *   - quarantine
+	 *   - adopt
+	 * ---
+	 *
+	 * [<row-id>]
+	 * : Row id from `workspace triage list` for ignore/quarantine/adopt.
+	 *
+	 * [--reason=<reason>]
+	 * : Required reason for ignore/quarantine metadata.
+	 *
+	 * [--name=<name>]
+	 * : Optional canonical primary name when adopting a safe row.
+	 *
+	 * [--status=<status>]
+	 * : Filter list by triage status.
+	 *
+	 * [--include-resolved]
+	 * : Include ignored, quarantined, and adopted rows in list output.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine-code workspace triage list
+	 *     wp datamachine-code workspace triage list --include-resolved --format=json
+	 *     wp datamachine-code workspace triage quarantine external:abc123 --reason='Created by raw git worktree outside DMC ownership'
+	 *     wp datamachine-code workspace triage ignore tmp --reason='Operator scratch directory, not DMC-owned'
+	 *     wp datamachine-code workspace triage adopt my-plugin
+	 *
+	 * @subcommand triage
+	 */
+	public function triage( array $args, array $assoc_args ): void {
+		$operation = (string) ( $args[0] ?? 'list' );
+		$workspace = new Workspace();
+
+		switch ( $operation ) {
+			case 'list':
+				$result = $workspace->workspace_row_triage_list(
+					array(
+						'status'           => isset($assoc_args['status']) ? (string) $assoc_args['status'] : '',
+						'include_resolved' => ! empty($assoc_args['include-resolved']),
+					)
+				);
+				$this->render_workspace_triage_result($result, $assoc_args, true);
+				return;
+
+			case 'ignore':
+			case 'quarantine':
+				if ( empty($args[1]) ) {
+					WP_CLI::error('Usage: wp datamachine-code workspace triage ' . $operation . ' <row-id> --reason=<reason>');
+					return;
+				}
+				$result = $workspace->workspace_row_triage_mark((string) $args[1], 'ignore' === $operation ? 'ignored' : 'quarantined', (string) ( $assoc_args['reason'] ?? '' ));
+				$this->render_workspace_triage_result($result, $assoc_args, false);
+				return;
+
+			case 'adopt':
+				if ( empty($args[1]) ) {
+					WP_CLI::error('Usage: wp datamachine-code workspace triage adopt <row-id> [--name=<name>]');
+					return;
+				}
+				$result = $workspace->workspace_row_triage_adopt((string) $args[1], isset($assoc_args['name']) ? (string) $assoc_args['name'] : null);
+				$this->render_workspace_triage_result($result, $assoc_args, false);
+				return;
+
+			default:
+				WP_CLI::error(sprintf('Unknown triage operation: %s', $operation));
+		}
+	}
+
+	/**
+	 * Render workspace row triage output.
+	 *
+	 * @param array<string,mixed>|\WP_Error $result     Result.
+	 * @param array<string,mixed>           $assoc_args CLI args.
+	 * @param bool                          $is_list    Whether result is a list.
+	 */
+	private function render_workspace_triage_result( array|\WP_Error $result, array $assoc_args, bool $is_list ): void {
+		if ( is_wp_error($result) ) {
+			WP_CLI::error($result->get_error_message());
+			return;
+		}
+
+		$format = (string) ( $assoc_args['format'] ?? 'table' );
+		if ( 'json' === $format ) {
+			WP_CLI::log( (string) wp_json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+			return;
+		}
+
+		if ( ! $is_list ) {
+			WP_CLI::success((string) ( $result['message'] ?? 'Workspace triage updated.' ));
+			$row = is_array($result['row'] ?? null) ? (array) $result['row'] : array();
+			if ( array() !== $row ) {
+				$this->format_items(array( $this->workspace_triage_table_row($row) ), array( 'row_id', 'status', 'issues', 'age_days', 'reason', 'path' ), $assoc_args, 'row_id');
+			}
+			return;
+		}
+
+		WP_CLI::log(sprintf('Workspace: %s', (string) ( $result['workspace_path'] ?? '' )));
+		$rows = array_map(fn( array $row ): array => $this->workspace_triage_table_row($row), (array) ( $result['rows'] ?? array() ));
+		if ( array() === $rows ) {
+			WP_CLI::log('No unresolved external, noncanonical, or non-git workspace rows.');
+			return;
+		}
+
+		$this->format_items($rows, array( 'row_id', 'status', 'issues', 'age_days', 'repo', 'path' ), $assoc_args, 'row_id');
+		WP_CLI::log('Next: use `workspace triage ignore|quarantine <row-id> --reason=<reason>` or `workspace triage adopt <row-id>` for safe primary rows.');
+	}
+
+	/**
+	 * Build a compact table row for workspace triage output.
+	 *
+	 * @param  array<string,mixed> $row Triage row.
+	 * @return array<string,mixed>
+	 */
+	private function workspace_triage_table_row( array $row ): array {
+		return array(
+			'row_id'   => (string) ( $row['row_id'] ?? '' ),
+			'status'   => (string) ( $row['triage_status'] ?? '' ),
+			'issues'   => implode(',', array_map('strval', (array) ( $row['issues'] ?? array() ))),
+			'age_days' => null === ( $row['age_days'] ?? null ) ? '-' : (string) $row['age_days'],
+			'repo'     => (string) ( $row['repo'] ?? '' ),
+			'reason'   => (string) ( $row['triage_reason'] ?? '' ),
+			'path'     => (string) ( $row['path'] ?? '' ),
+		);
+	}
+
+	/**
 	 * Render compact workspace list counts for cleanup triage.
 	 *
 	 * @param  array<string,mixed> $result     Workspace list ability result.
@@ -251,6 +398,9 @@ class WorkspaceCommand extends BaseCommand {
 
 		ksort($summary['repos']);
 		$summary['repos'] = array_values($summary['repos']);
+		if ( $summary['non_git'] > 0 ) {
+			$summary['triage_command'] = 'wp datamachine-code workspace triage list --format=json';
+		}
 
 		$format = (string) ( $assoc_args['format'] ?? 'table' );
 		if ( 'json' === $format ) {
@@ -290,6 +440,10 @@ class WorkspaceCommand extends BaseCommand {
 		if ( array() !== $summary['repos'] ) {
 			WP_CLI::log('Repos:');
 			$this->format_items($summary['repos'], array( 'repo', 'primary', 'worktree', 'context', 'total' ), array( 'format' => 'table' ), 'repo');
+		}
+
+		if ( ! empty($summary['triage_command']) ) {
+			WP_CLI::log(sprintf('Triage: %s', $summary['triage_command']));
 		}
 	}
 

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -22,6 +22,7 @@ require_once __DIR__ . '/WorkspaceGitOperations.php';
 require_once __DIR__ . '/WorkspaceHygieneReport.php';
 require_once __DIR__ . '/WorkspaceMetadataReconciliation.php';
 require_once __DIR__ . '/WorkspaceRepositoryLifecycle.php';
+require_once __DIR__ . '/WorkspaceRowTriage.php';
 require_once __DIR__ . '/WorkspaceWorktreeLifecycle.php';
 require_once __DIR__ . '/WorkspaceWorktreeCleanupEngine.php';
 require_once __DIR__ . '/WorkspaceWorktreeInventoryCleanup.php';
@@ -37,6 +38,7 @@ class Workspace {
 	use WorkspaceHygieneReport;
 	use WorkspaceMetadataReconciliation;
 	use WorkspaceRepositoryLifecycle;
+	use WorkspaceRowTriage;
 	use WorkspaceWorktreeLifecycle;
 	use WorkspaceWorktreeCleanupEngine;
 	use WorkspaceWorktreeInventoryCleanup;

--- a/inc/Workspace/WorkspaceMetadataReconciliation.php
+++ b/inc/Workspace/WorkspaceMetadataReconciliation.php
@@ -481,8 +481,11 @@ trait WorkspaceMetadataReconciliation {
 				continue;
 			}
 
+			$metadata      = is_array($wt['metadata'] ?? null) ? (array) $wt['metadata'] : array();
+			$triage_status = $this->workspace_row_triage_status_from_metadata($metadata);
+			$skip_reason   = in_array($triage_status, array( 'ignored', 'quarantined' ), true) ? 'triage_' . $triage_status : 'complete_metadata';
 			++$skipped;
-			$reasons['complete_metadata'] = (int) ( $reasons['complete_metadata'] ?? 0 ) + 1;
+			$reasons[ $skip_reason ] = (int) ( $reasons[ $skip_reason ] ?? 0 ) + 1;
 		}
 
 		return array(
@@ -503,6 +506,12 @@ trait WorkspaceMetadataReconciliation {
 	 * @param  array<string,mixed> $wt Worktree list row.
 	 */
 	private function worktree_metadata_reconciliation_candidate_reason( array $wt ): ?string {
+		$metadata      = is_array($wt['metadata'] ?? null) ? (array) $wt['metadata'] : array();
+		$triage_status = $this->workspace_row_triage_status_from_metadata($metadata);
+		if ( in_array($triage_status, array( 'ignored', 'quarantined' ), true) ) {
+			return null;
+		}
+
 		if ( ! empty($wt['external']) ) {
 			return 'external_worktree';
 		}

--- a/inc/Workspace/WorkspaceRowTriage.php
+++ b/inc/Workspace/WorkspaceRowTriage.php
@@ -1,0 +1,456 @@
+<?php
+/**
+ * Workspace row triage reporting and metadata-only actions.
+ *
+ * @package DataMachineCode\Workspace
+ */
+
+namespace DataMachineCode\Workspace;
+
+defined('ABSPATH') || exit;
+
+trait WorkspaceRowTriage {
+
+
+
+	/**
+	 * List workspace rows that need bounded operator triage.
+	 *
+	 * This is deliberately reporting-only. It surfaces external git worktrees,
+	 * noncanonical top-level handles, and non-git directories without removing or
+	 * moving anything.
+	 *
+	 * @param  array<string,mixed> $opts Options: status, include_resolved.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function workspace_row_triage_list( array $opts = array() ): array|\WP_Error {
+		$visible = $this->require_workspace_visible();
+		if ( null !== $visible ) {
+			return $visible;
+		}
+
+		$status_filter    = isset($opts['status']) ? trim( (string) $opts['status']) : '';
+		$include_resolved = ! empty($opts['include_resolved']);
+		$rows             = array_merge($this->workspace_top_level_triage_rows(), $this->workspace_external_worktree_triage_rows());
+
+		if ( '' !== $status_filter ) {
+			$rows = array_values(array_filter($rows, static fn( array $row ): bool => $status_filter === (string) ( $row['triage_status'] ?? '' )));
+		} elseif ( ! $include_resolved ) {
+			$rows = array_values(array_filter($rows, static fn( array $row ): bool => 'unresolved' === (string) ( $row['triage_status'] ?? '' )));
+		}
+
+		usort(
+			$rows,
+			static function ( array $a, array $b ): int {
+				$status_cmp = strcmp((string) ( $a['triage_status'] ?? '' ), (string) ( $b['triage_status'] ?? '' ));
+				return 0 !== $status_cmp ? $status_cmp : strcmp((string) ( $a['row_id'] ?? '' ), (string) ( $b['row_id'] ?? '' ));
+			}
+		);
+
+		return array(
+			'success'        => true,
+			'workspace_path' => $this->workspace_path,
+			'rows'           => $rows,
+			'summary'        => $this->workspace_row_triage_summary($rows),
+			'evidence'       => array(
+				'scope' => 'metadata-only workspace row triage',
+				'note'  => 'Actions from this surface write triage metadata or call safe primary adoption only; no cleanup/removal is performed.',
+			),
+		);
+	}
+
+	/**
+	 * Mark a triage row ignored or quarantined.
+	 *
+	 * @param  string $row_id Row id from workspace_row_triage_list().
+	 * @param  string $status ignored or quarantined.
+	 * @param  string $reason Operator reason.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function workspace_row_triage_mark( string $row_id, string $status, string $reason ): array|\WP_Error {
+		$row_id = trim($row_id);
+		$status = strtolower(trim($status));
+		$reason = trim($reason);
+
+		if ( '' === $row_id ) {
+			return new \WP_Error('missing_triage_row', 'A triage row id is required.', array( 'status' => 400 ));
+		}
+		if ( ! in_array($status, array( 'ignored', 'quarantined' ), true) ) {
+			return new \WP_Error('invalid_triage_status', 'Triage status must be ignored or quarantined.', array( 'status' => 400 ));
+		}
+		if ( '' === $reason ) {
+			return new \WP_Error('missing_triage_reason', 'A reason is required when marking a workspace row ignored or quarantined.', array( 'status' => 400 ));
+		}
+
+		$row = $this->workspace_row_triage_find($row_id, true);
+		if ( is_wp_error($row) ) {
+			return $row;
+		}
+
+		$now      = gmdate('c');
+		$metadata = array(
+			'triage_status'     => $status,
+			'triage_reason'     => $reason,
+			'triage_updated_at' => $now,
+			'triage_source'     => 'workspace_row_triage',
+			'handle'            => (string) ( $row['handle'] ?? $row_id ),
+			'path'              => (string) ( $row['path'] ?? '' ),
+			'repo'              => (string) ( $row['repo'] ?? '' ),
+			'row_kind'          => (string) ( $row['row_kind'] ?? '' ),
+			'row_issues'        => (array) ( $row['issues'] ?? array() ),
+		);
+
+		if ( empty($row['triage_metadata']) ) {
+			$metadata['triage_created_at'] = $now;
+		}
+
+		WorktreeContextInjector::store_lifecycle_metadata((string) ( $row['metadata_key'] ?? $row_id ), $metadata);
+
+		$updated = $this->workspace_row_triage_find($row_id, true);
+		if ( is_wp_error($updated) ) {
+			return $updated;
+		}
+
+		return array(
+			'success' => true,
+			'action'  => $status,
+			'row'     => $updated,
+			'message' => sprintf('Workspace row "%s" marked %s.', $row_id, $status),
+		);
+	}
+
+	/**
+	 * Adopt a safe unresolved top-level git primary row.
+	 *
+	 * @param  string      $row_id Row id from workspace_row_triage_list().
+	 * @param  string|null $name   Optional canonical primary name.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function workspace_row_triage_adopt( string $row_id, ?string $name = null ): array|\WP_Error {
+		$row = $this->workspace_row_triage_find($row_id, true);
+		if ( is_wp_error($row) ) {
+			$row = $this->workspace_row_triage_adoptable_top_level_row($row_id);
+			if ( is_wp_error($row) ) {
+				return $row;
+			}
+		}
+
+		if ( ! empty($row['external']) ) {
+			return new \WP_Error('triage_adopt_external_unsupported', 'External worktree rows cannot be adopted by metadata triage. Create a DMC-owned worktree instead, then quarantine the external row.', array( 'status' => 400 ));
+		}
+		if ( ! empty($row['non_git']) ) {
+			return new \WP_Error('triage_adopt_non_git_unsupported', 'Non-git rows cannot be adopted as workspace checkouts.', array( 'status' => 400 ));
+		}
+		if ( ! empty($row['is_linked_worktree']) ) {
+			return new \WP_Error('triage_adopt_linked_worktree_unsupported', 'Linked worktree rows cannot be adopted as primary checkouts.', array( 'status' => 400 ));
+		}
+
+		$adopt = $this->adopt_repo((string) ( $row['path'] ?? '' ), $name);
+		if ( is_wp_error($adopt) ) {
+			return $adopt;
+		}
+
+		WorktreeContextInjector::store_lifecycle_metadata(
+			(string) ( $row['metadata_key'] ?? $row_id ),
+			array(
+				'triage_status'     => 'adopted',
+				'triage_reason'     => 'Safe primary checkout adopted through workspace row triage.',
+				'triage_updated_at' => gmdate('c'),
+				'triage_source'     => 'workspace_row_triage',
+				'adopted_name'      => (string) ( $adopt['name'] ?? '' ),
+			)
+		);
+
+		return array(
+			'success' => true,
+			'action'  => 'adopted',
+			'adopt'   => $adopt,
+			'row'     => $this->workspace_row_triage_find($row_id, true),
+			'message' => sprintf('Workspace row "%s" adopted as %s.', $row_id, (string) ( $adopt['name'] ?? $row_id )),
+		);
+	}
+
+	/**
+	 * Build an adoptable canonical top-level primary row by handle.
+	 *
+	 * @param  string $row_id Top-level workspace basename.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private function workspace_row_triage_adoptable_top_level_row( string $row_id ): array|\WP_Error {
+		$parsed = $this->parse_handle($row_id);
+		if ( ! empty($parsed['is_worktree']) || (string) $parsed['dir_name'] !== $row_id ) {
+			return new \WP_Error('triage_row_not_found', sprintf('Workspace triage row "%s" was not found.', $row_id), array( 'status' => 404 ));
+		}
+
+		$path     = $this->workspace_path . '/' . $parsed['dir_name'];
+		$git_path = $path . '/.git';
+		if ( ! is_dir($path) || ! is_dir($git_path) ) {
+			return new \WP_Error('triage_row_not_found', sprintf('Workspace triage row "%s" was not found.', $row_id), array( 'status' => 404 ));
+		}
+
+		$metadata = WorktreeContextInjector::get_metadata($row_id) ?? array();
+		return $this->workspace_row_triage_normalize_row(
+			array(
+				'row_id'           => $row_id,
+				'metadata_key'     => $row_id,
+				'handle'           => $row_id,
+				'canonical_handle' => $row_id,
+				'repo'             => $row_id,
+				'row_kind'         => 'primary',
+				'path'             => $path,
+				'git'              => true,
+				'non_git'          => false,
+				'noncanonical'     => false,
+				'external'         => false,
+				'issues'           => array( 'adoptable_primary' ),
+				'metadata'         => $metadata,
+			)
+		);
+	}
+
+	/**
+	 * Build triage rows for top-level workspace directories.
+	 *
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function workspace_top_level_triage_rows(): array {
+		if ( '' === $this->workspace_path || ! is_dir($this->workspace_path) ) {
+			return array();
+		}
+
+		$entries = scandir($this->workspace_path);
+		if ( ! is_array($entries) ) {
+			return array();
+		}
+
+		$rows = array();
+		foreach ( $entries as $entry ) {
+			if ( '.' === $entry || '..' === $entry ) {
+				continue;
+			}
+
+			$path = $this->workspace_path . '/' . $entry;
+			if ( ! is_dir($path) ) {
+				continue;
+			}
+
+			$parsed             = $this->parse_handle($entry);
+			$git_path           = $path . '/.git';
+			$is_git             = is_dir($git_path) || is_file($git_path);
+			$is_linked_worktree = is_file($git_path);
+			$is_noncanonical    = (string) $parsed['dir_name'] !== $entry;
+			$is_non_git         = ! $is_git;
+			$issues             = array();
+
+			if ( $is_non_git ) {
+				$issues[] = 'non_git';
+			}
+			if ( $is_noncanonical ) {
+				$issues[] = 'noncanonical_handle';
+			}
+			if ( $is_linked_worktree && empty($parsed['is_worktree']) ) {
+				$issues[] = 'linked_worktree_without_worktree_handle';
+			}
+
+			if ( array() === $issues ) {
+				continue;
+			}
+
+			$metadata_key = $entry;
+			$metadata     = WorktreeContextInjector::get_metadata($metadata_key) ?? array();
+			$rows[]       = $this->workspace_row_triage_normalize_row(
+				array(
+					'row_id'             => $entry,
+					'metadata_key'       => $metadata_key,
+					'handle'             => $entry,
+					'canonical_handle'   => (string) $parsed['dir_name'],
+					'repo'               => (string) $parsed['repo'],
+					'branch_slug'        => $parsed['branch_slug'],
+					'row_kind'           => ! empty($parsed['is_worktree']) ? 'worktree' : 'primary',
+					'path'               => $path,
+					'git'                => $is_git,
+					'non_git'            => $is_non_git,
+					'noncanonical'       => $is_noncanonical,
+					'external'           => false,
+					'is_linked_worktree' => $is_linked_worktree,
+					'issues'             => $issues,
+					'metadata'           => $metadata,
+				)
+			);
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * Build triage rows for external git worktrees registered on primaries.
+	 *
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function workspace_external_worktree_triage_rows(): array {
+		$listing = $this->worktree_list(
+			null,
+			null,
+			array(
+				'include_status' => false,
+				'include_disk'   => false,
+			)
+		);
+		if ( is_wp_error($listing) ) {
+			return array();
+		}
+
+		$rows = array();
+		foreach ( (array) ( $listing['worktrees'] ?? array() ) as $wt ) {
+			if ( empty($wt['external']) ) {
+				continue;
+			}
+
+			$path         = (string) ( $wt['path'] ?? '' );
+			$row_id       = 'external:' . sha1($path);
+			$metadata_key = $row_id;
+			$metadata     = WorktreeContextInjector::get_metadata($metadata_key) ?? array();
+
+			$rows[] = $this->workspace_row_triage_normalize_row(
+				array(
+					'row_id'           => $row_id,
+					'metadata_key'     => $metadata_key,
+					'handle'           => (string) ( $wt['handle'] ?? $path ),
+					'canonical_handle' => null,
+					'repo'             => (string) ( $wt['repo'] ?? '' ),
+					'branch'           => (string) ( $wt['branch'] ?? '' ),
+					'head'             => (string) ( $wt['head'] ?? '' ),
+					'row_kind'         => 'external_worktree',
+					'path'             => $path,
+					'git'              => true,
+					'non_git'          => false,
+					'noncanonical'     => true,
+					'external'         => true,
+					'issues'           => array( 'external_worktree' ),
+					'metadata'         => $metadata,
+				)
+			);
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * Normalize a triage row for output.
+	 *
+	 * @param  array<string,mixed> $row Raw row.
+	 * @return array<string,mixed>
+	 */
+	private function workspace_row_triage_normalize_row( array $row ): array {
+		$metadata      = is_array($row['metadata'] ?? null) ? (array) $row['metadata'] : array();
+		$triage_status = $this->workspace_row_triage_status_from_metadata($metadata);
+
+		$created_at = isset($metadata['created_at']) ? (string) $metadata['created_at'] : null;
+		$mtime      = @filemtime((string) ( $row['path'] ?? '' )); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Best-effort provenance for local workspace rows.
+		if ( null === $created_at && false !== $mtime ) {
+			$created_at = gmdate('c', $mtime);
+		}
+
+		$owner = WorktreeContextInjector::summarize_owner($metadata);
+
+		return array_merge(
+			$row,
+			array(
+				'triage_status'   => $triage_status,
+				'triage_reason'   => isset($metadata['triage_reason']) ? (string) $metadata['triage_reason'] : null,
+				'triaged_at'      => isset($metadata['triage_updated_at']) ? (string) $metadata['triage_updated_at'] : null,
+				'triage_metadata' => array_intersect_key(
+					$metadata,
+					array(
+						'triage_status'     => true,
+						'triage_reason'     => true,
+						'triage_created_at' => true,
+						'triage_updated_at' => true,
+						'triage_source'     => true,
+						'adopted_name'      => true,
+					)
+				),
+				'created_at'      => $created_at,
+				'age_days'        => $this->calculate_age_days(is_string($created_at) ? $created_at : null),
+				'owner'           => $owner,
+				'provenance'      => array(
+					'origin_site'    => $owner['site'],
+					'origin_agent'   => $owner['agent'],
+					'origin_session' => isset($metadata['origin_session']) ? (string) $metadata['origin_session'] : null,
+					'created_at'     => $created_at,
+					'last_seen_at'   => isset($metadata['last_seen_at']) ? (string) $metadata['last_seen_at'] : null,
+				),
+			)
+		);
+	}
+
+	/**
+	 * Return a normalized triage status from row metadata.
+	 *
+	 * @param  array<string,mixed> $metadata Row metadata.
+	 * @return string
+	 */
+	protected function workspace_row_triage_status_from_metadata( array $metadata ): string {
+		$triage_status = isset($metadata['triage_status']) ? (string) $metadata['triage_status'] : 'unresolved';
+		return in_array($triage_status, array( 'unresolved', 'ignored', 'quarantined', 'adopted' ), true) ? $triage_status : 'unresolved';
+	}
+
+	/**
+	 * Find one triage row by id.
+	 *
+	 * @param  string $row_id           Row id.
+	 * @param  bool   $include_resolved Include resolved rows.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private function workspace_row_triage_find( string $row_id, bool $include_resolved ): array|\WP_Error {
+		$result = $this->workspace_row_triage_list(array( 'include_resolved' => $include_resolved ));
+		if ( is_wp_error($result) ) {
+			return $result;
+		}
+
+		foreach ( (array) ( $result['rows'] ?? array() ) as $row ) {
+			if ( $row_id === (string) ( $row['row_id'] ?? '' ) ) {
+				return $row;
+			}
+		}
+
+		return new \WP_Error('triage_row_not_found', sprintf('Workspace triage row "%s" was not found.', $row_id), array( 'status' => 404 ));
+	}
+
+	/**
+	 * Summarize triage rows.
+	 *
+	 * @param  array<int,array<string,mixed>> $rows Rows.
+	 * @return array<string,mixed>
+	 */
+	private function workspace_row_triage_summary( array $rows ): array {
+		$summary = array(
+			'total'              => count($rows),
+			'unresolved'         => 0,
+			'ignored'            => 0,
+			'quarantined'        => 0,
+			'adopted'            => 0,
+			'external_worktree'  => 0,
+			'noncanonical_handle' => 0,
+			'non_git'            => 0,
+			'by_issue'           => array(),
+		);
+
+		foreach ( $rows as $row ) {
+			$status = (string) ( $row['triage_status'] ?? 'unresolved' );
+			if ( isset($summary[ $status ]) ) {
+				++$summary[ $status ];
+			}
+			foreach ( (array) ( $row['issues'] ?? array() ) as $issue ) {
+				$issue                         = (string) $issue;
+				$summary['by_issue'][ $issue ] = (int) ( $summary['by_issue'][ $issue ] ?? 0 ) + 1;
+				if ( isset($summary[ $issue ]) ) {
+					++$summary[ $issue ];
+				}
+			}
+		}
+
+		ksort($summary['by_issue']);
+		return $summary;
+	}
+}

--- a/inc/Workspace/WorkspaceWorktreeInventoryCleanup.php
+++ b/inc/Workspace/WorkspaceWorktreeInventoryCleanup.php
@@ -73,6 +73,24 @@ trait WorkspaceWorktreeInventoryCleanup {
 				'metadata'    => $metadata,
 			);
 
+			if ( is_array($metadata) && array() !== $metadata ) {
+				$triage_status = $this->workspace_row_triage_status_from_metadata($metadata);
+				if ( in_array($triage_status, array( 'ignored', 'quarantined' ), true) ) {
+					$skipped[] = array_merge(
+						$base_row,
+						array(
+							'reason_code'   => 'triage_' . $triage_status,
+							'reason'        => sprintf('operator marked row %s: %s', $triage_status, (string) ( $metadata['triage_reason'] ?? '' )),
+							'hint'          => 'Intentional triage metadata excludes this row from unresolved cleanup blockers.',
+							'triage_status' => $triage_status,
+							'triage_reason' => $metadata['triage_reason'] ?? null,
+							'triaged_at'    => $metadata['triage_updated_at'] ?? null,
+						)
+					);
+					continue;
+				}
+			}
+
 			if ( ! is_array($metadata) || array() === $metadata ) {
 				$skipped[] = array_merge(
 					$base_row, array(

--- a/inc/Workspace/WorkspaceWorktreeLifecycle.php
+++ b/inc/Workspace/WorkspaceWorktreeLifecycle.php
@@ -775,7 +775,13 @@ trait WorkspaceWorktreeLifecycle {
 					$dirty_files = null;
 				}
 
-				$metadata        = ( ! $is_primary && $inside_ws ) ? WorktreeContextInjector::get_metadata($relative) : null;
+				$metadata_key     = null;
+				if ( ! $is_primary && $inside_ws ) {
+					$metadata_key = $relative;
+				} elseif ( ! $is_primary && ! $inside_ws ) {
+					$metadata_key = 'external:' . sha1($wt['path']);
+				}
+				$metadata        = null !== $metadata_key ? WorktreeContextInjector::get_metadata($metadata_key) : null;
 				$created_at      = is_array($metadata) ? ( $metadata['created_at'] ?? null ) : null;
 				$lifecycle_state = is_array($metadata) ? ( $metadata['lifecycle_state'] ?? null ) : null;
 				if ( null !== $state && $lifecycle_state !== $state ) {

--- a/inc/Workspace/WorktreeCleanupClassifier.php
+++ b/inc/Workspace/WorktreeCleanupClassifier.php
@@ -20,6 +20,7 @@ final class WorktreeCleanupClassifier {
 	public const BUCKET_NEEDS_FULL_REVIEW            = 'needs_full_review';
 	public const BUCKET_BLOCKED_BY_DIRTY_OR_UNPUSHED = 'blocked_by_dirty_or_unpushed';
 	public const BUCKET_ARTIFACT_ONLY_DIRTY          = 'artifact_only_dirty_worktree';
+	public const BUCKET_INTENTIONAL_TRIAGE           = 'intentional_triage';
 
 	/**
 	 * Reason codes that indicate metadata/lifecycle reconciliation should run
@@ -66,6 +67,16 @@ final class WorktreeCleanupClassifier {
 	);
 
 	/**
+	 * Reason codes intentionally resolved by operator triage metadata.
+	 *
+	 * @var string[]
+	 */
+	private const TRIAGE_REASONS = array(
+		'triage_ignored',
+		'triage_quarantined',
+	);
+
+	/**
 	 * Reason codes that can generate read-only resolver plan rows.
 	 *
 	 * @var string[]
@@ -92,6 +103,10 @@ final class WorktreeCleanupClassifier {
 
 		if ( in_array($reason_code, self::RECONCILIATION_REASONS, true) ) {
 			return self::BUCKET_NEEDS_RECONCILIATION;
+		}
+
+		if ( in_array($reason_code, self::TRIAGE_REASONS, true) ) {
+			return self::BUCKET_INTENTIONAL_TRIAGE;
 		}
 
 		if ( in_array($reason_code, self::FULL_REVIEW_REASONS, true) ) {
@@ -128,6 +143,7 @@ final class WorktreeCleanupClassifier {
 		$buckets['metadata_reconciliation_candidates']  = (int) ( $skipped_by_reason['needs_metadata_reconcile'] ?? 0 ) + (int) ( $skipped_by_reason['requires_full_scan'] ?? 0 ) + (int) ( $skipped_by_reason['missing_metadata'] ?? 0 );
 		$buckets['dirty_unpushed']                      = $buckets[ self::BUCKET_BLOCKED_BY_DIRTY_OR_UNPUSHED ];
 		$buckets['active_no_signal']                    = (int) ( $skipped_by_reason['active_no_signal'] ?? 0 ) + (int) ( $skipped_by_reason['no_inventory_cleanup_signal'] ?? 0 );
+		$buckets['intentional_triage']                   = (int) ( $skipped_by_reason['triage_ignored'] ?? 0 ) + (int) ( $skipped_by_reason['triage_quarantined'] ?? 0 );
 
 		ksort($buckets);
 		return $buckets;

--- a/tests/smoke-workspace-row-triage.php
+++ b/tests/smoke-workspace-row-triage.php
@@ -1,0 +1,228 @@
+<?php
+/**
+ * Smoke test for workspace row triage reporting and metadata-only actions.
+ *
+ * Run: php tests/smoke-workspace-row-triage.php
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Core\FilesRepository {
+	if ( ! class_exists(__NAMESPACE__ . '\\FilesystemHelper') ) {
+		class FilesystemHelper {
+			public static function get() {
+				return null;
+			}
+		}
+	}
+}
+
+namespace {
+	if ( ! defined('ABSPATH') ) {
+		define('ABSPATH', __DIR__ . '/');
+	}
+
+	if ( ! class_exists('WP_Error') ) {
+		class WP_Error {
+			public string $code;
+			public string $message;
+			public array $data;
+
+			public function __construct( $code = '', $message = '', $data = array() ) {
+				$this->code    = (string) $code;
+				$this->message = (string) $message;
+				$this->data    = (array) $data;
+			}
+
+			public function get_error_code(): string {
+				return $this->code;
+			}
+
+			public function get_error_message(): string {
+				return $this->message;
+			}
+		}
+	}
+
+	if ( ! function_exists('is_wp_error') ) {
+		function is_wp_error( $thing ): bool {
+			return $thing instanceof \WP_Error;
+		}
+	}
+
+	if ( ! function_exists('wp_mkdir_p') ) {
+		function wp_mkdir_p( string $path ): bool {
+			return is_dir($path) || mkdir($path, 0755, true);
+		}
+	}
+
+	if ( ! function_exists('get_option') ) {
+		function get_option( string $name, $default = false ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+			global $datamachine_code_test_options;
+			return $datamachine_code_test_options[ $name ] ?? $default;
+		}
+	}
+
+	if ( ! function_exists('update_option') ) {
+		function update_option( string $name, $value, $autoload = null ): bool { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+			global $datamachine_code_test_options;
+			$datamachine_code_test_options[ $name ] = $value;
+			return true;
+		}
+	}
+
+	if ( ! function_exists('current_time') ) {
+		function current_time( string $type, bool $gmt = false ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+			return gmdate('Y-m-d H:i:s');
+		}
+	}
+
+	if ( ! function_exists('wp_json_encode') ) {
+		function wp_json_encode( $value, int $flags = 0 ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+			return json_encode($value, $flags);
+		}
+	}
+
+	if ( ! function_exists('apply_filters') ) {
+		function apply_filters( string $hook_name, $value ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+			return $value;
+		}
+	}
+
+	include __DIR__ . '/../inc/Support/GitHubRemote.php';
+	include __DIR__ . '/../inc/Support/GitRunner.php';
+	include __DIR__ . '/../inc/Support/PathSecurity.php';
+	include __DIR__ . '/../inc/Workspace/WorkspaceMutationLock.php';
+	include __DIR__ . '/../inc/Workspace/WorktreeDiskBudget.php';
+	include __DIR__ . '/../inc/Workspace/WorktreeContextInjector.php';
+	include __DIR__ . '/../inc/Storage/WorktreeInventoryRepository.php';
+	include __DIR__ . '/../inc/Workspace/Workspace.php';
+
+	exec('git --version 2>&1', $_git_version, $git_version_exit);
+	if ( 0 !== $git_version_exit ) {
+		echo "SKIP: git not available\n";
+		exit(0);
+	}
+
+	$tmp = sys_get_temp_dir() . '/dmc-row-triage-smoke-' . bin2hex(random_bytes(4));
+	mkdir($tmp, 0755, true);
+	register_shutdown_function(
+		function () use ( $tmp ) {
+			if ( is_dir($tmp) ) {
+				exec('rm -rf ' . escapeshellarg($tmp));
+			}
+		}
+	);
+
+	define('DATAMACHINE_WORKSPACE_PATH', realpath($tmp) ?: $tmp);
+
+	$failures = 0;
+	$total    = 0;
+	$assert   = function ( $expected, $actual, string $message ) use ( &$failures, &$total ): void {
+		++$total;
+		if ( $expected === $actual ) {
+			echo "  ✓ {$message}\n";
+			return;
+		}
+		++$failures;
+		echo "  ✗ {$message}\n";
+		echo '    expected: ' . var_export($expected, true) . "\n";
+		echo '    actual:   ' . var_export($actual, true) . "\n";
+	};
+
+	$run = function ( string $cmd, string $cwd = '' ): array {
+		$full = '' === $cwd ? $cmd : sprintf('cd %s && %s', escapeshellarg($cwd), $cmd);
+		exec($full . ' 2>&1', $out, $rc);
+		return array(
+			'output' => implode("\n", $out),
+			'exit'   => $rc,
+		);
+	};
+
+	$make_repo = function ( string $name ) use ( $tmp, $run ): string {
+		$path = $tmp . '/' . $name;
+		mkdir($path, 0755, true);
+		$run('git init', $path);
+		$run('git config user.email test@example.com', $path);
+		$run('git config user.name test', $path);
+		file_put_contents($path . '/README.md', $name . "\n");
+		$run('git add README.md && git commit -m init', $path);
+		return $path;
+	};
+
+	echo "Setting up workspace at {$tmp}\n";
+	$primary      = $make_repo('canonical-plugin');
+	$noncanonical = $make_repo('bad@@name');
+	$non_git      = $tmp . '/not-git';
+	mkdir($non_git, 0755, true);
+
+	$run('git branch external-branch', $primary);
+	$external = sys_get_temp_dir() . '/dmc-row-triage-external-' . bin2hex(random_bytes(4));
+	register_shutdown_function(
+		function () use ( $external ) {
+			if ( is_dir($external) ) {
+				exec('rm -rf ' . escapeshellarg($external));
+			}
+		}
+	);
+	$run(sprintf('git worktree add %s external-branch', escapeshellarg($external)), $primary);
+
+	$ws = new \DataMachineCode\Workspace\Workspace();
+
+	echo "\nList unresolved rows\n";
+	$list = $ws->workspace_row_triage_list();
+	$assert(true, ! is_wp_error($list), 'triage list succeeds');
+	$rows = is_wp_error($list) ? array() : (array) $list['rows'];
+	$ids  = array_map(static fn( array $row ): string => (string) $row['row_id'], $rows);
+	$assert(true, in_array('not-git', $ids, true), 'non-git row is listed');
+	$assert(true, in_array('bad@@name', $ids, true), 'noncanonical row is listed');
+	$assert(true, 1 === count(array_filter($ids, static fn( string $id ): bool => str_starts_with($id, 'external:'))), 'external worktree row is listed');
+	$assert(1, (int) ( $list['summary']['non_git'] ?? 0 ), 'summary counts non-git rows');
+	$assert(1, (int) ( $list['summary']['external_worktree'] ?? 0 ), 'summary counts external rows');
+
+	$external_id = (string) array_values(array_filter($ids, static fn( string $id ): bool => str_starts_with($id, 'external:')))[0];
+
+	echo "\nQuarantine external row\n";
+	$marked = $ws->workspace_row_triage_mark($external_id, 'quarantined', 'raw git worktree outside DMC ownership');
+	$assert(true, ! is_wp_error($marked) && ( $marked['success'] ?? false ), 'quarantine metadata writes');
+	$assert('quarantined', is_wp_error($marked) ? '' : (string) ( $marked['row']['triage_status'] ?? '' ), 'quarantined row status is returned');
+
+	$unresolved_after_mark = $ws->workspace_row_triage_list();
+	$ids_after_mark        = is_wp_error($unresolved_after_mark) ? array() : array_map(static fn( array $row ): string => (string) $row['row_id'], (array) $unresolved_after_mark['rows']);
+	$assert(false, in_array($external_id, $ids_after_mark, true), 'quarantined row leaves unresolved default list');
+
+	echo "\nAdopt canonical primary\n";
+	$adopted = $ws->workspace_row_triage_adopt('canonical-plugin');
+	$assert(true, ! is_wp_error($adopted) && ( $adopted['success'] ?? false ), 'canonical primary can be adopted');
+	$assert('canonical-plugin', is_wp_error($adopted) ? '' : (string) ( $adopted['adopt']['name'] ?? '' ), 'adopted name is canonical handle');
+
+	$non_git_adopt = $ws->workspace_row_triage_adopt('not-git');
+	$assert('triage_adopt_non_git_unsupported', is_wp_error($non_git_adopt) ? $non_git_adopt->get_error_code() : '', 'non-git adoption is rejected');
+
+	echo "\nCleanup and reconciliation evidence separates quarantines\n";
+	\DataMachineCode\Workspace\WorktreeContextInjector::store_lifecycle_metadata(
+		'canonical-plugin@triaged',
+		array(
+			'handle'            => 'canonical-plugin@triaged',
+			'repo'              => 'canonical-plugin',
+			'branch'            => 'triaged',
+			'path'              => $tmp . '/canonical-plugin@triaged',
+			'created_at'        => gmdate('c', time() - 86400),
+			'lifecycle_state'   => 'active',
+			'triage_status'     => 'quarantined',
+			'triage_reason'     => 'operator review pending',
+			'triage_updated_at' => gmdate('c'),
+		)
+	);
+	mkdir($tmp . '/canonical-plugin@triaged', 0755, true);
+
+	$cleanup = $ws->worktree_cleanup_merged(array( 'dry_run' => true, 'inventory_only' => true ));
+	$assert(1, is_wp_error($cleanup) ? -1 : (int) ( $cleanup['summary']['skipped_by_reason']['triage_quarantined'] ?? 0 ), 'inventory cleanup counts triage quarantines separately');
+	$assert(1, is_wp_error($cleanup) ? -1 : (int) ( $cleanup['summary']['cleanup_buckets']['intentional_triage'] ?? 0 ), 'cleanup bucket exposes intentional triage');
+
+	$reconcile = $ws->worktree_reconcile_metadata(array( 'dry_run' => true ));
+	$assert(1, is_wp_error($reconcile) ? -1 : (int) ( $reconcile['summary']['prefiltered']['reasons']['triage_quarantined'] ?? 0 ), 'metadata reconciliation prefilter separates quarantines');
+
+	echo "\nResult: " . ( $total - $failures ) . "/{$total} passed\n";
+	exit($failures > 0 ? 1 : 0);
+}


### PR DESCRIPTION
## Summary
- Add a metadata-only workspace triage flow for external worktrees, noncanonical handles, and non-git workspace rows.
- Add `workspace triage list|ignore|quarantine|adopt` so operators can report, intentionally mark, or safely adopt rows without destructive cleanup.
- Separate `triage_ignored` / `triage_quarantined` evidence from unresolved cleanup and metadata reconciliation blockers.

Fixes #649.

## Verification
- `php -l inc/Workspace/WorkspaceRowTriage.php && php -l inc/Workspace/WorkspaceWorktreeLifecycle.php && php -l inc/Workspace/WorkspaceMetadataReconciliation.php && php -l inc/Workspace/WorkspaceWorktreeInventoryCleanup.php && php -l inc/Workspace/WorktreeCleanupClassifier.php && php -l inc/Cli/Commands/WorkspaceCommand.php && php -l tests/smoke-workspace-row-triage.php`
- `php tests/smoke-workspace-row-triage.php`
- `php tests/smoke-workspace-adopt.php`
- `php tests/smoke-workspace-hygiene-report.php`
- `php tests/smoke-worktree-cleanup-classifier.php`
- `php tests/smoke-worktree-metadata-reconcile.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the workspace row triage service/CLI, targeted smoke coverage, and verification loop. Chris remains responsible for review and merge.