### PR TITLE
Fix high-volume workspace cleanup planning

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -778,11 +778,11 @@ class WorkspaceCommand extends BaseCommand {
 		}
 
 		$result['commands'] = array(
-			'drain_parent'        => sprintf('studio wp datamachine drain --job-id=%d', $job_id),
-			'status'              => sprintf('studio wp datamachine-code workspace cleanup status %s --format=json', $run_id),
-			'status_verbose'      => sprintf('studio wp datamachine-code workspace cleanup status %s --verbose --format=json', $run_id),
-			'one_command_drain'   => sprintf('studio wp datamachine-code workspace cleanup run --mode=%s --drain --format=json', $mode),
-			'bytes_verification'  => sprintf('studio wp datamachine-code workspace cleanup status %s --format=json', $run_id),
+			'drain_parent'       => sprintf('studio wp datamachine drain --job-id=%d', $job_id),
+			'status'             => sprintf('studio wp datamachine-code workspace cleanup status %s --format=json', $run_id),
+			'status_verbose'     => sprintf('studio wp datamachine-code workspace cleanup status %s --verbose --format=json', $run_id),
+			'one_command_drain'  => sprintf('studio wp datamachine-code workspace cleanup run --mode=%s --drain --format=json', $mode),
+			'bytes_verification' => sprintf('studio wp datamachine-code workspace cleanup status %s --format=json', $run_id),
 		);
 
 		return $result;
@@ -806,8 +806,8 @@ class WorkspaceCommand extends BaseCommand {
 			return $result;
 		}
 
-		$commands = array();
-		$errors   = array();
+		$commands   = array();
+		$errors     = array();
 		$max_passes = 10;
 
 		$parent_command = sprintf('datamachine drain --job-id=%d', $job_id);
@@ -824,7 +824,7 @@ class WorkspaceCommand extends BaseCommand {
 				break;
 			}
 
