### PR TITLE
Fix cleanup pagination snapshots

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -3639,18 +3639,6 @@ class WorkspaceAbilities {
 		if ( isset($input['older_than']) && '' !== trim( (string) $input['older_than']) ) {
 			$params['worktree_older_than'] = trim( (string) $input['older_than']);
 		}
-		if ( 'artifacts' === $mode ) {
-			if ( isset($input['limit']) ) {
-				$params['limit'] = (int) $input['limit'];
-			}
-			if ( isset($input['offset']) ) {
-				$params['offset'] = (int) $input['offset'];
-			}
-			if ( ! empty($input['exhaustive']) ) {
-				$params['exhaustive'] = true;
-			}
-		}
-
 		$context = array();
 		if ( isset($input['user_id']) ) {
 			$context['user_id'] = (int) $input['user_id'];

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -654,9 +654,9 @@ class WorkspaceCommand extends BaseCommand {
 	 *     # Review artifact cleanup synchronously (bounded; default limit=100)
 	 *     wp datamachine-code workspace cleanup run --mode=artifacts --dry-run
 	 *
-	 *     # Walk a huge workspace in 100-worktree pages
-	 *     wp datamachine-code workspace cleanup run --mode=artifacts --dry-run --offset=0 --format=json
-	 *     wp datamachine-code workspace cleanup run --mode=artifacts --dry-run --offset=100 --format=json
+	 *     # Persist a snapshot-safe artifact cleanup plan, then apply it by run ID
+	 *     wp datamachine-code workspace cleanup run --mode=artifacts --dry-run --format=json
+	 *     wp datamachine-code workspace cleanup apply cleanup-run-20260504120000-abc123
 	 *
 	 *     # Full audit (slow on huge workspaces)
 	 *     wp datamachine-code workspace cleanup run --mode=artifacts --dry-run --exhaustive --format=json
@@ -903,17 +903,6 @@ class WorkspaceCommand extends BaseCommand {
 		if ( isset($assoc_args['older-than']) && '' !== trim( (string) $assoc_args['older-than']) ) {
 			$input['older_than'] = trim( (string) $assoc_args['older-than']);
 		}
-		if ( 'artifacts' === $mode ) {
-			if ( isset($assoc_args['limit']) ) {
-				$input['limit'] = (int) $assoc_args['limit'];
-			}
-			if ( isset($assoc_args['offset']) ) {
-				$input['offset'] = (int) $assoc_args['offset'];
-			}
-			if ( ! empty($assoc_args['exhaustive']) ) {
-				$input['exhaustive'] = true;
-			}
-		}
 
 		return $input;
 	}
@@ -931,6 +920,29 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 
+		$input = $this->cleanup_plan_input($mode, $assoc_args);
+		if ( 'json' !== (string) ( $assoc_args['format'] ?? 'table' ) ) {
+			$profile = ! empty($input['include_artifacts']) ? 'includes artifact scan' : 'local worktree merge signals';
+			WP_CLI::log(sprintf('Planning cleanup (%s; %s)...', $mode, $profile));
+		}
+
+		$result = $ability->execute($input);
+		if ( is_wp_error($result) ) {
+			WP_CLI::error($result->get_error_message());
+			return;
+		}
+
+		$this->render_cleanup_plan_result($result, $assoc_args);
+	}
+
+	/**
+	 * Normalize cleanup plan input shared by `cleanup plan` and dry-run `cleanup run`.
+	 *
+	 * @param  string $mode       Cleanup mode.
+	 * @param  array  $assoc_args CLI associative args.
+	 * @return array<string,mixed>
+	 */
+	private function cleanup_plan_input( string $mode, array $assoc_args ): array {
 		$include_artifacts = 'artifacts' === $mode || ! empty($assoc_args['include-artifacts']);
 		$include_worktrees = 'artifacts' !== $mode;
 		$input             = array(
@@ -945,18 +957,8 @@ class WorkspaceCommand extends BaseCommand {
 		if ( isset($assoc_args['force']) ) {
 			$input['force_artifact_cleanup'] = (bool) $assoc_args['force'];
 		}
-		if ( 'json' !== (string) ( $assoc_args['format'] ?? 'table' ) ) {
-			$profile = $include_artifacts ? 'includes artifact scan' : 'local worktree merge signals';
-			WP_CLI::log(sprintf('Planning cleanup (%s; %s)...', $mode, $profile));
-		}
 
-		$result = $ability->execute($input);
-		if ( is_wp_error($result) ) {
-			WP_CLI::error($result->get_error_message());
-			return;
-		}
-
-		$this->render_cleanup_plan_result($result, $assoc_args);
+		return $input;
 	}
 
 	private function run_cleanup_control_ability( string $operation, string $run_id, array $assoc_args ): void {
@@ -1008,28 +1010,13 @@ class WorkspaceCommand extends BaseCommand {
 				return;
 
 			case 'artifacts':
-				$ability        = wp_get_ability('datamachine-code/workspace-worktree-cleanup-artifacts');
-				$artifact_input = array(
-					'dry_run' => true,
-					'force'   => ! empty($assoc_args['force']),
-				);
-				if ( isset($assoc_args['limit']) ) {
-					$artifact_input['limit'] = (int) $assoc_args['limit'];
+				$ability = wp_get_ability('datamachine-code/workspace-cleanup-plan');
+				$result  = $ability ? $ability->execute($this->cleanup_plan_input($mode, $assoc_args)) : new \WP_Error('cleanup_plan_ability_missing', 'Workspace cleanup plan ability not registered.');
+				if ( is_wp_error($result) ) {
+					WP_CLI::error($result->get_error_message());
+					return;
 				}
-				if ( isset($assoc_args['offset']) ) {
-					$artifact_input['offset'] = (int) $assoc_args['offset'];
-				}
-				if ( ! empty($assoc_args['exhaustive']) ) {
-					$artifact_input['exhaustive'] = true;
-				}
-				if ( ! empty($assoc_args['safety-probes']) ) {
-					$artifact_input['safety_probes'] = true;
-				}
-				if ( isset($assoc_args['sort']) && '' !== trim( (string) $assoc_args['sort']) ) {
-					$artifact_input['sort'] = trim( (string) $assoc_args['sort']);
-				}
-				$result = $ability ? $ability->execute($artifact_input) : new \WP_Error('artifact_cleanup_ability_missing', 'Artifact cleanup ability not registered.');
-				$this->render_worktree_artifact_cleanup_result_from_ability($result, $assoc_args);
+				$this->render_cleanup_plan_result($result, $assoc_args);
 				return;
 
 			case 'emergency':

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -873,10 +873,6 @@ class WorkspaceCommand extends BaseCommand {
 	 * @return string Empty string on success.
 	 */
 	private function run_wp_cli_command( string $command ): string {
-		if ( ! method_exists('WP_CLI', 'runcommand') ) {
-			return 'WP_CLI::runcommand is unavailable; run the reported drain commands manually.';
-		}
-
 		try {
 			WP_CLI::runcommand(
 				$command,
@@ -1061,14 +1057,6 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 		$this->render_worktree_cleanup_result($result, $assoc_args);
-	}
-
-	private function render_worktree_artifact_cleanup_result_from_ability( array|\WP_Error $result, array $assoc_args ): void {
-		if ( is_wp_error($result) ) {
-			WP_CLI::error($result->get_error_message());
-			return;
-		}
-		$this->render_worktree_artifact_cleanup_result($result, $assoc_args);
 	}
 
 	private function render_worktree_emergency_cleanup_result_from_ability( array|\WP_Error $result, array $assoc_args ): void {

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -777,11 +777,11 @@ class WorkspaceCommand extends BaseCommand {
 		}
 
 		$result['commands'] = array(
-			'drain_parent'        => sprintf('studio wp datamachine drain --job-id=%d', $job_id),
-			'status'              => sprintf('studio wp datamachine-code workspace cleanup status %s --format=json', $run_id),
-			'status_verbose'      => sprintf('studio wp datamachine-code workspace cleanup status %s --verbose --format=json', $run_id),
-			'one_command_drain'   => sprintf('studio wp datamachine-code workspace cleanup run --mode=%s --drain --format=json', $mode),
-			'bytes_verification'  => sprintf('studio wp datamachine-code workspace cleanup status %s --format=json', $run_id),
+			'drain_parent'       => sprintf('studio wp datamachine drain --job-id=%d', $job_id),
+			'status'             => sprintf('studio wp datamachine-code workspace cleanup status %s --format=json', $run_id),
+			'status_verbose'     => sprintf('studio wp datamachine-code workspace cleanup status %s --verbose --format=json', $run_id),
+			'one_command_drain'  => sprintf('studio wp datamachine-code workspace cleanup run --mode=%s --drain --format=json', $mode),
+			'bytes_verification' => sprintf('studio wp datamachine-code workspace cleanup status %s --format=json', $run_id),
 		);
 
 		return $result;
@@ -805,8 +805,8 @@ class WorkspaceCommand extends BaseCommand {
 			return $result;
 		}
 
-		$commands = array();
-		$errors   = array();
+		$commands   = array();
+		$errors     = array();
 		$max_passes = 10;
 
 		$parent_command = sprintf('datamachine drain --job-id=%d', $job_id);
@@ -823,7 +823,7 @@ class WorkspaceCommand extends BaseCommand {
 				break;
 			}
 
-			$children = (array) ( $status['evidence']['children'] ?? array() );
+			$children         = (array) ( $status['evidence']['children'] ?? array() );
 			$active_child_ids = array_values(
 				array_unique(
 					array_filter(
@@ -850,17 +850,17 @@ class WorkspaceCommand extends BaseCommand {
 			}
 		}
 
-		$final = $this->cleanup_run_evidence_store()->read($run_id, false, ! empty($assoc_args['verbose']));
-		$output = $final instanceof \WP_Error ? $result : $final;
+		$final                 = $this->cleanup_run_evidence_store()->read($run_id, false, ! empty($assoc_args['verbose']));
+		$output                = $final instanceof \WP_Error ? $result : $final;
 		$output['initial_run'] = $result;
 		$output['drain']       = array(
-			'success'           => array() === $errors,
-			'commands'          => $commands,
-			'errors'            => $errors,
-			'verify_command'    => sprintf('studio wp datamachine-code workspace cleanup status %s --format=json', $run_id),
-			'bytes_reclaimed'   => (int) ( $output['cleanup_items']['bytes_reclaimed'] ?? 0 ),
-			'freed_human'       => (string) ( $output['cleanup_items']['freed_human'] ?? $this->format_bytes(0) ),
-			'completion_state'  => (string) ( $output['state'] ?? 'unknown' ),
+			'success'          => array() === $errors,
+			'commands'         => $commands,
+			'errors'           => $errors,
+			'verify_command'   => sprintf('studio wp datamachine-code workspace cleanup status %s --format=json', $run_id),
+			'bytes_reclaimed'  => (int) ( $output['cleanup_items']['bytes_reclaimed'] ?? 0 ),
+			'freed_human'      => (string) ( $output['cleanup_items']['freed_human'] ?? $this->format_bytes(0) ),
+			'completion_state' => (string) ( $output['state'] ?? 'unknown' ),
 		);
 
 		return $output;
@@ -1297,10 +1297,22 @@ class WorkspaceCommand extends BaseCommand {
 		WP_CLI::log('Drain summary:');
 		$this->format_items(
 			array(
-				array( 'metric' => 'success', 'value' => ! empty($drain['success']) ? 'yes' : 'no' ),
-				array( 'metric' => 'completion_state', 'value' => (string) ( $drain['completion_state'] ?? 'unknown' ) ),
-				array( 'metric' => 'bytes_reclaimed', 'value' => $this->format_bytes($drain['bytes_reclaimed'] ?? 0) ),
-				array( 'metric' => 'verify_command', 'value' => (string) ( $drain['verify_command'] ?? '' ) ),
+				array(
+					'metric' => 'success',
+					'value'  => ! empty($drain['success']) ? 'yes' : 'no',
+				),
+				array(
+					'metric' => 'completion_state',
+					'value'  => (string) ( $drain['completion_state'] ?? 'unknown' ),
+				),
+				array(
+					'metric' => 'bytes_reclaimed',
+					'value'  => $this->format_bytes($drain['bytes_reclaimed'] ?? 0),
+				),
+				array(
+					'metric' => 'verify_command',
+					'value'  => (string) ( $drain['verify_command'] ?? '' ),
+				),
 			),
 			array( 'metric', 'value' ),
 			array( 'format' => 'table' ),

--- a/inc/Tasks/WorkspaceRetentionCleanupTask.php
+++ b/inc/Tasks/WorkspaceRetentionCleanupTask.php
@@ -255,7 +255,7 @@ class WorkspaceRetentionCleanupTask extends SystemTask {
 		);
 
 		if ( ! empty($opts['artifact_cleanup']) ) {
-			$artifact_page  = $workspace->worktree_cleanup_artifacts(
+			$artifact_page = $workspace->worktree_cleanup_artifacts(
 				array(
 					'dry_run'       => true,
 					'force'         => ! empty($opts['force']),

--- a/inc/Tasks/WorkspaceRetentionCleanupTask.php
+++ b/inc/Tasks/WorkspaceRetentionCleanupTask.php
@@ -255,14 +255,11 @@ class WorkspaceRetentionCleanupTask extends SystemTask {
 		);
 
 		if ( ! empty($opts['artifact_cleanup']) ) {
-			$artifact_limit = isset($params['limit']) ? max(0, (int) $params['limit']) : 100;
 			$artifact_page  = $workspace->worktree_cleanup_artifacts(
 				array(
 					'dry_run'       => true,
 					'force'         => ! empty($opts['force']),
-					'limit'         => $artifact_limit,
-					'offset'        => isset($params['offset']) ? max(0, (int) $params['offset']) : 0,
-					'exhaustive'    => ! empty($params['exhaustive']),
+					'exhaustive'    => true,
 					'safety_probes' => true,
 				)
 			);

--- a/inc/Workspace/WorkspaceArtifactCleanup.php
+++ b/inc/Workspace/WorkspaceArtifactCleanup.php
@@ -21,12 +21,10 @@ trait WorkspaceArtifactCleanup {
 	 * plan-only so every destructive run revalidates the exact worktree and
 	 * profile-derived artifact paths from a reviewed dry-run.
 	 *
-	 * Dry-run is bounded by default to keep huge workspaces (~hundreds of
-	 * worktrees) responsive: only the cheap top-level inventory is scanned for
-	 * artifact directories, per-worktree git status / unpushed-commit probes are
-	 * deferred unless `safety_probes` is requested, and the result is paginated
-	 * via `limit` + `offset`. Pass `exhaustive=true` to restore the full scan
-	 * (full git status + unpushed checks for every worktree).
+	 * Direct low-level dry-run is bounded by default to keep huge workspaces
+	 * (~hundreds of worktrees) responsive. Operators should apply through the
+	 * high-level cleanup plan/apply commands, which persist reviewed rows by run
+	 * ID instead of replaying a mutable inventory offset.
 	 *
 	 * Apply paths revalidate the planned subset only — they pass `only_handles`
 	 * derived from the plan into the builder so safety probes run against the
@@ -55,7 +53,7 @@ trait WorkspaceArtifactCleanup {
 		if ( $exhaustive ) {
 			$limit = 0;
 		}
-		$apply_command = $this->build_artifact_cleanup_apply_command($limit, $offset, $exhaustive);
+		$apply_command = $this->build_artifact_cleanup_apply_command();
 		// Apply paths default to safety probing (small subset). Dry-run defaults
 		// to skipping the per-worktree git probes unless explicitly requested or
 		// the caller asked for exhaustive mode.
@@ -204,27 +202,11 @@ trait WorkspaceArtifactCleanup {
 	}
 
 	/**
-	 * Build the high-level command that applies the same artifact cleanup page.
-	 *
-	 * @param  int  $limit      Effective bounded scan limit.
-	 * @param  int  $offset     Bounded inventory offset.
-	 * @param  bool $exhaustive Whether the dry-run used exhaustive mode.
+	 * Build the high-level command that persists a snapshot-safe artifact plan.
 	 * @return string
 	 */
-	private function build_artifact_cleanup_apply_command( int $limit, int $offset, bool $exhaustive ): string {
-		$parts = array(
-			'studio wp datamachine-code workspace cleanup run',
-			'--mode=artifacts',
-		);
-		if ( $exhaustive ) {
-			$parts[] = '--exhaustive';
-		} else {
-			$parts[] = sprintf('--limit=%d', $limit);
-			$parts[] = sprintf('--offset=%d', $offset);
-		}
-		$parts[] = '--format=json';
-
-		return implode(' ', $parts);
+	private function build_artifact_cleanup_apply_command(): string {
+		return 'studio wp datamachine-code workspace cleanup run --mode=artifacts --dry-run --format=json';
 	}
 
 	/**

--- a/tests/smoke-workspace-cleanup-snapshot-pagination.php
+++ b/tests/smoke-workspace-cleanup-snapshot-pagination.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Smoke test for snapshot-safe cleanup pagination CLI routing.
+ *
+ *   php tests/smoke-workspace-cleanup-snapshot-pagination.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace {
+	if ( ! defined('ABSPATH') ) {
+		define('ABSPATH', __DIR__);
+	}
+
+	class WP_Error {
+		public function __construct( private string $code = '', private string $message = '' ) {}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+	}
+
+	class WP_CLI {
+		public static array $logs = array();
+
+		public static function error( string $message ): void {
+			throw new RuntimeException($message);
+		}
+
+		public static function success( string $message ): void {
+			self::$logs[] = $message;
+		}
+
+		public static function log( string $message ): void {
+			self::$logs[] = $message;
+		}
+	}
+
+	function is_wp_error( mixed $value ): bool {
+		return $value instanceof WP_Error;
+	}
+
+	function wp_json_encode( mixed $data, int $flags = 0 ): string|false {
+		return json_encode($data, $flags);
+	}
+
+	function wp_get_ability( string $name ): ?object {
+		return $GLOBALS['datamachine_code_snapshot_abilities'][ $name ] ?? null;
+	}
+
+	class DataMachineCodeSnapshotFakeAbility {
+		public array $calls = array();
+
+		public function __construct( private mixed $result ) {}
+
+		public function execute( array $input ): mixed {
+			$this->calls[] = $input;
+			return $this->result;
+		}
+	}
+}
+
+namespace DataMachine\Cli {
+	class BaseCommand {
+		protected function format_items( array $items, array $fields, array $assoc_args, string $default_sort = '' ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+			\WP_CLI::log('table:' . count($items));
+		}
+	}
+}
+
+namespace {
+	include_once dirname(__DIR__) . '/inc/Cleanup/CleanupRunEvidenceStoreInterface.php';
+	include_once dirname(__DIR__) . '/inc/Cleanup/CleanupRemainingWorkSummary.php';
+	include_once dirname(__DIR__) . '/inc/Cleanup/DataMachineJobCleanupRunEvidenceStore.php';
+	include_once dirname(__DIR__) . '/inc/Cli/Commands/WorkspaceCommand.php';
+
+	function datamachine_code_snapshot_assert( bool $condition, string $message ): void {
+		if ( ! $condition ) {
+			fwrite(STDERR, "FAIL: {$message}\n");
+			exit(1);
+		}
+		echo "ok - {$message}\n";
+	}
+
+	$plan_ability = new DataMachineCodeSnapshotFakeAbility(
+		array(
+			'success'         => true,
+			'run_id'          => 'cleanup-run-snapshot-page',
+			'plan_id'         => 'cleanup-plan-stable',
+			'inputs'          => array( 'include_artifacts' => true, 'include_worktrees' => false ),
+			'summary'         => array( 'total_rows' => 4, 'total_size_bytes' => 185204736 ),
+			'cleanup_storage' => array( 'type' => 'database', 'item_count' => 4 ),
+		)
+	);
+	$run_ability  = new DataMachineCodeSnapshotFakeAbility(
+		array(
+			'success' => true,
+			'state'   => 'jobs_queued',
+			'run_id'  => 'cleanup-run-123',
+			'job_id'  => 123,
+		)
+	);
+
+	$GLOBALS['datamachine_code_snapshot_abilities'] = array(
+		'datamachine-code/workspace-cleanup-plan' => $plan_ability,
+		'datamachine-code/workspace-cleanup-run'  => $run_ability,
+	);
+
+	$command = new \DataMachineCode\Cli\Commands\WorkspaceCommand();
+	$command->cleanup(
+		array( 'run' ),
+		array(
+			'mode'    => 'artifacts',
+			'dry-run' => true,
+			'limit'   => 100,
+			'offset'  => 400,
+			'format'  => 'json',
+		)
+	);
+
+	datamachine_code_snapshot_assert(1 === count($plan_ability->calls), 'artifact dry-run uses DB-backed cleanup plan ability');
+	datamachine_code_snapshot_assert(true === (bool) ( $plan_ability->calls[0]['include_artifacts'] ?? false ), 'artifact dry-run includes artifacts in persisted plan');
+	datamachine_code_snapshot_assert(false === (bool) ( $plan_ability->calls[0]['include_worktrees'] ?? true ), 'artifact dry-run excludes worktree deletion rows');
+	datamachine_code_snapshot_assert(! array_key_exists('offset', $plan_ability->calls[0]), 'artifact dry-run does not pass mutable offset into plan');
+	datamachine_code_snapshot_assert(str_contains(implode("\n", WP_CLI::$logs), 'cleanup-run-snapshot-page'), 'artifact dry-run output exposes run_id for stable apply');
+
+	WP_CLI::$logs = array();
+	$command->cleanup(
+		array( 'run' ),
+		array(
+			'mode'   => 'artifacts',
+			'force'  => true,
+			'limit'  => 100,
+			'offset' => 400,
+			'format' => 'json',
+		)
+	);
+
+	datamachine_code_snapshot_assert(1 === count($run_ability->calls), 'artifact apply schedules background cleanup once');
+	datamachine_code_snapshot_assert(! array_key_exists('offset', $run_ability->calls[0]), 'artifact apply does not forward mutable offset to background cleanup');
+	datamachine_code_snapshot_assert(! array_key_exists('limit', $run_ability->calls[0]), 'artifact apply does not forward page limit to background cleanup');
+	datamachine_code_snapshot_assert(true === (bool) ( $run_ability->calls[0]['force'] ?? false ), 'artifact apply preserves force flag');
+
+	echo "Workspace cleanup snapshot pagination smoke passed.\n";
+}


### PR DESCRIPTION
## Summary
- Routes artifact cleanup dry-run review through the DB-backed cleanup plan path so operators get a stable `run_id` to apply/resume instead of replaying mutable inventory offsets.
- Stops forwarding artifact `limit`/`offset` into destructive scheduled cleanup and plans full artifact cleanup chunks from the current workspace snapshot.
- Updates low-level artifact cleanup guidance to point operators at the snapshot-safe plan flow.

Fixes #678.

## Verification
- `php -l inc/Cli/Commands/WorkspaceCommand.php && php -l inc/Tasks/WorkspaceRetentionCleanupTask.php && php -l inc/Workspace/WorkspaceArtifactCleanup.php && php -l inc/Abilities/WorkspaceAbilities.php && php -l tests/smoke-workspace-cleanup-snapshot-pagination.php`
- `php tests/smoke-workspace-cleanup-snapshot-pagination.php`
- `php tests/smoke-cleanup-run-storage.php`
- `php tests/smoke-workspace-cleanup-run-context.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the cleanup pagination snapshot fix, added targeted smoke coverage, and ran verification commands. Chris remains responsible for review and merge.