### PR TITLE
Fix stale marker artifact cleanup

### DIFF
--- a/inc/Workspace/WorkspaceArtifactCleanup.php
+++ b/inc/Workspace/WorkspaceArtifactCleanup.php
@@ -305,10 +305,10 @@ trait WorkspaceArtifactCleanup {
 		$skipped    = array();
 
 		foreach ( $slice as $wt ) {
-			$handle          = (string) ( $wt['handle'] ?? '?' );
-			$repo            = (string) ( $wt['repo'] ?? '' );
-			$wt_path         = (string) ( $wt['path'] ?? '' );
-			$resolved_branch = '' !== $wt_path ? $this->resolve_worktree_branch_from_head_file($wt_path) : null;
+			$handle                = (string) ( $wt['handle'] ?? '?' );
+			$repo                  = (string) ( $wt['repo'] ?? '' );
+			$wt_path               = (string) ( $wt['path'] ?? '' );
+			$resolved_branch       = '' !== $wt_path ? $this->resolve_worktree_branch_from_head_file($wt_path) : null;
 			$stale_marker_recovery = null;
 			if ( $safety_probes ) {
 				$branch = (string) ( $resolved_branch ?? $wt['branch'] ?? $wt['branch_slug'] ?? '' );

--- a/inc/Workspace/WorkspaceArtifactCleanup.php
+++ b/inc/Workspace/WorkspaceArtifactCleanup.php
@@ -309,6 +309,7 @@ trait WorkspaceArtifactCleanup {
 			$repo            = (string) ( $wt['repo'] ?? '' );
 			$wt_path         = (string) ( $wt['path'] ?? '' );
 			$resolved_branch = '' !== $wt_path ? $this->resolve_worktree_branch_from_head_file($wt_path) : null;
+			$stale_marker_recovery = null;
 			if ( $safety_probes ) {
 				$branch = (string) ( $resolved_branch ?? $wt['branch'] ?? $wt['branch_slug'] ?? '' );
 			} else {
@@ -381,14 +382,20 @@ trait WorkspaceArtifactCleanup {
 					$dirty_probe = $this->probe_worktree_dirty_count($wt_path, self::CLEANUP_GIT_PROBE_TIMEOUT);
 					if ( is_wp_error($dirty_probe) ) {
 						$diagnostic = $this->classify_worktree_git_probe_failure($handle, $repo, $wt_path, $dirty_probe, 'artifact cleanup dirty-state probe', 'leaving artifacts in place');
-						$skipped[]  = array_merge(
-							$base_row,
-							$diagnostic,
-							array( 'artifacts' => $artifacts )
-						);
-						continue;
+						if ( $force && $this->is_stale_worktree_marker_diagnostic($diagnostic) ) {
+							$stale_marker_recovery = $diagnostic;
+							$dirty_count           = 0;
+						} else {
+							$skipped[] = array_merge(
+								$base_row,
+								$diagnostic,
+								array( 'artifacts' => $artifacts )
+							);
+							continue;
+						}
+					} else {
+						$dirty_count = (int) $dirty_probe;
 					}
-					$dirty_count = (int) $dirty_probe;
 				}
 				if ( $dirty_count > 0 && ! $force ) {
 					$skipped[] = array_merge(
@@ -402,26 +409,32 @@ trait WorkspaceArtifactCleanup {
 					continue;
 				}
 
-				$unpushed = $this->count_unpushed_commits($wt_path, self::CLEANUP_GIT_PROBE_TIMEOUT);
-				if ( is_wp_error($unpushed) ) {
-					$diagnostic = $this->classify_worktree_git_probe_failure($handle, $repo, $wt_path, $unpushed, 'artifact cleanup safety probe', 'leaving artifacts in place');
-					$skipped[]  = array_merge(
-						$base_row,
-						$diagnostic,
-						array( 'artifacts' => $artifacts )
-					);
-					continue;
-				}
-				if ( $unpushed > 0 && ! $force ) {
-					$skipped[] = array_merge(
-						$base_row, array(
-							'reason_code' => 'unpushed_commits',
-							'reason'      => sprintf('%d unpushed commit(s) - pass force=true to override artifact cleanup only', $unpushed),
-							'unpushed'    => $unpushed,
-							'artifacts'   => $artifacts,
-						)
-					);
-					continue;
+				if ( null === $stale_marker_recovery ) {
+					$unpushed = $this->count_unpushed_commits($wt_path, self::CLEANUP_GIT_PROBE_TIMEOUT);
+					if ( is_wp_error($unpushed) ) {
+						$diagnostic = $this->classify_worktree_git_probe_failure($handle, $repo, $wt_path, $unpushed, 'artifact cleanup safety probe', 'leaving artifacts in place');
+						if ( $force && $this->is_stale_worktree_marker_diagnostic($diagnostic) ) {
+							$stale_marker_recovery = $diagnostic;
+						} else {
+							$skipped[] = array_merge(
+								$base_row,
+								$diagnostic,
+								array( 'artifacts' => $artifacts )
+							);
+							continue;
+						}
+					}
+					if ( isset($unpushed) && ! is_wp_error($unpushed) && $unpushed > 0 && ! $force ) {
+						$skipped[] = array_merge(
+							$base_row, array(
+								'reason_code' => 'unpushed_commits',
+								'reason'      => sprintf('%d unpushed commit(s) - pass force=true to override artifact cleanup only', $unpushed),
+								'unpushed'    => $unpushed,
+								'artifacts'   => $artifacts,
+							)
+						);
+						continue;
+					}
 				}
 			}
 
@@ -440,6 +453,12 @@ trait WorkspaceArtifactCleanup {
 				// before deletion, so the candidate is reviewable but not
 				// destructible from a bounded plan alone.
 				$candidate['safety_probes_deferred'] = true;
+			}
+			if ( null !== $stale_marker_recovery ) {
+				$candidate['reason_code']                  = 'profile_artifacts_stale_worktree_marker';
+				$candidate['reason']                       = 'profile-derived reconstructable artifacts can be removed; git worktree marker is stale, but explicit force allows artifact-only cleanup after path containment validation';
+				$candidate['git_metadata_warning']         = $stale_marker_recovery['reason'] ?? 'git worktree metadata marker is stale or missing';
+				$candidate['metadata_reconciliation_hint'] = 'Run studio wp datamachine-code workspace worktree reconcile-metadata --dry-run --limit=25 --offset=0 --until-budget=30s --format=json to repair stale worktree metadata after artifact cleanup.';
 			}
 			$candidates[] = $candidate;
 		}
@@ -516,6 +535,16 @@ trait WorkspaceArtifactCleanup {
 			'removed_size_bytes'     => $removed_bytes,
 			'artifact_size_by_repo'  => $artifact_by_repo,
 		);
+	}
+
+	/**
+	 * Check whether a git probe diagnostic represents stale worktree metadata.
+	 *
+	 * @param  array<string,mixed> $diagnostic Classified git probe diagnostic.
+	 * @return bool
+	 */
+	private function is_stale_worktree_marker_diagnostic( array $diagnostic ): bool {
+		return 'stale_worktree_marker' === (string) ( $diagnostic['reason_code'] ?? '' );
 	}
 
 	/**

--- a/tests/smoke-worktree-cleanup-artifacts.php
+++ b/tests/smoke-worktree-cleanup-artifacts.php
@@ -193,6 +193,11 @@ namespace {
     $run('git add local.txt && git commit -m local', $tmp . '/demo@unpushed');
     symlink($tmp . '/demo@active', $site_tmp . '/wp-content/plugins/demo-active');
 
+    mkdir($tmp . '/demo@broken-marker/target', 0755, true);
+    file_put_contents($tmp . '/demo@broken-marker/.git', 'gitdir: ' . $primary . '/.git/worktrees/demo@broken-marker' . "\n");
+    file_put_contents($tmp . '/demo@broken-marker/Cargo.toml', "[package]\nname = \"demo\"\nversion = \"0.1.0\"\n");
+    file_put_contents($tmp . '/demo@broken-marker/target/artifact.bin', str_repeat('broken', 128));
+
     $workspace = new \DataMachineCode\Workspace\Workspace();
 
     echo "=== smoke-worktree-cleanup-artifacts ===\n";
@@ -218,6 +223,7 @@ namespace {
     $assert(true, in_array('demo@clean', $bounded_handles, true), 'bounded dry-run surfaces clean worktree');
     $assert(true, in_array('demo@dirty', $bounded_handles, true), 'bounded dry-run surfaces dirty worktree (deferred safety probes)');
     $assert(true, in_array('demo@unpushed', $bounded_handles, true), 'bounded dry-run surfaces unpushed worktree (deferred safety probes)');
+    $assert(true, in_array('demo@broken-marker', $bounded_handles, true), 'bounded dry-run surfaces stale-marker worktree for artifact review');
     foreach ( $plan['candidates'] ?? array() as $candidate ) {
         $assert(true, (bool) ( $candidate['safety_probes_deferred'] ?? false ), 'bounded candidate ' . ( $candidate['handle'] ?? '?' ) . ' is flagged safety_probes_deferred');
     }
@@ -301,18 +307,32 @@ namespace {
     $assert(false, is_dir($tmp . '/demo@clean/target'), 'apply-plan removes clean artifact directory');
     $assert(true, is_dir($tmp . '/demo@dirty/target'), 'apply-plan revalidation skips dirty worktree even when bounded plan flagged it');
     $assert(true, is_dir($tmp . '/demo@unpushed/target'), 'apply-plan revalidation skips unpushed worktree even when bounded plan flagged it');
+    $assert(true, is_dir($tmp . '/demo@broken-marker/target'), 'apply-plan revalidation skips stale-marker worktree without force');
     $assert(true, is_dir($tmp . '/demo@clean'), 'apply-plan leaves worktree directory in place');
 
     $apply_skip_reasons = array_column($apply['skipped'] ?? array(), 'reason_code', 'handle');
     $assert('dirty_worktree', $apply_skip_reasons['demo@dirty'] ?? '', 'apply-plan revalidation skips dirty rows with explicit reason');
     $assert('unpushed_commits', $apply_skip_reasons['demo@unpushed'] ?? '', 'apply-plan revalidation skips unpushed rows with explicit reason');
+    $assert('stale_worktree_marker', $apply_skip_reasons['demo@broken-marker'] ?? '', 'apply-plan revalidation gives stale marker recovery reason without force');
 
-    $force_plan = $workspace->worktree_cleanup_artifacts(array( 'dry_run' => true, 'exhaustive' => true, 'force' => true ));
+    $force_plan = $workspace->worktree_cleanup_artifacts(array( 'dry_run' => true, 'safety_probes' => true, 'force' => true ));
     $force_handles = array_column($force_plan['candidates'] ?? array(), 'handle');
-    $assert(true, in_array('demo@dirty', $force_handles, true), 'force permits dirty artifact candidate (exhaustive)');
-    $assert(true, in_array('demo@unpushed', $force_handles, true), 'force permits unpushed artifact candidate (exhaustive)');
+    $assert(true, in_array('demo@dirty', $force_handles, true), 'force permits dirty artifact candidate with bounded safety probes');
+    $assert(true, in_array('demo@unpushed', $force_handles, true), 'force permits unpushed artifact candidate with bounded safety probes');
+    $assert(true, in_array('demo@broken-marker', $force_handles, true), 'force permits stale-marker artifact candidate when path safety is validated');
+    $force_by_handle = array_column($force_plan['candidates'] ?? array(), null, 'handle');
     $force_skip_reasons = array_column($force_plan['skipped'] ?? array(), 'reason_code', 'handle');
     $assert('active_symlink_target', $force_skip_reasons['demo@active'] ?? '', 'force still protects active symlink target');
+
+    $broken_force_plan = array( 'candidates' => array( $force_by_handle['demo@broken-marker'] ?? array() ) );
+    $broken_force_apply = $workspace->worktree_cleanup_artifacts(array( 'apply_plan' => $broken_force_plan, 'force' => true ));
+    $assert(false, is_wp_error($broken_force_apply), 'force apply-plan for stale-marker artifact returns report');
+    $assert(1, (int) ( $broken_force_apply['summary']['removed_artifacts'] ?? 0 ), 'force apply-plan removes stale-marker reconstructable artifact');
+    $removed_by_handle = array_column($broken_force_apply['removed'] ?? array(), null, 'handle');
+    $assert('profile_artifacts_stale_worktree_marker', $removed_by_handle['demo@broken-marker']['reason_code'] ?? '', 'force apply-plan records explicit stale-marker recovery reason');
+    $assert(true, str_contains($removed_by_handle['demo@broken-marker']['metadata_reconciliation_hint'] ?? '', 'reconcile-metadata --dry-run'), 'force apply-plan points to metadata reconciliation after removal');
+    $assert(false, is_dir($tmp . '/demo@broken-marker/target'), 'force apply-plan removes stale-marker artifact directory');
+    $assert(true, is_dir($tmp . '/demo@broken-marker'), 'force apply-plan leaves stale-marker worktree directory in place');
 
     if ($failures > 0 ) {
         echo "\nFAILURES: {$failures}/{$total}\n";


### PR DESCRIPTION
## Summary
- Allows forced artifact cleanup to recover from stale `git worktree` marker metadata when the worktree path and reconstructable artifact path containment can still be validated.
- Keeps non-force artifact cleanup and whole-worktree cleanup blocked with `stale_worktree_marker` so source worktree safety remains explicit.
- Adds focused smoke coverage proving stale-marker artifacts are skipped without force, removed with forced apply-plan, and report the metadata reconciliation command afterward.

Fixes #676.

## Verification
- `php -l inc/Workspace/WorkspaceArtifactCleanup.php`
- `php -l tests/smoke-worktree-cleanup-artifacts.php`
- `php tests/smoke-worktree-cleanup-artifacts.php`
- `php tests/smoke-worktree-cleanup-cli.php`

Known existing broader smoke drift observed separately:
- `php tests/smoke-worktree-cleanup.php` currently reports duplicate-count assertion failures in dirty/external cleanup buckets (`152/161 passed`). This does not touch the artifact stale-marker path covered above.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the artifact cleanup stale-marker recovery implementation, added focused smoke-test coverage, and ran targeted verification. Chris remains responsible for review and merge.