### PR TITLE
Enforce workspace writable roots in mutation tools

### DIFF
--- a/inc/Support/PathSecurity.php
+++ b/inc/Support/PathSecurity.php
@@ -92,13 +92,14 @@ final class PathSecurity {
 	}
 
 	/**
-	 * Check whether a relative path is under any of a set of prefix roots.
+	 * Check whether a relative path is under any of a set of prefix roots or glob patterns.
 	 *
 	 * Used to enforce `allowed_paths` policy when staging for commit —
 	 * a path must sit inside at least one of the configured roots to be
 	 * stageable. Roots are compared as directory prefixes (so root
 	 * `articles` matches `articles/foo.md` but not `articlesX/foo.md`),
-	 * and an exact-match counts.
+	 * exact matches count, and glob roots such as docs-star-star or
+	 * plugins-star-star-README are matched with fnmatch().
 	 *
 	 * Empty `$allowed_paths` returns false — an empty allowlist means
 	 * nothing is allowed, matching the conservative Phase 2 default.
@@ -120,6 +121,9 @@ final class PathSecurity {
 				continue;
 			}
 			if ( $normalized === $root || str_starts_with($normalized, $root . '/') ) {
+				return true;
+			}
+			if ( strpbrk($root, '*?[') && fnmatch($root, $normalized) ) {
 				return true;
 			}
 		}

--- a/inc/Workspace/RemoteWorkspaceBackend.php
+++ b/inc/Workspace/RemoteWorkspaceBackend.php
@@ -8,6 +8,7 @@
 namespace DataMachineCode\Workspace;
 
 use DataMachineCode\Abilities\GitHubAbilities;
+use DataMachineCode\Support\PathSecurity;
 
 defined('ABSPATH') || exit;
 
@@ -482,6 +483,11 @@ class RemoteWorkspaceBackend {
 			return $path;
 		}
 
+		$policy_check = $this->ensure_writable_roots_allow_paths((string) $context['repo_name'], array( $path ));
+		if ( is_wp_error($policy_check) ) {
+			return $policy_check;
+		}
+
 		$state = $this->state();
 		$state['worktrees'][ $context['handle'] ]['pending_files'][ $path ] = $content;
 		$state['worktrees'][ $context['handle'] ]['changed_files'][ $path ] = $path;
@@ -495,6 +501,101 @@ class RemoteWorkspaceBackend {
 			'size'    => strlen($content),
 			'created' => true,
 		);
+	}
+
+	/**
+	 * Enforce configured writable roots before a remote mutation is staged.
+	 *
+	 * @param  string            $repo_name Repository name.
+	 * @param  array<int,string> $paths     Repo-relative paths.
+	 * @return true|\WP_Error
+	 */
+	private function ensure_writable_roots_allow_paths( string $repo_name, array $paths ): true|\WP_Error {
+		$writable_roots = $this->get_repo_writable_roots($repo_name);
+		if ( empty($writable_roots) ) {
+			return true;
+		}
+
+		$rejected = array();
+		foreach ( $paths as $path ) {
+			$relative = $this->normalize_policy_path($path);
+			if ( '' !== $relative && ! PathSecurity::isPathAllowed($relative, $writable_roots) ) {
+				$rejected[] = $relative;
+			}
+		}
+
+		$rejected = array_values(array_unique($rejected));
+		if ( empty($rejected) ) {
+			return true;
+		}
+
+		return new \WP_Error(
+			'path_not_allowed',
+			sprintf(
+				'Path(s) outside configured writable_roots: %s. Allowed writable_roots: %s.',
+				implode(', ', $rejected),
+				implode(', ', $writable_roots)
+			),
+			array(
+				'status'         => 403,
+				'rejected_paths' => $rejected,
+				'writable_roots' => $writable_roots,
+			)
+		);
+	}
+
+	/**
+	 * @return array<int,string>
+	 */
+	private function get_repo_writable_roots( string $repo_name ): array {
+		$policies = $this->get_workspace_git_policies();
+		$repo     = $policies['repos'][ $repo_name ] ?? array();
+		$paths    = $repo['writable_roots'] ?? $repo['allowed_paths'] ?? array();
+
+		return $this->normalize_policy_paths($paths);
+	}
+
+	/**
+	 * @return array{repos: array<string, array<string, mixed>>}
+	 */
+	private function get_workspace_git_policies(): array {
+		$defaults = array( 'repos' => array() );
+		$settings = function_exists('get_option') ? get_option('datamachine_workspace_git_policies', $defaults) : $defaults;
+		if ( ! is_array($settings) ) {
+			$settings = $defaults;
+		}
+		if ( ! isset($settings['repos']) || ! is_array($settings['repos']) ) {
+			$settings['repos'] = array();
+		}
+		if ( function_exists('apply_filters') ) {
+			$settings = apply_filters('datamachine_workspace_git_policies', $settings);
+		}
+
+		return isset($settings['repos']) && is_array($settings['repos']) ? $settings : $defaults;
+	}
+
+	/**
+	 * @param  mixed $paths Raw policy value.
+	 * @return array<int,string>
+	 */
+	private function normalize_policy_paths( mixed $paths ): array {
+		if ( ! is_array($paths) ) {
+			return array();
+		}
+
+		$clean = array();
+		foreach ( $paths as $path ) {
+			$normalized = $this->normalize_policy_path((string) $path);
+			if ( '' !== $normalized ) {
+				$clean[] = $normalized;
+			}
+		}
+
+		return array_values(array_unique($clean));
+	}
+
+	private function normalize_policy_path( string $path ): string {
+		return rtrim(ltrim(str_replace('\\', '/', trim($path)), '/'), '/');
 	}
 
 	/**
@@ -512,7 +613,17 @@ class RemoteWorkspaceBackend {
 			return $context;
 		}
 
-		$current = $this->read_file($handle, $path, PHP_INT_MAX);
+		$normalized_path = $this->normalize_path($path);
+		if ( is_wp_error($normalized_path) ) {
+			return $normalized_path;
+		}
+
+		$policy_check = $this->ensure_writable_roots_allow_paths((string) $context['repo_name'], array( $normalized_path ));
+		if ( is_wp_error($policy_check) ) {
+			return $policy_check;
+		}
+
+		$current = $this->read_file($handle, $normalized_path, PHP_INT_MAX);
 		if ( is_wp_error($current) ) {
 			return $current;
 		}
@@ -542,7 +653,7 @@ class RemoteWorkspaceBackend {
 			: substr_replace($content, $new_string, $offset, strlen($old_string));
 		}
 
-		$write = $this->write_file($handle, $path, $new_content);
+		$write = $this->write_file($handle, $normalized_path, $new_content);
 		if ( is_wp_error($write) ) {
 			return $write;
 		}

--- a/inc/Workspace/WorkspaceGitOperations.php
+++ b/inc/Workspace/WorkspaceGitOperations.php
@@ -1791,20 +1791,7 @@ trait WorkspaceGitOperations {
 	 * @return bool
 	 */
 	private function is_path_allowed( string $path, array $allowed_paths ): bool {
-		$normalized = ltrim(str_replace('\\', '/', $path), '/');
-
-		foreach ( $allowed_paths as $allowed ) {
-			$root = ltrim(str_replace('\\', '/', (string) $allowed), '/');
-			if ( '' === $root ) {
-				continue;
-			}
-
-			if ( $normalized === $root || str_starts_with($normalized, $root . '/') ) {
-				return true;
-			}
-		}
-
-		return false;
+		return PathSecurity::isPathAllowed($path, $allowed_paths);
 	}
 
 	/**

--- a/inc/Workspace/WorkspaceWriter.php
+++ b/inc/Workspace/WorkspaceWriter.php
@@ -69,6 +69,11 @@ class WorkspaceWriter {
 			return new \WP_Error('path_traversal', 'Path traversal detected. Access denied.', array( 'status' => 403 ));
 		}
 
+		$policy_check = $this->ensure_writable_roots_allow_paths($name, array( $path ));
+		if ( is_wp_error($policy_check) ) {
+			return $policy_check;
+		}
+
 		$file_path = $repo_path . '/' . $path;
 		$existed   = file_exists($file_path);
 
@@ -142,6 +147,11 @@ class WorkspaceWriter {
 
 		if ( ! $validation['valid'] ) {
 			return new \WP_Error('path_traversal', (string) ( $validation['message'] ?? 'Path traversal detected. Access denied.' ), array( 'status' => 403 ));
+		}
+
+		$policy_check = $this->ensure_writable_roots_allow_paths($name, array( $path ));
+		if ( is_wp_error($policy_check) ) {
+			return $policy_check;
 		}
 
 		$real_path = (string) ( $validation['real_path'] ?? '' );
@@ -252,8 +262,24 @@ class WorkspaceWriter {
 			return new \WP_Error('empty_patch', 'Patch content is required.', array( 'status' => 400 ));
 		}
 
-		if ( false === strpos($patch, '--- ') || false === strpos($patch, '+++ ') || false === strpos($patch, '@@') ) {
-			return new \WP_Error('invalid_patch', 'Patch must be a unified diff with file headers and at least one hunk.', array( 'status' => 400 ));
+		if ( false === strpos($patch, 'diff --git ') && ( false === strpos($patch, '--- ') || false === strpos($patch, '+++ ') ) ) {
+			return new \WP_Error('invalid_patch', 'Patch must be a unified diff with file headers.', array( 'status' => 400 ));
+		}
+
+		$patch_paths = $this->extract_patch_paths($patch);
+		if ( empty($patch_paths) ) {
+			return new \WP_Error('invalid_patch_paths', 'Patch must include at least one file path.', array( 'status' => 400 ));
+		}
+
+		foreach ( $patch_paths as $patch_path ) {
+			if ( PathSecurity::hasTraversal($patch_path) || str_starts_with($patch_path, '/') ) {
+				return new \WP_Error('path_traversal', sprintf('Path traversal detected in patch path "%s". Access denied.', $patch_path), array( 'status' => 403 ));
+			}
+		}
+
+		$policy_check = $this->ensure_writable_roots_allow_paths($name, $patch_paths);
+		if ( is_wp_error($policy_check) ) {
+			return $policy_check;
 		}
 
 		$temp = function_exists('wp_tempnam') ? wp_tempnam('datamachine-code-patch-') : tempnam(sys_get_temp_dir(), 'datamachine-code-patch-');
@@ -410,5 +436,176 @@ class WorkspaceWriter {
 		}
 
 		return array_values(array_unique($files));
+	}
+
+	/**
+	 * Enforce configured writable roots before a writer mutation touches disk.
+	 *
+	 * @param  string            $name  Workspace handle.
+	 * @param  array<int,string> $paths Repo-relative paths the mutation would touch.
+	 * @return true|\WP_Error
+	 */
+	private function ensure_writable_roots_allow_paths( string $name, array $paths ): true|\WP_Error {
+		$parsed         = $this->workspace->parse_handle($name);
+		$writable_roots = $this->get_repo_writable_roots($parsed['repo']);
+		if ( empty($writable_roots) ) {
+			return true;
+		}
+
+		$rejected = array();
+		foreach ( $paths as $path ) {
+			$relative = $this->normalize_policy_path($path);
+			if ( '' === $relative ) {
+				continue;
+			}
+
+			if ( ! PathSecurity::isPathAllowed($relative, $writable_roots) ) {
+				$rejected[] = $relative;
+			}
+		}
+
+		$rejected = array_values(array_unique($rejected));
+		if ( empty($rejected) ) {
+			return true;
+		}
+
+		return new \WP_Error(
+			'path_not_allowed',
+			sprintf(
+				'Path(s) outside configured writable_roots: %s. Allowed writable_roots: %s.',
+				implode(', ', $rejected),
+				implode(', ', $writable_roots)
+			),
+			array(
+				'status'         => 403,
+				'rejected_paths' => $rejected,
+				'writable_roots' => $writable_roots,
+			)
+		);
+	}
+
+	/**
+	 * Return writable roots for a repo from datamachine_workspace_git_policies.
+	 *
+	 * @param  string $repo_name Repository name.
+	 * @return array<int,string>
+	 */
+	private function get_repo_writable_roots( string $repo_name ): array {
+		$policies = $this->get_workspace_git_policies();
+		$repo     = $policies['repos'][ $repo_name ] ?? array();
+		$paths    = $repo['writable_roots'] ?? $repo['allowed_paths'] ?? array();
+
+		return $this->normalize_policy_paths($paths);
+	}
+
+	/**
+	 * Read workspace git policy settings.
+	 *
+	 * @return array{repos: array<string, array<string, mixed>>}
+	 */
+	private function get_workspace_git_policies(): array {
+		$defaults = array( 'repos' => array() );
+		$settings = function_exists('get_option') ? get_option('datamachine_workspace_git_policies', $defaults) : $defaults;
+		if ( ! is_array($settings) ) {
+			$settings = $defaults;
+		}
+		if ( ! isset($settings['repos']) || ! is_array($settings['repos']) ) {
+			$settings['repos'] = array();
+		}
+		if ( function_exists('apply_filters') ) {
+			$settings = apply_filters('datamachine_workspace_git_policies', $settings);
+		}
+
+		return isset($settings['repos']) && is_array($settings['repos']) ? $settings : $defaults;
+	}
+
+	/**
+	 * Normalize policy path lists.
+	 *
+	 * @param  mixed $paths Raw policy value.
+	 * @return array<int,string>
+	 */
+	private function normalize_policy_paths( mixed $paths ): array {
+		if ( ! is_array($paths) ) {
+			return array();
+		}
+
+		$clean = array();
+		foreach ( $paths as $path ) {
+			$normalized = $this->normalize_policy_path((string) $path);
+			if ( '' !== $normalized ) {
+				$clean[] = $normalized;
+			}
+		}
+
+		return array_values(array_unique($clean));
+	}
+
+	/**
+	 * Normalize a repo-relative policy path.
+	 */
+	private function normalize_policy_path( string $path ): string {
+		return rtrim(ltrim(str_replace('\\', '/', trim($path)), '/'), '/');
+	}
+
+	/**
+	 * Extract every file path touched by a unified diff.
+	 *
+	 * @param  string $patch Unified diff.
+	 * @return array<int,string>
+	 */
+	private function extract_patch_paths( string $patch ): array {
+		$paths = array();
+		$lines = preg_split('/\n/', $patch);
+		if ( false === $lines ) {
+			return array();
+		}
+
+		foreach ( $lines as $line ) {
+			if ( preg_match('/^diff --git\s+(\S+)\s+(\S+)/', $line, $matches) ) {
+				foreach ( array( $matches[1], $matches[2] ) as $raw_path ) {
+					$path = $this->normalize_patch_path($raw_path);
+					if ( '' !== $path ) {
+						$paths[] = $path;
+					}
+				}
+				continue;
+			}
+
+			if ( preg_match('/^(?:---|\+\+\+)\s+(\S+)/', $line, $matches) ) {
+				$path = $this->normalize_patch_path($matches[1]);
+				if ( '' !== $path ) {
+					$paths[] = $path;
+				}
+				continue;
+			}
+
+			if ( preg_match('/^(?:rename|copy) (?:from|to)\s+(.+)$/', $line, $matches) ) {
+				$path = $this->normalize_patch_path($matches[1]);
+				if ( '' !== $path ) {
+					$paths[] = $path;
+				}
+			}
+		}
+
+		return array_values(array_unique($paths));
+	}
+
+	/**
+	 * Normalize a patch header path to repo-relative form.
+	 */
+	private function normalize_patch_path( string $path ): string {
+		$path = trim($path);
+		if ( '/dev/null' === $path ) {
+			return '';
+		}
+		$path = preg_replace('/\t.*$/', '', $path) ?? $path;
+		$path = preg_replace('/^"(.*)"$/', '$1', $path) ?? $path;
+		$path = str_replace('\\', '/', $path);
+		if ( str_starts_with($path, 'a/') || str_starts_with($path, 'b/') ) {
+			$path = substr($path, 2);
+		}
+
+		return $this->normalize_policy_path($path);
 	}
 }

