### PR TITLE
Fix cleanup drain JSON run visibility

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -767,10 +767,26 @@ class WorkspaceCommand extends BaseCommand {
 
 		$result = $this->attach_cleanup_run_commands($result, $mode);
 		if ( ! empty($assoc_args['drain']) ) {
+			if ( 'json' === (string) ( $assoc_args['format'] ?? 'table' ) ) {
+				$this->render_cleanup_control_result($result + array( 'drain_state' => 'scheduled' ), $assoc_args);
+				$this->flush_cli_output();
+			}
 			$result = $this->drain_cleanup_run_to_status($result, $assoc_args);
 		}
 
 		$this->render_cleanup_control_result($result, $assoc_args);
+	}
+
+	/**
+	 * Flush stdout so JSON drain callers see the scheduled run before draining blocks.
+	 *
+	 * @return void
+	 */
+	private function flush_cli_output(): void {
+		if ( defined('STDOUT') ) {
+			fflush(STDOUT);
+		}
+		flush();
 	}
 
 	/**

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -44,6 +44,7 @@ namespace {
         {
             self::$runcommands[] = $command;
             if ('datamachine drain --job-id=123' === $command ) {
+                $GLOBALS['datamachine_code_cleanup_parent_drain_saw_scheduled_json'] = json_decode(self::$logs[0] ?? '', true);
                 $GLOBALS['datamachine_code_cleanup_parent_drained'] = true;
             }
             if ('datamachine drain --job-id=125' === $command ) {
@@ -1397,14 +1398,21 @@ namespace {
     WP_CLI::$runcommands = array();
     $GLOBALS['datamachine_code_cleanup_parent_drained'] = false;
     $GLOBALS['datamachine_code_cleanup_child_drained']  = false;
+    $GLOBALS['datamachine_code_cleanup_parent_drain_saw_scheduled_json'] = array();
     $command->cleanup(array( 'run' ), array( 'mode' => 'artifacts', 'drain' => true, 'format' => 'json' ));
-    $drained_json = json_decode(WP_CLI::$logs[0] ?? '', true);
+    $scheduled_json = json_decode(WP_CLI::$logs[0] ?? '', true);
+    $drained_json   = json_decode(end(WP_CLI::$logs) ?: '', true);
     datamachine_code_cleanup_assert(array( 'datamachine drain --job-id=123', 'datamachine drain --job-id=125' ) === WP_CLI::$runcommands, 'cleanup run --drain drains parent then active child jobs');
+    datamachine_code_cleanup_assert('cleanup-run-123' === ( $scheduled_json['run_id'] ?? '' ), 'cleanup run --drain JSON emits scheduled run id before final status');
+    datamachine_code_cleanup_assert(123 === (int) ( $scheduled_json['job_id'] ?? 0 ), 'cleanup run --drain JSON emits scheduled job id before final status');
+    datamachine_code_cleanup_assert('scheduled' === ( $scheduled_json['drain_state'] ?? '' ), 'cleanup run --drain JSON marks the early scheduled event');
+    datamachine_code_cleanup_assert('cleanup-run-123' === ( $GLOBALS['datamachine_code_cleanup_parent_drain_saw_scheduled_json']['run_id'] ?? '' ), 'cleanup run --drain exposes run id before invoking parent drain');
     datamachine_code_cleanup_assert(4096 === (int) ( $drained_json['drain']['bytes_reclaimed'] ?? 0 ), 'cleanup run --drain reports verified reclaimed bytes');
 	datamachine_code_cleanup_assert('failed' === (string) ( $drained_json['drain']['completion_state'] ?? '' ), 'cleanup run --drain reports final cleanup state');
 	datamachine_code_cleanup_assert('studio wp datamachine-code workspace cleanup status cleanup-run-123 --format=json' === (string) ( $drained_json['drain']['verify_command'] ?? '' ), 'cleanup run --drain emits one verification command');
 	$GLOBALS['datamachine_code_cleanup_parent_drained'] = false;
 	$GLOBALS['datamachine_code_cleanup_child_drained']  = false;
+    $GLOBALS['datamachine_code_cleanup_parent_drain_saw_scheduled_json'] = array();
 
 	WP_CLI::$logs      = array();
 	WP_CLI::$successes = array();
@@ -1422,9 +1430,13 @@ namespace {
 	WP_CLI::$runcommands = array();
 	$GLOBALS['datamachine_code_cleanup_parent_drained'] = false;
 	$GLOBALS['datamachine_code_cleanup_child_drained']  = false;
+	$GLOBALS['datamachine_code_cleanup_parent_drain_saw_scheduled_json'] = array();
 	$command->cleanup(array( 'run' ), array( 'mode' => 'retention', 'drain' => true, 'format' => 'json' ));
-	$no_work_drained_json = json_decode(WP_CLI::$logs[0] ?? '', true);
+	$no_work_scheduled_json = json_decode(WP_CLI::$logs[0] ?? '', true);
+	$no_work_drained_json   = json_decode(end(WP_CLI::$logs) ?: '', true);
 	datamachine_code_cleanup_assert(array( 'datamachine drain --job-id=123' ) === WP_CLI::$runcommands, 'cleanup run --drain drains no-work parent once and does not invent child drains');
+	datamachine_code_cleanup_assert('cleanup-run-123' === ( $no_work_scheduled_json['run_id'] ?? '' ), 'cleanup run --drain no-work JSON emits scheduled run id before draining');
+	datamachine_code_cleanup_assert('cleanup-run-123' === ( $GLOBALS['datamachine_code_cleanup_parent_drain_saw_scheduled_json']['run_id'] ?? '' ), 'cleanup run --drain no-work exposes run id before invoking parent drain');
 	datamachine_code_cleanup_assert('no_work' === (string) ( $no_work_drained_json['drain']['completion_state'] ?? '' ), 'cleanup run --drain reports no_work instead of successful running state for no-child/no-work parents');
 	datamachine_code_cleanup_assert(true === (bool) ( $no_work_drained_json['drain']['success'] ?? false ), 'cleanup run --drain succeeds after no-work convergence');
 	$GLOBALS['datamachine_code_cleanup_status_scenario'] = 'default';


### PR DESCRIPTION
## Summary
- Emits the scheduled cleanup run JSON before `--drain` invokes Data Machine jobs so operators immediately get the `run_id`, `job_id`, and status/drain commands.
- Keeps the existing high-level `workspace cleanup run --drain` path and still emits the final verified drain/status JSON after draining completes.
- Extends the focused cleanup CLI smoke to prove the scheduled JSON exists before the parent drain command runs.

Fixes #689.

## Verification
- `php tests/smoke-worktree-cleanup-cli.php`
- `php tests/smoke-workspace-cleanup-run-context.php`
- `php tests/smoke-cleanup-run-storage.php`
- `php -l inc/Cli/Commands/WorkspaceCommand.php && php -l tests/smoke-worktree-cleanup-cli.php`
- `git diff --check`
- `composer validate --strict` (reports existing package metadata warning: committed `version` field)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigating the cleanup drain CLI path, drafting the minimal code/test change, and running local verification. Chris remains responsible for review and acceptance.