### PR TITLE
fix: skip dotfile and non-git dirs in workspace list classifier (#694)

### DIFF
--- a/inc/Workspace/WorkspaceRepositoryLifecycle.php
+++ b/inc/Workspace/WorkspaceRepositoryLifecycle.php
@@ -57,6 +57,11 @@ trait WorkspaceRepositoryLifecycle {
 					continue;
 				}
 
+				// Skip dotfile entries (e.g. internal infra dirs like .locks).
+				if ( str_starts_with($entry, '.') ) {
+					continue;
+				}
+
 				$entry_path = $path . '/' . $entry;
 				if ( ! is_dir($entry_path) ) {
 					continue;
@@ -65,7 +70,14 @@ trait WorkspaceRepositoryLifecycle {
 				$git_path = $entry_path . '/.git';
 				$is_git   = is_dir($git_path) || is_file($git_path);
 				$is_wt    = is_file($git_path);
-				$parsed   = $this->parse_handle($entry);
+
+				// A real primary or worktree always has a .git entry. Non-git
+				// directories are not repositories and must not be emitted as rows.
+				if ( ! $is_git ) {
+					continue;
+				}
+
+				$parsed = $this->parse_handle($entry);
 
 				if ( null !== $repo_filter && $parsed['repo'] !== $repo_filter ) {
 					continue;

--- a/tests/smoke-workspace-list-repo-filter.php
+++ b/tests/smoke-workspace-list-repo-filter.php
@@ -85,8 +85,20 @@ namespace {
         }
     }
 
+    include __DIR__ . '/../inc/Support/GitRunner.php';
     include __DIR__ . '/../inc/Workspace/WorkspaceAliasResolver.php';
     include __DIR__ . '/../inc/Workspace/Workspace.php';
+
+    exec('git --version 2>&1', $_git_version, $_git_version_exit);
+    if ( 0 !== $_git_version_exit ) {
+        echo "SKIP: git not available\n";
+        exit(0);
+    }
+
+    $git_init = static function ( string $dir ): void {
+        mkdir($dir, 0755, true);
+        exec('cd ' . escapeshellarg($dir) . ' && git init -q 2>&1');
+    };
 
     $failures = 0;
     $total    = 0;
@@ -110,15 +122,23 @@ namespace {
 
     echo "=== smoke-workspace-list-repo-filter ===\n";
 
-	mkdir($workspace_path . '/my-plugin', 0755, true);
-	mkdir($workspace_path . '/my-plugin@feature-one', 0755, true);
-    mkdir($workspace_path . '/data-machine-code', 0755, true);
+	// Primaries carry a real .git directory; worktrees carry a .git file
+	// pointing back at the primary. Non-git directories (junk) and dotfile
+	// infra dirs (.locks) must never be listed (#694).
+	mkdir($workspace_path, 0755, true);
+	$git_init($workspace_path . '/my-plugin');
+	exec('cd ' . escapeshellarg($workspace_path . '/my-plugin') . ' && git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init 2>&1');
+	exec('cd ' . escapeshellarg($workspace_path . '/my-plugin') . ' && git worktree add -q ../my-plugin@feature-one -b feature-one 2>&1');
+	$git_init($workspace_path . '/data-machine-code');
+	mkdir($workspace_path . '/.locks', 0755, true);
+	file_put_contents($workspace_path . '/.locks/worktree-foo.lock', "lock\n");
+	mkdir($workspace_path . '/junk-no-git', 0755, true);
 
     $workspace = new \DataMachineCode\Workspace\Workspace();
 
-    echo "\n[1] Unfiltered list includes every workspace directory\n";
+    echo "\n[1] Unfiltered list includes every git workspace directory, excludes dotfiles and non-git dirs\n";
     $all = $workspace->list_repos();
-	$assert_same(array( 'data-machine-code', 'my-plugin', 'my-plugin@feature-one' ), $repo_names($all), 'unfiltered list includes all repos');
+	$assert_same(array( 'data-machine-code', 'my-plugin', 'my-plugin@feature-one' ), $repo_names($all), 'unfiltered list includes git repos but excludes .locks and junk-no-git');
 
     echo "\n[2] Repo filter includes primary checkout and worktrees\n";
 	$filtered = $workspace->list_repos('my-plugin');
@@ -144,6 +164,11 @@ namespace {
     $invalid = $workspace->list_repos(null, 'dirty');
     $assert_same(true, is_wp_error($invalid), 'invalid type returns WP_Error');
     $assert_same('invalid_workspace_type', is_wp_error($invalid) ? $invalid->get_error_code() : '', 'invalid type error code is stable');
+
+    echo "\n[8] Primary listing never includes dotfile infra dirs or non-git directories (#694)\n";
+    $primary_names = $repo_names($workspace->list_repos(null, 'primary'));
+    $assert_same(false, in_array('.locks', $primary_names, true), 'dotfile dir .locks is not listed as a primary');
+    $assert_same(false, in_array('junk-no-git', $primary_names, true), 'non-git directory is not listed as a primary');
 
     echo "\nResult: " . ( $total - $failures ) . "/{$total} passed\n";
     exit($failures > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

`workspace list` was emitting phantom `kind=primary` rows for directories that are not real cloned repos — most notably `.locks` (internal infra dir holding `worktree-*.lock` files for `WorkspaceMutationLock`) and any leftover non-git junk dirs (`foo`, `tmp`). This inflated the primary count that flows into the auto-generated `AGENTS.md` "Workspace Inventory" section.

Closes #694.

## Root cause

`inc/Workspace/WorkspaceRepositoryLifecycle.php`, the `scandir()` loop in `list_repos()` (~lines 54-112). The loop skipped only `.` and `..` — it had **no general dotfile skip** and **no `$is_git` guard** before emitting a row. A directory with no `.git` fell straight through with `is_worktree = false` and was emitted as a primary.

## Fix

Two guards added inside the scandir loop:

1. **Dotfile skip** — `if ( str_starts_with( $entry, '.' ) ) continue;` immediately after the `.`/`..` skip. Covers `.locks` and any future internal dot-dirs.
2. **Non-git skip** — after computing `$is_git`, `if ( ! $is_git ) continue;`. A real primary or worktree always carries a `.git` entry; non-git directories are not repositories.

`.locks` stays on disk untouched — it is simply no longer listed as a repo. The independent `context` type_filter branch (lines 115-134) needs no change; it iterates registered context repositories, not raw scandir entries.

## Tests

Updated `tests/smoke-workspace-list-repo-filter.php`:
- Fixtures now create **real** git repos (`git init`) for primaries and a real `git worktree` for the worktree case, so `$is_git` reflects reality instead of the prior bug where bare `mkdir` dirs were listed.
- Added fixtures for a `.locks` dotfile dir and a `junk-no-git` non-git dir.
- New assertion block [8] proves neither appears in the primary listing.

Result: **10/10 passing**. `smoke-workspace-row-triage` (15/15) and `smoke-workspace-hygiene-report` remain green. (`smoke-workspace-list-directory` has a pre-existing harness include-order failure on `WorkspaceReader`, unrelated to this change — fails identically on unmodified main.)