### PR TITLE
Fix worktree disk budget percentage refusal

### DIFF
--- a/inc/Workspace/WorkspaceWorktreeLifecycle.php
+++ b/inc/Workspace/WorkspaceWorktreeLifecycle.php
@@ -776,7 +776,7 @@ trait WorkspaceWorktreeLifecycle {
 					$dirty_files = null;
 				}
 
-				$metadata_key     = null;
+				$metadata_key = null;
 				if ( ! $is_primary && $inside_ws ) {
 					$metadata_key = $relative;
 				} elseif ( ! $is_primary && ! $inside_ws ) {

--- a/inc/Workspace/WorkspaceWorktreeLifecycle.php
+++ b/inc/Workspace/WorkspaceWorktreeLifecycle.php
@@ -108,11 +108,12 @@ trait WorkspaceWorktreeLifecycle {
 			return new \WP_Error(
 				'worktree_disk_budget_exceeded',
 				sprintf(
-					"Refusing to create worktree before bootstrap/install because the workspace disk budget is unsafe.\n%s\nThreshold: keep at least %.1f GiB free and %.1f%% free; effective floor on this filesystem is %.1f GiB.\nRun %s to review cleanup candidates, run %s to review artifact cleanup, or retry with --force only when a human explicitly accepts the disk-pressure risk.",
+					"Refusing to create worktree before bootstrap/install because the workspace disk budget is unsafe.\n%s\nThreshold: keep at least %.1f GiB free and %.1f%% free; effective floor on this filesystem is %.1f GiB.\nRun %s for a bounded cleanup path, run %s to review cleanup candidates, run %s to review artifact cleanup, or retry with --force only when a human explicitly accepts the disk-pressure risk.",
 					WorktreeDiskBudget::format_summary($disk_budget),
 					(float) ( $disk_budget['refuse_free_gib'] ?? 0 ),
 					(float) ( $disk_budget['refuse_free_percent'] ?? 0 ),
 					(float) ( $disk_budget['effective_refuse_gib'] ?? 0 ),
+					$disk_budget['emergency_cleanup_command'],
 					$disk_budget['cleanup_dry_run_command'],
 					$disk_budget['artifact_cleanup_command']
 				),

--- a/inc/Workspace/WorktreeDiskBudget.php
+++ b/inc/Workspace/WorktreeDiskBudget.php
@@ -90,8 +90,8 @@ final class WorktreeDiskBudget {
 		$warnings = array();
 		$refused  = false;
 
-		$effective_refuse_bytes = $thresholds['refuse_free_bytes'];
-		$effective_warn_bytes   = $thresholds['warn_free_bytes'];
+		$effective_refuse_bytes = (int) $thresholds['refuse_free_bytes'];
+		$effective_warn_bytes   = (int) $thresholds['warn_free_bytes'];
 		if ( null !== $total_bytes && $total_bytes > 0 ) {
 			$effective_refuse_bytes = self::effective_refuse_free_bytes_threshold(
 				(int) $thresholds['refuse_free_bytes'],

--- a/inc/Workspace/WorktreeDiskBudget.php
+++ b/inc/Workspace/WorktreeDiskBudget.php
@@ -93,7 +93,7 @@ final class WorktreeDiskBudget {
 		$effective_refuse_bytes = $thresholds['refuse_free_bytes'];
 		$effective_warn_bytes   = $thresholds['warn_free_bytes'];
 		if ( null !== $total_bytes && $total_bytes > 0 ) {
-			$effective_refuse_bytes = self::effective_free_bytes_threshold(
+			$effective_refuse_bytes = self::effective_refuse_free_bytes_threshold(
 				(int) $thresholds['refuse_free_bytes'],
 				$thresholds['refuse_free_percent'],
 				$total_bytes
@@ -109,11 +109,10 @@ final class WorktreeDiskBudget {
 			if ( $free_bytes < $effective_refuse_bytes ) {
 				$refused    = ! $forced;
 				$warnings[] = sprintf(
-					'Free disk space is %.1f GiB%s, below the refusal threshold of %.1f GiB or %.1f%% free, whichever is stricter.',
+					'Free disk space is %.1f GiB%s, below the refusal threshold of %.1f GiB.',
 					self::bytes_to_gib($free_bytes),
 					null === $free_percent ? '' : sprintf(' (%.1f%%)', $free_percent),
-					self::bytes_to_gib( (int) $thresholds['refuse_free_bytes'] ),
-					$thresholds['refuse_free_percent']
+					self::bytes_to_gib($effective_refuse_bytes)
 				);
 			} elseif ( $free_bytes < $effective_warn_bytes ) {
 				$warnings[] = sprintf(
@@ -323,6 +322,29 @@ final class WorktreeDiskBudget {
 		}
 
 		return max($absolute_bytes, $percent_bytes);
+	}
+
+	/**
+	 * Calculate the hard refusal threshold for a measured filesystem.
+	 *
+	 * Large filesystems can safely fall below a percentage threshold while still
+	 * having enough absolute free space for a bare worktree checkout. Keep the
+	 * percentage refusal only for filesystems smaller than the absolute floor,
+	 * where the absolute GiB floor is impossible to satisfy.
+	 *
+	 * @param  int   $absolute_bytes Absolute free-space threshold.
+	 * @param  float $percent        Percentage free-space threshold.
+	 * @param  int   $total_bytes    Measured filesystem size.
+	 * @return int
+	 */
+	private static function effective_refuse_free_bytes_threshold( int $absolute_bytes, float $percent, int $total_bytes ): int {
+		$percent_bytes = (int) ceil($total_bytes * ( $percent / 100 ));
+
+		if ( $total_bytes < $absolute_bytes ) {
+			return $percent_bytes;
+		}
+
+		return $absolute_bytes;
 	}
 
 	/**

--- a/tests/smoke-worktree-disk-budget.php
+++ b/tests/smoke-worktree-disk-budget.php
@@ -99,7 +99,7 @@ datamachine_code_budget_assert('warning' === $budget['status'], 'forced low-spac
 datamachine_code_budget_assert(true === $budget['forced'], 'forced flag is recorded');
 datamachine_code_budget_assert(true === $budget['force_override_applied'], 'force override is visible in output data');
 
-echo "\n[5] percent floor refuses even when absolute free space is above 10 GiB\n";
+echo "\n[5] percent floor warns when absolute free space is above 10 GiB\n";
 $budget = WorktreeDiskBudget::evaluate(
     array(
         'workspace_path' => '/tmp/workspace',
@@ -109,9 +109,24 @@ $budget = WorktreeDiskBudget::evaluate(
     ),
     $thresholds
 );
-datamachine_code_budget_assert('refused' === $budget['status'], 'refused status below 10 percent free');
-datamachine_code_budget_assert(20.0 === $budget['effective_refuse_gib'], 'effective refusal floor uses stricter percentage threshold');
+datamachine_code_budget_assert('warning' === $budget['status'], 'warning status below 10 percent free but above absolute refusal floor');
+datamachine_code_budget_assert(10.0 === $budget['effective_refuse_gib'], 'effective refusal floor uses absolute threshold on normal filesystems');
+datamachine_code_budget_assert(30.0 === $budget['effective_warn_gib'], 'effective warning floor still uses stricter percentage threshold');
+datamachine_code_budget_assert(false === $budget['force_override_required'], 'substantial absolute free space does not require force');
 datamachine_code_budget_assert(7.5 === $budget['free_percent'], 'free percentage is reported');
+
+echo "\n[5b] large filesystem below absolute floor still refuses\n";
+$budget = WorktreeDiskBudget::evaluate(
+    array(
+        'workspace_path' => '/tmp/workspace',
+        'free_bytes'     => 5 * $gib,
+        'total_bytes'    => 200 * $gib,
+        'worktree_count' => 10,
+    ),
+    $thresholds
+);
+datamachine_code_budget_assert('refused' === $budget['status'], 'large filesystem still refuses below absolute floor');
+datamachine_code_budget_assert(true === $budget['force_override_required'], 'low absolute free space still requires force');
 
 echo "\n[6] high worktree count warns independently\n";
 $budget = WorktreeDiskBudget::evaluate(

--- a/tests/smoke-worktree-lifecycle-metadata.php
+++ b/tests/smoke-worktree-lifecycle-metadata.php
@@ -360,7 +360,20 @@ namespace {
     $assert('unsupported_workspace_repo_argument', is_wp_error($bad_url_worktree) ? $bad_url_worktree->get_error_code() : null, 'missing URL primary returns a clear error code');
 
     $GLOBALS['datamachine_code_test_filters']['datamachine_worktree_disk_budget_thresholds'] = function ( array $thresholds ): array {
+        $thresholds['refuse_free_bytes']   = 1;
         $thresholds['refuse_free_percent'] = 100;
+        $thresholds['warn_free_percent']   = 100;
+        return $thresholds;
+    };
+    $percent_warning_worktree = $ws->worktree_add('demo', 'feature/percent-warning-skip-bootstrap', 'HEAD', false, false, true, false, false);
+    unset($GLOBALS['datamachine_code_test_filters']['datamachine_worktree_disk_budget_thresholds']);
+    $assert(false, is_wp_error($percent_warning_worktree), 'worktree_add with bootstrap disabled is not blocked by percentage threshold alone');
+    $assert('warning', is_wp_error($percent_warning_worktree) ? null : ( $percent_warning_worktree['disk_budget']['status'] ?? null ), 'percentage-only disk pressure remains visible as a warning');
+
+    $GLOBALS['datamachine_code_test_filters']['datamachine_worktree_disk_budget_thresholds'] = function ( array $thresholds ): array {
+        $thresholds['refuse_free_bytes']   = PHP_INT_MAX;
+        $thresholds['refuse_free_percent'] = 100;
+        $thresholds['warn_free_bytes']     = PHP_INT_MAX;
         $thresholds['warn_free_percent']   = 100;
         return $thresholds;
     };


### PR DESCRIPTION
## Summary
- Treat the worktree disk budget percentage threshold as a warning on normal-sized filesystems when absolute free space remains above the hard refusal floor.
- Preserve hard refusals for genuinely low absolute disk states and small filesystems where the absolute GiB floor is impossible to satisfy.
- Add regression coverage for bare `worktree_add()` with bootstrap disabled so percentage-only pressure does not block creation.

Closes #662.

## Verification
- `php tests/smoke-worktree-disk-budget.php`
- `php tests/smoke-worktree-lifecycle-metadata.php`
- `php -l inc/Workspace/WorktreeDiskBudget.php`
- `php -l inc/Workspace/WorkspaceWorktreeLifecycle.php`
- `php -l tests/smoke-worktree-disk-budget.php`
- `php -l tests/smoke-worktree-lifecycle-metadata.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the policy change, focused regression coverage, and verification commands; Chris remains responsible for review and merge.