### PR TITLE
Fix cleanup disk-pressure recommendations

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -886,6 +886,9 @@ class WorkspaceCommand extends BaseCommand {
 				if ( ! empty($assoc_args['safety-probes']) ) {
 					$artifact_input['safety_probes'] = true;
 				}
+				if ( isset($assoc_args['sort']) && '' !== trim( (string) $assoc_args['sort']) ) {
+					$artifact_input['sort'] = trim( (string) $assoc_args['sort']);
+				}
 				$result = $ability ? $ability->execute($artifact_input) : new \WP_Error('artifact_cleanup_ability_missing', 'Artifact cleanup ability not registered.');
 				$this->render_worktree_artifact_cleanup_result_from_ability($result, $assoc_args);
 				return;
@@ -2580,8 +2583,10 @@ class WorkspaceCommand extends BaseCommand {
 	 *   metadata older than the compact duration (cleanup only, e.g. 7d, 24h).
 	 *   Candidate worktrees without valid `created_at` metadata are skipped.
 	 *
-	 * [--sort=<field>]
-	 * : Sort cleanup candidates by reporting field (cleanup only).
+		 * [--sort=<field>]
+		 * : Sort cleanup candidates by reporting field. For artifact cleanup,
+		 *   `--sort=size` scans the cheap inventory once and returns the largest
+		 *   artifact opportunities without manual pagination.
 	 * ---
 	 * options:
 	 *   - size
@@ -3077,6 +3082,9 @@ class WorkspaceCommand extends BaseCommand {
 				}
 				if ( ! empty($assoc_args['safety-probes']) ) {
 					$input['safety_probes'] = true;
+				}
+				if ( isset($assoc_args['sort']) && '' !== trim( (string) $assoc_args['sort']) ) {
+					$input['sort'] = trim( (string) $assoc_args['sort']);
 				}
 				if ( ! empty($assoc_args['apply-plan']) ) {
 					$input['apply_plan'] = $this->read_worktree_cleanup_plan( (string) $assoc_args['apply-plan']);
@@ -4580,6 +4588,10 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 
+		if ( ! $dry_run ) {
+			WP_CLI::log(sprintf('Result: removed %d worktree(s); reclaimed %s; skipped %d.', (int) ( $summary['removed'] ?? count($removed) ), $this->format_bytes($summary['bytes_reclaimed'] ?? 0), (int) ( $summary['skipped'] ?? count($skipped) )));
+		}
+
 		WP_CLI::log('Summary:');
 		$summary_rows = array(
 			array(
@@ -4702,27 +4714,32 @@ class WorkspaceCommand extends BaseCommand {
 
 		if ( ! empty($skipped) ) {
 			WP_CLI::log('');
-			WP_CLI::log('Skipped:');
-			$skipped_rows = array_map(
-				fn( $s ) => array(
-					'handle'       => $s['handle'] ?? '',
-					'reason_code'  => $s['reason_code'] ?? '',
-					'reason'       => $verbose ? ( $s['reason'] ?? '' ) : $this->shorten_cleanup_reason( (string) ( $s['reason'] ?? '' )),
-					'age_days'     => $s['age_days'] ?? '',
-					'size'         => $this->format_bytes($s['size_bytes'] ?? null),
-					'artifacts'    => $this->format_bytes($s['artifact_size_bytes'] ?? 0),
-					'repo'         => $s['repo'] ?? '',
-					'branch'       => $s['branch'] ?? '',
-					'path'         => $s['path'] ?? '',
-					'primary_path' => $s['primary_path'] ?? '',
-					'missing'      => implode(',', (array) ( $s['missing_fields'] ?? array() )),
-					'hint'         => $s['hint'] ?? '',
-				),
-				array_slice($skipped, 0, $limit)
-			);
-			$fields       = $verbose ? array( 'handle', 'reason_code', 'reason', 'age_days', 'size', 'artifacts', 'repo', 'branch', 'path', 'primary_path', 'missing', 'hint' ) : array( 'handle', 'reason_code', 'age_days', 'size', 'artifacts', 'reason' );
-			$this->format_items($skipped_rows, $fields, array( 'format' => 'table' ), 'handle');
-			$this->render_cleanup_truncation_hint(count($skipped), $limit, 'skipped rows');
+			if ( $verbose ) {
+				WP_CLI::log('Skipped:');
+				$skipped_rows = array_map(
+					fn( $s ) => array(
+						'handle'       => $s['handle'] ?? '',
+						'reason_code'  => $s['reason_code'] ?? '',
+						'reason'       => $s['reason'] ?? '',
+						'age_days'     => $s['age_days'] ?? '',
+						'size'         => $this->format_bytes($s['size_bytes'] ?? null),
+						'artifacts'    => $this->format_bytes($s['artifact_size_bytes'] ?? 0),
+						'repo'         => $s['repo'] ?? '',
+						'branch'       => $s['branch'] ?? '',
+						'path'         => $s['path'] ?? '',
+						'primary_path' => $s['primary_path'] ?? '',
+						'missing'      => implode(',', (array) ( $s['missing_fields'] ?? array() )),
+						'hint'         => $s['hint'] ?? '',
+					),
+					array_slice($skipped, 0, $limit)
+				);
+				$this->format_items($skipped_rows, array( 'handle', 'reason_code', 'reason', 'age_days', 'size', 'artifacts', 'repo', 'branch', 'path', 'primary_path', 'missing', 'hint' ), array( 'format' => 'table' ), 'handle');
+				$this->render_cleanup_truncation_hint(count($skipped), $limit, 'skipped rows');
+			} else {
+				WP_CLI::log('Skipped summary:');
+				$this->format_items($this->summarize_cleanup_skipped_rows($skipped), array( 'reason_code', 'count', 'examples' ), array( 'format' => 'table' ), 'reason_code');
+				WP_CLI::log('Re-run with --verbose to list every skipped row or --only=<reason_code> to inspect one bucket.');
+			}
 		}
 
 		WP_CLI::log('');
@@ -5455,6 +5472,8 @@ class WorkspaceCommand extends BaseCommand {
 		$skipped    = (array) ( $result['skipped'] ?? array() );
 		$summary    = (array) ( $result['summary'] ?? array() );
 		$dry_run    = ! empty($result['dry_run']);
+		$verbose    = ! empty($assoc_args['verbose']);
+		$pagination = $result['pagination'] ?? ( $summary['pagination'] ?? null );
 
 		if ( empty($candidates) && empty($removed) && empty($skipped) ) {
 			WP_CLI::log('No worktree artifacts found.');
@@ -5488,7 +5507,7 @@ class WorkspaceCommand extends BaseCommand {
 
 		if ( ! empty($candidates) ) {
 			WP_CLI::log('');
-			WP_CLI::log($dry_run ? 'Would remove artifacts:' : 'Artifact candidates:');
+			WP_CLI::log($dry_run && is_array($pagination) && 'size' === (string) ( $pagination['sort'] ?? '' ) ? 'Largest artifact opportunities:' : ( $dry_run ? 'Would remove artifacts:' : 'Artifact candidates:' ));
 			$this->format_items($this->flatten_artifact_cleanup_rows($candidates), array( 'handle', 'repo', 'branch', 'artifact', 'size', 'path' ), array( 'format' => 'table' ), 'handle');
 		}
 
@@ -5500,24 +5519,29 @@ class WorkspaceCommand extends BaseCommand {
 
 		if ( ! empty($skipped) ) {
 			WP_CLI::log('');
-			WP_CLI::log('Skipped worktrees:');
-			$rows = array_map(
-				fn( $row ) => array(
-					'handle'      => $row['handle'] ?? '',
-					'repo'        => $row['repo'] ?? '',
-					'branch'      => $row['branch'] ?? '',
-					'artifacts'   => count( (array) ( $row['artifacts'] ?? array() )),
-					'reason_code' => $row['reason_code'] ?? '',
-					'reason'      => $row['reason'] ?? '',
-				),
-				$skipped
-			);
-			$this->format_items($rows, array( 'handle', 'repo', 'branch', 'artifacts', 'reason_code', 'reason' ), array( 'format' => 'table' ), 'handle');
+			if ( $verbose ) {
+				WP_CLI::log('Skipped worktrees:');
+				$rows = array_map(
+					fn( $row ) => array(
+						'handle'      => $row['handle'] ?? '',
+						'repo'        => $row['repo'] ?? '',
+						'branch'      => $row['branch'] ?? '',
+						'artifacts'   => count( (array) ( $row['artifacts'] ?? array() )),
+						'reason_code' => $row['reason_code'] ?? '',
+						'reason'      => $row['reason'] ?? '',
+					),
+					$skipped
+				);
+				$this->format_items($rows, array( 'handle', 'repo', 'branch', 'artifacts', 'reason_code', 'reason' ), array( 'format' => 'table' ), 'handle');
+			} else {
+				WP_CLI::log('Skipped worktrees summary:');
+				$this->format_items($this->summarize_cleanup_skipped_rows($skipped), array( 'reason_code', 'count', 'examples' ), array( 'format' => 'table' ), 'reason_code');
+				WP_CLI::log('Re-run with --verbose to list every skipped worktree.');
+			}
 		}
 
 		WP_CLI::log('');
 
-		$pagination = $result['pagination'] ?? ( $summary['pagination'] ?? null );
 		if ( is_array($pagination) ) {
 			$mode_label = (string) ( $pagination['mode'] ?? 'bounded_inventory' );
 			WP_CLI::log(
@@ -5534,6 +5558,8 @@ class WorkspaceCommand extends BaseCommand {
 			);
 			if ( ! empty($pagination['partial']) && isset($pagination['next_offset']) ) {
 				WP_CLI::log(sprintf('Partial scan — re-run with --offset=%d to continue, or pass --exhaustive for a full audit.', (int) $pagination['next_offset']));
+			} elseif ( 'size' === (string) ( $pagination['sort'] ?? '' ) ) {
+				WP_CLI::log(sprintf('Ranked by size across %d scanned worktree(s); showing the largest %d candidate(s).', (int) ( $pagination['scanned'] ?? 0 ), count($candidates)));
 			}
 			WP_CLI::log('');
 		}
@@ -5595,6 +5621,11 @@ class WorkspaceCommand extends BaseCommand {
 		$continuation = (array) ( $result['continuation'] ?? array() );
 		$dry_run      = ! empty($result['dry_run']);
 		$job_backed   = ! empty($result['job_backed']);
+		$verbose      = ! empty($assoc_args['verbose']);
+
+		if ( ! $dry_run ) {
+			WP_CLI::log(sprintf('Result: removed %d worktree(s); reclaimed %s; skipped %d.', (int) ( $summary['removed'] ?? count($removed) ), $this->format_bytes($summary['bytes_reclaimed'] ?? 0), (int) ( $summary['skipped'] ?? count($skipped) )));
+		}
 
 		WP_CLI::log('Bounded cleanup apply summary:');
 		$summary_rows = array(
@@ -5666,16 +5697,22 @@ class WorkspaceCommand extends BaseCommand {
 
 		if ( ! empty($skipped) ) {
 			WP_CLI::log('');
-			WP_CLI::log('Skipped:');
-			$rows = array_map(
-				fn( $row ) => array(
-					'handle'      => $row['handle'] ?? '',
-					'reason_code' => $row['reason_code'] ?? '',
-					'reason'      => $this->shorten_cleanup_reason( (string) ( $row['reason'] ?? '' )),
-				),
-				$skipped
-			);
-			$this->format_items($rows, array( 'handle', 'reason_code', 'reason' ), array( 'format' => 'table' ), 'handle');
+			if ( $verbose ) {
+				WP_CLI::log('Skipped:');
+				$rows = array_map(
+					fn( $row ) => array(
+						'handle'      => $row['handle'] ?? '',
+						'reason_code' => $row['reason_code'] ?? '',
+						'reason'      => $this->shorten_cleanup_reason( (string) ( $row['reason'] ?? '' )),
+					),
+					$skipped
+				);
+				$this->format_items($rows, array( 'handle', 'reason_code', 'reason' ), array( 'format' => 'table' ), 'handle');
+			} else {
+				WP_CLI::log('Skipped summary:');
+				$this->format_items($this->summarize_cleanup_skipped_rows($skipped), array( 'reason_code', 'count', 'examples' ), array( 'format' => 'table' ), 'reason_code');
+				WP_CLI::log('Re-run with --verbose to list every skipped row.');
+			}
 		}
 
 		WP_CLI::log('');
@@ -5939,6 +5976,43 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 		WP_CLI::log(sprintf('Showing %d of %d %s. Re-run with --verbose for all rows or --only=<reason_code> to filter.', $limit, $total, $label));
+	}
+
+	/**
+	 * Summarize skipped cleanup rows by reason with representative handles.
+	 *
+	 * @param  array<int,array<string,mixed>> $skipped Skipped rows.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function summarize_cleanup_skipped_rows( array $skipped ): array {
+		$summary = array();
+		foreach ( $skipped as $row ) {
+			$reason_code = (string) ( $row['reason_code'] ?? 'unknown' );
+			if ( ! isset($summary[ $reason_code ]) ) {
+				$summary[ $reason_code ] = array(
+					'reason_code' => $reason_code,
+					'count'       => 0,
+					'examples'    => array(),
+				);
+			}
+			++$summary[ $reason_code ]['count'];
+			$handle = (string) ( $row['handle'] ?? '' );
+			if ( '' !== $handle && count($summary[ $reason_code ]['examples']) < 3 ) {
+				$summary[ $reason_code ]['examples'][] = $handle;
+			}
+		}
+
+		ksort($summary);
+		return array_values(
+			array_map(
+				fn( $row ) => array(
+					'reason_code' => $row['reason_code'],
+					'count'       => $row['count'],
+					'examples'    => implode(', ', $row['examples']),
+				),
+				$summary
+			)
+		);
 	}
 
 	/**

--- a/inc/Workspace/WorkspaceArtifactCleanup.php
+++ b/inc/Workspace/WorkspaceArtifactCleanup.php
@@ -41,6 +41,7 @@ trait WorkspaceArtifactCleanup {
 		$force      = ! empty($opts['force']);
 		$apply_plan = isset($opts['apply_plan']) && is_array($opts['apply_plan']) ? $opts['apply_plan'] : null;
 		$exhaustive = ! empty($opts['exhaustive']);
+		$sort       = isset($opts['sort']) ? strtolower(trim( (string) $opts['sort'])) : '';
 		$limit      = isset($opts['limit']) ? (int) $opts['limit'] : self::ARTIFACT_CLEANUP_DEFAULT_LIMIT;
 		$offset     = isset($opts['offset']) ? max(0, (int) $opts['offset']) : 0;
 		if ( $limit < 0 ) {
@@ -87,11 +88,14 @@ trait WorkspaceArtifactCleanup {
 			$only_handles = array_keys($only_handles);
 		}
 
+		$rank_by_size = $dry_run && null === $apply_plan && ! $exhaustive && in_array($sort, array( 'size', 'bytes' ), true);
+		$plan_limit   = $rank_by_size ? 0 : $limit;
+
 		$plan = $this->build_worktree_artifact_cleanup_plan(
 			$force,
 			array(
-				'limit'         => $limit,
-				'offset'        => $offset,
+				'limit'         => $plan_limit,
+				'offset'        => $rank_by_size ? 0 : $offset,
 				'only_handles'  => $only_handles,
 				'safety_probes' => $safety_probes,
 			)
@@ -108,6 +112,25 @@ trait WorkspaceArtifactCleanup {
 			$scoped     = $this->scope_worktree_artifact_cleanup_to_plan($planned, $candidates, $skipped);
 			$candidates = $scoped['candidates'];
 			$skipped    = $scoped['skipped'];
+		}
+
+		if ( $rank_by_size ) {
+			usort($candidates, fn( $a, $b ) => (int) ( $b['artifact_size_bytes'] ?? 0 ) <=> (int) ( $a['artifact_size_bytes'] ?? 0 ));
+			$total_ranked = count($candidates);
+			$candidates   = array_slice($candidates, 0, $limit);
+			$pagination   = array(
+				'mode'          => 'ranked_inventory',
+				'limit'         => $limit,
+				'offset'        => 0,
+				'scanned'       => (int) ( $pagination['scanned'] ?? 0 ),
+				'total'         => (int) ( $pagination['total'] ?? 0 ),
+				'complete'      => true,
+				'partial'       => false,
+				'next_offset'   => null,
+				'safety_probes' => $safety_probes,
+				'sort'          => 'size',
+				'ranked_total'  => $total_ranked,
+			);
 		}
 
 		$summary = $this->build_worktree_artifact_cleanup_summary($candidates, array(), $skipped);

--- a/inc/Workspace/WorkspaceWorktreeLifecycle.php
+++ b/inc/Workspace/WorkspaceWorktreeLifecycle.php
@@ -105,16 +105,25 @@ trait WorkspaceWorktreeLifecycle {
 
 		$disk_budget = WorktreeDiskBudget::inspect($this->workspace_path, WorktreeDiskBudget::thresholds($repo, $branch), $force);
 		if ( 'refused' === ( $disk_budget['status'] ?? '' ) ) {
+			$recommendations = array_map(
+				fn( $row ) => sprintf(
+					'%d. %s: %s (target reclaim: %s)',
+					(int) ( $row['priority'] ?? 0 ),
+					(string) ( $row['action'] ?? 'cleanup' ),
+					(string) ( $row['command'] ?? '' ),
+					(string) ( $row['expected_reclaim'] ?? 'unknown' )
+				),
+				(array) ( $disk_budget['cleanup_recommendations'] ?? array() )
+			);
 			return new \WP_Error(
 				'worktree_disk_budget_exceeded',
 				sprintf(
-					"Refusing to create worktree before bootstrap/install because the workspace disk budget is unsafe.\n%s\nThreshold: keep at least %.1f GiB free and %.1f%% free; effective floor on this filesystem is %.1f GiB.\nRun %s to review cleanup candidates, run %s to review artifact cleanup, or retry with --force only when a human explicitly accepts the disk-pressure risk.",
+					"Refusing to create worktree before bootstrap/install because the workspace disk budget is unsafe.\n%s\nThreshold: keep at least %.1f GiB free and %.1f%% free; effective floor on this filesystem is %.1f GiB.\nRecommended cleanup, in order:\n%s\nRetry with --force only when a human explicitly accepts the disk-pressure risk.",
 					WorktreeDiskBudget::format_summary($disk_budget),
 					(float) ( $disk_budget['refuse_free_gib'] ?? 0 ),
 					(float) ( $disk_budget['refuse_free_percent'] ?? 0 ),
 					(float) ( $disk_budget['effective_refuse_gib'] ?? 0 ),
-					$disk_budget['cleanup_dry_run_command'],
-					$disk_budget['artifact_cleanup_command']
+					implode("\n", array_filter($recommendations))
 				),
 				array(
 					'status'      => 507,

--- a/inc/Workspace/WorktreeDiskBudget.php
+++ b/inc/Workspace/WorktreeDiskBudget.php
@@ -176,8 +176,45 @@ final class WorktreeDiskBudget {
 			'cleanup_dry_run_command'   => 'studio wp datamachine-code workspace worktree cleanup --dry-run',
 			'artifact_cleanup_command'  => 'studio wp datamachine-code workspace worktree cleanup-artifacts --dry-run',
 			'emergency_cleanup_command' => 'studio wp datamachine-code workspace worktree emergency-cleanup --format=json',
+			'cleanup_recommendations'   => self::cleanup_recommendations($free_bytes, $effective_refuse_bytes),
 			'force_override_required'   => $refused,
 			'force_override_applied'    => $forced && ! empty($warnings),
+		);
+	}
+
+	/**
+	 * Build concise operator remediation commands for disk-pressure failures.
+	 *
+	 * @param  int|null $free_bytes              Current free bytes.
+	 * @param  int      $effective_refuse_bytes Effective refusal floor.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function cleanup_recommendations( ?int $free_bytes, int $effective_refuse_bytes ): array {
+		$target_reclaim = null === $free_bytes ? null : max(0, $effective_refuse_bytes - $free_bytes);
+		$target_human   = null === $target_reclaim ? 'enough space to clear the refusal threshold' : self::format_bytes($target_reclaim);
+
+		return array(
+			array(
+				'priority'               => 1,
+				'action'                 => 'review largest reconstructable artifacts',
+				'expected_reclaim_bytes' => $target_reclaim,
+				'expected_reclaim'       => $target_human,
+				'command'                => 'studio wp datamachine-code workspace worktree cleanup-artifacts --dry-run --sort=size',
+			),
+			array(
+				'priority'               => 2,
+				'action'                 => 'apply reviewed cleanup-eligible worktrees',
+				'expected_reclaim_bytes' => $target_reclaim,
+				'expected_reclaim'       => $target_human,
+				'command'                => 'studio wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --dry-run --limit=25',
+			),
+			array(
+				'priority'               => 3,
+				'action'                 => 'generate combined emergency plan',
+				'expected_reclaim_bytes' => $target_reclaim,
+				'expected_reclaim'       => $target_human,
+				'command'                => 'studio wp datamachine-code workspace worktree emergency-cleanup --format=json',
+			),
 		);
 	}
 
@@ -271,6 +308,25 @@ final class WorktreeDiskBudget {
 			'refuse_free_percent' => $refuse_percent,
 			'warn_worktree_count' => $count,
 		);
+	}
+
+	/**
+	 * Format bytes for command guidance without WordPress runtime helpers.
+	 *
+	 * @param  int|float $bytes Bytes.
+	 * @return string
+	 */
+	private static function format_bytes( int|float $bytes ): string {
+		$bytes      = max(0, (float) $bytes);
+		$units      = array( 'B', 'KiB', 'MiB', 'GiB', 'TiB' );
+		$unit       = 0;
+		$unit_count = count($units);
+		while ( $bytes >= 1024 && $unit < $unit_count - 1 ) {
+			$bytes /= 1024;
+			++$unit;
+		}
+
+		return number_format($bytes, 0 === $unit ? 0 : 1) . ' ' . $units[ $unit ];
 	}
 
 	/**

--- a/tests/smoke-worktree-cleanup-artifacts.php
+++ b/tests/smoke-worktree-cleanup-artifacts.php
@@ -223,6 +223,14 @@ namespace {
     }
     $assert(true, is_dir($tmp . '/demo@clean/target'), 'bounded dry-run does not delete target directory');
 
+    $ranked_plan = $workspace->worktree_cleanup_artifacts(array( 'dry_run' => true, 'sort' => 'size', 'limit' => 2 ));
+    $assert(false, is_wp_error($ranked_plan), 'ranked artifact dry-run returns a plan');
+    $assert('ranked_inventory', $ranked_plan['pagination']['mode'] ?? '', 'ranked artifact dry-run scans full inventory once');
+    $assert('size', $ranked_plan['pagination']['sort'] ?? '', 'ranked artifact dry-run advertises size sort');
+    $assert(2, count($ranked_plan['candidates'] ?? array()), 'ranked artifact dry-run applies display limit after ranking');
+    $ranked_sizes = array_map(fn( $row ) => (int) ( $row['artifact_size_bytes'] ?? 0 ), $ranked_plan['candidates'] ?? array());
+    $assert(true, $ranked_sizes[0] >= $ranked_sizes[1], 'ranked artifact dry-run returns largest candidates first');
+
     // Exhaustive dry-run: full safety probes — restores the historical strict
     // view where dirty/unpushed worktrees are skipped at dry-run time.
     $exhaustive_plan = $workspace->worktree_cleanup_artifacts(array( 'dry_run' => true, 'exhaustive' => true ));

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -355,22 +355,34 @@ namespace {
                 $apply_command .= ' --limit=' . (int) ( $input['limit'] ?? 100 );
                 $apply_command .= ' --offset=' . (int) ( $input['offset'] ?? 0 );
             }
-            $apply_command .= ' --format=json';
-            return array(
-            'success'       => true,
-            'dry_run'       => ! empty($input['dry_run']),
-            'apply_command' => $apply_command,
-            'candidates'    => array(
-            array(
-            'handle'    => 'repo@old',
-            'repo'      => 'repo',
-            'branch'    => 'old',
-            'path'      => '/workspace/repo@old',
-            'artifacts' => array( array( 'path' => 'target', 'size_bytes' => 1024 ) ),
-            ),
-            ),
-            'removed'    => array(),
-            'skipped'    => array(
+			$apply_command .= ' --format=json';
+			$candidates = array(
+			array(
+			'handle'    => 'repo@old',
+			'repo'      => 'repo',
+			'branch'    => 'old',
+			'path'      => '/workspace/repo@old',
+			'artifacts' => array( array( 'path' => 'target', 'size_bytes' => 1024 ) ),
+			),
+			);
+			$pagination = array( 'mode' => 'bounded_inventory', 'scanned' => 1, 'total' => 1, 'offset' => 0, 'limit' => (int) ( $input['limit'] ?? 100 ), 'complete' => true, 'partial' => false, 'safety_probes' => false );
+			if ( 'size' === (string) ( $input['sort'] ?? '' ) ) {
+				$candidates[] = array(
+				'handle'    => 'repo@large',
+				'repo'      => 'repo',
+				'branch'    => 'large',
+				'path'      => '/workspace/repo@large',
+				'artifacts' => array( array( 'path' => 'target', 'size_bytes' => 4096 ) ),
+				);
+				$pagination = array( 'mode' => 'ranked_inventory', 'scanned' => 200, 'total' => 200, 'offset' => 0, 'limit' => (int) ( $input['limit'] ?? 100 ), 'complete' => true, 'partial' => false, 'safety_probes' => false, 'sort' => 'size', 'ranked_total' => 2 );
+			}
+			return array(
+			'success'       => true,
+			'dry_run'       => ! empty($input['dry_run']),
+			'apply_command' => $apply_command,
+			'candidates'    => $candidates,
+			'removed'    => array(),
+			'skipped'    => array(
             array(
             'handle'      => 'repo@active',
             'repo'        => 'repo',
@@ -380,16 +392,18 @@ namespace {
             'reason'      => 'worktree is an active symlink target',
             ),
             ),
-            'summary'    => array(
-            'apply_command'          => $apply_command,
-            'would_remove_artifacts' => 1,
-            'removed_artifacts'      => 0,
-            'skipped'                => 1,
-            'artifact_size_bytes'    => 1024,
-            ),
-            );
-        }
-    }
+			'summary'    => array(
+			'apply_command'          => $apply_command,
+			'would_remove_artifacts' => count($candidates),
+			'removed_artifacts'      => 0,
+			'skipped'                => 1,
+			'artifact_size_bytes'    => 1024,
+			'pagination'             => $pagination,
+			),
+			'pagination' => $pagination,
+			);
+		}
+	}
 
     class FakeEmergencyCleanupAbility
     {
@@ -1495,14 +1509,16 @@ namespace {
     WP_CLI::$successes = array();
     $command->worktree(array( 'cleanup' ), array( 'dry-run' => true, 'skip-github' => true ));
     datamachine_code_cleanup_assert(str_starts_with(WP_CLI::$logs[0] ?? '', 'Cleanup progress:'), 'human output streams cleanup progress before summary');
-    datamachine_code_cleanup_assert(in_array('Summary:', WP_CLI::$logs, true), 'human output includes summary after progress');
-    datamachine_code_cleanup_assert(in_array('table:1:handle,branch,age_days,size,artifacts,signal,reason_code', WP_CLI::$logs, true), 'default candidate table uses compact disk fields');
-    datamachine_code_cleanup_assert(in_array('table:10:handle,reason_code,age_days,size,artifacts,reason', WP_CLI::$logs, true), 'default skipped table omits path and hint fields but keeps disk fields');
-    datamachine_code_cleanup_assert(in_array('Top repos by worktree size:', WP_CLI::$logs, true), 'human output includes top repo size summary');
-    datamachine_code_cleanup_assert(in_array('Next commands for skipped buckets:', WP_CLI::$logs, true), 'human output includes actionable skipped command section');
-    datamachine_code_cleanup_assert(in_array('table:9:reason_code,count,destructive,command,alternative', WP_CLI::$logs, true), 'human output renders compact skipped command table');
-    datamachine_code_cleanup_assert(in_array('Showing 10 of 19 skipped rows. Re-run with --verbose for all rows or --only=<reason_code> to filter.', WP_CLI::$logs, true), 'human output truncates skipped rows with hint');
-    datamachine_code_cleanup_assert(1 === count(WP_CLI::$successes), 'human output keeps success suffix');
+	datamachine_code_cleanup_assert(in_array('Summary:', WP_CLI::$logs, true), 'human output includes summary after progress');
+	datamachine_code_cleanup_assert(in_array('table:1:handle,branch,age_days,size,artifacts,signal,reason_code', WP_CLI::$logs, true), 'default candidate table uses compact disk fields');
+	datamachine_code_cleanup_assert(in_array('Skipped summary:', WP_CLI::$logs, true), 'default cleanup output summarizes skipped rows by reason');
+	datamachine_code_cleanup_assert(in_array('table:9:reason_code,count,examples', WP_CLI::$logs, true), 'default skipped summary groups reasons instead of listing every row');
+	datamachine_code_cleanup_assert(in_array('Re-run with --verbose to list every skipped row or --only=<reason_code> to inspect one bucket.', WP_CLI::$logs, true), 'default skipped summary points to verbose or filtered follow-up');
+	datamachine_code_cleanup_assert(! in_array('table:10:handle,reason_code,age_days,size,artifacts,reason', WP_CLI::$logs, true), 'default skipped table does not list individual skipped rows');
+	datamachine_code_cleanup_assert(in_array('Top repos by worktree size:', WP_CLI::$logs, true), 'human output includes top repo size summary');
+	datamachine_code_cleanup_assert(in_array('Next commands for skipped buckets:', WP_CLI::$logs, true), 'human output includes actionable skipped command section');
+	datamachine_code_cleanup_assert(in_array('table:9:reason_code,count,destructive,command,alternative', WP_CLI::$logs, true), 'human output renders compact skipped command table');
+	datamachine_code_cleanup_assert(1 === count(WP_CLI::$successes), 'human output keeps success suffix');
 
     echo "\n[3] verbose output keeps detailed human fields\n";
     WP_CLI::$logs      = array();
@@ -1551,8 +1567,16 @@ namespace {
     echo "\n[7] --sort forwards cleanup sorting field\n";
     WP_CLI::$logs      = array();
     WP_CLI::$successes = array();
-    $command->worktree(array( 'cleanup' ), array( 'dry-run' => true, 'skip-github' => true, 'sort' => 'size', 'format' => 'json' ));
-    datamachine_code_cleanup_assert('size' === ( $ability->last_input['sort'] ?? null ), '--sort forwards to cleanup ability');
+	$command->worktree(array( 'cleanup' ), array( 'dry-run' => true, 'skip-github' => true, 'sort' => 'size', 'format' => 'json' ));
+	datamachine_code_cleanup_assert('size' === ( $ability->last_input['sort'] ?? null ), '--sort forwards to cleanup ability');
+
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->cleanup(array( 'run' ), array( 'mode' => 'artifacts', 'dry-run' => true, 'sort' => 'size', 'format' => 'json' ));
+	datamachine_code_cleanup_assert('size' === ( $artifact_ability->last_input['sort'] ?? null ), 'workspace cleanup artifact dry-run forwards size sort');
+	$ranked_artifact_json = json_decode(WP_CLI::$logs[0] ?? '', true);
+	datamachine_code_cleanup_assert('ranked_inventory' === ( $ranked_artifact_json['pagination']['mode'] ?? '' ), 'artifact size sort reports ranked inventory mode');
+	datamachine_code_cleanup_assert('size' === ( $ranked_artifact_json['pagination']['sort'] ?? '' ), 'artifact size sort advertises size ordering');
 
     echo "\n[8] --inventory-only forwards bounded cleanup review flag\n";
     WP_CLI::$logs      = array();
@@ -1563,12 +1587,27 @@ namespace {
     datamachine_code_cleanup_assert(str_contains($inventory_json['summary']['apply_command'] ?? '', 'bounded-cleanup-eligible-apply --limit=1'), 'inventory-only JSON exposes bounded cleanup-eligible apply command');
     WP_CLI::$logs      = array();
     WP_CLI::$successes = array();
-    $command->worktree(array( 'cleanup' ), array( 'dry-run' => true, 'inventory-only' => true, 'skip-github' => true ));
-    datamachine_code_cleanup_assert(str_contains(WP_CLI::$successes[0] ?? '', 'Apply this bounded reviewed class with: studio wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --limit=1'), 'inventory-only human output prints bounded apply command');
-    $command->worktree(array( 'cleanup' ), array( 'dry-run' => true, 'inventory-only' => true, 'include-repaired-metadata' => true, 'format' => 'json' ));
-    datamachine_code_cleanup_assert(true === ( $ability->last_input['include_repaired_metadata'] ?? null ), '--include-repaired-metadata forwards to cleanup ability');
+	$command->worktree(array( 'cleanup' ), array( 'dry-run' => true, 'inventory-only' => true, 'skip-github' => true ));
+	datamachine_code_cleanup_assert(str_contains(WP_CLI::$successes[0] ?? '', 'Apply this bounded reviewed class with: studio wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --limit=1'), 'inventory-only human output prints bounded apply command');
+	$command->worktree(array( 'cleanup' ), array( 'dry-run' => true, 'inventory-only' => true, 'include-repaired-metadata' => true, 'format' => 'json' ));
+	datamachine_code_cleanup_assert(true === ( $ability->last_input['include_repaired_metadata'] ?? null ), '--include-repaired-metadata forwards to cleanup ability');
 
-    echo "\n[8a] active/no-signal apply forwards bounded continuation flags\n";
+	$bounded_apply_ability->extra_skipped = 30;
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->worktree(array( 'bounded-cleanup-eligible-apply' ), array( 'limit' => 25 ));
+	datamachine_code_cleanup_assert(in_array('Result: removed 1 worktree(s); reclaimed 4.0 KiB; skipped 2.', WP_CLI::$logs, true), 'bounded cleanup apply highlights removed/reclaimed totals first');
+	datamachine_code_cleanup_assert(in_array('Skipped summary:', WP_CLI::$logs, true), 'bounded cleanup apply summarizes skipped rows by default');
+	datamachine_code_cleanup_assert(in_array('table:4:reason_code,count,examples', WP_CLI::$logs, true), 'bounded cleanup apply groups skipped reasons');
+	datamachine_code_cleanup_assert(! in_array('table:32:handle,reason_code,reason', WP_CLI::$logs, true), 'bounded cleanup apply default output does not list every skipped row');
+
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->worktree(array( 'bounded-cleanup-eligible-apply' ), array( 'limit' => 25, 'verbose' => true ));
+	datamachine_code_cleanup_assert(in_array('table:32:handle,reason_code,reason', WP_CLI::$logs, true), 'bounded cleanup apply verbose output lists skipped rows');
+	$bounded_apply_ability->extra_skipped = 0;
+
+	echo "\n[8a] active/no-signal apply forwards bounded continuation flags\n";
     WP_CLI::$logs      = array();
     WP_CLI::$successes = array();
     $command->worktree(
@@ -1610,12 +1649,27 @@ namespace {
     datamachine_code_cleanup_assert('studio wp datamachine-code workspace cleanup run --mode=artifacts --limit=100 --offset=0 --format=json' === ( $artifact_json['apply_command'] ?? '' ), 'cleanup-artifacts JSON includes matching high-level apply command');
     datamachine_code_cleanup_assert(( $artifact_json['apply_command'] ?? '' ) === ( $artifact_json['summary']['apply_command'] ?? null ), 'cleanup-artifacts summary repeats matching apply command');
 
-    WP_CLI::$logs      = array();
-    WP_CLI::$successes = array();
-    $command->worktree(array( 'cleanup-artifacts' ), array( 'dry-run' => true ));
-    datamachine_code_cleanup_assert(str_contains(WP_CLI::$successes[0] ?? '', 'workspace cleanup run --mode=artifacts --limit=100 --offset=0 --format=json'), 'cleanup-artifacts dry-run points daily apply path to same task-backed page');
-    datamachine_code_cleanup_assert(str_contains(WP_CLI::$successes[0] ?? '', 'low-level escape hatch'), 'cleanup-artifacts dry-run demotes apply-plan wording');
-    datamachine_code_cleanup_assert(! str_contains(WP_CLI::$successes[0] ?? '', 'Save JSON'), 'cleanup-artifacts dry-run does not normalize saving plan files');
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->worktree(array( 'cleanup-artifacts' ), array( 'dry-run' => true ));
+	datamachine_code_cleanup_assert(str_contains(WP_CLI::$successes[0] ?? '', 'workspace cleanup run --mode=artifacts --limit=100 --offset=0 --format=json'), 'cleanup-artifacts dry-run points daily apply path to same task-backed page');
+	datamachine_code_cleanup_assert(str_contains(WP_CLI::$successes[0] ?? '', 'low-level escape hatch'), 'cleanup-artifacts dry-run demotes apply-plan wording');
+	datamachine_code_cleanup_assert(! str_contains(WP_CLI::$successes[0] ?? '', 'Save JSON'), 'cleanup-artifacts dry-run does not normalize saving plan files');
+	datamachine_code_cleanup_assert(in_array('Skipped worktrees summary:', WP_CLI::$logs, true), 'cleanup-artifacts human output summarizes skipped worktrees by default');
+	datamachine_code_cleanup_assert(in_array('table:1:reason_code,count,examples', WP_CLI::$logs, true), 'cleanup-artifacts skipped summary is grouped by reason');
+	datamachine_code_cleanup_assert(! in_array('table:1:handle,repo,branch,artifacts,reason_code,reason', WP_CLI::$logs, true), 'cleanup-artifacts default output does not list every skipped worktree');
+
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->worktree(array( 'cleanup-artifacts' ), array( 'dry-run' => true, 'sort' => 'size' ));
+	datamachine_code_cleanup_assert('size' === ( $artifact_ability->last_input['sort'] ?? null ), 'cleanup-artifacts forwards size sort');
+	datamachine_code_cleanup_assert(in_array('Largest artifact opportunities:', WP_CLI::$logs, true), 'cleanup-artifacts size sort labels ranked opportunities');
+	datamachine_code_cleanup_assert(in_array('Ranked by size across 200 scanned worktree(s); showing the largest 2 candidate(s).', WP_CLI::$logs, true), 'cleanup-artifacts size sort explains full-inventory ranking');
+
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->worktree(array( 'cleanup-artifacts' ), array( 'dry-run' => true, 'verbose' => true ));
+	datamachine_code_cleanup_assert(in_array('table:1:handle,repo,branch,artifacts,reason_code,reason', WP_CLI::$logs, true), 'cleanup-artifacts verbose output lists skipped worktrees');
 
     WP_CLI::$logs      = array();
     WP_CLI::$successes = array();

--- a/tests/smoke-worktree-disk-budget.php
+++ b/tests/smoke-worktree-disk-budget.php
@@ -83,6 +83,9 @@ datamachine_code_budget_assert(in_array('free_space_refusal_threshold', $budget[
 datamachine_code_budget_assert(str_contains($budget['cleanup_dry_run_command'], 'workspace worktree cleanup --dry-run'), 'cleanup dry-run command is present');
 datamachine_code_budget_assert(str_contains($budget['artifact_cleanup_command'], 'workspace worktree cleanup-artifacts --dry-run'), 'artifact cleanup dry-run command is present');
 datamachine_code_budget_assert(str_contains($budget['emergency_cleanup_command'], 'workspace worktree emergency-cleanup'), 'emergency cleanup command is present');
+datamachine_code_budget_assert(3 === count($budget['cleanup_recommendations'] ?? array()), 'refusal includes ranked cleanup recommendations');
+datamachine_code_budget_assert(str_contains($budget['cleanup_recommendations'][0]['command'] ?? '', 'cleanup-artifacts --dry-run --sort=size'), 'first recommendation discovers largest artifacts');
+datamachine_code_budget_assert(5 * $gib === (int) ( $budget['cleanup_recommendations'][0]['expected_reclaim_bytes'] ?? 0 ), 'recommendation records target reclaim bytes');
 
 echo "\n[4] force makes low-space override explicit\n";
 $budget = WorktreeDiskBudget::evaluate(

--- a/tests/smoke-worktree-lifecycle-metadata.php
+++ b/tests/smoke-worktree-lifecycle-metadata.php
@@ -369,7 +369,9 @@ namespace {
     $assert(true, is_wp_error($refused), 'worktree_add refuses before creation when disk budget is unsafe');
     $assert(false, is_dir(DATAMACHINE_WORKSPACE_PATH . '/demo@feature-disk-budget-refusal'), 'refused disk budget does not leave a worktree directory');
     $assert(true, str_contains($refused->get_error_message(), DATAMACHINE_WORKSPACE_PATH), 'disk budget refusal names workspace root');
-    $assert(true, str_contains($refused->get_error_message(), 'cleanup-artifacts --dry-run'), 'disk budget refusal suggests artifact cleanup');
+    $assert(true, str_contains($refused->get_error_message(), 'Recommended cleanup, in order:'), 'disk budget refusal groups remediation commands');
+    $assert(true, str_contains($refused->get_error_message(), 'cleanup-artifacts --dry-run --sort=size'), 'disk budget refusal suggests largest artifact review');
+    $assert(true, str_contains($refused->get_error_message(), 'target reclaim:'), 'disk budget refusal includes target reclaim estimate');
 
     $result = $ws->worktree_add('demo', 'feature/metadata', 'HEAD', false, false, true, false);
     $assert(true, ! is_wp_error($result) && ( $result['success'] ?? false ), 'worktree_add succeeds without context injection');


### PR DESCRIPTION
## Summary
- Adds ranked disk-pressure remediation commands to worktree add refusal guidance, prioritizing size-ranked artifact cleanup before bounded cleanup-eligible apply and emergency planning.
- Makes cleanup, artifact cleanup, and bounded cleanup-eligible apply human output concise by summarizing skipped rows unless `--verbose` is requested.
- Adds `cleanup-artifacts --dry-run --sort=size` support so large artifact opportunities are discoverable without manually walking offset pages.

Closes #665

## Testing
- `php tests/smoke-worktree-disk-budget.php`
- `php tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-worktree-cleanup-artifacts.php`
- `php tests/smoke-worktree-lifecycle-metadata.php`
- `php -l inc/Workspace/WorktreeDiskBudget.php`
- `php -l inc/Workspace/WorkspaceWorktreeLifecycle.php`
- `php -l inc/Workspace/WorkspaceArtifactCleanup.php`
- `php -l inc/Cli/Commands/WorkspaceCommand.php`
- `php -l tests/smoke-worktree-cleanup-cli.php`
- `php -l tests/smoke-worktree-cleanup-artifacts.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspected issue #665 and existing cleanup/disk-gate code, drafted the implementation and focused regression tests, ran targeted verification, and prepared this PR for Chris to review.