### PR TITLE
fix(agents-md): generate datamachine-code sections from real command tree (#671)

### DIFF
--- a/inc/Runtime/AgentsMdSections.php
+++ b/inc/Runtime/AgentsMdSections.php
@@ -88,6 +88,23 @@ MD;
 					? "On this site, scope memory commands with `--agent={$agent_slug}` when reading, writing, searching, or composing agent memory."
 					: 'On multi-agent installs, pass `--agent=<slug>` to memory commands when auto-resolution is ambiguous.';
 
+				// Generate DMC's own command surface from reflection so the lists
+				// never drift from the registered truth (see #671). The fallback
+				// pipe-lists are only used if a command class is somehow
+				// unavailable in this compose context.
+				$workspace_subcmds = CommandIntrospector::pipe_list(
+					'\\DataMachineCode\\Cli\\Commands\\WorkspaceCommand',
+					'adopt|clone|list|show|path|hygiene|remove|worktree|read|write|grep|edit|git|patch|ls'
+				);
+				$github_subcmds = CommandIntrospector::pipe_list(
+					'\\DataMachineCode\\Cli\\Commands\\GitHubCommand',
+					'issues|pulls|repos|status|view|close|review-flow|comment'
+				);
+				$gitsync_subcmds = CommandIntrospector::pipe_list(
+					'\\DataMachineCode\\Cli\\Commands\\GitSyncCommand',
+					'bind|list|status|pull|submit|push|policy|unbind'
+				);
+
 				return <<<MD
 ## Data Machine
 
@@ -124,10 +141,10 @@ Discover the full command surface: `{$wp} datamachine --help`. The groups below 
 
 **Code (data-machine-code):** All code changes happen in Data Machine Code worktrees under `{$workspace_path}`. DMC owns workspace lifecycle, evidence capture, GitHub workflow glue, and GitSync; file CRUD inside a worktree uses whatever tool is fastest.
 - Workspace root: `{$workspace_path}`
-- **Workspace lifecycle:** `{$wp} datamachine-code workspace adopt|clone|list|show|path|hygiene|remove|worktree` — keeps the on-disk registry consistent and enforces the `<repo>@<slug>` handle convention.
+- **Workspace:** `{$wp} datamachine-code workspace {$workspace_subcmds}` — lifecycle (clone/adopt/list/show/path/hygiene/remove/worktree), plus the file-I/O surface you work through inside a worktree (`read`, `write`, `grep`, `edit`, `patch`, `ls`, `git`). Keeps the on-disk registry consistent and enforces the `<repo>@<slug>` handle convention.
 - **Worktrees:** `{$wp} datamachine-code workspace worktree add|list|remove|prune|cleanup|cleanup-artifacts|reconcile-metadata|refresh-context|finalize|mark-cleanup-eligible` — create isolated branches, refresh agent context, attach lifecycle metadata, and clean up safely.
-- **GitHub:** `{$wp} datamachine-code github issues|pulls|repos|status|view|close|review-flow|comment` — list/read GitHub state, manage issues, install review flows, and comment on reviews.
-- **Git sync:** `{$wp} datamachine-code gitsync bind|list|status|pull|submit|push|policy|unbind` — bind site-owned directories to remotes; `submit` opens or updates the PR path, while `push` writes directly to the configured branch.
+- **GitHub:** `{$wp} datamachine-code github {$github_subcmds}` — list/read GitHub state, manage issues and PRs, install review flows, and comment on reviews.
+- **Git sync:** `{$wp} datamachine-code gitsync {$gitsync_subcmds}` — bind site-owned directories to remotes; `submit` opens or updates the PR path, while `push` writes directly to the configured branch.
 - **Editing inside a worktree:** any tool. Local agents on the same disk should use native file I/O and raw `git`; routing edits through workspace abilities is ceremony, not safety.
 - **Workflow:** reuse the existing primary when one exists for the remote; otherwise `workspace clone <repo>` once → `worktree add <repo> <branch>` → edit files in the worktree with any tool → commit → push → PR.
 - **Primary freshness:** before using a primary checkout for investigation or verification, inspect `workspace list|show|hygiene` freshness metadata. If the primary is stale, run `workspace git pull <repo> --allow-primary-mutation` or create the worktree from an explicit remote ref with `worktree add <repo> <branch> --from=origin/<base>`. Do not clone a second top-level primary for the same remote just to get fresh code.

--- a/inc/Runtime/AgentsMdSections.php
+++ b/inc/Runtime/AgentsMdSections.php
@@ -96,11 +96,11 @@ MD;
 					'\\DataMachineCode\\Cli\\Commands\\WorkspaceCommand',
 					'adopt|clone|list|show|path|hygiene|remove|worktree|read|write|grep|edit|git|patch|ls'
 				);
