### PR TITLE
Fix local primary worktree routing

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -3418,6 +3418,21 @@ class WorkspaceAbilities {
 			$task['task_ref'] = (string) $input['task_ref'];
 		}
 
+		$workspace = new Workspace();
+		if ( RemoteWorkspaceBackend::should_handle() && self::hasLocalPrimaryCheckout($workspace, (string) ( $input['repo'] ?? '' )) ) {
+			return $workspace->worktree_add(
+				$input['repo'] ?? '',
+				$input['branch'] ?? '',
+				$input['from'] ?? null,
+				$inject_context,
+				$bootstrap,
+				$allow_stale,
+				$rebase_base,
+				$force,
+				$task
+			);
+		}
+
 		if ( RemoteWorkspaceBackend::should_handle() ) {
 			$result = ( new RemoteWorkspaceBackend() )->worktree_add(
 				$input['repo'] ?? '',
@@ -3429,7 +3444,6 @@ class WorkspaceAbilities {
 			}
 		}
 
-		$workspace = new Workspace();
 		return $workspace->worktree_add(
 			$input['repo'] ?? '',
 			$input['branch'] ?? '',
@@ -3441,6 +3455,23 @@ class WorkspaceAbilities {
 			$force,
 			$task
 		);
+	}
+
+	/**
+	 * Whether a repo argument resolves to an editable local primary checkout.
+	 */
+	private static function hasLocalPrimaryCheckout( Workspace $workspace, string $repo ): bool {
+		if ( '' === trim($repo) ) {
+			return false;
+		}
+
+		$result = $workspace->show_repo($repo);
+		if ( is_wp_error($result) ) {
+			return false;
+		}
+
+		$path = (string) ( $result['path'] ?? '' );
+		return empty($result['is_worktree']) && '' !== $path && ! str_starts_with($path, 'github://');
 	}
 
 	/**

--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -3470,8 +3470,9 @@ class WorkspaceAbilities {
 			return false;
 		}
 
-		$path = (string) ( $result['path'] ?? '' );
-		return empty($result['is_worktree']) && '' !== $path && ! str_starts_with($path, 'github://');
+		$path        = (string) ( $result['path'] ?? '' );
+		$is_worktree = (bool) ( $result['is_worktree'] ?? false );
+		return ! $is_worktree && '' !== $path && ! str_starts_with($path, 'github://');
 	}
 
 	/**

--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -3470,9 +3470,8 @@ class WorkspaceAbilities {
 			return false;
 		}
 
-		$path        = (string) ( $result['path'] ?? '' );
-		$is_worktree = (bool) ( $result['is_worktree'] ?? false );
-		return ! $is_worktree && '' !== $path && ! str_starts_with($path, 'github://');
+		$path = (string) ( $result['path'] ?? '' );
+		return '' !== $path && ! str_starts_with($path, 'github://') && ! str_contains(basename($path), '@');
 	}
 
 	/**

--- a/tests/smoke-workspace-local-fallback.php
+++ b/tests/smoke-workspace-local-fallback.php
@@ -22,6 +22,7 @@ namespace DataMachineCode\Workspace {
 	{
 		public static array $show_input = array();
 		public static array $worktree_input = array();
+		public static bool $worktree_returns_remote_success = false;
 
 		public static function should_handle(): bool
 		{
@@ -37,9 +38,17 @@ namespace DataMachineCode\Workspace {
 			);
 		}
 
-		public function worktree_add( string $repo_name, string $branch, ?string $from = null ): \WP_Error
+		public function worktree_add( string $repo_name, string $branch, ?string $from = null ): array|\WP_Error
 		{
 			self::$worktree_input = compact('repo_name', 'branch', 'from');
+			if ( self::$worktree_returns_remote_success ) {
+				return array(
+					'success' => true,
+					'handle'  => $repo_name . '@' . str_replace('/', '-', $branch),
+					'path'    => 'github://Automattic/' . $repo_name . '#' . $branch,
+				);
+			}
+
 			return new \WP_Error(
 				'remote_workspace_repo_not_found',
 				'Remote workspace repository "wpcom-codebox" is not registered. Call workspace_clone first.'
@@ -156,6 +165,8 @@ namespace {
 	$assert('local show fallback attempted', 'wpcom-codebox' === ( \DataMachineCode\Workspace\Workspace::$show_input['handle'] ?? '' ));
 	$assert('show returns local listed primary', is_array($show) && '/Users/chubes/Developer/wpcom-codebox' === ( $show['path'] ?? '' ));
 
+	\DataMachineCode\Workspace\RemoteWorkspaceBackend::$worktree_returns_remote_success = true;
+	\DataMachineCode\Workspace\RemoteWorkspaceBackend::$worktree_input = array();
 	$worktree = \DataMachineCode\Abilities\WorkspaceAbilities::worktreeAdd(
 		array(
 			'repo'                 => 'wpcom-codebox',
@@ -171,12 +182,13 @@ namespace {
 		)
 	);
 
-	$assert('remote worktree add attempted first', 'wpcom-codebox' === ( \DataMachineCode\Workspace\RemoteWorkspaceBackend::$worktree_input['repo_name'] ?? '' ));
+	$assert('remote github worktree row is ignored when local primary exists', array() === \DataMachineCode\Workspace\RemoteWorkspaceBackend::$worktree_input);
 	$assert('local worktree add fallback attempted', 'wpcom-codebox' === ( \DataMachineCode\Workspace\Workspace::$worktree_input['repo'] ?? '' ));
 	$assert('worktree add preserves base ref', 'origin/main' === ( \DataMachineCode\Workspace\Workspace::$worktree_input['from'] ?? '' ));
 	$assert('worktree add preserves local options', false === ( \DataMachineCode\Workspace\Workspace::$worktree_input['inject_context'] ?? null ) && true === ( \DataMachineCode\Workspace\Workspace::$worktree_input['allow_stale'] ?? null ));
 	$assert('worktree add preserves task metadata', 'Extra-Chill/data-machine-code#635' === ( \DataMachineCode\Workspace\Workspace::$worktree_input['task']['task_ref'] ?? '' ));
 	$assert('worktree add returns local worktree result', is_array($worktree) && 'wpcom-codebox@fix-listed-primary-resolution' === ( $worktree['handle'] ?? '' ));
+	$assert('worktree add returns editable local path', is_array($worktree) && '/Users/chubes/Developer/wpcom-codebox@fix-listed-primary-resolution' === ( $worktree['path'] ?? '' ));
 
 	if ( $failures ) {
 		echo "\nFailures:\n";


### PR DESCRIPTION
## Summary
- Prefer an editable local primary checkout for `workspace worktree add` when remote workspace routing is active.
- Keep remote fallback for repos that are not present locally.
- Extend smoke coverage for the `github://` remote-success case that blocked issue #672.

Fixes #672.

## Verification
- `php -l inc/Abilities/WorkspaceAbilities.php && php -l tests/smoke-workspace-local-fallback.php`
- `php tests/smoke-workspace-local-fallback.php`
- `php tests/smoke-workspace-path-cli.php`
- `php tests/smoke-worktree-lifecycle-metadata.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the routing fix and regression smoke coverage; Chris remains responsible for review and validation.