### PR TITLE
Fix cleanup plan local worktree signals

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -283,7 +283,7 @@ class WorkspaceCommand extends BaseCommand {
 					WP_CLI::error('Usage: wp datamachine-code workspace triage ' . $operation . ' <row-id> --reason=<reason>');
 					return;
 				}
-				$result = $workspace->workspace_row_triage_mark((string) $args[1], 'ignore' === $operation ? 'ignored' : 'quarantined', (string) ( $assoc_args['reason'] ?? '' ));
+				$result = $workspace->workspace_row_triage_mark( (string) $args[1], 'ignore' === $operation ? 'ignored' : 'quarantined', (string) ( $assoc_args['reason'] ?? '' ) );
 				$this->render_workspace_triage_result($result, $assoc_args, false);
 				return;
 
@@ -292,7 +292,7 @@ class WorkspaceCommand extends BaseCommand {
 					WP_CLI::error('Usage: wp datamachine-code workspace triage adopt <row-id> [--name=<name>]');
 					return;
 				}
-				$result = $workspace->workspace_row_triage_adopt((string) $args[1], isset($assoc_args['name']) ? (string) $assoc_args['name'] : null);
+				$result = $workspace->workspace_row_triage_adopt( (string) $args[1], isset($assoc_args['name']) ? (string) $assoc_args['name'] : null );
 				$this->render_workspace_triage_result($result, $assoc_args, false);
 				return;
 