-				$github_subcmds = CommandIntrospector::pipe_list(
+				$github_subcmds    = CommandIntrospector::pipe_list(
 					'\\DataMachineCode\\Cli\\Commands\\GitHubCommand',
 					'issues|pulls|repos|status|view|close|review-flow|comment'
 				);
-				$gitsync_subcmds = CommandIntrospector::pipe_list(
+				$gitsync_subcmds   = CommandIntrospector::pipe_list(
 					'\\DataMachineCode\\Cli\\Commands\\GitSyncCommand',
 					'bind|list|status|pull|submit|push|policy|unbind'
 				);

--- a/inc/Runtime/CommandIntrospector.php
+++ b/inc/Runtime/CommandIntrospector.php
@@ -41,16 +41,13 @@ final class CommandIntrospector {
 	 * @return array<string,string> Ordered map of subcommand => description.
 	 */
 	public static function subcommands( string $command_class ): array {
+		// class_exists() triggers autoloading; once it returns true the
+		// ReflectionClass constructor cannot throw, so no try/catch is needed.
 		if ( ! class_exists($command_class) ) {
 			return array();
 		}
 
-		try {
-			$reflection = new \ReflectionClass($command_class);
-		} catch ( \Throwable $e ) {
-			return array();
-		}
-
+		$reflection  = new \ReflectionClass($command_class);
 		$subcommands = array();
 
 		foreach ( $reflection->getMethods(\ReflectionMethod::IS_PUBLIC) as $method ) {

--- a/inc/Runtime/CommandIntrospector.php
+++ b/inc/Runtime/CommandIntrospector.php
@@ -37,16 +37,16 @@ final class CommandIntrospector {
 	 * Returns an empty array when the class is unavailable or has no subcommands,
 	 * so callers can fall back gracefully without fatals in any context.
 	 *
-	 * @param string $class Fully-qualified command class name.
+	 * @param string $command_class Fully-qualified command class name.
 	 * @return array<string,string> Ordered map of subcommand => description.
 	 */
-	public static function subcommands( string $class ): array {
-		if ( ! class_exists($class) ) {
+	public static function subcommands( string $command_class ): array {
+		if ( ! class_exists($command_class) ) {
 			return array();
 		}
 
 		try {
-			$reflection = new \ReflectionClass($class);
+			$reflection = new \ReflectionClass($command_class);
 		} catch ( \Throwable $e ) {
 			return array();
 		}
@@ -77,11 +77,11 @@ final class CommandIntrospector {
 	/**
 	 * Return only the subcommand names for a class, in declaration order.
 	 *
-	 * @param string $class Fully-qualified command class name.
+	 * @param string $command_class Fully-qualified command class name.
 	 * @return string[] Ordered list of subcommand names.
 	 */
-	public static function subcommand_names( string $class ): array {
-		return array_keys(self::subcommands($class));
+	public static function subcommand_names( string $command_class ): array {
+		return array_keys(self::subcommands($command_class));
 	}
 
 	/**
@@ -90,12 +90,12 @@ final class CommandIntrospector {
 	 * Falls back to the supplied default string when reflection yields nothing,
 	 * so AGENTS.md never renders an empty command line.
 	 *
-	 * @param string $class    Fully-qualified command class name.
-	 * @param string $fallback Pipe-list to use when reflection is unavailable.
+	 * @param string $command_class Fully-qualified command class name.
+	 * @param string $fallback      Pipe-list to use when reflection is unavailable.
 	 * @return string
 	 */
-	public static function pipe_list( string $class, string $fallback = '' ): string {
-		$names = self::subcommand_names($class);
+	public static function pipe_list( string $command_class, string $fallback = '' ): string {
+		$names = self::subcommand_names($command_class);
 		if ( empty($names) ) {
 			return $fallback;
 		}

--- a/inc/Runtime/CommandIntrospector.php
+++ b/inc/Runtime/CommandIntrospector.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Reflection-based introspection of Data Machine Code WP-CLI command classes.
+ *
+ * AGENTS.md sections must describe the *real* command surface, not a hand-typed
+ * pipe-list that silently drifts (see Extra-Chill/data-machine-code#671). This
+ * helper reflects over the command classes' `@subcommand` annotations and PHPDoc
+ * summaries to produce truthful subcommand lists.
+ *
+ * IMPORTANT: this is a DMC-local stopgap pending the shared, substrate-level
+ * command-tree introspector tracked in Extra-Chill/data-machine#2613. Once that
+ * lands, both this helper and the consuming AGENTS.md sections should migrate to
+ * the shared implementation. Until then, keep this self-contained.
+ *
+ * Context safety: this runs on `plugins_loaded` in web/cron compose contexts,
+ * NOT only under WP-CLI. It therefore reflects over autoloadable command CLASSES
+ * (via ReflectionClass) and never touches the live WP_CLI runner. Reflecting a
+ * class does not instantiate it, so command-class constructor dependencies are
+ * never exercised.
+ *
+ * @package DataMachineCode\Runtime
+ */
+
+namespace DataMachineCode\Runtime;
+
+defined('ABSPATH') || exit;
+
+final class CommandIntrospector {
+
+	/**
+	 * Reflect over a command class and return its subcommands as
+	 * `[ 'name' => 'short description', ... ]`, preserving declaration order.
+	 *
+	 * Each public method annotated with `@subcommand <name>` becomes an entry.
+	 * The description is the first non-tag line of the method's PHPDoc summary.
+	 *
+	 * Returns an empty array when the class is unavailable or has no subcommands,
+	 * so callers can fall back gracefully without fatals in any context.
+	 *
+	 * @param string $class Fully-qualified command class name.
+	 * @return array<string,string> Ordered map of subcommand => description.
+	 */
+	public static function subcommands( string $class ): array {
+		if ( ! class_exists($class) ) {
+			return array();
+		}
+
+		try {
+			$reflection = new \ReflectionClass($class);
+		} catch ( \Throwable $e ) {
+			return array();
+		}
+
+		$subcommands = array();
+
+		foreach ( $reflection->getMethods(\ReflectionMethod::IS_PUBLIC) as $method ) {
+			if ( $method->isStatic() || $method->getDeclaringClass()->getName() !== $reflection->getName() ) {
+				continue;
+			}
+
+			$doc = $method->getDocComment();
+			if ( false === $doc || '' === $doc ) {
+				continue;
+			}
+
+			$name = self::extract_subcommand_name($doc);
+			if ( '' === $name ) {
+				continue;
+			}
+
+			$subcommands[ $name ] = self::extract_summary($doc);
+		}
+
+		return $subcommands;
+	}
+
+	/**
+	 * Return only the subcommand names for a class, in declaration order.
+	 *
+	 * @param string $class Fully-qualified command class name.
+	 * @return string[] Ordered list of subcommand names.
+	 */
+	public static function subcommand_names( string $class ): array {
+		return array_keys(self::subcommands($class));
+	}
+
+	/**
+	 * Render a `a|b|c` pipe-list of a class's subcommand names.
+	 *
+	 * Falls back to the supplied default string when reflection yields nothing,
+	 * so AGENTS.md never renders an empty command line.
+	 *
+	 * @param string $class    Fully-qualified command class name.
+	 * @param string $fallback Pipe-list to use when reflection is unavailable.
+	 * @return string
+	 */
+	public static function pipe_list( string $class, string $fallback = '' ): string {
+		$names = self::subcommand_names($class);
+		if ( empty($names) ) {
+			return $fallback;
+		}
+
+		return implode('|', $names);
+	}
+
+	/**
+	 * Pull the `@subcommand <name>` value out of a PHPDoc block.
+	 *
+	 * @param string $doc Raw docblock text.
+	 * @return string Subcommand name, or '' when not annotated.
+	 */
+	private static function extract_subcommand_name( string $doc ): string {
+		if ( preg_match('/@subcommand\s+(\S+)/', $doc, $matches) ) {
+			return trim($matches[1]);
+		}
+
+		return '';
+	}
+
+	/**
+	 * Extract the first non-empty, non-tag summary line from a docblock.
+	 *
+	 * @param string $doc Raw docblock text.
+	 * @return string Short description, or '' when none is present.
+	 */
+	private static function extract_summary( string $doc ): string {
+		$lines = preg_split('/\r\n|\r|\n/', $doc);
+		if ( false === $lines ) {
+			return '';
+		}
+
+		foreach ( $lines as $line ) {
+			$line = trim($line);
+			$line = ltrim($line, '/*');
+			$line = trim($line);
+
+			if ( '' === $line ) {
+				continue;
+			}
+
+			// Skip annotation/usage lines; we only want the prose summary.
+			if ( '@' === $line[0] || '#' === $line[0] ) {
+				continue;
+			}
+
+			return $line;
+		}
+
+		return '';
+	}
+}

--- a/tests/smoke-agents-md-marker.php
+++ b/tests/smoke-agents-md-marker.php
@@ -45,9 +45,17 @@ $stale_marker               = 'datamachine agent compose AGENTS.md';
 $expected_memory_agent_note = 'On multi-agent installs, pass `--agent=<slug>` to memory commands when auto-resolution is ambiguous.';
 $expected_agent_cli         = 'datamachine agent list|create|access|token|installed|install|diff';
 $stale_agent_cli            = 'datamachine agents list|create|access|tokens';
-$expected_workspace_cli     = 'datamachine-code workspace adopt|clone|list|show|path|hygiene|remove|worktree';
+// Workspace / GitHub / GitSync subcommand lists are now generated from the
+// command classes via CommandIntrospector (see #671) instead of hardcoded
+// pipe-lists, so the source asserts on the generation wiring + interpolation
+// tokens rather than a frozen string. The actual produced surface is exercised
+// against the real command classes further down.
+$expected_workspace_token   = 'datamachine-code workspace {$workspace_subcmds}';
+$expected_github_token       = 'datamachine-code github {$github_subcmds}';
+$expected_gitsync_token      = 'datamachine-code gitsync {$gitsync_subcmds}';
+$expected_introspect_wiring  = 'CommandIntrospector::pipe_list(';
+$stale_hardcoded_workspace   = 'workspace adopt|clone|list|show|path|hygiene|remove|worktree';
 $expected_worktree_cli      = 'datamachine-code workspace worktree add|list|remove|prune|cleanup|cleanup-artifacts|reconcile-metadata|refresh-context|finalize|mark-cleanup-eligible';
-$expected_gitsync_cli       = 'gitsync bind|list|status|pull|submit|push|policy|unbind';
 $expected_inventory_time    = 'Generated {$generated_at} from cloned repos';
 $expected_inventory_truth   = 'workspace list` is the source of truth';
 $expected_inventory_refresh = 'datamachine memory compose AGENTS.md{$agent_suffix}';
@@ -88,8 +96,16 @@ $assert(
     ! str_contains($source, $stale_agent_cli)
 );
 $assert(
-    'workspace lifecycle guidance includes current command family',
-    str_contains($source, $expected_workspace_cli)
+    'workspace guidance is generated from the command class, not hardcoded',
+    str_contains($source, $expected_workspace_token) && str_contains($source, $expected_introspect_wiring)
+);
+$assert(
+    'stale hardcoded workspace pipe-list is gone (#671)',
+    ! str_contains($source, $stale_hardcoded_workspace)
+);
+$assert(
+    'GitHub guidance is generated from the command class',
+    str_contains($source, $expected_github_token)
 );
 $assert(
     'worktree guidance includes current maintenance surfaces',
@@ -112,8 +128,8 @@ $assert(
     str_contains($source, $expected_abilities_note) && ! str_contains($source, $stale_abilities_cli)
 );
 $assert(
-    'GitSync guidance distinguishes compact sync family',
-    str_contains($source, $expected_gitsync_cli)
+    'GitSync guidance is generated from the command class',
+    str_contains($source, $expected_gitsync_token)
 );
 $assert(
     'AGENTS.md sections declare Data Machine Code ownership',
@@ -142,6 +158,56 @@ $assert(
 $assert(
     'plugin entrypoint no longer contains AGENTS.md heredoc sections',
     ! str_contains($entrypoint, $expected_agent_cli)
+);
+
+/*
+ * Exercise the reflection introspector against the real command classes in a
+ * non-WP-CLI context. This proves the workspace file-I/O surface that #671 was
+ * about (read/write/grep/edit/git/patch/ls) is actually produced, and that the
+ * helper runs without the WP_CLI runner being present.
+ */
+echo "\nCommandIntrospector against real command classes:\n";
+
+if (! defined('ABSPATH') ) {
+    define('ABSPATH', __DIR__ . '/');
+}
+if (! class_exists('WP_CLI') ) {
+    eval('class WP_CLI {}');
+}
+if (! class_exists('DataMachine\\Cli\\BaseCommand') ) {
+    eval('namespace DataMachine\\Cli; class BaseCommand {}');
+}
+
+require_once __DIR__ . '/../inc/Runtime/CommandIntrospector.php';
+require_once __DIR__ . '/../inc/Cli/Commands/WorkspaceCommand.php';
+require_once __DIR__ . '/../inc/Cli/Commands/GitHubCommand.php';
+require_once __DIR__ . '/../inc/Cli/Commands/GitSyncCommand.php';
+
+$workspace_subs = \DataMachineCode\Runtime\CommandIntrospector::subcommand_names('\\DataMachineCode\\Cli\\Commands\\WorkspaceCommand');
+$github_subs    = \DataMachineCode\Runtime\CommandIntrospector::subcommand_names('\\DataMachineCode\\Cli\\Commands\\GitHubCommand');
+$gitsync_subs   = \DataMachineCode\Runtime\CommandIntrospector::subcommand_names('\\DataMachineCode\\Cli\\Commands\\GitSyncCommand');
+
+$required_file_io = array( 'read', 'write', 'grep', 'edit', 'git', 'patch', 'ls' );
+$missing_file_io  = array_values(array_diff($required_file_io, $workspace_subs));
+
+$assert(
+    'workspace reflection surfaces the file-I/O subcommands omitted by #671',
+    empty($missing_file_io)
+);
+if (! empty($missing_file_io) ) {
+    echo '    missing: ' . implode(', ', $missing_file_io) . "\n";
+}
+$assert(
+    'workspace reflection still surfaces lifecycle subcommands',
+    empty(array_diff(array( 'clone', 'adopt', 'worktree', 'hygiene' ), $workspace_subs))
+);
+$assert(
+    'github reflection surfaces issue + PR subcommands',
+    empty(array_diff(array( 'issues', 'pulls', 'review-flow', 'comment' ), $github_subs))
+);
+$assert(
+    'gitsync reflection surfaces bind/submit/push subcommands',
+    empty(array_diff(array( 'bind', 'submit', 'push', 'policy' ), $gitsync_subs))
 );
 
 if (! empty($failures) ) {


### PR DESCRIPTION
## Summary

Fixes #671. The `datamachine-code` AGENTS.md section hardcoded subcommand pipe-lists that had drifted from the registered CLI surface and **omitted the entire file-I/O surface** an agent works through inside a worktree (`read`/`write`/`grep`/`edit`/`git`/`patch`/`ls`). An agent reading AGENTS.md to learn its tools had no idea those existed and fell back to raw bash — defeating the point of the workspace abstraction.

The heredoc claimed 8 workspace subcommands (`adopt|clone|list|show|path|hygiene|remove|worktree`); the real `wp datamachine-code workspace` surface is 19.

## What changed

- **New `inc/Runtime/CommandIntrospector.php`** — a self-contained helper that reflects over the DMC command **classes** (`ReflectionClass` over `@subcommand` annotations + PHPDoc summaries). It never touches the live `WP_CLI` runner, so it is safe in the web/cron `plugins_loaded` compose contexts where these section callbacks run. Reflecting a class does not instantiate it, so command-class constructor deps are never exercised.
- **`inc/Runtime/AgentsMdSections.php`** — the `workspace` / `github` / `gitsync` lines in the **Code** subsection now generate their pipe-lists from the introspector. The prior hand-typed lists remain only as graceful fallbacks if a class is somehow unavailable.
- **`tests/smoke-agents-md-marker.php`** — updated to assert the generation wiring is present (and the stale hardcoded list is gone), plus a new block that exercises the introspector against the real command classes and asserts `read/write/grep/edit/git/patch/ls` are produced.

## Dependency / scope note

This is the **fallback path** from #671. The preferred fix uses the shared substrate-level introspection helper tracked in **Extra-Chill/data-machine#2613** — but #2613 is still an open issue with no PR, and `DataMachine\Engine\AI\CliCommandIntrospector` does not exist in the deployed data-machine (v0.142.8). So this PR ships a DMC-local, self-contained introspector that is later swappable to the shared helper. Both this helper and the consuming sections should migrate to the data-machine#2613 implementation once it lands (noted in the class docblock).

Scoped to DMC's **own** command classes (which it can reflect over directly). The broader curated `datamachine` substrate groups (Memory/Automation/Communication/Content ops) are editorial and owned by data-machine — left untouched.

## Verification

`php -l` clean on all three files. The AGENTS.md marker smoke test passes 29/29 including the new reflection checks:

```
  PASS workspace guidance is generated from the command class, not hardcoded
  PASS stale hardcoded workspace pipe-list is gone (#671)
  PASS GitHub guidance is generated from the command class
  PASS GitSync guidance is generated from the command class
  ...
CommandIntrospector against real command classes:
  PASS workspace reflection surfaces the file-I/O subcommands omitted by #671
  PASS workspace reflection still surfaces lifecycle subcommands
  PASS github reflection surfaces issue + PR subcommands
  PASS gitsync reflection surfaces bind/submit/push subcommands
```

The generated **Code** subsection lines (rendered via a standalone reproduction of the callback, since the new code is not yet deployed) now read:

```
- **Workspace:** wp ... datamachine-code workspace path|list|triage|clone|adopt|cleanup|remove|hygiene|inventory|show|read|ls|grep|write|edit|patch|delete|git|worktree — lifecycle ..., plus the file-I/O surface you work through inside a worktree (read, write, grep, edit, patch, ls, git). ...
- **GitHub:** wp ... datamachine-code github issues|view|close|comment|pulls|merge|cleanup-pr|repos|status|migrate-credentials|review-flow — ...
- **Git sync:** wp ... datamachine-code gitsync list|bind|unbind|pull|status|submit|push|policy — ...
```

> Note: the live `wp datamachine memory compose AGENTS.md` on production still emits the old 8-item list because this fix is PR-only and not yet deployed. Once merged + deployed, the next compose surfaces the full reflected surface with no heredoc edit.

## Related
- Extra-Chill/data-machine#2613 (substrate helper — migrate to it once it lands)
- Extra-Chill/extrachill-cli#28 (same class of bug, CLI section)