### PR TITLE
Fix local workspace path precedence

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -2493,6 +2493,14 @@ class WorkspaceAbilities {
 	 * @return array Result.
 	 */
 	public static function showRepo( array $input ): array|\WP_Error {
+		$workspace = new Workspace();
+		if ( RemoteWorkspaceBackend::should_handle() ) {
+			$local_result = self::showLocalWorkspaceHandleIfPresent($workspace, (string) ( $input['name'] ?? '' ));
+			if ( null !== $local_result ) {
+				return $local_result;
+			}
+		}
+
 		if ( RemoteWorkspaceBackend::should_handle() ) {
 			$result = ( new RemoteWorkspaceBackend() )->show($input['name'] ?? '');
 			if ( ! self::shouldFallbackToLocalWorkspace($result) ) {
@@ -2500,7 +2508,6 @@ class WorkspaceAbilities {
 			}
 		}
 
-		$workspace = new Workspace();
 		return $workspace->show_repo($input['name'] ?? '');
 	}
 
@@ -3461,17 +3468,34 @@ class WorkspaceAbilities {
 	 * Whether a repo argument resolves to an editable local primary checkout.
 	 */
 	private static function hasLocalPrimaryCheckout( Workspace $workspace, string $repo ): bool {
-		if ( '' === trim($repo) ) {
-			return false;
-		}
-
-		$result = $workspace->show_repo($repo);
-		if ( is_wp_error($result) ) {
+		$result = self::showLocalWorkspaceHandleIfPresent($workspace, $repo);
+		if ( null === $result ) {
 			return false;
 		}
 
 		$path = (string) ( $result['path'] ?? '' );
-		return '' !== $path && ! str_starts_with($path, 'github://') && ! str_contains(basename($path), '@');
+		return ! str_contains(basename($path), '@');
+	}
+
+	/**
+	 * Return local workspace details for an existing local handle, if present.
+	 */
+	private static function showLocalWorkspaceHandleIfPresent( Workspace $workspace, string $handle ): ?array {
+		if ( '' === trim($handle) ) {
+			return null;
+		}
+
+		$result = $workspace->show_repo($handle);
+		if ( is_wp_error($result) ) {
+			return null;
+		}
+
+		$path = (string) ( $result['path'] ?? '' );
+		if ( '' === $path || str_starts_with($path, 'github://') ) {
+			return null;
+		}
+
+		return $result;
 	}
 
 	/**

--- a/tests/smoke-workspace-local-fallback.php
+++ b/tests/smoke-workspace-local-fallback.php
@@ -22,6 +22,7 @@ namespace DataMachineCode\Workspace {
 	{
 		public static array $show_input = array();
 		public static array $worktree_input = array();
+		public static bool $show_returns_remote_success = false;
 		public static bool $worktree_returns_remote_success = false;
 
 		public static function should_handle(): bool
@@ -29,9 +30,19 @@ namespace DataMachineCode\Workspace {
 			return true;
 		}
 
-		public function show( string $handle ): \WP_Error
+		public function show( string $handle ): array|\WP_Error
 		{
 			self::$show_input = compact('handle');
+			if ( self::$show_returns_remote_success ) {
+				return array(
+					'success'     => true,
+					'name'        => $handle,
+					'repo'        => $handle,
+					'is_worktree' => str_contains($handle, '@'),
+					'path'        => 'github://Automattic/' . str_replace('@', '#', $handle),
+				);
+			}
+
 			return new \WP_Error(
 				'remote_workspace_repo_not_found',
 				'Remote workspace repository "wpcom-codebox" is not registered. Call workspace_clone first.'
@@ -64,13 +75,17 @@ namespace DataMachineCode\Workspace {
 		public function show_repo( string $handle ): array
 		{
 			self::$show_input = compact('handle');
+			$parsed = explode('@', $handle, 2);
+			$repo   = $parsed[0];
+			$slug   = $parsed[1] ?? '';
+			$path   = '/Users/chubes/Developer/' . $handle;
 			return array(
 				'success'     => true,
 				'name'        => $handle,
-				'repo'        => $handle,
-				'is_worktree' => false,
-				'path'        => '/Users/chubes/Developer/' . $handle,
-				'branch'      => 'main',
+				'repo'        => $repo,
+				'is_worktree' => '' !== $slug,
+				'path'        => $path,
+				'branch'      => '' !== $slug ? str_replace('-', '/', $slug) : 'main',
 				'remote'      => 'git@github.a8c.com:Automattic/wpcom-codebox.git',
 				'commit'      => 'abc123 listed primary',
 				'dirty'       => 0,
@@ -161,9 +176,30 @@ namespace {
 		)
 	);
 
-	$assert('remote show attempted first', 'wpcom-codebox' === ( \DataMachineCode\Workspace\RemoteWorkspaceBackend::$show_input['handle'] ?? '' ));
-	$assert('local show fallback attempted', 'wpcom-codebox' === ( \DataMachineCode\Workspace\Workspace::$show_input['handle'] ?? '' ));
+	$assert('remote show is not consulted when local primary exists', array() === \DataMachineCode\Workspace\RemoteWorkspaceBackend::$show_input);
+	$assert('local show attempted first', 'wpcom-codebox' === ( \DataMachineCode\Workspace\Workspace::$show_input['handle'] ?? '' ));
 	$assert('show returns local listed primary', is_array($show) && '/Users/chubes/Developer/wpcom-codebox' === ( $show['path'] ?? '' ));
+
+	\DataMachineCode\Workspace\RemoteWorkspaceBackend::$show_returns_remote_success = true;
+	\DataMachineCode\Workspace\RemoteWorkspaceBackend::$show_input = array();
+	\DataMachineCode\Workspace\Workspace::$show_input = array();
+	$duplicate_show = \DataMachineCode\Abilities\WorkspaceAbilities::showRepo(
+		array(
+			'name' => 'wpcom-codebox',
+		)
+	);
+
+	$assert('duplicate remote show is not consulted when local primary exists', array() === \DataMachineCode\Workspace\RemoteWorkspaceBackend::$show_input);
+	$assert('duplicate local primary wins show path', is_array($duplicate_show) && '/Users/chubes/Developer/wpcom-codebox' === ( $duplicate_show['path'] ?? '' ));
+
+	$duplicate_path = \DataMachineCode\Abilities\WorkspaceAbilities::getPath(
+		array(
+			'name' => 'wpcom-codebox@fix-listed-primary-resolution',
+		)
+	);
+
+	$assert('workspace path returns local worktree when duplicate remote exists', is_array($duplicate_path) && '/Users/chubes/Developer/wpcom-codebox@fix-listed-primary-resolution' === ( $duplicate_path['path'] ?? '' ));
+	$assert('workspace path marks local worktree handle as existing', is_array($duplicate_path) && true === ( $duplicate_path['exists'] ?? null ));
 
 	\DataMachineCode\Workspace\RemoteWorkspaceBackend::$worktree_returns_remote_success = true;
 	\DataMachineCode\Workspace\RemoteWorkspaceBackend::$worktree_input = array();


### PR DESCRIPTION
## Summary
- Prefer an existing local workspace handle before consulting the remote workspace backend for `workspace show` and `workspace path`.
- Reuse the local-handle lookup for worktree creation so duplicate remote/local records cannot route editable worktrees to `github://`.
- Extend the local fallback smoke test to cover duplicate remote success rows losing to local primary/worktree paths.

Fixes https://github.com/Extra-Chill/data-machine-code/issues/687

## Verification
- `php -l inc/Abilities/WorkspaceAbilities.php`
- `php -l tests/smoke-workspace-local-fallback.php`
- `php tests/smoke-workspace-local-fallback.php`
- `php tests/smoke-workspace-path-cli.php`
- `php tests/smoke-workspace-adopt.php`
- `php tests/smoke-worktree-handles.php`

## Live command note
The exact `studio wp datamachine-code workspace ...` commands from #687 still exercise the installed plugin at `wp-content/plugins/data-machine-code` on this Studio site, not this PR worktree. I tried a read-only `--skip-plugins=data-machine-code --require=<worktree>/data-machine-code.php` WP-CLI load path, but it did not register the command surface. Re-run the exact #687 commands after this PR is merged/synced into the active plugin.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the local workspace precedence fix and focused smoke coverage; Chris remains responsible for review and merge.