### PR TITLE
Clarify cleanup chunk drain progress

### DIFF
--- a/inc/Cleanup/DataMachineJobCleanupRunEvidenceStore.php
+++ b/inc/Cleanup/DataMachineJobCleanupRunEvidenceStore.php
@@ -51,6 +51,7 @@ class DataMachineJobCleanupRunEvidenceStore implements CleanupRunEvidenceStoreIn
 			'artifact_cleanup'       => $aggregate['artifact_cleanup'],
 			'cleanup_items'          => $aggregate['cleanup_items'],
 			'remaining_work_summary' => CleanupRemainingWorkSummary::from_job_aggregate($aggregate),
+			'drain'                  => $this->cleanup_run_drain_summary($job_id, $state, $children, $aggregate),
 			'children'               => $children_for_output,
 		);
 
@@ -228,6 +229,48 @@ class DataMachineJobCleanupRunEvidenceStore implements CleanupRunEvidenceStoreIn
 			'pending_truncated'       => count($pending) > $limit,
 			'processing_truncated'    => count($processing) > $limit,
 			'diagnostic_job_id_lists' => 'Re-run status with --verbose or use cleanup evidence for full child job IDs.',
+		);
+	}
+
+	/**
+	 * Build exact Data Machine drain and verification commands for a cleanup run.
+	 *
+	 * @param  int    $job_id    Parent cleanup job ID.
+	 * @param  string $state     Computed cleanup state.
+	 * @param  array  $children  Full child job aggregate.
+	 * @param  array  $aggregate Full cleanup aggregate.
+	 * @return array<string,mixed>
+	 */
+	private function cleanup_run_drain_summary( int $job_id, string $state, array $children, array $aggregate ): array {
+		$active_child_ids = array_values(
+			array_unique(
+				array_filter(
+					array_map(
+						'intval',
+						array_merge(
+							(array) ( $children['pending_job_ids'] ?? array() ),
+							(array) ( $children['processing_job_ids'] ?? array() )
+						)
+					)
+				)
+			)
+		);
+		$run_id        = $this->cleanup_run_id($job_id);
+		$cleanup_items = (array) ( $aggregate['cleanup_items'] ?? array() );
+		$commands      = array(
+			'parent' => sprintf('studio wp datamachine drain --job-id=%d', $job_id),
+			'verify' => sprintf('studio wp datamachine-code workspace cleanup status %s --format=json', $run_id),
+		);
+		if ( array() !== $active_child_ids ) {
+			$commands['active_children'] = sprintf('studio wp datamachine drain --job-id=%s', implode(',', $active_child_ids));
+		}
+
+		return array(
+			'needed'               => in_array($state, array( 'running', 'children_processing' ), true),
+			'commands'             => $commands,
+			'active_child_job_ids' => $active_child_ids,
+			'bytes_reclaimed'      => (int) ( $cleanup_items['bytes_reclaimed'] ?? 0 ),
+			'freed_human'          => (string) ( $cleanup_items['freed_human'] ?? $this->format_bytes(0) ),
 		);
 	}
 

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -626,6 +626,10 @@ class WorkspaceCommand extends BaseCommand {
 	 * [--verbose]
 	 * : Include full diagnostic child job ID lists in task-backed cleanup status output.
 	 *
+	 * [--drain]
+	 * : For `cleanup run`, drain the queued parent job, drain active child cleanup
+	 *   jobs discovered from cleanup status, then print verified bytes reclaimed.
+	 *
 	 * [--format=<format>]
 	 * : Output format.
 	 * ---
@@ -750,7 +754,142 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 
+		$result = $this->attach_cleanup_run_commands($result, $mode);
+		if ( ! empty($assoc_args['drain']) ) {
+			$result = $this->drain_cleanup_run_to_status($result, $assoc_args);
+		}
+
 		$this->render_cleanup_control_result($result, $assoc_args);
+	}
+
+	/**
+	 * Attach operator commands to a queued cleanup run response.
+	 *
+	 * @param  array<string,mixed> $result Cleanup run result.
+	 * @param  string              $mode   Cleanup mode.
+	 * @return array<string,mixed>
+	 */
+	private function attach_cleanup_run_commands( array $result, string $mode ): array {
+		$job_id = (int) ( $result['job_id'] ?? 0 );
+		$run_id = (string) ( $result['run_id'] ?? ( $job_id > 0 ? $this->cleanup_run_id($job_id) : '' ) );
+		if ( $job_id <= 0 || '' === $run_id ) {
+			return $result;
+		}
+
+		$result['commands'] = array(
+			'drain_parent'        => sprintf('studio wp datamachine drain --job-id=%d', $job_id),
+			'status'              => sprintf('studio wp datamachine-code workspace cleanup status %s --format=json', $run_id),
+			'status_verbose'      => sprintf('studio wp datamachine-code workspace cleanup status %s --verbose --format=json', $run_id),
+			'one_command_drain'   => sprintf('studio wp datamachine-code workspace cleanup run --mode=%s --drain --format=json', $mode),
+			'bytes_verification'  => sprintf('studio wp datamachine-code workspace cleanup status %s --format=json', $run_id),
+		);
+
+		return $result;
+	}
+
+	/**
+	 * Drain a queued job-backed cleanup run through Data Machine, then return status evidence.
+	 *
+	 * @param  array<string,mixed> $result     Initial cleanup run result.
+	 * @param  array<string,mixed> $assoc_args CLI associative args.
+	 * @return array<string,mixed>
+	 */
+	private function drain_cleanup_run_to_status( array $result, array $assoc_args ): array {
+		$job_id = (int) ( $result['job_id'] ?? 0 );
+		$run_id = (string) ( $result['run_id'] ?? ( $job_id > 0 ? $this->cleanup_run_id($job_id) : '' ) );
+		if ( $job_id <= 0 || '' === $run_id ) {
+			$result['drain'] = array(
+				'success' => false,
+				'error'   => 'Cleanup run did not return a job id to drain.',
+			);
+			return $result;
+		}
+
+		$commands = array();
+		$errors   = array();
+		$max_passes = 10;
+
+		$parent_command = sprintf('datamachine drain --job-id=%d', $job_id);
+		$commands[]     = 'studio wp ' . $parent_command;
+		$error          = $this->run_wp_cli_command($parent_command);
+		if ( '' !== $error ) {
+			$errors[] = $error;
+		}
+
+		for ( $pass = 0; $pass < $max_passes; ++$pass ) {
+			$status = $this->cleanup_run_evidence_store()->read($run_id, true, true);
+			if ( $status instanceof \WP_Error ) {
+				$errors[] = $status->get_error_message();
+				break;
+			}
+
+			$children = (array) ( $status['evidence']['children'] ?? array() );
+			$active_child_ids = array_values(
+				array_unique(
+					array_filter(
+						array_map(
+							'intval',
+							array_merge(
+								(array) ( $children['pending_job_ids'] ?? array() ),
+								(array) ( $children['processing_job_ids'] ?? array() )
+							)
+						)
+					)
+				)
+			);
+			if ( array() === $active_child_ids ) {
+				break;
+			}
+
+			$child_command = sprintf('datamachine drain --job-id=%s', implode(',', $active_child_ids));
+			$commands[]    = 'studio wp ' . $child_command;
+			$error         = $this->run_wp_cli_command($child_command);
+			if ( '' !== $error ) {
+				$errors[] = $error;
+				break;
+			}
+		}
+
+		$final = $this->cleanup_run_evidence_store()->read($run_id, false, ! empty($assoc_args['verbose']));
+		$output = $final instanceof \WP_Error ? $result : $final;
+		$output['initial_run'] = $result;
+		$output['drain']       = array(
+			'success'           => array() === $errors,
+			'commands'          => $commands,
+			'errors'            => $errors,
+			'verify_command'    => sprintf('studio wp datamachine-code workspace cleanup status %s --format=json', $run_id),
+			'bytes_reclaimed'   => (int) ( $output['cleanup_items']['bytes_reclaimed'] ?? 0 ),
+			'freed_human'       => (string) ( $output['cleanup_items']['freed_human'] ?? $this->format_bytes(0) ),
+			'completion_state'  => (string) ( $output['state'] ?? 'unknown' ),
+		);
+
+		return $output;
+	}
+
+	/**
+	 * Run a WP-CLI command and return an error message on failure.
+	 *
+	 * @param  string $command Command without the leading `wp` binary.
+	 * @return string Empty string on success.
+	 */
+	private function run_wp_cli_command( string $command ): string {
+		if ( ! method_exists('WP_CLI', 'runcommand') ) {
+			return 'WP_CLI::runcommand is unavailable; run the reported drain commands manually.';
+		}
+
+		try {
+			WP_CLI::runcommand(
+				$command,
+				array(
+					'return'     => true,
+					'exit_error' => false,
+				)
+			);
+		} catch ( \Throwable $e ) {
+			return $e->getMessage();
+		}
+
+		return '';
 	}
 
 	private function cleanup_run_input( string $mode, array $assoc_args ): array {
@@ -1052,6 +1191,12 @@ class WorkspaceCommand extends BaseCommand {
 		if ( ! empty($result['progress']) && is_array($result['progress']) ) {
 			$this->render_cleanup_progress_summary( (array) $result['progress']);
 		}
+		if ( ! empty($result['commands']) && is_array($result['commands']) ) {
+			$this->render_cleanup_command_hints( (array) $result['commands']);
+		}
+		if ( ! empty($result['drain']) && is_array($result['drain']) ) {
+			$this->render_cleanup_drain_summary( (array) $result['drain']);
+		}
 		if ( ! empty($result['remaining_work_summary']) && is_array($result['remaining_work_summary']) ) {
 			$this->render_cleanup_remaining_work_summary( (array) $result['remaining_work_summary']);
 		}
@@ -1130,6 +1275,47 @@ class WorkspaceCommand extends BaseCommand {
 			);
 			$this->format_items($rows, array( 'bucket', 'review_command', 'apply_command', 'apply_destructive' ), array( 'format' => 'table' ), 'bucket');
 		}
+	}
+
+	/**
+	 * Render cleanup command hints.
+	 *
+	 * @param  array<string,string> $commands Commands keyed by purpose.
+	 * @return void
+	 */
+	private function render_cleanup_command_hints( array $commands ): void {
+		WP_CLI::log('');
+		WP_CLI::log('Cleanup commands:');
+		$rows = array();
+		foreach ( $commands as $purpose => $command ) {
+			$rows[] = array(
+				'purpose' => (string) $purpose,
+				'command' => (string) $command,
+			);
+		}
+		$this->format_items($rows, array( 'purpose', 'command' ), array( 'format' => 'table' ), 'purpose');
+	}
+
+	/**
+	 * Render cleanup drain summary.
+	 *
+	 * @param  array<string,mixed> $drain Drain summary.
+	 * @return void
+	 */
+	private function render_cleanup_drain_summary( array $drain ): void {
+		WP_CLI::log('');
+		WP_CLI::log('Drain summary:');
+		$this->format_items(
+			array(
+				array( 'metric' => 'success', 'value' => ! empty($drain['success']) ? 'yes' : 'no' ),
+				array( 'metric' => 'completion_state', 'value' => (string) ( $drain['completion_state'] ?? 'unknown' ) ),
+				array( 'metric' => 'bytes_reclaimed', 'value' => $this->format_bytes($drain['bytes_reclaimed'] ?? 0) ),
+				array( 'metric' => 'verify_command', 'value' => (string) ( $drain['verify_command'] ?? '' ) ),
+			),
+			array( 'metric', 'value' ),
+			array( 'format' => 'table' ),
+			'metric'
+		);
 	}
 
 	private function render_cleanup_progress_summary( array $progress ): void {

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -18,6 +18,7 @@ namespace {
     {
         public static array $logs = array();
         public static array $successes = array();
+        public static array $runcommands = array();
 
         public static function error( string $message ): void
         {
@@ -37,6 +38,18 @@ namespace {
         public static function warning( string $message ): void
         {
             self::$logs[] = 'warning: ' . $message;
+        }
+
+        public static function runcommand( string $command, array $options = array() ): string
+        {
+            self::$runcommands[] = $command;
+            if ('datamachine drain --job-id=123' === $command ) {
+                $GLOBALS['datamachine_code_cleanup_parent_drained'] = true;
+            }
+            if ('datamachine drain --job-id=125' === $command ) {
+                $GLOBALS['datamachine_code_cleanup_child_drained'] = true;
+            }
+            return '';
         }
     }
 
@@ -893,10 +906,10 @@ namespace {
                 'job_id'        => 125,
                 'parent_job_id' => 124,
                 'source'        => 'batch',
-                'status'        => 'processing',
+                'status'        => ! empty($GLOBALS['datamachine_code_cleanup_child_drained']) ? 'completed' : 'processing',
                 'engine_data'   => array(
-                 'batch_id'  => 'dm_batch_123',
-                 'task_type' => 'worktree_cleanup_chunk',
+                  'batch_id'  => 'dm_batch_123',
+                  'task_type' => 'worktree_cleanup_chunk',
                    ),
                   ),
                   array(
@@ -1086,6 +1099,7 @@ namespace {
     datamachine_code_cleanup_assert(str_contains($cleanup_doc_comment, 'Control task-backed workspace cleanup runs.'), 'workspace cleanup command documents task-backed controller surface');
     datamachine_code_cleanup_assert(str_contains($cleanup_doc_comment, '<plan|apply|run|status|resume|cancel|evidence>'), 'workspace cleanup synopsis exposes DB-backed and task-backed cleanup operations');
     datamachine_code_cleanup_assert(str_contains($cleanup_doc_comment, '[--dry-run]'), 'task-backed cleanup synopsis keeps synchronous dry-run review');
+    datamachine_code_cleanup_assert(str_contains($cleanup_doc_comment, '[--drain]'), 'task-backed cleanup synopsis exposes drain option');
     datamachine_code_cleanup_assert(str_contains($cleanup_doc_comment, 'apply runs freeze eligible candidates'), 'workspace cleanup limit help clarifies artifact apply scoping');
     datamachine_code_cleanup_assert(str_contains($doc_comment, 'positive maximum worktrees to scan'), 'worktree limit help requires positive page sizes');
     datamachine_code_cleanup_assert(str_contains($doc_comment, 'Use `--exhaustive` instead of `--limit=0`'), 'worktree limit help points unbounded artifact scans to exhaustive mode');
@@ -1142,6 +1156,8 @@ namespace {
     $run_json = json_decode(WP_CLI::$logs[0] ?? '', true);
     datamachine_code_cleanup_assert('jobs_queued' === ( $run_json['state'] ?? '' ), 'cleanup run queues a system task');
     datamachine_code_cleanup_assert('cleanup-run-123' === ( $run_json['run_id'] ?? '' ), 'cleanup run returns stable run id');
+    datamachine_code_cleanup_assert('studio wp datamachine drain --job-id=123' === ( $run_json['commands']['drain_parent'] ?? '' ), 'cleanup run JSON includes exact parent drain command');
+    datamachine_code_cleanup_assert(str_contains((string) ( $run_json['commands']['one_command_drain'] ?? '' ), '--drain'), 'cleanup run JSON exposes one-command drain path');
     datamachine_code_cleanup_assert('retention' === ( $cleanup_run_ability->last_input['mode'] ?? '' ), 'cleanup run ability receives mode');
     datamachine_code_cleanup_assert('workspace_cleanup_cli' === ( $cleanup_run_ability->last_input['source'] ?? '' ), 'cleanup run ability identifies explicit CLI source');
 
@@ -1226,6 +1242,8 @@ namespace {
     datamachine_code_cleanup_assert(1 === (int) ( $status_json['remaining_work_summary']['skipped_by_reason']['stale_worktree_marker']['count'] ?? 0 ), 'cleanup status groups stale marker blockers separately');
     datamachine_code_cleanup_assert(1 === (int) ( $status_json['remaining_work_summary']['skipped_by_reason']['primary_missing']['count'] ?? 0 ), 'cleanup status groups missing primary blockers separately');
     datamachine_code_cleanup_assert(10240 === (int) ( $status_json['remaining_work_summary']['remaining_reclaimable_artifact_bytes'] ?? 0 ), 'cleanup status reports remaining reclaimable artifact bytes');
+    datamachine_code_cleanup_assert('studio wp datamachine drain --job-id=125' === ( $status_json['drain']['commands']['active_children'] ?? '' ), 'cleanup status includes exact active child drain command');
+    datamachine_code_cleanup_assert(4096 === (int) ( $status_json['drain']['bytes_reclaimed'] ?? 0 ), 'cleanup status drain summary verifies bytes reclaimed');
     datamachine_code_cleanup_assert(str_contains((string) wp_json_encode($status_json['remaining_work_summary']['recommended_commands'] ?? array()), 'workspace cleanup run --mode=artifacts'), 'cleanup status recommends next DMC commands per bucket');
     datamachine_code_cleanup_assert(str_contains((string) wp_json_encode($status_json['remaining_work_summary']['recommended_commands'] ?? array()), 'git -C <worktree-path> status --short --branch'), 'cleanup status recommends dirty git status evidence');
     datamachine_code_cleanup_assert(str_contains((string) wp_json_encode($status_json['remaining_work_summary']['recommended_commands'] ?? array()), 'git -C <worktree-path> log --oneline --decorate @{u}..HEAD'), 'cleanup status recommends unpushed git log evidence');
@@ -1233,6 +1251,20 @@ namespace {
     datamachine_code_cleanup_assert(str_contains((string) wp_json_encode($status_json['remaining_work_summary']['recommended_commands'] ?? array()), 'workspace show <repo>'), 'cleanup status recommends missing primary report');
     datamachine_code_cleanup_assert('4.0 KiB' === ( $status_json['system_task_result']['report']['freed_human'] ?? '' ), 'cleanup status replaces pending child job freed placeholder');
     datamachine_code_cleanup_assert(! isset($status_json['system_task_result']['children']['job_ids']), 'cleanup status system task result omits full child job ids by default');
+
+    WP_CLI::$logs        = array();
+    WP_CLI::$successes   = array();
+    WP_CLI::$runcommands = array();
+    $GLOBALS['datamachine_code_cleanup_parent_drained'] = false;
+    $GLOBALS['datamachine_code_cleanup_child_drained']  = false;
+    $command->cleanup(array( 'run' ), array( 'mode' => 'artifacts', 'drain' => true, 'format' => 'json' ));
+    $drained_json = json_decode(WP_CLI::$logs[0] ?? '', true);
+    datamachine_code_cleanup_assert(array( 'datamachine drain --job-id=123', 'datamachine drain --job-id=125' ) === WP_CLI::$runcommands, 'cleanup run --drain drains parent then active child jobs');
+    datamachine_code_cleanup_assert(4096 === (int) ( $drained_json['drain']['bytes_reclaimed'] ?? 0 ), 'cleanup run --drain reports verified reclaimed bytes');
+    datamachine_code_cleanup_assert('partial_failed' === (string) ( $drained_json['drain']['completion_state'] ?? '' ), 'cleanup run --drain reports final cleanup state');
+    datamachine_code_cleanup_assert('studio wp datamachine-code workspace cleanup status cleanup-run-123 --format=json' === (string) ( $drained_json['drain']['verify_command'] ?? '' ), 'cleanup run --drain emits one verification command');
+    $GLOBALS['datamachine_code_cleanup_parent_drained'] = false;
+    $GLOBALS['datamachine_code_cleanup_child_drained']  = false;
 
     WP_CLI::$logs      = array();
     WP_CLI::$successes = array();


### PR DESCRIPTION
## Summary
- Add `workspace cleanup run --drain` so a queued cleanup run can drain the parent job, discover active child cleanup jobs, drain them, and report verified reclaimed bytes in one command.
- Add cleanup run/status command hints that show the parent drain command, active child drain command when known, and the verification command.
- Extend cleanup CLI smoke coverage for parent cleanup runs with child chunk jobs.

Closes #663.

## Testing
- `php tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-cleanup-run-storage.php`
- `php tests/smoke-workspace-cleanup-run-context.php`
- `php tests/smoke-workspace-retention-task.php`
- `php -l inc/Cli/Commands/WorkspaceCommand.php`
- `php -l inc/Cleanup/DataMachineJobCleanupRunEvidenceStore.php`
- `php -l tests/smoke-worktree-cleanup-cli.php`
- `git diff --check`

## Caveats
- `php tests/smoke-worktree-cleanup-chunks.php` still fails on the existing repaired-metadata skip reason assertion: expected `no_merge_signal`, actual `plan_mismatch`. This PR does not touch that path.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the cleanup drain/status CLI changes and focused regression coverage; Chris remains responsible for review and testing.