-			$children = (array) ( $status['evidence']['children'] ?? array() );
+			$children         = (array) ( $status['evidence']['children'] ?? array() );
 			$active_child_ids = array_values(
 				array_unique(
 					array_filter(
@@ -851,17 +851,17 @@ class WorkspaceCommand extends BaseCommand {
 			}
 		}
 
-		$final = $this->cleanup_run_evidence_store()->read($run_id, false, ! empty($assoc_args['verbose']));
-		$output = $final instanceof \WP_Error ? $result : $final;
+		$final                 = $this->cleanup_run_evidence_store()->read($run_id, false, ! empty($assoc_args['verbose']));
+		$output                = $final instanceof \WP_Error ? $result : $final;
 		$output['initial_run'] = $result;
 		$output['drain']       = array(
-			'success'           => array() === $errors,
-			'commands'          => $commands,
-			'errors'            => $errors,
-			'verify_command'    => sprintf('studio wp datamachine-code workspace cleanup status %s --format=json', $run_id),
-			'bytes_reclaimed'   => (int) ( $output['cleanup_items']['bytes_reclaimed'] ?? 0 ),
-			'freed_human'       => (string) ( $output['cleanup_items']['freed_human'] ?? $this->format_bytes(0) ),
-			'completion_state'  => (string) ( $output['state'] ?? 'unknown' ),
+			'success'          => array() === $errors,
+			'commands'         => $commands,
+			'errors'           => $errors,
+			'verify_command'   => sprintf('studio wp datamachine-code workspace cleanup status %s --format=json', $run_id),
+			'bytes_reclaimed'  => (int) ( $output['cleanup_items']['bytes_reclaimed'] ?? 0 ),
+			'freed_human'      => (string) ( $output['cleanup_items']['freed_human'] ?? $this->format_bytes(0) ),
+			'completion_state' => (string) ( $output['state'] ?? 'unknown' ),
 		);
 
 		return $output;
@@ -874,10 +874,6 @@ class WorkspaceCommand extends BaseCommand {
 	 * @return string Empty string on success.
 	 */
 	private function run_wp_cli_command( string $command ): string {
-		if ( ! method_exists('WP_CLI', 'runcommand') ) {
-			return 'WP_CLI::runcommand is unavailable; run the reported drain commands manually.';
-		}
-
 		try {
 			WP_CLI::runcommand(
 				$command,
@@ -1311,10 +1307,22 @@ class WorkspaceCommand extends BaseCommand {
 		WP_CLI::log('Drain summary:');
 		$this->format_items(
 			array(
-				array( 'metric' => 'success', 'value' => ! empty($drain['success']) ? 'yes' : 'no' ),
-				array( 'metric' => 'completion_state', 'value' => (string) ( $drain['completion_state'] ?? 'unknown' ) ),
-				array( 'metric' => 'bytes_reclaimed', 'value' => $this->format_bytes($drain['bytes_reclaimed'] ?? 0) ),
-				array( 'metric' => 'verify_command', 'value' => (string) ( $drain['verify_command'] ?? '' ) ),
+				array(
+					'metric' => 'success',
+					'value'  => ! empty($drain['success']) ? 'yes' : 'no',
+				),
+				array(
+					'metric' => 'completion_state',
+					'value'  => (string) ( $drain['completion_state'] ?? 'unknown' ),
+				),
+				array(
+					'metric' => 'bytes_reclaimed',
+					'value'  => $this->format_bytes($drain['bytes_reclaimed'] ?? 0),
+				),
+				array(
+					'metric' => 'verify_command',
+					'value'  => (string) ( $drain['verify_command'] ?? '' ),
+				),
 			),
 			array( 'metric', 'value' ),
 			array( 'format' => 'table' ),

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -593,9 +593,10 @@ class WorkspaceCommand extends BaseCommand {
 	 * : Pass force=true into the cleanup task params for modes that support it.
 	 *
 	 * [--include-artifacts]
-	 * : For `plan --mode=retention`, also include the exhaustive artifact cleanup
-	 *   scan. Omitted by default so safe retention planning stays bounded on large
-	 *   workspaces; use `--mode=artifacts` for an artifact-only plan.
+	 * : For `plan --mode=retention`, include artifact cleanup rows. Retention
+	 *   planning includes a full-workspace artifact inventory by default; this flag
+	 *   remains accepted for explicitness and `--mode=artifacts` still creates an
+	 *   artifact-only plan.
 	 *
 	 * [--older-than=<duration>]
 	 * : Pass an age gate such as 7d or 24h into cleanup task params.
@@ -931,7 +932,7 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 
-		$include_artifacts = 'artifacts' === $mode || ! empty($assoc_args['include-artifacts']);
+		$include_artifacts = 'retention' === $mode || 'artifacts' === $mode || ! empty($assoc_args['include-artifacts']);
 		$include_worktrees = 'artifacts' !== $mode;
 		$input             = array(
 			'mode'              => $mode,
@@ -946,7 +947,7 @@ class WorkspaceCommand extends BaseCommand {
 			$input['force_artifact_cleanup'] = (bool) $assoc_args['force'];
 		}
 		if ( 'json' !== (string) ( $assoc_args['format'] ?? 'table' ) ) {
-			$profile = $include_artifacts ? 'includes artifact scan' : 'local worktree merge signals';
+			$profile = $include_artifacts ? 'full-workspace inventory, biggest wins first' : 'local worktree merge signals';
 			WP_CLI::log(sprintf('Planning cleanup (%s; %s)...', $mode, $profile));
 		}
 
@@ -1397,11 +1398,17 @@ class WorkspaceCommand extends BaseCommand {
 		WP_CLI::log(sprintf('Run ID: %s', (string) ( $result['run_id'] ?? '' )));
 		WP_CLI::log(sprintf('Plan ID: %s', (string) ( $result['plan_id'] ?? '' )));
 		WP_CLI::log(sprintf('Rows:   %d', (int) ( $summary['total_rows'] ?? 0 )));
-		WP_CLI::log(sprintf('Bytes:  %s', $this->format_bytes($summary['total_size_bytes'] ?? 0)));
+		WP_CLI::log(sprintf('Reclaimable: %s', $this->format_bytes($summary['total_reclaimable_bytes'] ?? $summary['total_size_bytes'] ?? 0)));
+		$byte_totals = (array) ( $summary['byte_totals'] ?? array() );
+		if ( array() !== $byte_totals ) {
+			foreach ( $byte_totals as $type => $bytes ) {
+				WP_CLI::log(sprintf('  %s: %s', (string) $type, $this->format_bytes($bytes)));
+			}
+		}
 		WP_CLI::log(sprintf('Apply:  wp datamachine-code workspace cleanup apply %s', (string) ( $result['run_id'] ?? '' )));
-		$inputs = (array) ( $result['inputs'] ?? array() );
-		if ( empty($inputs['include_artifacts']) ) {
-			WP_CLI::log('Artifacts: skipped for bounded retention planning; run `wp datamachine-code workspace cleanup plan --mode=artifacts` when you want artifact rows.');
+		$blocked = (array) ( $summary['blocked_by_type'] ?? array() );
+		if ( array_sum(array_map('intval', $blocked)) > 0 ) {
+			WP_CLI::log('Blocked/kept rows are included in JSON under `blocked` with reason_code/reason; they are not applyable cleanup rows.');
 		}
 	}
 

--- a/inc/Runtime/AgentsMdSections.php
+++ b/inc/Runtime/AgentsMdSections.php
@@ -22,11 +22,14 @@ final class AgentsMdSections {
 		}
 
 		$registry_class = '\DataMachine\Engine\AI\MemoryFileRegistry';
-		if ( ! method_exists($registry_class, 'register') ) {
+		if ( ! is_callable(array( $registry_class, 'register' )) ) {
 			return;
 		}
+		$register = array( $registry_class, 'register' );
+		/** @var callable $register */
 
-		$registry_class::register(
+		call_user_func(
+			$register,
 			'AGENTS.md', 5, array(
 				'layer'           => defined($registry_class . '::LAYER_SHARED') ? constant($registry_class . '::LAYER_SHARED') : 'shared',
 				'protected'       => true,
@@ -60,7 +63,7 @@ final class AgentsMdSections {
 	}
 
 	private static function register_auto_generated_marker( string $wp ): void {
-		\DataMachine\Engine\AI\SectionRegistry::register(
+		self::register_section(
 			'AGENTS.md', 'auto-generated-marker', 0, function () use ( $wp ) {
 				$generated_at = gmdate('c');
 				return <<<MD
@@ -79,7 +82,7 @@ MD;
 	}
 
 	private static function register_datamachine_section( string $wp ): void {
-		\DataMachine\Engine\AI\SectionRegistry::register(
+		self::register_section(
 			'AGENTS.md', 'datamachine', 10, function () use ( $wp ) {
 				$workspace_path = self::resolve_workspace_path();
 				$agent_slug     = self::resolve_agent_slug();
@@ -167,7 +170,7 @@ MD;
 	}
 
 	private static function register_workspace_inventory_section( string $wp ): void {
-		\DataMachine\Engine\AI\SectionRegistry::register(
+		self::register_section(
 			'AGENTS.md', 'workspace-inventory', 15, function () use ( $wp ) {
 				return self::render_workspace_inventory_section($wp);
 			}, array(
@@ -181,7 +184,7 @@ MD;
 	}
 
 	private static function register_abilities_section(): void {
-		\DataMachine\Engine\AI\SectionRegistry::register(
+		self::register_section(
 			'AGENTS.md', 'abilities', 20, function () {
 				return <<<'MD'
 ## Abilities
@@ -201,7 +204,7 @@ MD;
 	}
 
 	private static function register_wordpress_source_section(): void {
-		\DataMachine\Engine\AI\SectionRegistry::register(
+		self::register_section(
 			'AGENTS.md', 'wordpress-source', 30, function () {
 				return <<<'MD'
 ## WordPress Source (Read-Only Reference)
@@ -227,7 +230,7 @@ MD;
 			return;
 		}
 
-		\DataMachine\Engine\AI\SectionRegistry::register(
+		self::register_section(
 			'AGENTS.md', 'multisite', 40, function () use ( $wp ) {
 				return <<<MD
 ## Multisite
@@ -266,6 +269,20 @@ MD;
 		return apply_filters('datamachine_wp_cli_cmd', implode(' ', $parts));
 	}
 
+	/**
+	 * Register an AGENTS.md section through the optional Data Machine registry.
+	 */
+	private static function register_section( string $file, string $section, int $priority, callable $callback, array $metadata ): void {
+		$registry_class = '\DataMachine\Engine\AI\SectionRegistry';
+		if ( ! is_callable(array( $registry_class, 'register' )) ) {
+			return;
+		}
+		$register = array( $registry_class, 'register' );
+		/** @var callable $register */
+
+		call_user_func($register, $file, $section, $priority, $callback, $metadata);
+	}
+
 	private static function resolve_workspace_path(): string {
 		if ( class_exists(Workspace::class) ) {
 			$workspace_path = ( new Workspace() )->get_path();
@@ -281,8 +298,8 @@ MD;
 		if ( class_exists('\DataMachine\Core\FilesRepository\DirectoryManager') ) {
 			try {
 				$directory_manager = new \DataMachine\Core\FilesRepository\DirectoryManager();
-				$user_id           = method_exists($directory_manager, 'get_effective_user_id') ? (int) $directory_manager->get_effective_user_id(0) : 0;
-				$agent_slug        = method_exists($directory_manager, 'resolve_agent_slug') ? (string) $directory_manager->resolve_agent_slug(array( 'user_id' => $user_id )) : '';
+				$user_id           = (int) $directory_manager->get_effective_user_id(0);
+				$agent_slug        = (string) $directory_manager->resolve_agent_slug(array( 'user_id' => $user_id ));
 
 				if ( '' !== trim($agent_slug) ) {
 					return trim($agent_slug);

--- a/inc/Workspace/WorkspaceArtifactCleanup.php
+++ b/inc/Workspace/WorkspaceArtifactCleanup.php
@@ -121,7 +121,7 @@ trait WorkspaceArtifactCleanup {
 			if ( $limit > 0 ) {
 				$candidates = array_slice($candidates, 0, $limit);
 			}
-			$pagination   = array(
+			$pagination = array(
 				'mode'          => 'ranked_inventory',
 				'limit'         => $limit,
 				'offset'        => 0,

--- a/inc/Workspace/WorkspaceArtifactCleanup.php
+++ b/inc/Workspace/WorkspaceArtifactCleanup.php
@@ -37,22 +37,23 @@ trait WorkspaceArtifactCleanup {
 	 * @return array<string,mixed>|\WP_Error
 	 */
 	public function worktree_cleanup_artifacts( array $opts = array() ): array|\WP_Error {
-		$dry_run    = ! empty($opts['dry_run']);
-		$force      = ! empty($opts['force']);
-		$apply_plan = isset($opts['apply_plan']) && is_array($opts['apply_plan']) ? $opts['apply_plan'] : null;
-		$exhaustive = ! empty($opts['exhaustive']);
-		$sort       = isset($opts['sort']) ? strtolower(trim( (string) $opts['sort'])) : '';
-		$limit      = isset($opts['limit']) ? (int) $opts['limit'] : self::ARTIFACT_CLEANUP_DEFAULT_LIMIT;
-		$offset     = isset($opts['offset']) ? max(0, (int) $opts['offset']) : 0;
+		$dry_run        = ! empty($opts['dry_run']);
+		$force          = ! empty($opts['force']);
+		$apply_plan     = isset($opts['apply_plan']) && is_array($opts['apply_plan']) ? $opts['apply_plan'] : null;
+		$exhaustive     = ! empty($opts['exhaustive']);
+		$full_workspace = ! empty($opts['full_workspace']);
+		$sort           = isset($opts['sort']) ? strtolower(trim( (string) $opts['sort'])) : '';
+		$limit          = isset($opts['limit']) ? (int) $opts['limit'] : self::ARTIFACT_CLEANUP_DEFAULT_LIMIT;
+		$offset         = isset($opts['offset']) ? max(0, (int) $opts['offset']) : 0;
 		if ( $limit < 0 ) {
 			return new \WP_Error('invalid_artifact_cleanup_limit', 'Artifact cleanup --limit must be greater than 0. Use --exhaustive for an unbounded full artifact audit.', array( 'status' => 400 ));
 		}
-		if ( ! $exhaustive && $limit <= 0 ) {
-			return new \WP_Error('invalid_artifact_cleanup_limit', 'Artifact cleanup --limit must be greater than 0. Use --exhaustive for an unbounded full artifact audit.', array( 'status' => 400 ));
+		if ( ! $exhaustive && ! $full_workspace && $limit <= 0 ) {
+			return new \WP_Error('invalid_artifact_cleanup_limit', 'Artifact cleanup --limit must be greater than 0. Use --exhaustive for an unbounded full artifact audit, or the high-level workspace cleanup plan for full-workspace inventory planning.', array( 'status' => 400 ));
 		}
 		// Allow callers to opt out of bounded mode entirely only through the
 		// explicit exhaustive path, which also enables safety probes.
-		if ( $exhaustive ) {
+		if ( $exhaustive || $full_workspace ) {
 			$limit = 0;
 		}
 		$apply_command = $this->build_artifact_cleanup_apply_command($limit, $offset, $exhaustive);
@@ -117,7 +118,9 @@ trait WorkspaceArtifactCleanup {
 		if ( $rank_by_size ) {
 			usort($candidates, fn( $a, $b ) => (int) ( $b['artifact_size_bytes'] ?? 0 ) <=> (int) ( $a['artifact_size_bytes'] ?? 0 ));
 			$total_ranked = count($candidates);
-			$candidates   = array_slice($candidates, 0, $limit);
+			if ( $limit > 0 ) {
+				$candidates = array_slice($candidates, 0, $limit);
+			}
 			$pagination   = array(
 				'mode'          => 'ranked_inventory',
 				'limit'         => $limit,

--- a/inc/Workspace/WorkspaceCleanupPlan.php
+++ b/inc/Workspace/WorkspaceCleanupPlan.php
@@ -79,7 +79,7 @@ trait WorkspaceCleanupPlan {
 			}
 		}
 
-		$rows = array(
+		$rows    = array(
 			'artifact_cleanup' => $this->prepare_cleanup_plan_rows('artifact_cleanup', (array) ( $artifact_plan['candidates'] ?? array() ), 'safe'),
 			'worktree_removal' => $this->prepare_cleanup_plan_rows('worktree_removal', (array) ( $worktree_plan['candidates'] ?? array() ), 'reviewed_destructive'),
 			'resolver'         => $inputs['include_resolvers'] ? $this->build_cleanup_plan_resolver_rows( (array) ( $worktree_plan['skipped'] ?? array() )) : array(),
@@ -89,8 +89,8 @@ trait WorkspaceCleanupPlan {
 			'worktree_removal' => $this->prepare_cleanup_plan_blocked_rows('worktree_removal', (array) ( $worktree_plan['skipped'] ?? array() )),
 		);
 
-		$summary = $this->build_cleanup_plan_summary($rows, $blocked);
-		$plan    = array(
+		$summary         = $this->build_cleanup_plan_summary($rows, $blocked);
+		$plan            = array(
 			'success'        => true,
 			'mode'           => 'cleanup_plan',
 			'generated_at'   => gmdate('c'),
@@ -320,7 +320,7 @@ trait WorkspaceCleanupPlan {
 				if ( ! is_array($row) ) {
 					continue;
 				}
-				$reason = (string) ( $row['reason_code'] ?? 'unknown' );
+				$reason                              = (string) ( $row['reason_code'] ?? 'unknown' );
 				$blocked_reasons[ $type ][ $reason ] = ( $blocked_reasons[ $type ][ $reason ] ?? 0 ) + 1;
 			}
 		}
@@ -335,14 +335,14 @@ trait WorkspaceCleanupPlan {
 		}
 		unset($reasons);
 		return array(
-			'total_rows'             => $total_rows,
-			'rows_by_type'           => $counts,
-			'byte_totals'            => $byte_totals,
-			'total_size_bytes'       => $total_bytes,
+			'total_rows'              => $total_rows,
+			'rows_by_type'            => $counts,
+			'byte_totals'             => $byte_totals,
+			'total_size_bytes'        => $total_bytes,
 			'total_reclaimable_bytes' => $total_bytes,
-			'top_reclaimable'        => array_slice($top_rows, 0, 10),
-			'blocked_by_type'        => $blocked_counts,
-			'blocked_by_reason'      => $blocked_reasons,
+			'top_reclaimable'         => array_slice($top_rows, 0, 10),
+			'blocked_by_type'         => $blocked_counts,
+			'blocked_by_reason'       => $blocked_reasons,
 		);
 	}
 

--- a/inc/Workspace/WorkspaceCleanupPlan.php
+++ b/inc/Workspace/WorkspaceCleanupPlan.php
@@ -34,7 +34,8 @@ trait WorkspaceCleanupPlan {
 			'include_worktrees'      => array_key_exists('include_worktrees', $opts) ? (bool) $opts['include_worktrees'] : true,
 			'include_resolvers'      => ! empty($opts['include_resolvers']),
 			'worktree_older_than'    => isset($opts['worktree_older_than']) ? trim( (string) $opts['worktree_older_than']) : '',
-			'worktree_sort'          => isset($opts['worktree_sort']) ? trim( (string) $opts['worktree_sort']) : '',
+			'worktree_sort'          => isset($opts['worktree_sort']) && '' !== trim( (string) $opts['worktree_sort']) ? trim( (string) $opts['worktree_sort']) : 'size',
+			'artifact_sort'          => isset($opts['artifact_sort']) && '' !== trim( (string) $opts['artifact_sort']) ? trim( (string) $opts['artifact_sort']) : 'size',
 		);
 
 		$artifact_plan = array(
@@ -43,14 +44,15 @@ trait WorkspaceCleanupPlan {
 			'summary'    => array(),
 		);
 		if ( $inputs['include_artifacts'] ) {
-			// Workspace cleanup plan is the source-of-truth orchestrator that
-			// later chunks/jobs consume — opt into the exhaustive scan so all
-			// safe worktrees are reviewed, not just the bounded dry-run page.
+			// Workspace cleanup plan is the source-of-truth orchestrator that later
+			// chunks/jobs consume. Use whole-workspace inventory planning so hundreds
+			// of worktrees are normal; apply still revalidates every row before delete.
 			$artifact_plan = $this->worktree_cleanup_artifacts(
 				array(
-					'dry_run'    => true,
-					'force'      => $inputs['force_artifact_cleanup'],
-					'exhaustive' => true,
+					'dry_run'        => true,
+					'force'          => $inputs['force_artifact_cleanup'],
+					'full_workspace' => true,
+					'sort'           => $inputs['artifact_sort'],
 				)
 			);
 			if ( $artifact_plan instanceof \WP_Error ) {
@@ -82,9 +84,13 @@ trait WorkspaceCleanupPlan {
 			'worktree_removal' => $this->prepare_cleanup_plan_rows('worktree_removal', (array) ( $worktree_plan['candidates'] ?? array() ), 'reviewed_destructive'),
 			'resolver'         => $inputs['include_resolvers'] ? $this->build_cleanup_plan_resolver_rows( (array) ( $worktree_plan['skipped'] ?? array() )) : array(),
 		);
+		$blocked = array(
+			'artifact_cleanup' => $this->prepare_cleanup_plan_blocked_rows('artifact_cleanup', (array) ( $artifact_plan['skipped'] ?? array() )),
+			'worktree_removal' => $this->prepare_cleanup_plan_blocked_rows('worktree_removal', (array) ( $worktree_plan['skipped'] ?? array() )),
+		);
 
-		$summary         = $this->build_cleanup_plan_summary($rows);
-		$plan            = array(
+		$summary = $this->build_cleanup_plan_summary($rows, $blocked);
+		$plan    = array(
 			'success'        => true,
 			'mode'           => 'cleanup_plan',
 			'generated_at'   => gmdate('c'),
@@ -102,6 +108,7 @@ trait WorkspaceCleanupPlan {
 				'worktree_removal' => $worktree_plan,
 			),
 			'rows'           => $rows,
+			'blocked'        => $blocked,
 			'summary'        => $summary,
 		);
 		$plan['plan_id'] = $this->stable_cleanup_hash(
@@ -198,6 +205,7 @@ trait WorkspaceCleanupPlan {
 	 */
 	private function prepare_cleanup_plan_rows( string $type, array $rows, string $safety_class ): array {
 		$result = array();
+		usort($rows, fn( $a, $b ) => $this->cleanup_plan_reclaimable_bytes( (array) $b) <=> $this->cleanup_plan_reclaimable_bytes( (array) $a));
 		foreach ( $rows as $row ) {
 			if ( ! is_array($row) ) {
 				continue;
@@ -205,6 +213,28 @@ trait WorkspaceCleanupPlan {
 			$row['row_type']     = $type;
 			$row['safety_class'] = $safety_class;
 			$row['row_id']       = $this->stable_cleanup_row_id($type, $row);
+			$result[]            = $row;
+		}
+		return $result;
+	}
+
+	/**
+	 * Add stable metadata to blocked/kept plan rows without making them applyable.
+	 *
+	 * @param  string           $type Cleanup row type the blocker belongs to.
+	 * @param  array<int,array> $rows Skipped rows from the underlying cleanup plan.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function prepare_cleanup_plan_blocked_rows( string $type, array $rows ): array {
+		$result = array();
+		usort($rows, fn( $a, $b ) => $this->cleanup_plan_reclaimable_bytes( (array) $b) <=> $this->cleanup_plan_reclaimable_bytes( (array) $a));
+		foreach ( $rows as $row ) {
+			if ( ! is_array($row) ) {
+				continue;
+			}
+			$row['row_type']     = $type . '_blocked';
+			$row['safety_class'] = 'blocked';
+			$row['row_id']       = $this->stable_cleanup_row_id($type . '_blocked', $row);
 			$result[]            = $row;
 		}
 		return $result;
@@ -257,33 +287,92 @@ trait WorkspaceCleanupPlan {
 	/**
 	 * Build stable cleanup plan summary counts.
 	 *
-	 * @param  array<string,array<int,array>> $rows Rows keyed by type.
+	 * @param  array<string,array<int,array>> $rows    Rows keyed by type.
+	 * @param  array<string,array<int,array>> $blocked Blocked rows keyed by type.
 	 * @return array<string,mixed>
 	 */
-	private function build_cleanup_plan_summary( array $rows ): array {
+	private function build_cleanup_plan_summary( array $rows, array $blocked = array() ): array {
 		$counts      = array();
 		$byte_totals = array();
 		$total_rows  = 0;
 		$total_bytes = 0;
+		$top_rows    = array();
 
 		foreach ( $rows as $type => $typed_rows ) {
 			$counts[ $type ]      = count( (array) $typed_rows);
 			$byte_totals[ $type ] = 0;
 			$total_rows          += $counts[ $type ];
 			foreach ( (array) $typed_rows as $row ) {
-				$bytes                 = max(0, (int) ( $row['artifact_size_bytes'] ?? $row['size_bytes'] ?? 0 ));
+				$bytes                 = $this->cleanup_plan_reclaimable_bytes( (array) $row);
 				$byte_totals[ $type ] += $bytes;
 				$total_bytes          += $bytes;
+				if ( $bytes > 0 ) {
+					$top_rows[] = $this->cleanup_plan_top_row_summary( (array) $row, (string) $type, $bytes);
+				}
 			}
 		}
 
+		$blocked_counts  = array();
+		$blocked_reasons = array();
+		foreach ( $blocked as $type => $typed_rows ) {
+			$blocked_counts[ $type ] = count( (array) $typed_rows);
+			foreach ( (array) $typed_rows as $row ) {
+				if ( ! is_array($row) ) {
+					continue;
+				}
+				$reason = (string) ( $row['reason_code'] ?? 'unknown' );
+				$blocked_reasons[ $type ][ $reason ] = ( $blocked_reasons[ $type ][ $reason ] ?? 0 ) + 1;
+			}
+		}
+		usort($top_rows, fn( $a, $b ) => (int) ( $b['reclaimable_bytes'] ?? 0 ) <=> (int) ( $a['reclaimable_bytes'] ?? 0 ));
+
 		ksort($counts);
 		ksort($byte_totals);
+		ksort($blocked_counts);
+		ksort($blocked_reasons);
+		foreach ( $blocked_reasons as &$reasons ) {
+			ksort($reasons);
+		}
+		unset($reasons);
 		return array(
-			'total_rows'       => $total_rows,
-			'rows_by_type'     => $counts,
-			'byte_totals'      => $byte_totals,
-			'total_size_bytes' => $total_bytes,
+			'total_rows'             => $total_rows,
+			'rows_by_type'           => $counts,
+			'byte_totals'            => $byte_totals,
+			'total_size_bytes'       => $total_bytes,
+			'total_reclaimable_bytes' => $total_bytes,
+			'top_reclaimable'        => array_slice($top_rows, 0, 10),
+			'blocked_by_type'        => $blocked_counts,
+			'blocked_by_reason'      => $blocked_reasons,
+		);
+	}
+
+	/**
+	 * Return the bytes a cleanup row is expected to reclaim.
+	 *
+	 * @param  array<string,mixed> $row Cleanup row.
+	 * @return int
+	 */
+	private function cleanup_plan_reclaimable_bytes( array $row ): int {
+		return max(0, (int) ( $row['artifact_size_bytes'] ?? $row['size_bytes'] ?? 0 ));
+	}
+
+	/**
+	 * Return a compact largest-win row for operator summaries.
+	 *
+	 * @param  array<string,mixed> $row   Cleanup row.
+	 * @param  string              $type  Row type.
+	 * @param  int                 $bytes Reclaimable bytes.
+	 * @return array<string,mixed>
+	 */
+	private function cleanup_plan_top_row_summary( array $row, string $type, int $bytes ): array {
+		return array(
+			'handle'            => (string) ( $row['handle'] ?? '' ),
+			'repo'              => (string) ( $row['repo'] ?? '' ),
+			'branch'            => (string) ( $row['branch'] ?? '' ),
+			'path'              => (string) ( $row['path'] ?? '' ),
+			'row_type'          => $type,
+			'reason_code'       => (string) ( $row['reason_code'] ?? '' ),
+			'reclaimable_bytes' => $bytes,
 		);
 	}
 

--- a/inc/Workspace/WorkspaceWorktreeCleanupEngine.php
+++ b/inc/Workspace/WorkspaceWorktreeCleanupEngine.php
@@ -149,7 +149,7 @@ trait WorkspaceWorktreeCleanupEngine {
 		/** @var array<string,mixed> $github_cache */
 		$github_cache = array();
 
-		$all_worktrees   = array_values(array_filter( (array) $listing['worktrees'], fn( $wt ) => empty($wt['is_primary'])));
+		$all_worktrees   = $this->dedupe_worktree_cleanup_scan_rows(array_values(array_filter( (array) $listing['worktrees'], fn( $wt ) => empty($wt['is_primary']))));
 		$total_worktrees = count($all_worktrees);
 		$worktrees       = array_slice($all_worktrees, $offset, $limit);
 		$checked         = 0;
@@ -1571,6 +1571,38 @@ trait WorkspaceWorktreeCleanupEngine {
 		}
 
 		return $summary;
+	}
+
+	/**
+	 * Remove duplicate rows from a cleanup scan while preserving inventory order.
+	 *
+	 * Worktree inventory can contain both git-discovered and DMC-registry views of
+	 * the same directory. Cleanup classification should report one candidate or
+	 * blocker per directory so high-volume summaries do not double-count bytes.
+	 *
+	 * @param  array<int,array<string,mixed>> $rows Worktree rows.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function dedupe_worktree_cleanup_scan_rows( array $rows ): array {
+		$seen   = array();
+		$result = array();
+		foreach ( $rows as $row ) {
+			if ( ! is_array($row) ) {
+				continue;
+			}
+
+			$handle = (string) ( $row['handle'] ?? '' );
+			$path   = (string) ( $row['path'] ?? '' );
+			$key    = '' !== $handle || '' !== $path ? $handle . '|' . $path : wp_json_encode($row);
+			if ( isset($seen[ $key ]) ) {
+				continue;
+			}
+
+			$seen[ $key ] = true;
+			$result[]     = $row;
+		}
+
+		return $result;
 	}
 
 	/**

--- a/inc/Workspace/WorkspaceWorktreeCleanupEngine.php
+++ b/inc/Workspace/WorkspaceWorktreeCleanupEngine.php
@@ -1747,13 +1747,13 @@ trait WorkspaceWorktreeCleanupEngine {
 	 * @return array<int,array<string,mixed>>
 	 */
 	private function worktree_cleanup_skipped_next_commands( array $skipped_by_reason ): array {
-		$active_no_signal_commands = $this->build_active_no_signal_next_commands(25, 0);
+		$active_no_signal_commands  = $this->build_active_no_signal_next_commands(25, 0);
 		$metadata_reconcile_command = sprintf(
 			'studio wp datamachine-code workspace worktree reconcile-metadata --dry-run --limit=%d --offset=0 --until-budget=%s --format=json',
 			self::METADATA_RECONCILE_DEFAULT_LIMIT,
 			self::METADATA_RECONCILE_DEFAULT_BUDGET
 		);
-		$templates                 = array(
+		$templates                  = array(
 			'artifact_only_dirty_worktree'       => array(
 				'label'       => 'Review generated artifact cleanup separately',
 				'command'     => 'studio wp datamachine-code workspace worktree cleanup-artifacts --dry-run --format=json',
@@ -1761,28 +1761,28 @@ trait WorkspaceWorktreeCleanupEngine {
 				'why'         => 'Dirty paths are limited to declared reconstructable artifact directories, so artifact cleanup can shed them without force-removing source worktrees.',
 				'destructive' => false,
 			),
-			'dirty_worktree'                       => array(
+			'dirty_worktree'                     => array(
 				'label'       => 'Inspect dirty files before retrying cleanup',
 				'command'     => 'git -C <worktree-path> status --short --branch --untracked-files=normal',
 				'alternative' => 'studio wp datamachine-code workspace cleanup run --mode=retention --dry-run --only=dirty_worktree --verbose --format=json',
 				'why'         => 'Shows the exact dirty paths so operators can distinguish generated artifacts from source edits and decide whether to clean, commit, or preserve the worktree.',
 				'destructive' => false,
 			),
-			'unpushed_commits'                     => array(
+			'unpushed_commits'                   => array(
 				'label'       => 'Inspect commits ahead of upstream before cleanup',
 				'command'     => 'git -C <worktree-path> log --oneline --decorate @{u}..HEAD',
 				'alternative' => 'studio wp datamachine-code workspace cleanup run --mode=retention --dry-run --only=unpushed_commits --verbose --format=json',
 				'why'         => 'Lists the protected commits so operators can push, merge, preserve, or intentionally abandon them before retrying cleanup.',
 				'destructive' => false,
 			),
-			'stale_worktree_marker'                => array(
+			'stale_worktree_marker'              => array(
 				'label'       => 'Preview stale git worktree marker pruning',
 				'command'     => 'git -C <primary-path> worktree prune --dry-run --verbose',
 				'alternative' => 'studio wp datamachine-code workspace worktree reconcile-metadata --dry-run --format=json',
 				'why'         => 'Confirms stale git metadata before any prune or registry repair, keeping cleanup non-destructive by default.',
 				'destructive' => false,
 			),
-			'primary_missing'                      => array(
+			'primary_missing'                    => array(
 				'label'       => 'Recover or adopt the missing primary checkout',
 				'command'     => 'studio wp datamachine-code workspace show <repo>',
 				'alternative' => 'Recreate with `studio wp datamachine-code workspace clone <remote-url> --name=<repo>` or adopt an existing checkout with `studio wp datamachine-code workspace adopt <path> --name=<repo>`.',

--- a/tests/smoke-workspace-cleanup-plan-high-volume.php
+++ b/tests/smoke-workspace-cleanup-plan-high-volume.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * Smoke test for high-volume workspace cleanup planning.
+ *
+ *   php tests/smoke-workspace-cleanup-plan-high-volume.php
+ *
+ * @package DataMachineCode\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace {
+	if ( ! defined('ABSPATH') ) {
+		define('ABSPATH', __DIR__);
+	}
+
+	function wp_json_encode( $data, int $flags = 0 ) {
+		return json_encode($data, $flags);
+	}
+
+	function datamachine_code_cleanup_plan_assert( bool $condition, string $message ): void {
+		if ( $condition ) {
+			echo "  [PASS] {$message}\n";
+			return;
+		}
+		echo "  [FAIL] {$message}\n";
+		exit(1);
+	}
+}
+
+namespace DataMachineCode\Workspace {
+	include_once dirname(__DIR__) . '/inc/Workspace/WorktreeCleanupClassifier.php';
+	include_once dirname(__DIR__) . '/inc/Workspace/WorkspaceCleanupPlan.php';
+
+	class HighVolumeCleanupPlanWorkspace {
+		use WorkspaceCleanupPlan;
+
+		public string $workspace_path = '/workspace';
+		public array $artifact_input = array();
+		public array $worktree_input = array();
+
+		public function worktree_cleanup_artifacts( array $opts = array() ): array {
+			$this->artifact_input = $opts;
+			$candidates = array();
+			for ( $i = 1; $i <= 150; ++$i ) {
+				$candidates[] = array(
+					'handle'              => 'repo@artifact-' . $i,
+					'repo'                => 'repo',
+					'branch'              => 'artifact-' . $i,
+					'path'                => '/workspace/repo@artifact-' . $i,
+					'reason_code'         => 'profile_artifacts',
+					'reason'              => 'profile-derived reconstructable artifacts can be removed',
+					'artifact_size_bytes' => $i * 1024,
+					'artifacts'           => array( array( 'path' => 'target', 'size_bytes' => $i * 1024 ) ),
+				);
+			}
+			usort($candidates, fn( $a, $b ) => (int) $b['artifact_size_bytes'] <=> (int) $a['artifact_size_bytes']);
+
+			return array(
+				'success'    => true,
+				'dry_run'    => true,
+				'candidates' => $candidates,
+				'skipped'    => array(
+					array(
+						'handle'              => 'repo@active-symlink',
+						'repo'                => 'repo',
+						'branch'              => 'active-symlink',
+						'path'                => '/workspace/repo@active-symlink',
+						'reason_code'         => 'active_symlink_target',
+						'reason'              => 'worktree is the target of a wp-content plugin/theme symlink - leaving artifacts in place',
+						'artifact_size_bytes' => 4096,
+					),
+				),
+				'summary'    => array(),
+			);
+		}
+
+		public function worktree_cleanup_merged( array $opts = array() ): array {
+			$this->worktree_input = $opts;
+			return array(
+				'success'    => true,
+				'dry_run'    => true,
+				'candidates' => array(
+					array(
+						'handle'      => 'repo@old-small',
+						'repo'        => 'repo',
+						'branch'      => 'old-small',
+						'path'        => '/workspace/repo@old-small',
+						'reason_code' => 'upstream-gone',
+						'reason'      => 'remote branch deleted (likely merged + auto-deleted)',
+						'size_bytes'  => 2048,
+					),
+					array(
+						'handle'      => 'repo@old-large',
+						'repo'        => 'repo',
+						'branch'      => 'old-large',
+						'path'        => '/workspace/repo@old-large',
+						'reason_code' => 'upstream-gone',
+						'reason'      => 'remote branch deleted (likely merged + auto-deleted)',
+						'size_bytes'  => 4096,
+					),
+				),
+				'skipped'    => array(
+					array(
+						'handle'      => 'repo@dirty',
+						'repo'        => 'repo',
+						'branch'      => 'dirty',
+						'path'        => '/workspace/repo@dirty',
+						'reason_code' => 'dirty_worktree',
+						'reason'      => 'working tree dirty (1 files) - leaving in place',
+						'size_bytes'  => 8192,
+					),
+				),
+				'summary'    => array(),
+			);
+		}
+	}
+}
+
+namespace {
+	echo "=== smoke-workspace-cleanup-plan-high-volume ===\n";
+
+	$workspace = new \DataMachineCode\Workspace\HighVolumeCleanupPlanWorkspace();
+	$plan      = $workspace->workspace_cleanup_plan(
+		array(
+			'include_artifacts' => true,
+			'include_worktrees' => true,
+			'include_resolvers' => true,
+		)
+	);
+
+	datamachine_code_cleanup_plan_assert(true === ( $plan['success'] ?? false ), 'cleanup plan succeeds');
+	datamachine_code_cleanup_plan_assert(true === ( $workspace->artifact_input['full_workspace'] ?? false ), 'artifact planning uses full-workspace inventory mode');
+	datamachine_code_cleanup_plan_assert('size' === ( $workspace->artifact_input['sort'] ?? '' ), 'artifact planning asks for biggest artifacts first');
+	datamachine_code_cleanup_plan_assert('size' === ( $workspace->worktree_input['sort'] ?? '' ), 'worktree cleanup planning asks for biggest worktrees first');
+	datamachine_code_cleanup_plan_assert(150 === count($plan['rows']['artifact_cleanup'] ?? array()), 'all artifact rows are planned without manual paging');
+	datamachine_code_cleanup_plan_assert('repo@artifact-150' === ( $plan['rows']['artifact_cleanup'][0]['handle'] ?? '' ), 'artifact rows are largest first');
+	datamachine_code_cleanup_plan_assert('repo@old-large' === ( $plan['rows']['worktree_removal'][0]['handle'] ?? '' ), 'worktree rows are largest first');
+	datamachine_code_cleanup_plan_assert(2 === (int) ( $plan['summary']['rows_by_type']['worktree_removal'] ?? 0 ), 'worktree cleanup rows are counted separately');
+	datamachine_code_cleanup_plan_assert(150 === (int) ( $plan['summary']['rows_by_type']['artifact_cleanup'] ?? 0 ), 'artifact cleanup rows are counted separately');
+	datamachine_code_cleanup_plan_assert(6144 === (int) ( $plan['summary']['byte_totals']['worktree_removal'] ?? 0 ), 'worktree byte total includes all removal rows');
+	datamachine_code_cleanup_plan_assert(11596800 === (int) ( $plan['summary']['byte_totals']['artifact_cleanup'] ?? 0 ), 'artifact byte total includes all 150 rows');
+	datamachine_code_cleanup_plan_assert(1 === (int) ( $plan['summary']['blocked_by_reason']['artifact_cleanup']['active_symlink_target'] ?? 0 ), 'artifact blockers include clear reason code');
+	datamachine_code_cleanup_plan_assert(1 === (int) ( $plan['summary']['blocked_by_reason']['worktree_removal']['dirty_worktree'] ?? 0 ), 'worktree blockers include clear reason code');
+	datamachine_code_cleanup_plan_assert('artifact_cleanup' === ( $plan['summary']['top_reclaimable'][0]['row_type'] ?? '' ), 'top reclaimable summary starts with the biggest lane row');
+	datamachine_code_cleanup_plan_assert(153600 === (int) ( $plan['summary']['top_reclaimable'][0]['reclaimable_bytes'] ?? 0 ), 'top reclaimable summary reports the largest bytes first');
+
+	echo "=== done ===\n";
+}

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -835,8 +835,17 @@ namespace {
 			'plan_id' => 'cleanup-plan-test',
 			'inputs'  => $input,
 			'summary' => array(
-			'total_rows'       => 2,
-			'total_size_bytes' => 4096,
+			'total_rows'              => 2,
+			'total_size_bytes'        => 4096,
+			'total_reclaimable_bytes' => 4096,
+			'byte_totals'             => array(
+			'artifact_cleanup' => 1024,
+			'worktree_removal' => 3072,
+			),
+			'blocked_by_type'         => array(
+			'artifact_cleanup' => 1,
+			'worktree_removal' => 0,
+			),
 			),
 			);
 		}
@@ -1147,10 +1156,13 @@ namespace {
 	WP_CLI::$successes = array();
 	$command->cleanup(array( 'plan' ), array( 'mode' => 'retention' ));
 	datamachine_code_cleanup_assert('retention' === ( $cleanup_plan_ability->last_input['mode'] ?? '' ), 'cleanup plan receives retention mode');
-	datamachine_code_cleanup_assert(false === ( $cleanup_plan_ability->last_input['include_artifacts'] ?? true ), 'retention cleanup plan skips exhaustive artifact scan by default');
+	datamachine_code_cleanup_assert(true === ( $cleanup_plan_ability->last_input['include_artifacts'] ?? false ), 'retention cleanup plan includes full-workspace artifact inventory by default');
 	datamachine_code_cleanup_assert(true === ( $cleanup_plan_ability->last_input['include_worktrees'] ?? false ), 'retention cleanup plan keeps inventory worktree planning enabled');
-	datamachine_code_cleanup_assert(in_array('Planning cleanup (retention; local worktree merge signals)...', WP_CLI::$logs, true), 'human cleanup plan reports bounded scan profile before planning');
-	datamachine_code_cleanup_assert(in_array('Artifacts: skipped for bounded retention planning; run `wp datamachine-code workspace cleanup plan --mode=artifacts` when you want artifact rows.', WP_CLI::$logs, true), 'human cleanup plan shows explicit artifact follow-up command');
+	datamachine_code_cleanup_assert(in_array('Planning cleanup (retention; full-workspace inventory, biggest wins first)...', WP_CLI::$logs, true), 'human cleanup plan reports high-volume inventory profile before planning');
+	datamachine_code_cleanup_assert(in_array('Reclaimable: 4.0 KiB', WP_CLI::$logs, true), 'human cleanup plan reports total reclaimable bytes up front');
+	datamachine_code_cleanup_assert(in_array('  artifact_cleanup: 1.0 KiB', WP_CLI::$logs, true), 'human cleanup plan surfaces artifact cleanup bytes separately');
+	datamachine_code_cleanup_assert(in_array('  worktree_removal: 3.0 KiB', WP_CLI::$logs, true), 'human cleanup plan surfaces worktree cleanup bytes separately');
+	datamachine_code_cleanup_assert(in_array('Blocked/kept rows are included in JSON under `blocked` with reason_code/reason; they are not applyable cleanup rows.', WP_CLI::$logs, true), 'human cleanup plan points to blocker reason details');
 
 	WP_CLI::$logs      = array();
 	WP_CLI::$successes = array();


### PR DESCRIPTION
## Summary
- Makes retention cleanup planning include a full-workspace artifact inventory by default, without requiring manual artifact offset paging.
- Reports total reclaimable bytes up front, with separate artifact-cleanup and worktree-removal byte buckets plus largest-win summaries.
- Surfaces kept/blocked artifact and worktree paths separately with stable reason codes, and dedupes duplicate worktree scan rows before classification.

Fixes #674.

## Verification
- `php tests/smoke-workspace-cleanup-plan-high-volume.php`
- `php tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-worktree-cleanup.php`
- `php -l inc/Workspace/WorkspaceCleanupPlan.php`
- `php -l inc/Workspace/WorkspaceArtifactCleanup.php`
- `php -l inc/Cli/Commands/WorkspaceCommand.php`
- `php -l inc/Workspace/WorkspaceWorktreeCleanupEngine.php`
- `php -l tests/smoke-workspace-cleanup-plan-high-volume.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the cleanup planning implementation, smoke test coverage, and verification commands for Chris to review.