### PR TITLE
Fix cleanup idle wrapper convergence

### DIFF
--- a/inc/Cleanup/DataMachineJobCleanupRunEvidenceStore.php
+++ b/inc/Cleanup/DataMachineJobCleanupRunEvidenceStore.php
@@ -142,25 +142,34 @@ class DataMachineJobCleanupRunEvidenceStore implements CleanupRunEvidenceStoreIn
 			),
 		);
 
+		$parent_job_ids = array();
+		foreach ( $child_jobs as $child ) {
+			$parent_job_id = (int) ( is_array($child) ? ( $child['parent_job_id'] ?? 0 ) : 0 );
+			if ( $parent_job_id > 0 ) {
+				$parent_job_ids[ $parent_job_id ] = true;
+			}
+		}
+
 		foreach ( $child_jobs as $child ) {
 			$child_job_id = (int) ( $child['job_id'] ?? 0 );
 			$status       = (string) ( $child['status'] ?? '' );
 			$engine_data  = $this->normalize_engine_data($child['engine_data'] ?? array());
 			$result       = $this->extract_system_task_result($engine_data);
+			$idle_wrapper = $this->is_idle_cleanup_wrapper_job($child, $engine_data, $result, $parent_job_ids);
 
 			++$summary['children']['total'];
 			if ( $child_job_id > 0 ) {
 				$summary['children']['job_ids'][] = $child_job_id;
 				if ( 'pending' === $status ) {
 					$summary['children']['pending_job_ids'][] = $child_job_id;
-				} elseif ( 'processing' === $status ) {
+				} elseif ( 'processing' === $status && ! $idle_wrapper ) {
 					$summary['children']['processing_job_ids'][] = $child_job_id;
 				} elseif ( str_starts_with($status, 'failed') ) {
 					$summary['children']['failed_job_ids'][] = $child_job_id;
 				}
 			}
 
-			$this->count_cleanup_child_status($summary['children'], $status);
+			$this->count_cleanup_child_status($summary['children'], $idle_wrapper ? 'skipped - idle_wrapper' : $status);
 			if ( isset($summary['children']['statuses'][ $status ]) ) {
 				++$summary['children']['statuses'][ $status ];
 			} elseif ( '' !== $status ) {
@@ -464,6 +473,31 @@ class DataMachineJobCleanupRunEvidenceStore implements CleanupRunEvidenceStoreIn
 		}
 
 		return array();
+	}
+
+	/**
+	 * Detect drained wrapper jobs that have no cleanup evidence or descendants.
+	 *
+	 * @param  array<string,mixed> $child          Child job row.
+	 * @param  array<string,mixed> $engine_data    Normalized engine data.
+	 * @param  array<string,mixed> $result         Extracted task result.
+	 * @param  array<int,bool>     $parent_job_ids Child IDs that have descendants.
+	 * @return bool
+	 */
+	private function is_idle_cleanup_wrapper_job( array $child, array $engine_data, array $result, array $parent_job_ids ): bool {
+		$child_job_id = (int) ( $child['job_id'] ?? 0 );
+		$status       = (string) ( $child['status'] ?? '' );
+		$source       = (string) ( $child['source'] ?? '' );
+
+		if ( 'processing' !== $status || 'pipeline_system_task' !== $source || $child_job_id <= 0 || isset($parent_job_ids[ $child_job_id ]) ) {
+			return false;
+		}
+
+		if ( array() !== $result || isset($engine_data['batch_id']) || 'worktree_cleanup_chunk' === (string) ( $engine_data['task_type'] ?? '' ) ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -965,6 +965,25 @@ namespace {
 					'total'   => 0,
 					);
 				}
+				if ( 'idle_wrapper' === $scenario ) {
+					$jobs = 123 === (int) $input['parent_job_id']
+						? array(
+							array(
+								'job_id'        => 128,
+								'parent_job_id' => 123,
+								'source'        => 'pipeline_system_task',
+								'status'        => 'processing',
+								'engine_data'   => array(),
+							),
+						)
+						: array();
+
+					return array(
+						'success' => true,
+						'jobs'    => $jobs,
+						'total'   => count($jobs),
+					);
+				}
 
 				$children = array(
 				 123 => array(
@@ -1094,7 +1113,7 @@ namespace {
 			'flow_id'      => null,
 			'pipeline_id'  => null,
 			'source'       => 'system',
-			'status'       => in_array($scenario, array( 'no_work', 'completed_children' ), true) ? 'processing' : 'completed',
+			'status'       => in_array($scenario, array( 'no_work', 'completed_children', 'idle_wrapper' ), true) ? 'processing' : 'completed',
 			'created_at'   => '2026-05-03 00:00:00',
 			'completed_at' => '2026-05-03 00:10:00',
 			'engine_data'  => $engine_data,
@@ -1452,6 +1471,18 @@ namespace {
 	datamachine_code_cleanup_assert('processing' === ( $completed_children_status_json['parent_status'] ?? '' ), 'completed-children cleanup status preserves stale active parent job status separately');
 	datamachine_code_cleanup_assert(4 === (int) ( $completed_children_status_json['children']['completed'] ?? 0 ), 'completed-children cleanup status counts terminal descendants');
 	datamachine_code_cleanup_assert(false === (bool) ( $completed_children_status_json['drain']['needed'] ?? true ), 'completed-children cleanup status does not request more drain passes');
+	$GLOBALS['datamachine_code_cleanup_status_scenario'] = 'default';
+
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$GLOBALS['datamachine_code_cleanup_status_scenario'] = 'idle_wrapper';
+	$command->cleanup(array( 'status', 'cleanup-run-123' ), array( 'format' => 'json' ));
+	$idle_wrapper_status_json = json_decode(WP_CLI::$logs[0] ?? '', true);
+	datamachine_code_cleanup_assert('complete' === ( $idle_wrapper_status_json['state'] ?? '' ), 'cleanup status converges empty processing wrapper jobs instead of waiting forever');
+	datamachine_code_cleanup_assert('processing' === ( $idle_wrapper_status_json['parent_status'] ?? '' ), 'idle-wrapper cleanup status preserves raw parent job status separately');
+	datamachine_code_cleanup_assert(0 === (int) ( $idle_wrapper_status_json['children']['running'] ?? -1 ), 'idle-wrapper cleanup status does not count empty wrappers as running children');
+	datamachine_code_cleanup_assert(array() === ( $idle_wrapper_status_json['children']['processing_job_ids'] ?? array() ), 'idle-wrapper cleanup status omits empty wrappers from active child drain ids');
+	datamachine_code_cleanup_assert(false === (bool) ( $idle_wrapper_status_json['drain']['needed'] ?? true ), 'idle-wrapper cleanup status does not request another drain pass');
 	$GLOBALS['datamachine_code_cleanup_status_scenario'] = 'default';
 
 	WP_CLI::$logs      = array();


### PR DESCRIPTION
## Summary
- Treat empty `pipeline_system_task` wrapper descendants as terminal idle wrappers in cleanup status aggregation.
- Prevent cleanup runs from staying `waiting_on_children` forever when drain reports no runnable work remains.
- Add smoke coverage for the issue #691 shape: processing parent, empty processing wrapper child, zero cleanup rows.

Fixes #691.

## Verification
- `php tests/smoke-worktree-cleanup-cli.php`
- `php -l inc/Cleanup/DataMachineJobCleanupRunEvidenceStore.php`
- `php -l tests/smoke-worktree-cleanup-cli.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the cleanup convergence failure, drafted the fix and smoke coverage, and ran local verification. Chris remains responsible for review and testing.