--- a/tests/smoke-workspace-apply-patch.php
+++ b/tests/smoke-workspace-apply-patch.php
@@ -67,7 +67,9 @@ namespace DataMachine\Core\FilesRepository {
 }
 
 namespace {
+    include __DIR__ . '/../inc/Support/PathSecurity.php';
     include __DIR__ . '/../inc/Support/GitRunner.php';
+    include __DIR__ . '/../inc/Workspace/WorkspaceAliasResolver.php';
     include __DIR__ . '/../inc/Workspace/Workspace.php';
     include __DIR__ . '/../inc/Workspace/WorkspaceWriter.php';
 

--- a/tests/smoke-workspace-policy-enforcement.php
+++ b/tests/smoke-workspace-policy-enforcement.php
@@ -58,8 +58,10 @@ if (! function_exists('apply_filters') ) {
 
 require __DIR__ . '/../vendor/autoload.php';
 require __DIR__ . '/../inc/Workspace/Workspace.php';
+require __DIR__ . '/../inc/Workspace/WorkspaceWriter.php';
 
 use DataMachineCode\Workspace\Workspace;
+use DataMachineCode\Workspace\WorkspaceWriter;
 
 $failures = array();
 $total    = 0;
@@ -207,6 +209,54 @@ $assert('git_add rejects nested .git paths', in_array('nested_git', $nested_git_
 $gitlink = $workspace->git_add('demo', array( 'work/nested' ), true);
 $gitlink_reasons = is_wp_error($gitlink) ? array_column($gitlink->get_error_data()['workspace_violations'] ?? array(), 'reason') : array();
 $assert('git_add rejects gitlink changes', in_array('gitlink', $gitlink_reasons, true));
+
+$run('git reset -q --hard origin/main && git clean -q -fd', $repo);
+$GLOBALS['dmc_workspace_policy_options']['datamachine_workspace_git_policies']['repos']['demo'] = array();
+$writer = new WorkspaceWriter($workspace);
+$unrestricted_write = $writer->write_file('demo', 'unrestricted/notes.txt', "unrestricted\n");
+$assert('workspace_write remains permissive without writable_roots', ! is_wp_error($unrestricted_write) && is_file($repo . '/unrestricted/notes.txt'));
+$run('git reset -q --hard origin/main && git clean -q -fd', $repo);
+
+$GLOBALS['dmc_workspace_policy_options']['datamachine_workspace_git_policies']['repos']['demo'] = array(
+    'writable_roots' => array( 'README.md', 'docs/**', 'plugins/**/README.md' ),
+);
+
+$write_docs = $writer->write_file('demo', 'docs/guide.md', "docs allowed\n");
+$assert('workspace_write allows configured docs path', ! is_wp_error($write_docs) && is_file($repo . '/docs/guide.md'));
+
+$edit_docs = $writer->edit_file('demo', 'docs/guide.md', 'docs allowed', 'docs edited');
+$assert('workspace_edit allows configured docs path', ! is_wp_error($edit_docs) && "docs edited\n" === file_get_contents($repo . '/docs/guide.md'));
+
+$write_plugin_readme = $writer->write_file('demo', 'plugins/amp/README.md', "plugin readme allowed\n");
+$assert('workspace_write allows configured plugin README glob', ! is_wp_error($write_plugin_readme) && is_file($repo . '/plugins/amp/README.md'));
+
+$write_agents = $writer->write_file('demo', 'plugins/amp/AGENTS.md', "blocked\n");
+$assert('workspace_write rejects plugin AGENTS outside writable_roots', is_wp_error($write_agents) && 'path_not_allowed' === $write_agents->get_error_code());
+$assert('workspace_write rejects plugin AGENTS before mutation', ! file_exists($repo . '/plugins/amp/AGENTS.md'));
+
+$patch_docs = $writer->apply_patch(
+    'demo',
+    "diff --git a/docs/patch.md b/docs/patch.md\nnew file mode 100644\nindex 0000000..d95f3ad\n--- /dev/null\n+++ b/docs/patch.md\n@@ -0,0 +1 @@\n+patch allowed\n",
+    true
+);
+$assert('workspace_apply_patch allows configured docs path', ! is_wp_error($patch_docs) && is_file($repo . '/docs/patch.md'));
+
+$patch_agents = $writer->apply_patch(
+    'demo',
+    "diff --git a/plugins/amp/AGENTS.md b/plugins/amp/AGENTS.md\nnew file mode 100644\nindex 0000000..2e65efe\n--- /dev/null\n+++ b/plugins/amp/AGENTS.md\n@@ -0,0 +1 @@\n+blocked\n",
+    true
+);
+$assert('workspace_apply_patch rejects plugin AGENTS outside writable_roots', is_wp_error($patch_agents) && 'path_not_allowed' === $patch_agents->get_error_code());
+$assert('workspace_apply_patch error names writable_roots', is_wp_error($patch_agents) && str_contains($patch_agents->get_error_message(), 'writable_roots'));
+$assert('workspace_apply_patch rejects plugin AGENTS before mutation', ! file_exists($repo . '/plugins/amp/AGENTS.md'));
+
+$rename_agents = $writer->apply_patch(
+    'demo',
+    "diff --git a/docs/guide.md b/plugins/amp/AGENTS.md\nsimilarity index 100%\nrename from docs/guide.md\nrename to plugins/amp/AGENTS.md\n",
+    true
+);
+$assert('workspace_apply_patch checks rename destination paths', is_wp_error($rename_agents) && 'path_not_allowed' === $rename_agents->get_error_code());
+$assert('workspace_apply_patch rejects rename before mutation', is_file($repo . '/docs/guide.md') && ! file_exists($repo . '/plugins/amp/AGENTS.md'));
 
 if (! empty($failures) ) {
     echo "\nFAIL: " . count($failures) . " assertion(s) failed out of {$total}\n";


### PR DESCRIPTION
## Summary
- Enforces configured `writable_roots`/`allowed_paths` before `workspace_write`, `workspace_edit`, and `workspace_apply_patch` mutate local worktrees.
- Applies the same preflight to the remote workspace backend before staged write/edit mutations.
- Extends policy smoke coverage for permissive defaults, allowed docs/plugin README paths, rejected `plugins/*/AGENTS.md`, and patch rename destination checks.

Fixes #660.

## Tests
- `php -l inc/Support/PathSecurity.php && php -l inc/Workspace/WorkspaceGitOperations.php && php -l inc/Workspace/WorkspaceWriter.php && php -l inc/Workspace/RemoteWorkspaceBackend.php && php -l tests/smoke-workspace-policy-enforcement.php`
- `php tests/smoke-workspace-policy-enforcement.php`
- `php tests/smoke-workspace-policy-tools.php`
- `php tests/smoke-ability-tool-projections.php`
- `php tests/smoke-workspace-alias-tools.php`
- `php tests/smoke-remote-workspace-backend.php`
- `php -l tests/smoke-workspace-apply-patch.php && php tests/smoke-workspace-apply-patch.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, smoke-test updates, and verification commands for Chris to review.