### PR TITLE
Improve cleanup plan summary

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1387,7 +1387,7 @@ class WorkspaceCommand extends BaseCommand {
 		}
 		WP_CLI::log('');
 		WP_CLI::log($label);
-		$rows   = array();
+		$rows = array();
 		foreach ( $reasons as $reason => $bucket ) {
 			$bucket   = (array) $bucket;
 			$examples = array_map(fn( $row ) => is_array($row) ? (string) ( $row['handle'] ?? '' ) : (string) $row, (array) ( $bucket['examples'] ?? array() ));
@@ -1442,7 +1442,7 @@ class WorkspaceCommand extends BaseCommand {
 			'build_outputs'        => 'build outputs',
 			'caches'               => 'caches',
 		);
-		$rows = array();
+		$rows   = array();
 		foreach ( $labels as $category => $label ) {
 			$rows[] = array(
 				'category' => $label,

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -600,6 +600,10 @@ class WorkspaceCommand extends BaseCommand {
 	 * [--older-than=<duration>]
 	 * : Pass an age gate such as 7d or 24h into cleanup task params.
 	 *
+	 * [--top=<count>]
+	 * : For `plan`, number of largest reclaimable paths to show in the upfront
+	 *   summary. Defaults to 10.
+	 *
 	 * [--limit=<count>]
 	 * : For DB-backed `apply` / `resume`, maximum pending rows to process in this
 	 *   invocation (default 25, max 100). For `--mode=artifacts` pages, maximum
@@ -941,6 +945,9 @@ class WorkspaceCommand extends BaseCommand {
 		);
 		if ( isset($assoc_args['older-than']) && '' !== trim( (string) $assoc_args['older-than']) ) {
 			$input['worktree_older_than'] = trim( (string) $assoc_args['older-than']);
+		}
+		if ( isset($assoc_args['top']) ) {
+			$input['top_n'] = (int) $assoc_args['top'];
 		}
 		if ( isset($assoc_args['force']) ) {
 			$input['force_artifact_cleanup'] = (bool) $assoc_args['force'];
@@ -1399,10 +1406,129 @@ class WorkspaceCommand extends BaseCommand {
 		WP_CLI::log(sprintf('Rows:   %d', (int) ( $summary['total_rows'] ?? 0 )));
 		WP_CLI::log(sprintf('Bytes:  %s', $this->format_bytes($summary['total_size_bytes'] ?? 0)));
 		WP_CLI::log(sprintf('Apply:  wp datamachine-code workspace cleanup apply %s', (string) ( $result['run_id'] ?? '' )));
+		$this->render_cleanup_plan_category_totals( (array) ( $summary['category_totals'] ?? array() ) );
+		$this->render_cleanup_plan_top_reclaimable( (array) ( $summary['top_reclaimable'] ?? array() ) );
+		$this->render_cleanup_plan_blockers( (array) ( $summary['blockers'] ?? array() ) );
+		$this->render_cleanup_plan_recommended_commands( (array) ( $summary['recommended_commands'] ?? array() ), (string) ( $result['run_id'] ?? '' ) );
 		$inputs = (array) ( $result['inputs'] ?? array() );
 		if ( empty($inputs['include_artifacts']) ) {
 			WP_CLI::log('Artifacts: skipped for bounded retention planning; run `wp datamachine-code workspace cleanup plan --mode=artifacts` when you want artifact rows.');
 		}
+	}
+
+	/**
+	 * Render reclaimable cleanup bytes by category.
+	 *
+	 * @param array<string,int> $totals Category totals.
+	 */
+	private function render_cleanup_plan_category_totals( array $totals ): void {
+		if ( array() === $totals ) {
+			return;
+		}
+
+		WP_CLI::log('');
+		WP_CLI::log('Reclaimable space by category:');
+		$labels = array(
+			'whole_worktrees'      => 'whole worktrees',
+			'dependency_artifacts' => 'dependency artifacts',
+			'build_outputs'        => 'build outputs',
+			'caches'               => 'caches',
+		);
+		$rows = array();
+		foreach ( $labels as $category => $label ) {
+			$rows[] = array(
+				'category' => $label,
+				'bytes'    => $this->format_bytes($totals[ $category ] ?? 0),
+			);
+		}
+		$this->format_items($rows, array( 'category', 'bytes' ), array( 'format' => 'table' ), 'category');
+	}
+
+	/**
+	 * Render largest reclaimable paths.
+	 *
+	 * @param array<int,array<string,mixed>> $paths Top paths.
+	 */
+	private function render_cleanup_plan_top_reclaimable( array $paths ): void {
+		if ( array() === $paths ) {
+			return;
+		}
+
+		WP_CLI::log('');
+		WP_CLI::log('Top reclaimable paths:');
+		$rows = array_map(
+			fn( $row ) => array(
+				'size'     => is_array($row) ? $this->format_bytes($row['size_bytes'] ?? 0) : '0 B',
+				'category' => is_array($row) ? (string) ( $row['category'] ?? '' ) : '',
+				'risk'     => is_array($row) ? (string) ( $row['safety_class'] ?? '' ) : '',
+				'handle'   => is_array($row) ? (string) ( $row['handle'] ?? '' ) : '',
+				'path'     => is_array($row) ? (string) ( $row['path'] ?? '' ) : '',
+			),
+			$paths
+		);
+		$this->format_items($rows, array( 'size', 'category', 'risk', 'handle', 'path' ), array( 'format' => 'table' ), 'size');
+	}
+
+	/**
+	 * Render blockers grouped by reason and repo.
+	 *
+	 * @param array<string,array<string,mixed>> $blockers Blocker buckets.
+	 */
+	private function render_cleanup_plan_blockers( array $blockers ): void {
+		if ( array() === $blockers ) {
+			return;
+		}
+
+		WP_CLI::log('');
+		WP_CLI::log('Blockers by reason and repo:');
+		$rows = array();
+		foreach ( $blockers as $reason => $bucket ) {
+			$bucket = (array) $bucket;
+			$repos  = array();
+			foreach ( (array) ( $bucket['repos'] ?? array() ) as $repo => $repo_bucket ) {
+				$repo_bucket = (array) $repo_bucket;
+				$repos[]     = sprintf('%s=%d', (string) $repo, (int) ( $repo_bucket['count'] ?? 0 ));
+			}
+			$rows[] = array(
+				'reason'   => (string) $reason,
+				'count'    => (int) ( $bucket['count'] ?? 0 ),
+				'bytes'    => $this->format_bytes($bucket['size_bytes'] ?? 0),
+				'repos'    => implode(', ', array_slice($repos, 0, 5)),
+				'examples' => implode(', ', array_slice(array_map('strval', (array) ( $bucket['examples'] ?? array() )), 0, 5)),
+			);
+		}
+		$this->format_items($rows, array( 'reason', 'count', 'bytes', 'repos', 'examples' ), array( 'format' => 'table' ), 'reason');
+	}
+
+	/**
+	 * Render directly executable recommended cleanup commands.
+	 *
+	 * @param array<int,array<string,string>> $commands Recommended commands.
+	 * @param string                          $run_id   Cleanup run ID.
+	 */
+	private function render_cleanup_plan_recommended_commands( array $commands, string $run_id ): void {
+		if ( array() === $commands ) {
+			return;
+		}
+
+		WP_CLI::log('');
+		WP_CLI::log('Recommended commands:');
+		$rows = array_map(
+			function ( $row ) use ( $run_id ): array {
+				$row     = (array) $row;
+				$command = (string) ( $row['command'] ?? '' );
+				if ( '' !== $run_id ) {
+					$command = str_replace('<run-id>', $run_id, $command);
+				}
+				return array(
+					'label'   => (string) ( $row['label'] ?? '' ),
+					'risk'    => (string) ( $row['risk'] ?? '' ),
+					'command' => $command,
+				);
+			},
+			$commands
+		);
+		$this->format_items($rows, array( 'label', 'risk', 'command' ), array( 'format' => 'table' ), 'label');
 	}
 
 	private function cleanup_run_id( int $job_id ): string {

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -781,11 +781,11 @@ class WorkspaceCommand extends BaseCommand {
 		}
 
 		$result['commands'] = array(
-			'drain_parent'        => sprintf('studio wp datamachine drain --job-id=%d', $job_id),
-			'status'              => sprintf('studio wp datamachine-code workspace cleanup status %s --format=json', $run_id),
-			'status_verbose'      => sprintf('studio wp datamachine-code workspace cleanup status %s --verbose --format=json', $run_id),
-			'one_command_drain'   => sprintf('studio wp datamachine-code workspace cleanup run --mode=%s --drain --format=json', $mode),
-			'bytes_verification'  => sprintf('studio wp datamachine-code workspace cleanup status %s --format=json', $run_id),
+			'drain_parent'       => sprintf('studio wp datamachine drain --job-id=%d', $job_id),
+			'status'             => sprintf('studio wp datamachine-code workspace cleanup status %s --format=json', $run_id),
+			'status_verbose'     => sprintf('studio wp datamachine-code workspace cleanup status %s --verbose --format=json', $run_id),
+			'one_command_drain'  => sprintf('studio wp datamachine-code workspace cleanup run --mode=%s --drain --format=json', $mode),
+			'bytes_verification' => sprintf('studio wp datamachine-code workspace cleanup status %s --format=json', $run_id),
 		);
 
 		return $result;
@@ -809,8 +809,8 @@ class WorkspaceCommand extends BaseCommand {
 			return $result;
 		}
 
-		$commands = array();
-		$errors   = array();
+		$commands   = array();
+		$errors     = array();
 		$max_passes = 10;
 
 		$parent_command = sprintf('datamachine drain --job-id=%d', $job_id);
@@ -827,7 +827,7 @@ class WorkspaceCommand extends BaseCommand {
 				break;
 			}
 
-			$children = (array) ( $status['evidence']['children'] ?? array() );
+			$children         = (array) ( $status['evidence']['children'] ?? array() );
 			$active_child_ids = array_values(
 				array_unique(
 					array_filter(
@@ -854,17 +854,17 @@ class WorkspaceCommand extends BaseCommand {
 			}
 		}
 
-		$final = $this->cleanup_run_evidence_store()->read($run_id, false, ! empty($assoc_args['verbose']));
-		$output = $final instanceof \WP_Error ? $result : $final;
+		$final                 = $this->cleanup_run_evidence_store()->read($run_id, false, ! empty($assoc_args['verbose']));
+		$output                = $final instanceof \WP_Error ? $result : $final;
 		$output['initial_run'] = $result;
 		$output['drain']       = array(
-			'success'           => array() === $errors,
-			'commands'          => $commands,
-			'errors'            => $errors,
-			'verify_command'    => sprintf('studio wp datamachine-code workspace cleanup status %s --format=json', $run_id),
-			'bytes_reclaimed'   => (int) ( $output['cleanup_items']['bytes_reclaimed'] ?? 0 ),
-			'freed_human'       => (string) ( $output['cleanup_items']['freed_human'] ?? $this->format_bytes(0) ),
-			'completion_state'  => (string) ( $output['state'] ?? 'unknown' ),
+			'success'          => array() === $errors,
+			'commands'         => $commands,
+			'errors'           => $errors,
+			'verify_command'   => sprintf('studio wp datamachine-code workspace cleanup status %s --format=json', $run_id),
+			'bytes_reclaimed'  => (int) ( $output['cleanup_items']['bytes_reclaimed'] ?? 0 ),
+			'freed_human'      => (string) ( $output['cleanup_items']['freed_human'] ?? $this->format_bytes(0) ),
+			'completion_state' => (string) ( $output['state'] ?? 'unknown' ),
 		);
 
 		return $output;
@@ -877,10 +877,6 @@ class WorkspaceCommand extends BaseCommand {
 	 * @return string Empty string on success.
 	 */
 	private function run_wp_cli_command( string $command ): string {
-		if ( ! method_exists('WP_CLI', 'runcommand') ) {
-			return 'WP_CLI::runcommand is unavailable; run the reported drain commands manually.';
-		}
-
 		try {
 			WP_CLI::runcommand(
 				$command,
@@ -1317,10 +1313,22 @@ class WorkspaceCommand extends BaseCommand {
 		WP_CLI::log('Drain summary:');
 		$this->format_items(
 			array(
-				array( 'metric' => 'success', 'value' => ! empty($drain['success']) ? 'yes' : 'no' ),
-				array( 'metric' => 'completion_state', 'value' => (string) ( $drain['completion_state'] ?? 'unknown' ) ),
-				array( 'metric' => 'bytes_reclaimed', 'value' => $this->format_bytes($drain['bytes_reclaimed'] ?? 0) ),
-				array( 'metric' => 'verify_command', 'value' => (string) ( $drain['verify_command'] ?? '' ) ),
+				array(
+					'metric' => 'success',
+					'value'  => ! empty($drain['success']) ? 'yes' : 'no',
+				),
+				array(
+					'metric' => 'completion_state',
+					'value'  => (string) ( $drain['completion_state'] ?? 'unknown' ),
+				),
+				array(
+					'metric' => 'bytes_reclaimed',
+					'value'  => $this->format_bytes($drain['bytes_reclaimed'] ?? 0),
+				),
+				array(
+					'metric' => 'verify_command',
+					'value'  => (string) ( $drain['verify_command'] ?? '' ),
+				),
 			),
 			array( 'metric', 'value' ),
 			array( 'format' => 'table' ),
@@ -1379,7 +1387,7 @@ class WorkspaceCommand extends BaseCommand {
 		}
 		WP_CLI::log('');
 		WP_CLI::log($label);
-		$rows = array();
+		$rows   = array();
 		foreach ( $reasons as $reason => $bucket ) {
 			$bucket   = (array) $bucket;
 			$examples = array_map(fn( $row ) => is_array($row) ? (string) ( $row['handle'] ?? '' ) : (string) $row, (array) ( $bucket['examples'] ?? array() ));
@@ -1458,11 +1466,11 @@ class WorkspaceCommand extends BaseCommand {
 		WP_CLI::log('Top reclaimable paths:');
 		$rows = array_map(
 			fn( $row ) => array(
-				'size'     => is_array($row) ? $this->format_bytes($row['size_bytes'] ?? 0) : '0 B',
-				'category' => is_array($row) ? (string) ( $row['category'] ?? '' ) : '',
-				'risk'     => is_array($row) ? (string) ( $row['safety_class'] ?? '' ) : '',
-				'handle'   => is_array($row) ? (string) ( $row['handle'] ?? '' ) : '',
-				'path'     => is_array($row) ? (string) ( $row['path'] ?? '' ) : '',
+				'size'     => $this->format_bytes($row['size_bytes'] ?? 0),
+				'category' => (string) ( $row['category'] ?? '' ),
+				'risk'     => (string) ( $row['safety_class'] ?? '' ),
+				'handle'   => (string) ( $row['handle'] ?? '' ),
+				'path'     => (string) ( $row['path'] ?? '' ),
 			),
 			$paths
 		);

--- a/inc/Workspace/CleanupRunService.php
+++ b/inc/Workspace/CleanupRunService.php
@@ -14,8 +14,8 @@ defined('ABSPATH') || exit;
 
 class CleanupRunService {
 
-	private const DEFAULT_APPLY_LIMIT        = 25;
-	private const MAX_APPLY_LIMIT            = 100;
+	private const DEFAULT_APPLY_LIMIT = 25;
+	private const MAX_APPLY_LIMIT     = 100;
 
 
 
@@ -136,9 +136,12 @@ class CleanupRunService {
 					'limit'      => count($artifact_batch),
 				)
 			);
+			if ( $results['artifact_cleanup'] instanceof \WP_Error ) {
+				return $results['artifact_cleanup'];
+			}
 			$this->record_apply_result($artifact_batch, $results['artifact_cleanup'], 'removed');
-			$applied_rows += count((array) ( $results['artifact_cleanup']['removed'] ?? array() ));
-			$skipped_rows += count((array) ( $results['artifact_cleanup']['skipped'] ?? array() ));
+			$applied_rows += count( (array) ( $results['artifact_cleanup']['removed'] ?? array() ) );
+			$skipped_rows += count( (array) ( $results['artifact_cleanup']['skipped'] ?? array() ) );
 		}
 
 		$remaining_capacity = max(0, $limit - $processed_rows);
@@ -154,9 +157,12 @@ class CleanupRunService {
 					'skip_github'       => true,
 				)
 			);
+			if ( $results['worktree_removal'] instanceof \WP_Error ) {
+				return $results['worktree_removal'];
+			}
 			$this->record_apply_result($worktree_batch, $results['worktree_removal'], 'removed');
-			$applied_rows += count((array) ( $results['worktree_removal']['removed'] ?? array() ));
-			$skipped_rows += count((array) ( $results['worktree_removal']['skipped'] ?? array() ));
+			$applied_rows += count( (array) ( $results['worktree_removal']['removed'] ?? array() ) );
+			$skipped_rows += count( (array) ( $results['worktree_removal']['skipped'] ?? array() ) );
 		}
 
 		$status          = $this->status($run_id);

--- a/inc/Workspace/CleanupRunService.php
+++ b/inc/Workspace/CleanupRunService.php
@@ -53,6 +53,8 @@ class CleanupRunService {
 		if ( $run_id instanceof \WP_Error ) {
 			return $run_id;
 		}
+		$plan['summary'] = $this->materialize_plan_recommended_commands( (array) ( $plan['summary'] ?? array() ), $run_id );
+		$this->repository->update_run($run_id, array( 'summary' => $plan['summary'] ));
 
 		$inserted = $this->repository->add_items($run_id, $items);
 		if ( $inserted instanceof \WP_Error ) {
@@ -68,6 +70,26 @@ class CleanupRunService {
 		);
 
 		return $plan;
+	}
+
+	/**
+	 * Replace run-id placeholders in persisted plan command recommendations.
+	 *
+	 * @param  array<string,mixed> $summary Plan summary.
+	 * @param  string              $run_id  Cleanup run ID.
+	 * @return array<string,mixed>
+	 */
+	private function materialize_plan_recommended_commands( array $summary, string $run_id ): array {
+		$commands = array();
+		foreach ( (array) ( $summary['recommended_commands'] ?? array() ) as $row ) {
+			if ( ! is_array($row) ) {
+				continue;
+			}
+			$row['command'] = str_replace('<run-id>', $run_id, (string) ( $row['command'] ?? '' ));
+			$commands[]     = $row;
+		}
+		$summary['recommended_commands'] = $commands;
+		return $summary;
 	}
 
 	/**

--- a/inc/Workspace/WorkspaceCleanupPlan.php
+++ b/inc/Workspace/WorkspaceCleanupPlan.php
@@ -284,13 +284,13 @@ trait WorkspaceCleanupPlan {
 		$category_total  = array_sum(array_map('intval', $category_totals));
 
 		return array(
-			'total_rows'       => $total_rows,
-			'rows_by_type'     => $counts,
-			'byte_totals'      => $byte_totals,
-			'total_size_bytes' => $category_total > 0 ? $category_total : $total_bytes,
-			'category_totals'  => $category_totals,
-			'top_reclaimable'  => $this->cleanup_plan_top_reclaimable_paths($rows, (int) ( $inputs['top_n'] ?? 10 )),
-			'blockers'         => $this->cleanup_plan_blockers($artifact_plan, $worktree_plan),
+			'total_rows'           => $total_rows,
+			'rows_by_type'         => $counts,
+			'byte_totals'          => $byte_totals,
+			'total_size_bytes'     => $category_total > 0 ? $category_total : $total_bytes,
+			'category_totals'      => $category_totals,
+			'top_reclaimable'      => $this->cleanup_plan_top_reclaimable_paths($rows, (int) ( $inputs['top_n'] ?? 10 )),
+			'blockers'             => $this->cleanup_plan_blockers($artifact_plan, $worktree_plan),
 			'recommended_commands' => $this->cleanup_plan_recommended_commands($inputs),
 		);
 	}
@@ -303,10 +303,10 @@ trait WorkspaceCleanupPlan {
 	 */
 	private function cleanup_plan_category_totals( array $rows ): array {
 		$totals = array(
-			'whole_worktrees'       => 0,
-			'dependency_artifacts'  => 0,
-			'build_outputs'         => 0,
-			'caches'                => 0,
+			'whole_worktrees'      => 0,
+			'dependency_artifacts' => 0,
+			'build_outputs'        => 0,
+			'caches'               => 0,
 		);
 
 		foreach ( (array) ( $rows['worktree_removal'] ?? array() ) as $row ) {
@@ -320,7 +320,7 @@ trait WorkspaceCleanupPlan {
 				if ( ! is_array($artifact) ) {
 					continue;
 				}
-				$category            = $this->cleanup_artifact_category( (string) ( $artifact['path'] ?? '' ));
+				$category             = $this->cleanup_artifact_category( (string) ( $artifact['path'] ?? '' ));
 				$totals[ $category ] += max(0, (int) ( $artifact['size_bytes'] ?? 0 ));
 			}
 		}
@@ -361,13 +361,13 @@ trait WorkspaceCleanupPlan {
 				continue;
 			}
 			$paths[] = array(
-				'path'          => (string) ( $row['path'] ?? '' ),
-				'handle'        => (string) ( $row['handle'] ?? '' ),
-				'repo'          => (string) ( $row['repo'] ?? '' ),
-				'category'      => 'whole_worktrees',
-				'row_type'      => 'worktree_removal',
-				'safety_class'  => (string) ( $row['safety_class'] ?? 'reviewed_destructive' ),
-				'size_bytes'    => max(0, (int) ( $row['size_bytes'] ?? 0 )),
+				'path'         => (string) ( $row['path'] ?? '' ),
+				'handle'       => (string) ( $row['handle'] ?? '' ),
+				'repo'         => (string) ( $row['repo'] ?? '' ),
+				'category'     => 'whole_worktrees',
+				'row_type'     => 'worktree_removal',
+				'safety_class' => (string) ( $row['safety_class'] ?? 'reviewed_destructive' ),
+				'size_bytes'   => max(0, (int) ( $row['size_bytes'] ?? 0 )),
 			);
 		}
 
@@ -380,13 +380,13 @@ trait WorkspaceCleanupPlan {
 					continue;
 				}
 				$paths[] = array(
-					'path'          => (string) ( $artifact['path'] ?? '' ),
-					'handle'        => (string) ( $row['handle'] ?? '' ),
-					'repo'          => (string) ( $row['repo'] ?? '' ),
-					'category'      => $this->cleanup_artifact_category( (string) ( $artifact['path'] ?? '' )),
-					'row_type'      => 'artifact_cleanup',
-					'safety_class'  => (string) ( $row['safety_class'] ?? 'safe' ),
-					'size_bytes'    => max(0, (int) ( $artifact['size_bytes'] ?? 0 )),
+					'path'         => (string) ( $artifact['path'] ?? '' ),
+					'handle'       => (string) ( $row['handle'] ?? '' ),
+					'repo'         => (string) ( $row['repo'] ?? '' ),
+					'category'     => $this->cleanup_artifact_category( (string) ( $artifact['path'] ?? '' )),
+					'row_type'     => 'artifact_cleanup',
+					'safety_class' => (string) ( $row['safety_class'] ?? 'safe' ),
+					'size_bytes'   => max(0, (int) ( $artifact['size_bytes'] ?? 0 )),
 				);
 			}
 		}
@@ -404,7 +404,10 @@ trait WorkspaceCleanupPlan {
 	 */
 	private function cleanup_plan_blockers( array $artifact_plan, array $worktree_plan ): array {
 		$blockers = array();
-		foreach ( array( 'artifact_cleanup' => $artifact_plan, 'worktree_removal' => $worktree_plan ) as $type => $plan ) {
+		foreach ( array(
+			'artifact_cleanup' => $artifact_plan,
+			'worktree_removal' => $worktree_plan,
+		) as $type => $plan ) {
 			foreach ( (array) ( $plan['skipped'] ?? array() ) as $row ) {
 				if ( ! is_array($row) ) {
 					continue;
@@ -414,21 +417,21 @@ trait WorkspaceCleanupPlan {
 				if ( '' === $repo ) {
 					$repo = 'unknown';
 				}
-				$bytes = max(0, (int) ( $row['artifact_size_bytes'] ?? $row['size_bytes'] ?? 0 ));
-				$blockers[ $reason ] ??= array(
+				$bytes                                   = max(0, (int) ( $row['artifact_size_bytes'] ?? $row['size_bytes'] ?? 0 ));
+				$blockers[ $reason ]                   ??= array(
 					'count'      => 0,
 					'size_bytes' => 0,
 					'repos'      => array(),
 					'examples'   => array(),
 				);
-				$blockers[ $reason ]['count']      = (int) $blockers[ $reason ]['count'] + 1;
-				$blockers[ $reason ]['size_bytes'] += $bytes;
+				$blockers[ $reason ]['count']            = (int) $blockers[ $reason ]['count'] + 1;
+				$blockers[ $reason ]['size_bytes']      += $bytes;
 				$blockers[ $reason ]['repos'][ $repo ] ??= array(
 					'count'      => 0,
 					'size_bytes' => 0,
 					'examples'   => array(),
 				);
-				$blockers[ $reason ]['repos'][ $repo ]['count']      = (int) $blockers[ $reason ]['repos'][ $repo ]['count'] + 1;
+				$blockers[ $reason ]['repos'][ $repo ]['count']       = (int) $blockers[ $reason ]['repos'][ $repo ]['count'] + 1;
 				$blockers[ $reason ]['repos'][ $repo ]['size_bytes'] += $bytes;
 				if ( count($blockers[ $reason ]['examples']) < 5 ) {
 					$blockers[ $reason ]['examples'][] = (string) ( $row['handle'] ?? $row['path'] ?? '' );
@@ -439,9 +442,21 @@ trait WorkspaceCleanupPlan {
 			}
 		}
 
-		uasort($blockers, fn( $a, $b ) => (int) ( $b['size_bytes'] ?? 0 ) <=> (int) ( $a['size_bytes'] ?? 0 ) ?: (int) ( $b['count'] ?? 0 ) <=> (int) ( $a['count'] ?? 0 ));
+		uasort($blockers, function ( $a, $b ): int {
+			$size_compare = (int) ( $b['size_bytes'] ?? 0 ) <=> (int) ( $a['size_bytes'] ?? 0 );
+			if ( 0 !== $size_compare ) {
+				return $size_compare;
+			}
+			return (int) ( $b['count'] ?? 0 ) <=> (int) ( $a['count'] ?? 0 );
+		});
 		foreach ( $blockers as &$bucket ) {
-			uasort($bucket['repos'], fn( $a, $b ) => (int) ( $b['size_bytes'] ?? 0 ) <=> (int) ( $a['size_bytes'] ?? 0 ) ?: (int) ( $b['count'] ?? 0 ) <=> (int) ( $a['count'] ?? 0 ));
+			uasort($bucket['repos'], function ( $a, $b ): int {
+				$size_compare = (int) ( $b['size_bytes'] ?? 0 ) <=> (int) ( $a['size_bytes'] ?? 0 );
+				if ( 0 !== $size_compare ) {
+					return $size_compare;
+				}
+				return (int) ( $b['count'] ?? 0 ) <=> (int) ( $a['count'] ?? 0 );
+			});
 		}
 		unset($bucket);
 
@@ -457,28 +472,28 @@ trait WorkspaceCleanupPlan {
 	private function cleanup_plan_recommended_commands( array $inputs ): array {
 		$commands = array(
 			array(
-				'label'      => 'apply_reviewed_plan',
-				'risk'       => 'reviewed_destructive',
-				'command'    => 'studio wp datamachine-code workspace cleanup apply <run-id>',
-				'when'       => 'after reviewing this plan; revalidates every destructive row before removal',
+				'label'   => 'apply_reviewed_plan',
+				'risk'    => 'reviewed_destructive',
+				'command' => 'studio wp datamachine-code workspace cleanup apply <run-id>',
+				'when'    => 'after reviewing this plan; revalidates every destructive row before removal',
 			),
 			array(
-				'label'      => 'inspect_full_plan_json',
-				'risk'       => 'none',
-				'command'    => 'studio wp datamachine-code workspace cleanup plan --mode=retention --format=json',
-				'when'       => 'export the full plan for review or archival',
+				'label'   => 'inspect_full_plan_json',
+				'risk'    => 'none',
+				'command' => 'studio wp datamachine-code workspace cleanup plan --mode=retention --format=json',
+				'when'    => 'export the full plan for review or archival',
 			),
 			array(
-				'label'      => 'resolve_metadata_blockers',
-				'risk'       => 'none',
-				'command'    => 'studio wp datamachine-code workspace worktree reconcile-metadata --dry-run --limit=25 --offset=0 --until-budget=30s --format=json',
-				'when'       => 'metadata blockers prevent classification',
+				'label'   => 'resolve_metadata_blockers',
+				'risk'    => 'none',
+				'command' => 'studio wp datamachine-code workspace worktree reconcile-metadata --dry-run --limit=25 --offset=0 --until-budget=30s --format=json',
+				'when'    => 'metadata blockers prevent classification',
 			),
 			array(
-				'label'      => 'refresh_merge_signals',
-				'risk'       => 'none',
-				'command'    => 'studio wp datamachine-code workspace worktree cleanup --dry-run --format=json',
-				'when'       => 'active or lifecycle rows need full merge/PR signal review',
+				'label'   => 'refresh_merge_signals',
+				'risk'    => 'none',
+				'command' => 'studio wp datamachine-code workspace worktree cleanup --dry-run --format=json',
+				'when'    => 'active or lifecycle rows need full merge/PR signal review',
 			),
 		);
 

--- a/inc/Workspace/WorkspaceCleanupPlan.php
+++ b/inc/Workspace/WorkspaceCleanupPlan.php
@@ -33,6 +33,7 @@ trait WorkspaceCleanupPlan {
 			'include_artifacts'      => array_key_exists('include_artifacts', $opts) ? (bool) $opts['include_artifacts'] : true,
 			'include_worktrees'      => array_key_exists('include_worktrees', $opts) ? (bool) $opts['include_worktrees'] : true,
 			'include_resolvers'      => ! empty($opts['include_resolvers']),
+			'top_n'                  => isset($opts['top_n']) ? max(1, min(50, (int) $opts['top_n'])) : 10,
 			'worktree_older_than'    => isset($opts['worktree_older_than']) ? trim( (string) $opts['worktree_older_than']) : '',
 			'worktree_sort'          => isset($opts['worktree_sort']) ? trim( (string) $opts['worktree_sort']) : '',
 		);
@@ -83,7 +84,7 @@ trait WorkspaceCleanupPlan {
 			'resolver'         => $inputs['include_resolvers'] ? $this->build_cleanup_plan_resolver_rows( (array) ( $worktree_plan['skipped'] ?? array() )) : array(),
 		);
 
-		$summary         = $this->build_cleanup_plan_summary($rows);
+		$summary         = $this->build_cleanup_plan_summary($rows, $artifact_plan, $worktree_plan, $inputs);
 		$plan            = array(
 			'success'        => true,
 			'mode'           => 'cleanup_plan',
@@ -260,7 +261,7 @@ trait WorkspaceCleanupPlan {
 	 * @param  array<string,array<int,array>> $rows Rows keyed by type.
 	 * @return array<string,mixed>
 	 */
-	private function build_cleanup_plan_summary( array $rows ): array {
+	private function build_cleanup_plan_summary( array $rows, array $artifact_plan = array(), array $worktree_plan = array(), array $inputs = array() ): array {
 		$counts      = array();
 		$byte_totals = array();
 		$total_rows  = 0;
@@ -279,12 +280,225 @@ trait WorkspaceCleanupPlan {
 
 		ksort($counts);
 		ksort($byte_totals);
+		$category_totals = $this->cleanup_plan_category_totals($rows);
+		$category_total  = array_sum(array_map('intval', $category_totals));
+
 		return array(
 			'total_rows'       => $total_rows,
 			'rows_by_type'     => $counts,
 			'byte_totals'      => $byte_totals,
-			'total_size_bytes' => $total_bytes,
+			'total_size_bytes' => $category_total > 0 ? $category_total : $total_bytes,
+			'category_totals'  => $category_totals,
+			'top_reclaimable'  => $this->cleanup_plan_top_reclaimable_paths($rows, (int) ( $inputs['top_n'] ?? 10 )),
+			'blockers'         => $this->cleanup_plan_blockers($artifact_plan, $worktree_plan),
+			'recommended_commands' => $this->cleanup_plan_recommended_commands($inputs),
 		);
+	}
+
+	/**
+	 * Summarize reclaimable bytes by operator-facing category.
+	 *
+	 * @param  array<string,array<int,array>> $rows Cleanup rows keyed by type.
+	 * @return array<string,int>
+	 */
+	private function cleanup_plan_category_totals( array $rows ): array {
+		$totals = array(
+			'whole_worktrees'       => 0,
+			'dependency_artifacts'  => 0,
+			'build_outputs'         => 0,
+			'caches'                => 0,
+		);
+
+		foreach ( (array) ( $rows['worktree_removal'] ?? array() ) as $row ) {
+			if ( is_array($row) ) {
+				$totals['whole_worktrees'] += max(0, (int) ( $row['size_bytes'] ?? 0 ));
+			}
+		}
+
+		foreach ( (array) ( $rows['artifact_cleanup'] ?? array() ) as $row ) {
+			foreach ( (array) ( is_array($row) ? ( $row['artifacts'] ?? array() ) : array() ) as $artifact ) {
+				if ( ! is_array($artifact) ) {
+					continue;
+				}
+				$category            = $this->cleanup_artifact_category( (string) ( $artifact['path'] ?? '' ));
+				$totals[ $category ] += max(0, (int) ( $artifact['size_bytes'] ?? 0 ));
+			}
+		}
+
+		return $totals;
+	}
+
+	/**
+	 * Classify a reconstructable artifact path for high-level reporting.
+	 *
+	 * @param  string $path Artifact path.
+	 * @return string
+	 */
+	private function cleanup_artifact_category( string $path ): string {
+		$name = strtolower(basename($path));
+		if ( in_array($name, array( 'node_modules', 'vendor', '.pnpm-store', '.yarn', 'bower_components' ), true) ) {
+			return 'dependency_artifacts';
+		}
+
+		if ( in_array($name, array( '.cache', 'cache', 'caches', '.npm', '.composer', '.turbo' ), true) ) {
+			return 'caches';
+		}
+
+		return 'build_outputs';
+	}
+
+	/**
+	 * Return the largest reclaimable paths across worktree and artifact rows.
+	 *
+	 * @param  array<string,array<int,array>> $rows Cleanup rows keyed by type.
+	 * @param  int                            $limit Maximum paths to return.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function cleanup_plan_top_reclaimable_paths( array $rows, int $limit ): array {
+		$paths = array();
+		foreach ( (array) ( $rows['worktree_removal'] ?? array() ) as $row ) {
+			if ( ! is_array($row) ) {
+				continue;
+			}
+			$paths[] = array(
+				'path'          => (string) ( $row['path'] ?? '' ),
+				'handle'        => (string) ( $row['handle'] ?? '' ),
+				'repo'          => (string) ( $row['repo'] ?? '' ),
+				'category'      => 'whole_worktrees',
+				'row_type'      => 'worktree_removal',
+				'safety_class'  => (string) ( $row['safety_class'] ?? 'reviewed_destructive' ),
+				'size_bytes'    => max(0, (int) ( $row['size_bytes'] ?? 0 )),
+			);
+		}
+
+		foreach ( (array) ( $rows['artifact_cleanup'] ?? array() ) as $row ) {
+			if ( ! is_array($row) ) {
+				continue;
+			}
+			foreach ( (array) ( $row['artifacts'] ?? array() ) as $artifact ) {
+				if ( ! is_array($artifact) ) {
+					continue;
+				}
+				$paths[] = array(
+					'path'          => (string) ( $artifact['path'] ?? '' ),
+					'handle'        => (string) ( $row['handle'] ?? '' ),
+					'repo'          => (string) ( $row['repo'] ?? '' ),
+					'category'      => $this->cleanup_artifact_category( (string) ( $artifact['path'] ?? '' )),
+					'row_type'      => 'artifact_cleanup',
+					'safety_class'  => (string) ( $row['safety_class'] ?? 'safe' ),
+					'size_bytes'    => max(0, (int) ( $artifact['size_bytes'] ?? 0 )),
+				);
+			}
+		}
+
+		usort($paths, fn( $a, $b ) => (int) ( $b['size_bytes'] ?? 0 ) <=> (int) ( $a['size_bytes'] ?? 0 ));
+		return array_slice($paths, 0, max(1, $limit));
+	}
+
+	/**
+	 * Group blocked cleanup opportunities by reason and repo.
+	 *
+	 * @param  array<string,mixed> $artifact_plan Artifact plan.
+	 * @param  array<string,mixed> $worktree_plan Worktree plan.
+	 * @return array<string,array<string,mixed>>
+	 */
+	private function cleanup_plan_blockers( array $artifact_plan, array $worktree_plan ): array {
+		$blockers = array();
+		foreach ( array( 'artifact_cleanup' => $artifact_plan, 'worktree_removal' => $worktree_plan ) as $type => $plan ) {
+			foreach ( (array) ( $plan['skipped'] ?? array() ) as $row ) {
+				if ( ! is_array($row) ) {
+					continue;
+				}
+				$reason = (string) ( $row['reason_code'] ?? 'unknown' );
+				$repo   = (string) ( $row['repo'] ?? 'unknown' );
+				if ( '' === $repo ) {
+					$repo = 'unknown';
+				}
+				$bytes = max(0, (int) ( $row['artifact_size_bytes'] ?? $row['size_bytes'] ?? 0 ));
+				$blockers[ $reason ] ??= array(
+					'count'      => 0,
+					'size_bytes' => 0,
+					'repos'      => array(),
+					'examples'   => array(),
+				);
+				$blockers[ $reason ]['count']      = (int) $blockers[ $reason ]['count'] + 1;
+				$blockers[ $reason ]['size_bytes'] += $bytes;
+				$blockers[ $reason ]['repos'][ $repo ] ??= array(
+					'count'      => 0,
+					'size_bytes' => 0,
+					'examples'   => array(),
+				);
+				$blockers[ $reason ]['repos'][ $repo ]['count']      = (int) $blockers[ $reason ]['repos'][ $repo ]['count'] + 1;
+				$blockers[ $reason ]['repos'][ $repo ]['size_bytes'] += $bytes;
+				if ( count($blockers[ $reason ]['examples']) < 5 ) {
+					$blockers[ $reason ]['examples'][] = (string) ( $row['handle'] ?? $row['path'] ?? '' );
+				}
+				if ( count($blockers[ $reason ]['repos'][ $repo ]['examples']) < 3 ) {
+					$blockers[ $reason ]['repos'][ $repo ]['examples'][] = (string) ( $row['handle'] ?? $row['path'] ?? '' );
+				}
+			}
+		}
+
+		uasort($blockers, fn( $a, $b ) => (int) ( $b['size_bytes'] ?? 0 ) <=> (int) ( $a['size_bytes'] ?? 0 ) ?: (int) ( $b['count'] ?? 0 ) <=> (int) ( $a['count'] ?? 0 ));
+		foreach ( $blockers as &$bucket ) {
+			uasort($bucket['repos'], fn( $a, $b ) => (int) ( $b['size_bytes'] ?? 0 ) <=> (int) ( $a['size_bytes'] ?? 0 ) ?: (int) ( $b['count'] ?? 0 ) <=> (int) ( $a['count'] ?? 0 ));
+		}
+		unset($bucket);
+
+		return $blockers;
+	}
+
+	/**
+	 * Build directly executable cleanup recommendations with risk labels.
+	 *
+	 * @param  array<string,mixed> $inputs Plan inputs.
+	 * @return array<int,array<string,string>>
+	 */
+	private function cleanup_plan_recommended_commands( array $inputs ): array {
+		$commands = array(
+			array(
+				'label'      => 'apply_reviewed_plan',
+				'risk'       => 'reviewed_destructive',
+				'command'    => 'studio wp datamachine-code workspace cleanup apply <run-id>',
+				'when'       => 'after reviewing this plan; revalidates every destructive row before removal',
+			),
+			array(
+				'label'      => 'inspect_full_plan_json',
+				'risk'       => 'none',
+				'command'    => 'studio wp datamachine-code workspace cleanup plan --mode=retention --format=json',
+				'when'       => 'export the full plan for review or archival',
+			),
+			array(
+				'label'      => 'resolve_metadata_blockers',
+				'risk'       => 'none',
+				'command'    => 'studio wp datamachine-code workspace worktree reconcile-metadata --dry-run --limit=25 --offset=0 --until-budget=30s --format=json',
+				'when'       => 'metadata blockers prevent classification',
+			),
+			array(
+				'label'      => 'refresh_merge_signals',
+				'risk'       => 'none',
+				'command'    => 'studio wp datamachine-code workspace worktree cleanup --dry-run --format=json',
+				'when'       => 'active or lifecycle rows need full merge/PR signal review',
+			),
+		);
+
+		if ( empty($inputs['include_artifacts']) ) {
+			$commands[] = array(
+				'label'   => 'audit_artifacts',
+				'risk'    => 'none',
+				'command' => 'studio wp datamachine-code workspace cleanup plan --mode=artifacts',
+				'when'    => 'include dependency artifacts, build outputs, and caches in a separate full plan',
+			);
+		}
+
+		$commands[] = array(
+			'label'   => 'force_dirty_artifacts_only',
+			'risk'    => 'high_destructive',
+			'command' => 'studio wp datamachine-code workspace cleanup plan --mode=artifacts --force',
+			'when'    => 'operator explicitly accepts artifact cleanup in dirty worktrees; source edits remain protected from worktree removal',
+		);
+
+		return $commands;
 	}
 
 	/**

--- a/tests/smoke-cleanup-run-storage.php
+++ b/tests/smoke-cleanup-run-storage.php
@@ -156,9 +156,19 @@ class DataMachineCodeCleanupRunFakeWorkspace extends \DataMachineCode\Workspace\
         array( 'handle' => 'demo@needs-metadata-4', 'row_type' => 'resolver', 'reason_code' => 'needs_metadata_reconcile', 'reason' => 'missing metadata' ),
         ),
         ),
-        'summary'       => array( 'total_rows' => 8, 'total_size_bytes' => 74 ),
-        );
-    }
+		'summary'       => array(
+		'total_rows'       => 8,
+		'total_size_bytes' => 74,
+		'recommended_commands' => array(
+		array(
+		'label'   => 'apply_reviewed_plan',
+		'risk'    => 'reviewed_destructive',
+		'command' => 'studio wp datamachine-code workspace cleanup apply <run-id>',
+		),
+		),
+		),
+		);
+	}
     public function worktree_cleanup_artifacts( array $opts = array() ): array|WP_Error
     {
         $this->artifact_calls[] = $opts;
@@ -218,6 +228,8 @@ $plan = $service->plan(array( 'mode' => 'retention' ));
 datamachine_code_cleanup_run_assert(! is_wp_error($plan), 'plan succeeds');
 datamachine_code_cleanup_run_assert(isset($plan['run_id']), 'plan returns run_id');
 datamachine_code_cleanup_run_assert(8 === (int) ( $plan['cleanup_storage']['item_count'] ?? 0 ), 'plan persists cleanup items');
+datamachine_code_cleanup_run_assert(str_contains((string) ( $plan['summary']['recommended_commands'][0]['command'] ?? '' ), (string) $plan['run_id']), 'plan materializes recommended command run id');
+datamachine_code_cleanup_run_assert(! str_contains((string) ( $plan['summary']['recommended_commands'][0]['command'] ?? '' ), '<run-id>'), 'plan recommended commands are directly executable');
 
 $status = $service->status($plan['run_id']);
 datamachine_code_cleanup_run_assert(8 === (int) ( $status['summary']['total_items'] ?? 0 ), 'status aggregates items');

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -837,6 +837,48 @@ namespace {
 			'summary' => array(
 			'total_rows'       => 2,
 			'total_size_bytes' => 4096,
+			'category_totals'  => array(
+			'whole_worktrees'      => 1024,
+			'dependency_artifacts' => 2048,
+			'build_outputs'        => 512,
+			'caches'               => 512,
+			),
+			'top_reclaimable'  => array(
+			array(
+			'path'         => '/workspace/repo@feature/node_modules',
+			'handle'       => 'repo@feature',
+			'repo'         => 'repo',
+			'category'     => 'dependency_artifacts',
+			'safety_class' => 'safe',
+			'size_bytes'   => 2048,
+			),
+			),
+			'blockers'         => array(
+			'dirty_worktree' => array(
+			'count'      => 1,
+			'size_bytes' => 1024,
+			'repos'      => array(
+			'repo' => array(
+			'count'      => 1,
+			'size_bytes' => 1024,
+			'examples'   => array( 'repo@dirty' ),
+			),
+			),
+			'examples'   => array( 'repo@dirty' ),
+			),
+			),
+			'recommended_commands' => array(
+			array(
+			'label'   => 'apply_reviewed_plan',
+			'risk'    => 'reviewed_destructive',
+			'command' => 'studio wp datamachine-code workspace cleanup apply <run-id>',
+			),
+			array(
+			'label'   => 'resolve_metadata_blockers',
+			'risk'    => 'none',
+			'command' => 'studio wp datamachine-code workspace worktree reconcile-metadata --dry-run --limit=25 --offset=0 --until-budget=30s --format=json',
+			),
+			),
 			),
 			);
 		}
@@ -1150,7 +1192,20 @@ namespace {
 	datamachine_code_cleanup_assert(false === ( $cleanup_plan_ability->last_input['include_artifacts'] ?? true ), 'retention cleanup plan skips exhaustive artifact scan by default');
 	datamachine_code_cleanup_assert(true === ( $cleanup_plan_ability->last_input['include_worktrees'] ?? false ), 'retention cleanup plan keeps inventory worktree planning enabled');
 	datamachine_code_cleanup_assert(in_array('Planning cleanup (retention; local worktree merge signals)...', WP_CLI::$logs, true), 'human cleanup plan reports bounded scan profile before planning');
+	datamachine_code_cleanup_assert(in_array('Reclaimable space by category:', WP_CLI::$logs, true), 'human cleanup plan reports category totals up front');
+	datamachine_code_cleanup_assert(in_array('Top reclaimable paths:', WP_CLI::$logs, true), 'human cleanup plan reports top reclaimable paths');
+	datamachine_code_cleanup_assert(in_array('Blockers by reason and repo:', WP_CLI::$logs, true), 'human cleanup plan reports blockers before apply');
+	datamachine_code_cleanup_assert(in_array('Recommended commands:', WP_CLI::$logs, true), 'human cleanup plan reports directly executable commands');
+	datamachine_code_cleanup_assert(in_array('table:4:category,bytes', WP_CLI::$logs, true), 'category table has expected report shape');
+	datamachine_code_cleanup_assert(in_array('table:1:size,category,risk,handle,path', WP_CLI::$logs, true), 'top reclaimable table has expected report shape');
+	datamachine_code_cleanup_assert(in_array('table:1:reason,count,bytes,repos,examples', WP_CLI::$logs, true), 'blocker table has expected report shape');
+	datamachine_code_cleanup_assert(in_array('table:2:label,risk,command', WP_CLI::$logs, true), 'recommended command table includes risk labels');
 	datamachine_code_cleanup_assert(in_array('Artifacts: skipped for bounded retention planning; run `wp datamachine-code workspace cleanup plan --mode=artifacts` when you want artifact rows.', WP_CLI::$logs, true), 'human cleanup plan shows explicit artifact follow-up command');
+
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->cleanup(array( 'plan' ), array( 'mode' => 'retention', 'top' => 3 ));
+	datamachine_code_cleanup_assert(3 === (int) ( $cleanup_plan_ability->last_input['top_n'] ?? 0 ), 'cleanup plan forwards top-N summary size');
 
 	WP_CLI::$logs      = array();
 	WP_CLI::$successes = array();


### PR DESCRIPTION
## Summary
- Adds an upfront cleanup plan report with total reclaimable bytes by category, top reclaimable paths, blockers grouped by reason/repo, and recommended commands with destructive risk labels.
- Adds `--top=<count>` for controlling the largest-path summary and materializes stored cleanup run commands with the actual run ID.
- Covers the new CLI report shape and DB-backed command materialization in smoke tests.

Closes #679

## Verification
- `php -l inc/Workspace/WorkspaceCleanupPlan.php`
- `php -l inc/Workspace/CleanupRunService.php`
- `php -l inc/Cli/Commands/WorkspaceCommand.php`
- `php -l tests/smoke-worktree-cleanup-cli.php`
- `php -l tests/smoke-cleanup-run-storage.php`
- `php tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-cleanup-run-storage.php`
- `php tests/smoke-worktree-cleanup-artifacts.php`
- `php tests/smoke-worktree-cleanup-plan-scope.php`
- `git diff --check`

## Known existing smoke failure
- `php tests/smoke-worktree-cleanup.php` currently fails on duplicate skipped-row expectations for dirty/external dry-run fixtures (`152/161 passed`). The failures reproduce independently of the new plan summary path; the targeted plan/CLI/storage/artifact checks above pass.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the cleanup plan summary/report changes and drafted targeted smoke coverage; Chris remains responsible for review and merge.