@@ -321,7 +321,7 @@ class WorkspaceCommand extends BaseCommand {
 		}
 
 		if ( ! $is_list ) {
-			WP_CLI::success((string) ( $result['message'] ?? 'Workspace triage updated.' ));
+			WP_CLI::success( (string) ( $result['message'] ?? 'Workspace triage updated.' ) );
 			$row = is_array($result['row'] ?? null) ? (array) $result['row'] : array();
 			if ( array() !== $row ) {
 				$this->format_items(array( $this->workspace_triage_table_row($row) ), array( 'row_id', 'status', 'issues', 'age_days', 'reason', 'path' ), $assoc_args, 'row_id');
@@ -4155,7 +4155,7 @@ class WorkspaceCommand extends BaseCommand {
 		WP_CLI::log('Stale workspace locks:');
 		WP_CLI::log(sprintf('Preview: %s', (string) ( $report['preview_command'] ?? 'wp datamachine-code workspace worktree locks --prune-stale --dry-run --format=json' )));
 		WP_CLI::log(sprintf('Apply:   %s', (string) ( $report['apply_command'] ?? 'wp datamachine-code workspace worktree locks --prune-stale --format=json' )));
-		WP_CLI::log((string) ( $report['safety'] ?? 'Active filesystem flocks are reported and protected.' ));
+		WP_CLI::log( (string) ( $report['safety'] ?? 'Active filesystem flocks are reported and protected.' ) );
 
 		$rows = array();
 		foreach ( (array) ( $report['database'] ?? array() ) as $row ) {

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -807,7 +807,7 @@ class WorkspaceCommand extends BaseCommand {
 			$input['force_artifact_cleanup'] = (bool) $assoc_args['force'];
 		}
 		if ( 'json' !== (string) ( $assoc_args['format'] ?? 'table' ) ) {
-			$profile = $include_artifacts ? 'includes artifact scan' : 'worktree inventory only';
+			$profile = $include_artifacts ? 'includes artifact scan' : 'local worktree merge signals';
 			WP_CLI::log(sprintf('Planning cleanup (%s; %s)...', $mode, $profile));
 		}
 

--- a/inc/Workspace/WorkspaceCleanupPlan.php
+++ b/inc/Workspace/WorkspaceCleanupPlan.php
@@ -66,11 +66,10 @@ trait WorkspaceCleanupPlan {
 		if ( $inputs['include_worktrees'] ) {
 			$worktree_plan = $this->worktree_cleanup_merged(
 				array(
-					'dry_run'        => true,
-					'skip_github'    => true,
-					'inventory_only' => true,
-					'older_than'     => $inputs['worktree_older_than'],
-					'sort'           => $inputs['worktree_sort'],
+					'dry_run'     => true,
+					'skip_github' => true,
+					'older_than'  => $inputs['worktree_older_than'],
+					'sort'        => $inputs['worktree_sort'],
 				)
 			);
 			if ( $worktree_plan instanceof \WP_Error ) {

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -1121,7 +1121,7 @@ namespace {
 	datamachine_code_cleanup_assert('retention' === ( $cleanup_plan_ability->last_input['mode'] ?? '' ), 'cleanup plan receives retention mode');
 	datamachine_code_cleanup_assert(false === ( $cleanup_plan_ability->last_input['include_artifacts'] ?? true ), 'retention cleanup plan skips exhaustive artifact scan by default');
 	datamachine_code_cleanup_assert(true === ( $cleanup_plan_ability->last_input['include_worktrees'] ?? false ), 'retention cleanup plan keeps inventory worktree planning enabled');
-	datamachine_code_cleanup_assert(in_array('Planning cleanup (retention; worktree inventory only)...', WP_CLI::$logs, true), 'human cleanup plan reports bounded scan profile before planning');
+	datamachine_code_cleanup_assert(in_array('Planning cleanup (retention; local worktree merge signals)...', WP_CLI::$logs, true), 'human cleanup plan reports bounded scan profile before planning');
 	datamachine_code_cleanup_assert(in_array('Artifacts: skipped for bounded retention planning; run `wp datamachine-code workspace cleanup plan --mode=artifacts` when you want artifact rows.', WP_CLI::$logs, true), 'human cleanup plan shows explicit artifact follow-up command');
 
 	WP_CLI::$logs      = array();

--- a/tests/smoke-worktree-cleanup.php
+++ b/tests/smoke-worktree-cleanup.php
@@ -599,6 +599,7 @@ namespace {
     $artifact_row = $cleanup_plan['rows']['artifact_cleanup'][0] ?? array();
     $assert(true, str_starts_with((string) ( $artifact_row['row_id'] ?? '' ), 'cleanup-row-'), 'artifact cleanup row has stable row ID');
     $assert(true, isset($cleanup_plan['rows']['worktree_removal']), 'cleanup plan includes worktree removal row bucket');
+    $assert_contains($cleanup_plan['rows']['worktree_removal'] ?? array(), 'demo@unmerged-feature', 'cleanup plan promotes locally clean remote-backed worktree instead of active/no-signal resolver');
     $assert(true, isset($cleanup_plan['rows']['resolver']), 'cleanup plan includes optional resolver row bucket');
     $chunk_report = $ws->workspace_cleanup_plan_chunks(
         array(


### PR DESCRIPTION
## Summary
- Let retention cleanup planning run local worktree merge/remote-clean signal detection instead of inventory-only metadata classification.
- Update the human cleanup-plan label so operators can see that retention planning uses local worktree merge signals while still skipping artifact scans by default.
- Add a smoke assertion that a clean active remote-backed worktree is promoted into cleanup-plan removal rows instead of falling through to active/no-signal resolver rows.

## Testing
- `php tests/smoke-worktree-cleanup-cli.php`
- `php -l inc/Workspace/WorkspaceCleanupPlan.php`
- `php -l inc/Cli/Commands/WorkspaceCommand.php`
- `php -l tests/smoke-worktree-cleanup-cli.php`
- `php -l tests/smoke-worktree-cleanup.php`
- `php tests/smoke-worktree-cleanup.php` currently reports 152/161 passed; the new cleanup-plan assertion passes, while existing duplicate dirty/external skip-count expectations still fail outside this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated the cleanup planning classification bug, drafted the code/test changes, and ran local verification commands for Chris to review.