### PR TITLE
Add stale worktree cleanup profile

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -1562,19 +1562,19 @@ class WorkspaceAbilities {
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
-							'mode'       => array(
+							'mode'                => array(
 								'type'        => 'string',
 								'description' => 'Cleanup mode: inventory, artifacts, retention, stale-worktrees, or emergency.',
 							),
-							'force'      => array(
+							'force'               => array(
 								'type'        => 'boolean',
 								'description' => 'Forward force=true to cleanup tasks that support it.',
 							),
-							'dry_run'    => array(
+							'dry_run'             => array(
 								'type'        => 'boolean',
 								'description' => 'Rejected for background cleanup scheduling; use review abilities for dry-runs.',
 							),
-							'older_than' => array(
+							'older_than'          => array(
 								'type'        => 'string',
 								'description' => 'Optional worktree retention age gate such as 14d.',
 							),
@@ -1582,13 +1582,13 @@ class WorkspaceAbilities {
 								'type'        => 'boolean',
 								'description' => 'Only plan stale/inactive worktrees for destructive removal.',
 							),
-							'source'     => array(
+							'source'              => array(
 								'type'        => 'string',
 								'description' => 'Caller source marker.',
 							),
-							'user_id'    => array( 'type' => 'integer' ),
-							'agent_id'   => array( 'type' => 'integer' ),
-							'agent_slug' => array( 'type' => 'string' ),
+							'user_id'             => array( 'type' => 'integer' ),
+							'agent_id'            => array( 'type' => 'integer' ),
+							'agent_slug'          => array( 'type' => 'string' ),
 						),
 					),
 					'output_schema'       => array(
@@ -2338,9 +2338,9 @@ class WorkspaceAbilities {
 					'output_schema'       => array(
 						'type'       => 'object',
 						'properties' => array(
-							'success' => array( 'type' => 'boolean' ),
-							'mode'    => array( 'type' => 'string' ),
-							'plan_id' => array( 'type' => 'string' ),
+							'success'     => array( 'type' => 'boolean' ),
+							'mode'        => array( 'type' => 'string' ),
+							'plan_id'     => array( 'type' => 'string' ),
 							'rows'        => array( 'type' => 'object' ),
 							'action_rows' => array( 'type' => 'object' ),
 							'chunks'      => array( 'type' => 'array' ),
@@ -3591,7 +3591,7 @@ class WorkspaceAbilities {
 
 		$mode = strtolower(preg_replace('/[^a-z0-9_\-]/', '', (string) ( $input['mode'] ?? 'retention' )));
 		$map  = array(
-			'inventory' => array(
+			'inventory'       => array(
 				'task_type' => 'workspace_hygiene_report',
 				'params'    => array(
 					'include_cleanup'         => true,
@@ -3600,7 +3600,7 @@ class WorkspaceAbilities {
 					'size_limit'              => 200,
 				),
 			),
-			'artifacts' => array(
+			'artifacts'       => array(
 				'task_type' => 'workspace_retention_cleanup',
 				'params'    => array(
 					'dry_run'          => false,
@@ -3612,15 +3612,15 @@ class WorkspaceAbilities {
 			'stale-worktrees' => array(
 				'task_type' => 'workspace_retention_cleanup',
 				'params'    => array(
-					'dry_run'              => false,
-					'artifact_cleanup'     => false,
-					'worktree_cleanup'     => true,
-					'skip_github'          => true,
-					'worktree_older_than'  => '14d',
-					'worktree_stale_only'  => true,
+					'dry_run'             => false,
+					'artifact_cleanup'    => false,
+					'worktree_cleanup'    => true,
+					'skip_github'         => true,
+					'worktree_older_than' => '14d',
+					'worktree_stale_only' => true,
 				),
 			),
-			'retention' => array(
+			'retention'       => array(
 				'task_type' => 'workspace_retention_cleanup',
 				'params'    => array(
 					'dry_run'             => false,
@@ -3630,7 +3630,7 @@ class WorkspaceAbilities {
 					'worktree_older_than' => '14d',
 				),
 			),
-			'emergency' => array(
+			'emergency'       => array(
 				'task_type' => 'workspace_disk_emergency_cleanup',
 				'params'    => array(
 					'artifact_chunk_size' => 10,

--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -1564,7 +1564,7 @@ class WorkspaceAbilities {
 						'properties' => array(
 							'mode'       => array(
 								'type'        => 'string',
-								'description' => 'Cleanup mode: inventory, artifacts, retention, or emergency.',
+								'description' => 'Cleanup mode: inventory, artifacts, retention, stale-worktrees, or emergency.',
 							),
 							'force'      => array(
 								'type'        => 'boolean',
@@ -1577,6 +1577,10 @@ class WorkspaceAbilities {
 							'older_than' => array(
 								'type'        => 'string',
 								'description' => 'Optional worktree retention age gate such as 14d.',
+							),
+							'worktree_stale_only' => array(
+								'type'        => 'boolean',
+								'description' => 'Only plan stale/inactive worktrees for destructive removal.',
 							),
 							'source'     => array(
 								'type'        => 'string',
@@ -2327,6 +2331,7 @@ class WorkspaceAbilities {
 							'force_artifact_cleanup' => array( 'type' => 'boolean' ),
 							'worktree_older_than'    => array( 'type' => 'string' ),
 							'worktree_sort'          => array( 'type' => 'string' ),
+							'worktree_stale_only'    => array( 'type' => 'boolean' ),
 							'plan'                   => array( 'type' => 'object' ),
 						),
 					),
@@ -2336,9 +2341,10 @@ class WorkspaceAbilities {
 							'success' => array( 'type' => 'boolean' ),
 							'mode'    => array( 'type' => 'string' ),
 							'plan_id' => array( 'type' => 'string' ),
-							'rows'    => array( 'type' => 'object' ),
-							'chunks'  => array( 'type' => 'array' ),
-							'summary' => array( 'type' => 'object' ),
+							'rows'        => array( 'type' => 'object' ),
+							'action_rows' => array( 'type' => 'object' ),
+							'chunks'      => array( 'type' => 'array' ),
+							'summary'     => array( 'type' => 'object' ),
 						),
 					),
 					'execute_callback'    => array( self::class, 'workspaceCleanupPlan' ),
@@ -3603,6 +3609,17 @@ class WorkspaceAbilities {
 					'skip_github'      => true,
 				),
 			),
+			'stale-worktrees' => array(
+				'task_type' => 'workspace_retention_cleanup',
+				'params'    => array(
+					'dry_run'              => false,
+					'artifact_cleanup'     => false,
+					'worktree_cleanup'     => true,
+					'skip_github'          => true,
+					'worktree_older_than'  => '14d',
+					'worktree_stale_only'  => true,
+				),
+			),
 			'retention' => array(
 				'task_type' => 'workspace_retention_cleanup',
 				'params'    => array(
@@ -3638,6 +3655,9 @@ class WorkspaceAbilities {
 		}
 		if ( isset($input['older_than']) && '' !== trim( (string) $input['older_than']) ) {
 			$params['worktree_older_than'] = trim( (string) $input['older_than']);
+		}
+		if ( isset($input['worktree_stale_only']) ) {
+			$params['worktree_stale_only'] = (bool) $input['worktree_stale_only'];
 		}
 		if ( 'artifacts' === $mode ) {
 			if ( isset($input['limit']) ) {
@@ -4034,6 +4054,7 @@ class WorkspaceAbilities {
 			'force_artifact_cleanup' => ! empty($input['force_artifact_cleanup']),
 			'include_resolvers'      => ! empty($input['include_resolvers']),
 			'mode'                   => (string) ( $input['mode'] ?? 'cleanup_plan' ),
+			'worktree_stale_only'    => ! empty($input['worktree_stale_only']),
 		);
 		foreach ( array( 'include_artifacts', 'include_worktrees' ) as $key ) {
 			if ( array_key_exists($key, $input) ) {

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -783,11 +783,11 @@ class WorkspaceCommand extends BaseCommand {
 		}
 
 		$result['commands'] = array(
-			'drain_parent'        => sprintf('studio wp datamachine drain --job-id=%d', $job_id),
-			'status'              => sprintf('studio wp datamachine-code workspace cleanup status %s --format=json', $run_id),
-			'status_verbose'      => sprintf('studio wp datamachine-code workspace cleanup status %s --verbose --format=json', $run_id),
-			'one_command_drain'   => sprintf('studio wp datamachine-code workspace cleanup run --mode=%s --drain --format=json', $mode),
-			'bytes_verification'  => sprintf('studio wp datamachine-code workspace cleanup status %s --format=json', $run_id),
+			'drain_parent'       => sprintf('studio wp datamachine drain --job-id=%d', $job_id),
+			'status'             => sprintf('studio wp datamachine-code workspace cleanup status %s --format=json', $run_id),
+			'status_verbose'     => sprintf('studio wp datamachine-code workspace cleanup status %s --verbose --format=json', $run_id),
+			'one_command_drain'  => sprintf('studio wp datamachine-code workspace cleanup run --mode=%s --drain --format=json', $mode),
+			'bytes_verification' => sprintf('studio wp datamachine-code workspace cleanup status %s --format=json', $run_id),
 		);
 
 		return $result;
@@ -811,8 +811,8 @@ class WorkspaceCommand extends BaseCommand {
 			return $result;
 		}
 
-		$commands = array();
-		$errors   = array();
+		$commands   = array();
+		$errors     = array();
 		$max_passes = 10;
 
 		$parent_command = sprintf('datamachine drain --job-id=%d', $job_id);
@@ -829,7 +829,7 @@ class WorkspaceCommand extends BaseCommand {
 				break;
 			}
 
-			$children = (array) ( $status['evidence']['children'] ?? array() );
+			$children         = (array) ( $status['evidence']['children'] ?? array() );
 			$active_child_ids = array_values(
 				array_unique(
 					array_filter(
@@ -856,17 +856,17 @@ class WorkspaceCommand extends BaseCommand {
 			}
 		}
 
-		$final = $this->cleanup_run_evidence_store()->read($run_id, false, ! empty($assoc_args['verbose']));
-		$output = $final instanceof \WP_Error ? $result : $final;
+		$final                 = $this->cleanup_run_evidence_store()->read($run_id, false, ! empty($assoc_args['verbose']));
+		$output                = $final instanceof \WP_Error ? $result : $final;
 		$output['initial_run'] = $result;
 		$output['drain']       = array(
-			'success'           => array() === $errors,
-			'commands'          => $commands,
-			'errors'            => $errors,
-			'verify_command'    => sprintf('studio wp datamachine-code workspace cleanup status %s --format=json', $run_id),
-			'bytes_reclaimed'   => (int) ( $output['cleanup_items']['bytes_reclaimed'] ?? 0 ),
-			'freed_human'       => (string) ( $output['cleanup_items']['freed_human'] ?? $this->format_bytes(0) ),
-			'completion_state'  => (string) ( $output['state'] ?? 'unknown' ),
+			'success'          => array() === $errors,
+			'commands'         => $commands,
+			'errors'           => $errors,
+			'verify_command'   => sprintf('studio wp datamachine-code workspace cleanup status %s --format=json', $run_id),
+			'bytes_reclaimed'  => (int) ( $output['cleanup_items']['bytes_reclaimed'] ?? 0 ),
+			'freed_human'      => (string) ( $output['cleanup_items']['freed_human'] ?? $this->format_bytes(0) ),
+			'completion_state' => (string) ( $output['state'] ?? 'unknown' ),
 		);
 
 		return $output;
@@ -879,10 +879,6 @@ class WorkspaceCommand extends BaseCommand {
 	 * @return string Empty string on success.
 	 */
 	private function run_wp_cli_command( string $command ): string {
-		if ( ! method_exists('WP_CLI', 'runcommand') ) {
-			return 'WP_CLI::runcommand is unavailable; run the reported drain commands manually.';
-		}
-
 		try {
 			WP_CLI::runcommand(
 				$command,
@@ -1070,7 +1066,7 @@ class WorkspaceCommand extends BaseCommand {
 					'stale_liveness_only' => true,
 					'older_than'          => isset($assoc_args['older-than']) && '' !== trim( (string) $assoc_args['older-than']) ? trim( (string) $assoc_args['older-than']) : '14d',
 				);
-				$result = $ability ? $ability->execute($input) : new \WP_Error('worktree_cleanup_ability_missing', 'Worktree cleanup ability not registered.');
+				$result  = $ability ? $ability->execute($input) : new \WP_Error('worktree_cleanup_ability_missing', 'Worktree cleanup ability not registered.');
 				$this->render_worktree_cleanup_result_from_ability($result, $assoc_args);
 				return;
 
@@ -1341,10 +1337,22 @@ class WorkspaceCommand extends BaseCommand {
 		WP_CLI::log('Drain summary:');
 		$this->format_items(
 			array(
-				array( 'metric' => 'success', 'value' => ! empty($drain['success']) ? 'yes' : 'no' ),
-				array( 'metric' => 'completion_state', 'value' => (string) ( $drain['completion_state'] ?? 'unknown' ) ),
-				array( 'metric' => 'bytes_reclaimed', 'value' => $this->format_bytes($drain['bytes_reclaimed'] ?? 0) ),
-				array( 'metric' => 'verify_command', 'value' => (string) ( $drain['verify_command'] ?? '' ) ),
+				array(
+					'metric' => 'success',
+					'value'  => ! empty($drain['success']) ? 'yes' : 'no',
+				),
+				array(
+					'metric' => 'completion_state',
+					'value'  => (string) ( $drain['completion_state'] ?? 'unknown' ),
+				),
+				array(
+					'metric' => 'bytes_reclaimed',
+					'value'  => $this->format_bytes($drain['bytes_reclaimed'] ?? 0),
+				),
+				array(
+					'metric' => 'verify_command',
+					'value'  => (string) ( $drain['verify_command'] ?? '' ),
+				),
 			),
 			array( 'metric', 'value' ),
 			array( 'format' => 'table' ),

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -31,7 +31,7 @@ class WorkspaceCommand extends BaseCommand {
 
 	private const CLEANUP_CLI_SOURCE = 'workspace_cleanup_cli';
 
-	private const CLEANUP_MODES = array( 'inventory', 'artifacts', 'retention', 'emergency' );
+	private const CLEANUP_MODES = array( 'inventory', 'artifacts', 'retention', 'stale-worktrees', 'emergency' );
 
 	private const METADATA_RECONCILE_DEFAULT_LIMIT = 25;
 
@@ -583,6 +583,7 @@ class WorkspaceCommand extends BaseCommand {
 	 *   - metadata
 	 *   - artifacts
 	 *   - retention
+	 *   - stale-worktrees
 	 *   - emergency
 	 * ---
 	 *
@@ -596,6 +597,7 @@ class WorkspaceCommand extends BaseCommand {
 	 * : For `plan --mode=retention`, also include the exhaustive artifact cleanup
 	 *   scan. Omitted by default so safe retention planning stays bounded on large
 	 *   workspaces; use `--mode=artifacts` for an artifact-only plan.
+	 *   `--mode=stale-worktrees` never includes artifacts unless this flag is passed.
 	 *
 	 * [--older-than=<duration>]
 	 * : Pass an age gate such as 7d or 24h into cleanup task params.
@@ -650,6 +652,10 @@ class WorkspaceCommand extends BaseCommand {
 	 *
 	 *     # Start task-backed retention cleanup and capture the returned run_id
 	 *     wp datamachine-code workspace cleanup run --mode=retention
+	 *
+	 *     # Review and then apply destructive stale worktree removal only
+	 *     wp datamachine-code workspace cleanup plan --mode=stale-worktrees --older-than=14d --format=json
+	 *     wp datamachine-code workspace cleanup run --mode=stale-worktrees --older-than=14d
 	 *
 	 *     # Review artifact cleanup synchronously (bounded; default limit=100)
 	 *     wp datamachine-code workspace cleanup run --mode=artifacts --dry-run
@@ -903,6 +909,12 @@ class WorkspaceCommand extends BaseCommand {
 		if ( isset($assoc_args['older-than']) && '' !== trim( (string) $assoc_args['older-than']) ) {
 			$input['older_than'] = trim( (string) $assoc_args['older-than']);
 		}
+		if ( 'stale-worktrees' === $mode ) {
+			$input['worktree_stale_only'] = true;
+			if ( ! isset($input['older_than']) ) {
+				$input['older_than'] = '14d';
+			}
+		}
 		if ( 'artifacts' === $mode ) {
 			if ( isset($assoc_args['limit']) ) {
 				$input['limit'] = (int) $assoc_args['limit'];
@@ -944,6 +956,12 @@ class WorkspaceCommand extends BaseCommand {
 		}
 		if ( isset($assoc_args['force']) ) {
 			$input['force_artifact_cleanup'] = (bool) $assoc_args['force'];
+		}
+		if ( 'stale-worktrees' === $mode ) {
+			$input['worktree_stale_only'] = true;
+			if ( empty($input['worktree_older_than']) ) {
+				$input['worktree_older_than'] = '14d';
+			}
 		}
 		if ( 'json' !== (string) ( $assoc_args['format'] ?? 'table' ) ) {
 			$profile = $include_artifacts ? 'includes artifact scan' : 'local worktree merge signals';
@@ -1041,6 +1059,19 @@ class WorkspaceCommand extends BaseCommand {
 				)
 				) : new \WP_Error('emergency_cleanup_ability_missing', 'Emergency cleanup ability not registered.');
 				$this->render_worktree_emergency_cleanup_result_from_ability($result, $assoc_args);
+				return;
+
+			case 'stale-worktrees':
+				$ability = wp_get_ability('datamachine-code/workspace-worktree-cleanup');
+				$input   = array(
+					'dry_run'             => true,
+					'force'               => ! empty($assoc_args['force']),
+					'skip_github'         => true,
+					'stale_liveness_only' => true,
+					'older_than'          => isset($assoc_args['older-than']) && '' !== trim( (string) $assoc_args['older-than']) ? trim( (string) $assoc_args['older-than']) : '14d',
+				);
+				$result = $ability ? $ability->execute($input) : new \WP_Error('worktree_cleanup_ability_missing', 'Worktree cleanup ability not registered.');
+				$this->render_worktree_cleanup_result_from_ability($result, $assoc_args);
 				return;
 
 			case 'retention':

--- a/inc/Tasks/WorkspaceRetentionCleanupTask.php
+++ b/inc/Tasks/WorkspaceRetentionCleanupTask.php
@@ -87,12 +87,12 @@ class WorkspaceRetentionCleanupTask extends SystemTask {
 		}
 
 		$opts = array(
-			'dry_run'                 => ! empty($params['dry_run']),
-			'force'                   => ! empty($params['force']),
-			'skip_github'             => array_key_exists('skip_github', $params) ? (bool) $params['skip_github'] : true,
-			'worktree_cleanup'        => array_key_exists('worktree_cleanup', $params) ? (bool) $params['worktree_cleanup'] : true,
-			'artifact_cleanup'        => array_key_exists('artifact_cleanup', $params) ? (bool) $params['artifact_cleanup'] : true,
-			'worktree_stale_only'    => ! empty($params['worktree_stale_only']),
+			'dry_run'             => ! empty($params['dry_run']),
+			'force'               => ! empty($params['force']),
+			'skip_github'         => array_key_exists('skip_github', $params) ? (bool) $params['skip_github'] : true,
+			'worktree_cleanup'    => array_key_exists('worktree_cleanup', $params) ? (bool) $params['worktree_cleanup'] : true,
+			'artifact_cleanup'    => array_key_exists('artifact_cleanup', $params) ? (bool) $params['artifact_cleanup'] : true,
+			'worktree_stale_only' => ! empty($params['worktree_stale_only']),
 		);
 		if ( isset($params['worktree_older_than']) && '' !== trim( (string) $params['worktree_older_than']) ) {
 			$opts['worktree_older_than'] = trim( (string) $params['worktree_older_than']);

--- a/inc/Tasks/WorkspaceRetentionCleanupTask.php
+++ b/inc/Tasks/WorkspaceRetentionCleanupTask.php
@@ -87,11 +87,12 @@ class WorkspaceRetentionCleanupTask extends SystemTask {
 		}
 
 		$opts = array(
-			'dry_run'          => ! empty($params['dry_run']),
-			'force'            => ! empty($params['force']),
-			'skip_github'      => array_key_exists('skip_github', $params) ? (bool) $params['skip_github'] : true,
-			'worktree_cleanup' => array_key_exists('worktree_cleanup', $params) ? (bool) $params['worktree_cleanup'] : true,
-			'artifact_cleanup' => array_key_exists('artifact_cleanup', $params) ? (bool) $params['artifact_cleanup'] : true,
+			'dry_run'                 => ! empty($params['dry_run']),
+			'force'                   => ! empty($params['force']),
+			'skip_github'             => array_key_exists('skip_github', $params) ? (bool) $params['skip_github'] : true,
+			'worktree_cleanup'        => array_key_exists('worktree_cleanup', $params) ? (bool) $params['worktree_cleanup'] : true,
+			'artifact_cleanup'        => array_key_exists('artifact_cleanup', $params) ? (bool) $params['artifact_cleanup'] : true,
+			'worktree_stale_only'    => ! empty($params['worktree_stale_only']),
 		);
 		if ( isset($params['worktree_older_than']) && '' !== trim( (string) $params['worktree_older_than']) ) {
 			$opts['worktree_older_than'] = trim( (string) $params['worktree_older_than']);
@@ -217,6 +218,7 @@ class WorkspaceRetentionCleanupTask extends SystemTask {
 				'worktree_cleanup'    => (bool) $opts['worktree_cleanup'],
 				'artifact_cleanup'    => (bool) $opts['artifact_cleanup'],
 				'worktree_older_than' => (string) ( $opts['worktree_older_than'] ?? '14d' ),
+				'worktree_stale_only' => (bool) $opts['worktree_stale_only'],
 				'skip_github'         => (bool) $opts['skip_github'],
 				'force'               => (bool) $opts['force'],
 			),
@@ -275,11 +277,12 @@ class WorkspaceRetentionCleanupTask extends SystemTask {
 		if ( ! empty($opts['worktree_cleanup']) ) {
 			$worktree_plan = $workspace->worktree_cleanup_merged(
 				array(
-					'dry_run'     => true,
-					'force'       => ! empty($opts['force']),
-					'skip_github' => ! empty($opts['skip_github']),
-					'older_than'  => (string) ( $opts['worktree_older_than'] ?? '14d' ),
-					'sort'        => 'age',
+					'dry_run'             => true,
+					'force'               => ! empty($opts['force']),
+					'skip_github'         => ! empty($opts['skip_github']),
+					'older_than'          => (string) ( $opts['worktree_older_than'] ?? '14d' ),
+					'sort'                => 'age',
+					'stale_liveness_only' => ! empty($opts['worktree_stale_only']),
 				)
 			);
 			if ( $worktree_plan instanceof \WP_Error ) {
@@ -323,11 +326,12 @@ class WorkspaceRetentionCleanupTask extends SystemTask {
 		foreach ( array( 'artifacts', 'metadata', 'worktrees' ) as $type ) {
 			foreach ( array_chunk( (array) ( $chunk_rows[ $type ] ?? array() ), $sizes[ $type ]) as $index => $rows ) {
 				$item_params[] = array(
-					'chunk_type'  => $type,
-					'chunk_index' => $index,
-					'rows'        => $rows,
-					'force'       => ! empty($opts['force']),
-					'skip_github' => ! empty($opts['skip_github']),
+					'chunk_type'          => $type,
+					'chunk_index'         => $index,
+					'rows'                => $rows,
+					'force'               => ! empty($opts['force']),
+					'skip_github'         => ! empty($opts['skip_github']),
+					'stale_liveness_only' => ! empty($opts['worktree_stale_only']),
 				);
 			}
 		}

--- a/inc/Tasks/WorktreeCleanupChunkTask.php
+++ b/inc/Tasks/WorktreeCleanupChunkTask.php
@@ -117,7 +117,7 @@ class WorktreeCleanupChunkTask extends SystemTask {
 		};
 
 		if ( $result instanceof \WP_Error ) {
-			$failed = $this->rows_to_failed($rows, $result->get_error_code(), $result->get_error_message());
+			$failed = $this->rows_to_failed($rows, (string) $result->get_error_code(), $result->get_error_message());
 			$this->completeJob(
 				$jobId,
 				$this->build_chunk_result(
@@ -247,7 +247,7 @@ class WorktreeCleanupChunkTask extends SystemTask {
 					$planned,
 					array(),
 					$skipped,
-					$this->rows_to_failed($planned, $result->get_error_code(), $result->get_error_message()),
+					$this->rows_to_failed($planned, (string) $result->get_error_code(), $result->get_error_message()),
 					0,
 					$started_at,
 					array(

--- a/inc/Tasks/WorktreeCleanupChunkTask.php
+++ b/inc/Tasks/WorktreeCleanupChunkTask.php
@@ -110,6 +110,7 @@ class WorktreeCleanupChunkTask extends SystemTask {
 					'apply_plan'                => array( 'candidates' => $rows ),
 					'skip_github'               => array_key_exists('skip_github', $params) ? (bool) $params['skip_github'] : true,
 					'include_repaired_metadata' => ! empty($params['include_repaired_metadata']),
+					'stale_liveness_only'       => ! empty($params['stale_liveness_only']),
 				)
 			),
 			default     => new \WP_Error('invalid_cleanup_chunk_type', sprintf('Unknown cleanup chunk type: %s', $chunk_type), array( 'status' => 400 )),

--- a/inc/Workspace/CleanupRunService.php
+++ b/inc/Workspace/CleanupRunService.php
@@ -14,8 +14,8 @@ defined('ABSPATH') || exit;
 
 class CleanupRunService {
 
-	private const DEFAULT_APPLY_LIMIT        = 25;
-	private const MAX_APPLY_LIMIT            = 100;
+	private const DEFAULT_APPLY_LIMIT = 25;
+	private const MAX_APPLY_LIMIT     = 100;
 
 
 
@@ -92,16 +92,16 @@ class CleanupRunService {
 			)
 		);
 
-		$items          = $this->repository->get_items($run_id);
-		$artifact_rows  = $this->pending_rows_of_type($items, 'artifact_cleanup');
-		$worktree_rows  = $this->pending_rows_of_type($items, 'worktree_removal');
+		$items                = $this->repository->get_items($run_id);
+		$artifact_rows        = $this->pending_rows_of_type($items, 'artifact_cleanup');
+		$worktree_rows        = $this->pending_rows_of_type($items, 'worktree_removal');
 		$stale_worktrees_only = 'stale-worktrees' === (string) ( $run['mode'] ?? '' );
-		$batch_type     = '';
-		$processed_rows = 0;
-		$applied_rows   = 0;
-		$skipped_rows   = 0;
-		$remaining_rows = max(0, count($artifact_rows) + count($worktree_rows));
-		$results        = array();
+		$batch_type           = '';
+		$processed_rows       = 0;
+		$applied_rows         = 0;
+		$skipped_rows         = 0;
+		$remaining_rows       = max(0, count($artifact_rows) + count($worktree_rows));
+		$results              = array();
 
 		if ( array() !== $artifact_rows ) {
 			$artifact_batch  = array_slice($artifact_rows, 0, $limit);
@@ -116,8 +116,12 @@ class CleanupRunService {
 				)
 			);
 			$this->record_apply_result($artifact_batch, $results['artifact_cleanup'], 'removed');
-			$applied_rows += count((array) ( $results['artifact_cleanup']['removed'] ?? array() ));
-			$skipped_rows += count((array) ( $results['artifact_cleanup']['skipped'] ?? array() ));
+			if ( ! is_wp_error($results['artifact_cleanup']) ) {
+				$applied_rows += count( (array) ( $results['artifact_cleanup']['removed'] ?? array() ) );
+				$skipped_rows += count( (array) ( $results['artifact_cleanup']['skipped'] ?? array() ) );
+			} else {
+				$skipped_rows += count($artifact_batch);
+			}
 		}
 
 		$remaining_capacity = max(0, $limit - $processed_rows);
@@ -135,8 +139,12 @@ class CleanupRunService {
 				)
 			);
 			$this->record_apply_result($worktree_batch, $results['worktree_removal'], 'removed');
-			$applied_rows += count((array) ( $results['worktree_removal']['removed'] ?? array() ));
-			$skipped_rows += count((array) ( $results['worktree_removal']['skipped'] ?? array() ));
+			if ( ! is_wp_error($results['worktree_removal']) ) {
+				$applied_rows += count( (array) ( $results['worktree_removal']['removed'] ?? array() ) );
+				$skipped_rows += count( (array) ( $results['worktree_removal']['skipped'] ?? array() ) );
+			} else {
+				$skipped_rows += count($worktree_batch);
+			}
 		}
 
 		$status          = $this->status($run_id);

--- a/inc/Workspace/CleanupRunService.php
+++ b/inc/Workspace/CleanupRunService.php
@@ -95,6 +95,7 @@ class CleanupRunService {
 		$items          = $this->repository->get_items($run_id);
 		$artifact_rows  = $this->pending_rows_of_type($items, 'artifact_cleanup');
 		$worktree_rows  = $this->pending_rows_of_type($items, 'worktree_removal');
+		$stale_worktrees_only = 'stale-worktrees' === (string) ( $run['mode'] ?? '' );
 		$batch_type     = '';
 		$processed_rows = 0;
 		$applied_rows   = 0;
@@ -127,9 +128,10 @@ class CleanupRunService {
 			$this->mark_batch_applying($worktree_batch, $run_id, $batch_type, $limit, $remaining_rows);
 			$results['worktree_removal'] = $this->workspace->worktree_cleanup_merged(
 				array(
-					'apply_plan'        => array( 'candidates' => array_map(fn( $item ) => $item['evidence'], $worktree_batch) ),
-					'direct_apply_plan' => true,
-					'skip_github'       => true,
+					'apply_plan'          => array( 'candidates' => array_map(fn( $item ) => $item['evidence'], $worktree_batch) ),
+					'direct_apply_plan'   => true,
+					'skip_github'         => true,
+					'stale_liveness_only' => $stale_worktrees_only,
 				)
 			);
 			$this->record_apply_result($worktree_batch, $results['worktree_removal'], 'removed');

--- a/inc/Workspace/WorkspaceCleanupPlan.php
+++ b/inc/Workspace/WorkspaceCleanupPlan.php
@@ -35,6 +35,7 @@ trait WorkspaceCleanupPlan {
 			'include_resolvers'      => ! empty($opts['include_resolvers']),
 			'worktree_older_than'    => isset($opts['worktree_older_than']) ? trim( (string) $opts['worktree_older_than']) : '',
 			'worktree_sort'          => isset($opts['worktree_sort']) ? trim( (string) $opts['worktree_sort']) : '',
+			'worktree_stale_only'    => ! empty($opts['worktree_stale_only']),
 		);
 
 		$artifact_plan = array(
@@ -66,10 +67,11 @@ trait WorkspaceCleanupPlan {
 		if ( $inputs['include_worktrees'] ) {
 			$worktree_plan = $this->worktree_cleanup_merged(
 				array(
-					'dry_run'     => true,
-					'skip_github' => true,
-					'older_than'  => $inputs['worktree_older_than'],
-					'sort'        => $inputs['worktree_sort'],
+					'dry_run'             => true,
+					'skip_github'         => true,
+					'older_than'          => $inputs['worktree_older_than'],
+					'sort'                => $inputs['worktree_sort'],
+					'stale_liveness_only' => $inputs['worktree_stale_only'],
 				)
 			);
 			if ( $worktree_plan instanceof \WP_Error ) {
@@ -83,7 +85,17 @@ trait WorkspaceCleanupPlan {
 			'resolver'         => $inputs['include_resolvers'] ? $this->build_cleanup_plan_resolver_rows( (array) ( $worktree_plan['skipped'] ?? array() )) : array(),
 		);
 
+		$action_rows     = array(
+			'remove_artifacts' => $rows['artifact_cleanup'],
+			'remove_worktree'  => $rows['worktree_removal'],
+			'resolve_signal'   => $rows['resolver'],
+		);
 		$summary         = $this->build_cleanup_plan_summary($rows);
+		$summary['rows_by_action'] = array(
+			'remove_artifacts' => count($action_rows['remove_artifacts']),
+			'remove_worktree'  => count($action_rows['remove_worktree']),
+			'resolve_signal'   => count($action_rows['resolve_signal']),
+		);
 		$plan            = array(
 			'success'        => true,
 			'mode'           => 'cleanup_plan',
@@ -102,6 +114,7 @@ trait WorkspaceCleanupPlan {
 				'worktree_removal' => $worktree_plan,
 			),
 			'rows'           => $rows,
+			'action_rows'    => $action_rows,
 			'summary'        => $summary,
 		);
 		$plan['plan_id'] = $this->stable_cleanup_hash(

--- a/inc/Workspace/WorkspaceCleanupPlan.php
+++ b/inc/Workspace/WorkspaceCleanupPlan.php
@@ -85,18 +85,20 @@ trait WorkspaceCleanupPlan {
 			'resolver'         => $inputs['include_resolvers'] ? $this->build_cleanup_plan_resolver_rows( (array) ( $worktree_plan['skipped'] ?? array() )) : array(),
 		);
 
-		$action_rows     = array(
+		$action_rows = array(
 			'remove_artifacts' => $rows['artifact_cleanup'],
 			'remove_worktree'  => $rows['worktree_removal'],
 			'resolve_signal'   => $rows['resolver'],
 		);
-		$summary         = $this->build_cleanup_plan_summary($rows);
+
+		$summary                   = $this->build_cleanup_plan_summary($rows);
 		$summary['rows_by_action'] = array(
 			'remove_artifacts' => count($action_rows['remove_artifacts']),
 			'remove_worktree'  => count($action_rows['remove_worktree']),
 			'resolve_signal'   => count($action_rows['resolve_signal']),
 		);
-		$plan            = array(
+
+		$plan = array(
 			'success'        => true,
 			'mode'           => 'cleanup_plan',
 			'generated_at'   => gmdate('c'),
@@ -117,6 +119,7 @@ trait WorkspaceCleanupPlan {
 			'action_rows'    => $action_rows,
 			'summary'        => $summary,
 		);
+
 		$plan['plan_id'] = $this->stable_cleanup_hash(
 			array(
 				'inputs' => $inputs,

--- a/inc/Workspace/WorkspaceHygieneReport.php
+++ b/inc/Workspace/WorkspaceHygieneReport.php
@@ -158,6 +158,7 @@ trait WorkspaceHygieneReport {
 		$skip_github         = array_key_exists('skip_github', $opts) ? (bool) $opts['skip_github'] : true;
 		$worktree_cleanup    = array_key_exists('worktree_cleanup', $opts) ? (bool) $opts['worktree_cleanup'] : true;
 		$artifact_cleanup    = array_key_exists('artifact_cleanup', $opts) ? (bool) $opts['artifact_cleanup'] : true;
+		$worktree_stale_only = ! empty($opts['worktree_stale_only']);
 		$worktree_older_than = isset($opts['worktree_older_than']) && '' !== trim( (string) $opts['worktree_older_than']) ? trim( (string) $opts['worktree_older_than']) : '14d';
 
 		$worktree_result = null;
@@ -167,11 +168,12 @@ trait WorkspaceHygieneReport {
 		if ( $worktree_cleanup ) {
 			$worktree_result = $this->worktree_cleanup_merged(
 				array(
-					'dry_run'     => $dry_run,
-					'force'       => $force,
-					'skip_github' => $skip_github,
-					'older_than'  => $worktree_older_than,
-					'sort'        => 'age',
+					'dry_run'             => $dry_run,
+					'force'               => $force,
+					'skip_github'         => $skip_github,
+					'older_than'          => $worktree_older_than,
+					'sort'                => 'age',
+					'stale_liveness_only' => $worktree_stale_only,
 				)
 			);
 			if ( $worktree_result instanceof \WP_Error ) {
@@ -220,6 +222,7 @@ trait WorkspaceHygieneReport {
 				'worktree_cleanup'    => $worktree_cleanup,
 				'artifact_cleanup'    => $artifact_cleanup,
 				'worktree_older_than' => $worktree_older_than,
+				'worktree_stale_only' => $worktree_stale_only,
 				'skip_github'         => $skip_github,
 				'force'               => $force,
 			),

--- a/inc/Workspace/WorkspaceHygieneReport.php
+++ b/inc/Workspace/WorkspaceHygieneReport.php
@@ -368,7 +368,7 @@ trait WorkspaceHygieneReport {
 
 		$rows = array();
 		foreach ( $entries as $entry ) {
-			if ( '.' === $entry || '..' === $entry || str_starts_with((string) $entry, '.') ) {
+			if ( '.' === $entry || '..' === $entry || str_starts_with( (string) $entry, '.' ) ) {
 				continue;
 			}
 
@@ -447,7 +447,7 @@ trait WorkspaceHygieneReport {
 		$dirs = array_values(
 			array_filter(
 				$entries,
-				fn( $entry ) => '.' !== $entry && '..' !== $entry && ! str_starts_with((string) $entry, '.') && is_dir($this->workspace_path . '/' . $entry)
+				fn( $entry ) => '.' !== $entry && '..' !== $entry && ! str_starts_with( (string) $entry, '.' ) && is_dir($this->workspace_path . '/' . $entry)
 			)
 		);
 		sort($dirs, SORT_NATURAL);

--- a/inc/Workspace/WorkspaceWorktreeCleanupEngine.php
+++ b/inc/Workspace/WorkspaceWorktreeCleanupEngine.php
@@ -54,6 +54,7 @@ trait WorkspaceWorktreeCleanupEngine {
 		$direct_apply_plan         = ! empty($opts['direct_apply_plan']);
 		$inventory_only            = ! empty($opts['inventory_only']);
 		$include_repaired_metadata = ! empty($opts['include_repaired_metadata']);
+		$stale_liveness_only       = ! empty($opts['stale_liveness_only']);
 		$apply_plan                = isset($opts['apply_plan']) && is_array($opts['apply_plan']) ? $opts['apply_plan'] : null;
 		$older_than                = isset($opts['older_than']) ? trim( (string) $opts['older_than']) : '';
 		$sort                      = isset($opts['sort']) ? trim( (string) $opts['sort']) : '';
@@ -107,7 +108,7 @@ trait WorkspaceWorktreeCleanupEngine {
 			$force = false;
 
 			if ( $direct_apply_plan && ! $dry_run ) {
-				return $this->apply_worktree_cleanup_plan_candidates($planned_candidates, $force, $started_at);
+				return $this->apply_worktree_cleanup_plan_candidates($planned_candidates, $force, $started_at, $stale_liveness_only);
 			}
 		}
 
@@ -179,6 +180,7 @@ trait WorkspaceWorktreeCleanupEngine {
 			$wt_path      = $wt['path'] ?? '';
 			$metadata     = $wt['metadata'] ?? null;
 			$created_at   = $wt['created_at'] ?? null;
+			$liveness     = (string) ( $wt['liveness'] ?? '' );
 			$disk_fields  = $this->extract_worktree_disk_fields($wt);
 			$identity     = $this->recover_worktree_identity_from_metadata($wt);
 			$repo         = (string) $identity['repo'];
@@ -207,6 +209,24 @@ trait WorkspaceWorktreeCleanupEngine {
 
 			++$checked;
 			$this->emit_worktree_cleanup_progress($progress, 'checking', (string) $handle, $checked, $total_worktrees, $candidates, $skipped, $removed_count, $started_at);
+
+			if ( $stale_liveness_only && 'stale' !== $liveness ) {
+				$skipped[] = array_merge(
+					array(
+						'handle'      => $handle,
+						'repo'        => $repo,
+						'branch'      => $branch,
+						'path'        => $wt_path,
+						'reason_code' => 'active_or_recent_worktree',
+						'reason'      => sprintf('worktree liveness is %s; stale-worktrees mode only removes stale/inactive worktrees', '' !== $liveness ? $liveness : 'unknown'),
+						'liveness'    => $liveness,
+						'created_at'  => $created_at,
+						'metadata'    => $metadata,
+					),
+					$disk_fields
+				);
+				continue;
+			}
 
 			if ( '' === $repo || '' === $branch || '' === $wt_path ) {
 				$missing_fields = array();
@@ -573,6 +593,7 @@ trait WorkspaceWorktreeCleanupEngine {
 					'reason'      => $signal['reason'],
 					'pr_url'      => $signal['pr_url'] ?? null,
 					'created_at'  => $created_at,
+					'liveness'    => $liveness,
 					'metadata'    => $metadata,
 				), $disk_fields
 			);
@@ -582,6 +603,8 @@ trait WorkspaceWorktreeCleanupEngine {
 			$candidates[] = $candidate;
 		}
 
+		$candidates = $this->dedupe_worktree_cleanup_rows($candidates);
+		$skipped    = $this->dedupe_worktree_cleanup_rows($skipped);
 		$candidates = $this->sort_worktree_cleanup_rows($candidates, $sort);
 
 		if ( null !== $planned_candidates ) {
@@ -654,7 +677,13 @@ trait WorkspaceWorktreeCleanupEngine {
 				);
 				continue;
 			}
-			$removed[] = $cand;
+			$removed[] = array_merge(
+				$cand,
+				array(
+					'removed_path'       => (string) ( $cand['path'] ?? '' ),
+					'path_exists_after' => is_dir( (string) ( $cand['path'] ?? '' ) ),
+				)
+			);
 			++$removed_count;
 		}
 
@@ -713,6 +742,34 @@ trait WorkspaceWorktreeCleanupEngine {
 			'next_command'   => $command,
 			'budget_stopped' => $budget_stopped,
 		);
+	}
+
+	/**
+	 * Collapse duplicate cleanup rows emitted by overlapping inventory/git sources.
+	 *
+	 * @param  array<int,array<string,mixed>> $rows Cleanup rows.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function dedupe_worktree_cleanup_rows( array $rows ): array {
+		$seen   = array();
+		$result = array();
+		foreach ( $rows as $row ) {
+			if ( ! is_array($row) ) {
+				continue;
+			}
+			$key = implode('|', array(
+				(string) ( $row['handle'] ?? '' ),
+				(string) ( $row['path'] ?? '' ),
+				(string) ( $row['reason_code'] ?? $row['signal'] ?? '' ),
+			));
+			if ( isset($seen[ $key ]) ) {
+				continue;
+			}
+			$seen[ $key ] = true;
+			$result[]     = $row;
+		}
+
+		return $result;
 	}
 
 	/**
@@ -1089,7 +1146,7 @@ trait WorkspaceWorktreeCleanupEngine {
 	 * @param  float                          $started_at Start timestamp.
 	 * @return array<string,mixed>
 	 */
-	private function apply_worktree_cleanup_plan_candidates( array $candidates, bool $force, float $started_at ): array {
+	private function apply_worktree_cleanup_plan_candidates( array $candidates, bool $force, float $started_at, bool $stale_liveness_only = false ): array {
 		$processed       = 0;
 		$removed         = array();
 		$skipped         = array();
@@ -1097,7 +1154,7 @@ trait WorkspaceWorktreeCleanupEngine {
 
 		foreach ( $candidates as $candidate ) {
 			++$processed;
-			$revalidated = $this->revalidate_bounded_cleanup_eligible_candidate($candidate, $force);
+			$revalidated = $this->revalidate_bounded_cleanup_eligible_candidate($candidate, $force, $stale_liveness_only);
 			if ( isset($revalidated['skipped']) ) {
 				$skipped[] = $revalidated['skipped'];
 				continue;
@@ -1147,7 +1204,14 @@ trait WorkspaceWorktreeCleanupEngine {
 				continue;
 			}
 
-			$removed[]        = array_merge($validated, array( 'size_bytes' => $size ));
+			$removed[]        = array_merge(
+				$validated,
+				array(
+					'size_bytes'        => $size,
+					'removed_path'      => $wt_path,
+					'path_exists_after' => is_dir($wt_path),
+				)
+			);
 			$bytes_reclaimed += max(0, $size);
 		}
 
@@ -1190,11 +1254,26 @@ trait WorkspaceWorktreeCleanupEngine {
 	 * @param  bool  $force     Allow dirty worktrees.
 		 * @return array<string,mixed>
 		 */
-	private function revalidate_bounded_cleanup_eligible_candidate( array $candidate, bool $force ): array {
-		$handle  = (string) ( $candidate['handle'] ?? '' );
-		$repo    = (string) ( $candidate['repo'] ?? '' );
-		$branch  = (string) ( $candidate['branch'] ?? '' );
-		$wt_path = (string) ( $candidate['path'] ?? '' );
+	private function revalidate_bounded_cleanup_eligible_candidate( array $candidate, bool $force, bool $stale_liveness_only = false ): array {
+		$handle   = (string) ( $candidate['handle'] ?? '' );
+		$repo     = (string) ( $candidate['repo'] ?? '' );
+		$branch   = (string) ( $candidate['branch'] ?? '' );
+		$wt_path  = (string) ( $candidate['path'] ?? '' );
+		$liveness = (string) ( $candidate['liveness'] ?? '' );
+
+		if ( $stale_liveness_only && 'stale' !== $liveness ) {
+			return array(
+				'skipped' => array(
+					'handle'      => $handle,
+					'repo'        => $repo,
+					'branch'      => $branch,
+					'path'        => $wt_path,
+					'reason_code' => 'active_or_recent_worktree',
+					'reason'      => sprintf('planned row liveness is %s; stale-worktrees apply only removes stale/inactive worktrees', '' !== $liveness ? $liveness : 'unknown'),
+					'liveness'    => $liveness,
+				),
+			);
+		}
 
 		$missing_fields = array();
 		foreach (

--- a/inc/Workspace/WorkspaceWorktreeCleanupEngine.php
+++ b/inc/Workspace/WorkspaceWorktreeCleanupEngine.php
@@ -680,7 +680,7 @@ trait WorkspaceWorktreeCleanupEngine {
 			$removed[] = array_merge(
 				$cand,
 				array(
-					'removed_path'       => (string) ( $cand['path'] ?? '' ),
+					'removed_path'      => (string) ( $cand['path'] ?? '' ),
 					'path_exists_after' => is_dir( (string) ( $cand['path'] ?? '' ) ),
 				)
 			);
@@ -1794,13 +1794,13 @@ trait WorkspaceWorktreeCleanupEngine {
 	 * @return array<int,array<string,mixed>>
 	 */
 	private function worktree_cleanup_skipped_next_commands( array $skipped_by_reason ): array {
-		$active_no_signal_commands = $this->build_active_no_signal_next_commands(25, 0);
+		$active_no_signal_commands  = $this->build_active_no_signal_next_commands(25, 0);
 		$metadata_reconcile_command = sprintf(
 			'studio wp datamachine-code workspace worktree reconcile-metadata --dry-run --limit=%d --offset=0 --until-budget=%s --format=json',
 			self::METADATA_RECONCILE_DEFAULT_LIMIT,
 			self::METADATA_RECONCILE_DEFAULT_BUDGET
 		);
-		$templates                 = array(
+		$templates                  = array(
 			'artifact_only_dirty_worktree'       => array(
 				'label'       => 'Review generated artifact cleanup separately',
 				'command'     => 'studio wp datamachine-code workspace worktree cleanup-artifacts --dry-run --format=json',
@@ -1808,28 +1808,28 @@ trait WorkspaceWorktreeCleanupEngine {
 				'why'         => 'Dirty paths are limited to declared reconstructable artifact directories, so artifact cleanup can shed them without force-removing source worktrees.',
 				'destructive' => false,
 			),
-			'dirty_worktree'                       => array(
+			'dirty_worktree'                     => array(
 				'label'       => 'Inspect dirty files before retrying cleanup',
 				'command'     => 'git -C <worktree-path> status --short --branch --untracked-files=normal',
 				'alternative' => 'studio wp datamachine-code workspace cleanup run --mode=retention --dry-run --only=dirty_worktree --verbose --format=json',
 				'why'         => 'Shows the exact dirty paths so operators can distinguish generated artifacts from source edits and decide whether to clean, commit, or preserve the worktree.',
 				'destructive' => false,
 			),
-			'unpushed_commits'                     => array(
+			'unpushed_commits'                   => array(
 				'label'       => 'Inspect commits ahead of upstream before cleanup',
 				'command'     => 'git -C <worktree-path> log --oneline --decorate @{u}..HEAD',
 				'alternative' => 'studio wp datamachine-code workspace cleanup run --mode=retention --dry-run --only=unpushed_commits --verbose --format=json',
 				'why'         => 'Lists the protected commits so operators can push, merge, preserve, or intentionally abandon them before retrying cleanup.',
 				'destructive' => false,
 			),
-			'stale_worktree_marker'                => array(
+			'stale_worktree_marker'              => array(
 				'label'       => 'Preview stale git worktree marker pruning',
 				'command'     => 'git -C <primary-path> worktree prune --dry-run --verbose',
 				'alternative' => 'studio wp datamachine-code workspace worktree reconcile-metadata --dry-run --format=json',
 				'why'         => 'Confirms stale git metadata before any prune or registry repair, keeping cleanup non-destructive by default.',
 				'destructive' => false,
 			),
-			'primary_missing'                      => array(
+			'primary_missing'                    => array(
 				'label'       => 'Recover or adopt the missing primary checkout',
 				'command'     => 'studio wp datamachine-code workspace show <repo>',
 				'alternative' => 'Recreate with `studio wp datamachine-code workspace clone <remote-url> --name=<repo>` or adopt an existing checkout with `studio wp datamachine-code workspace adopt <path> --name=<repo>`.',

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -1114,6 +1114,7 @@ namespace {
     datamachine_code_cleanup_assert(str_contains($cleanup_doc_comment, '<plan|apply|run|status|resume|cancel|evidence>'), 'workspace cleanup synopsis exposes DB-backed and task-backed cleanup operations');
     datamachine_code_cleanup_assert(str_contains($cleanup_doc_comment, '[--dry-run]'), 'task-backed cleanup synopsis keeps synchronous dry-run review');
     datamachine_code_cleanup_assert(str_contains($cleanup_doc_comment, '[--drain]'), 'task-backed cleanup synopsis exposes drain option');
+	datamachine_code_cleanup_assert(str_contains($cleanup_doc_comment, 'stale-worktrees'), 'workspace cleanup synopsis exposes stale-worktrees destructive profile');
     datamachine_code_cleanup_assert(str_contains($cleanup_doc_comment, 'apply runs freeze eligible candidates'), 'workspace cleanup limit help clarifies artifact apply scoping');
     datamachine_code_cleanup_assert(str_contains($doc_comment, 'positive maximum worktrees to scan'), 'worktree limit help requires positive page sizes');
     datamachine_code_cleanup_assert(str_contains($doc_comment, 'Use `--exhaustive` instead of `--limit=0`'), 'worktree limit help points unbounded artifact scans to exhaustive mode');
@@ -1166,6 +1167,15 @@ namespace {
 
 	WP_CLI::$logs      = array();
 	WP_CLI::$successes = array();
+	$command->cleanup(array( 'plan' ), array( 'mode' => 'stale-worktrees', 'format' => 'json' ));
+	datamachine_code_cleanup_assert('stale-worktrees' === ( $cleanup_plan_ability->last_input['mode'] ?? '' ), 'stale-worktrees cleanup plan receives explicit destructive profile');
+	datamachine_code_cleanup_assert(false === ( $cleanup_plan_ability->last_input['include_artifacts'] ?? true ), 'stale-worktrees cleanup plan skips artifact rows by default');
+	datamachine_code_cleanup_assert(true === ( $cleanup_plan_ability->last_input['include_worktrees'] ?? false ), 'stale-worktrees cleanup plan keeps worktree removal rows');
+	datamachine_code_cleanup_assert(true === ( $cleanup_plan_ability->last_input['worktree_stale_only'] ?? false ), 'stale-worktrees cleanup plan requires stale liveness');
+	datamachine_code_cleanup_assert('14d' === ( $cleanup_plan_ability->last_input['worktree_older_than'] ?? '' ), 'stale-worktrees cleanup plan defaults to 14d age gate');
+
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
 	$command->cleanup(array( 'run' ), array( 'mode' => 'retention', 'format' => 'json' ));
     $run_json = json_decode(WP_CLI::$logs[0] ?? '', true);
     datamachine_code_cleanup_assert('jobs_queued' === ( $run_json['state'] ?? '' ), 'cleanup run queues a system task');
@@ -1183,7 +1193,15 @@ namespace {
     datamachine_code_cleanup_assert(50 === (int) ( $cleanup_run_ability->last_input['offset'] ?? 0 ), 'cleanup run forwards artifact apply offset');
     $last_scheduled_cleanup_run = $cleanup_run_ability->last_input;
 
-    WP_CLI::$logs      = array();
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->cleanup(array( 'run' ), array( 'mode' => 'stale-worktrees', 'older-than' => '30d', 'format' => 'json' ));
+	datamachine_code_cleanup_assert('stale-worktrees' === ( $cleanup_run_ability->last_input['mode'] ?? '' ), 'cleanup run can schedule stale-worktrees mode');
+	datamachine_code_cleanup_assert(true === ( $cleanup_run_ability->last_input['worktree_stale_only'] ?? false ), 'cleanup run forwards stale-worktrees liveness guard');
+	datamachine_code_cleanup_assert('30d' === ( $cleanup_run_ability->last_input['older_than'] ?? '' ), 'cleanup run forwards stale-worktrees age gate');
+	$last_scheduled_cleanup_run = $cleanup_run_ability->last_input;
+
+	WP_CLI::$logs      = array();
     WP_CLI::$successes = array();
     $command->cleanup(array( 'run' ), array( 'mode' => 'artifacts', 'dry-run' => true, 'format' => 'json' ));
     datamachine_code_cleanup_assert(true === ( $artifact_ability->last_input['dry_run'] ?? false ), 'cleanup run --dry-run uses artifact cleanup ability directly');

--- a/tests/smoke-worktree-cleanup.php
+++ b/tests/smoke-worktree-cleanup.php
@@ -599,6 +599,9 @@ namespace {
     $artifact_row = $cleanup_plan['rows']['artifact_cleanup'][0] ?? array();
     $assert(true, str_starts_with((string) ( $artifact_row['row_id'] ?? '' ), 'cleanup-row-'), 'artifact cleanup row has stable row ID');
     $assert(true, isset($cleanup_plan['rows']['worktree_removal']), 'cleanup plan includes worktree removal row bucket');
+	$assert(true, isset($cleanup_plan['action_rows']['remove_artifacts']), 'cleanup plan exposes remove_artifacts action rows separately');
+	$assert(true, isset($cleanup_plan['action_rows']['remove_worktree']), 'cleanup plan exposes remove_worktree action rows separately');
+	$assert(count($cleanup_plan['rows']['worktree_removal'] ?? array()), count($cleanup_plan['action_rows']['remove_worktree'] ?? array()), 'remove_worktree action rows mirror worktree removal rows');
     $assert_contains($cleanup_plan['rows']['worktree_removal'] ?? array(), 'demo@unmerged-feature', 'cleanup plan promotes locally clean remote-backed worktree instead of active/no-signal resolver');
     $assert(true, isset($cleanup_plan['rows']['resolver']), 'cleanup plan includes optional resolver row bucket');
     $chunk_report = $ws->workspace_cleanup_plan_chunks(


### PR DESCRIPTION
## Summary
- Adds an explicit `stale-worktrees` cleanup profile for destructive whole-worktree removal, separate from artifact cleanup.
- Exposes `remove_artifacts` and `remove_worktree` action buckets in cleanup plans while keeping dirty, unpushed, recent, active, protected, and non-stale worktrees guarded by default.
- Carries stale-liveness policy through CLI, abilities, task-backed cleanup chunks, DB-backed apply, and removal evidence (`removed_path`, `path_exists_after`, reclaimed bytes).

Closes #675.

## Verification
- `php -l inc/Cli/Commands/WorkspaceCommand.php && php -l inc/Abilities/WorkspaceAbilities.php && php -l inc/Tasks/WorkspaceRetentionCleanupTask.php && php -l inc/Tasks/WorktreeCleanupChunkTask.php && php -l inc/Workspace/CleanupRunService.php && php -l inc/Workspace/WorkspaceCleanupPlan.php && php -l inc/Workspace/WorkspaceHygieneReport.php && php -l inc/Workspace/WorkspaceWorktreeCleanupEngine.php`
- `git diff --check`
- `php tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-cleanup-run-storage.php`
- `php tests/smoke-worktree-cleanup-artifacts.php`
- `php tests/smoke-worktree-cleanup.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the cleanup profile, safety propagation, tests, and verification commands for Chris to review.