### PR TITLE
Fix branch pulls for detached primary workspaces

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -841,6 +841,14 @@ class WorkspaceAbilities {
 								'type'        => 'boolean',
 								'description' => 'Permit mutation on the primary checkout (default false). Worktrees are always allowed.',
 							),
+							'remote'                 => array(
+								'type'        => 'string',
+								'description' => 'Remote name for pull when branch is supplied (default origin).',
+							),
+							'branch'                 => array(
+								'type'        => 'string',
+								'description' => 'Remote branch to pull. Useful when the checkout is detached.',
+							),
 						),
 						'required'   => array( 'name' ),
 					),
@@ -2991,7 +2999,9 @@ class WorkspaceAbilities {
 		return $workspace->git_pull(
 			$input['name'] ?? '',
 			! empty($input['allow_dirty']),
-			! empty($input['allow_primary_mutation'])
+			! empty($input['allow_primary_mutation']),
+			(string) ( $input['remote'] ?? 'origin' ),
+			isset($input['branch']) ? (string) $input['branch'] : null
 		);
 	}
 

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -2554,10 +2554,10 @@ class WorkspaceCommand extends BaseCommand {
 	 * : Permit mutating ops (pull/add/commit/push) on the primary checkout. Default-deny — use a worktree handle (`<repo>@<branch-slug>`) instead whenever possible.
 	 *
 	 * [--remote=<remote>]
-	 * : Remote name for push (default: origin).
+	 * : Remote name for pull/push (default: origin).
 	 *
 	 * [--branch=<branch>]
-	 * : Branch override for push.
+	 * : Branch override for pull/push. For pull, supplies an explicit remote branch when the checkout is detached.
 	 *
 	 * [--from=<ref>]
 	 * : From ref for diff.
@@ -2640,6 +2640,10 @@ class WorkspaceCommand extends BaseCommand {
 
 		if ( 'pull' === $operation ) {
 			$input['allow_dirty'] = ! empty($assoc_args['allow-dirty']);
+			$input['remote']      = $assoc_args['remote'] ?? 'origin';
+			if ( ! empty($assoc_args['branch']) ) {
+				$input['branch'] = (string) $assoc_args['branch'];
+			}
 		}
 
 		if ( 'add' === $operation ) {

--- a/inc/Workspace/WorkspaceGitOperations.php
+++ b/inc/Workspace/WorkspaceGitOperations.php
@@ -77,7 +77,7 @@ trait WorkspaceGitOperations {
 	 * @param  bool   $allow_dirty Allow pull with dirty working tree.
 	 * @return array
 	 */
-	public function git_pull( string $handle, bool $allow_dirty = false, bool $allow_primary_mutation = false ): array|\WP_Error {
+	public function git_pull( string $handle, bool $allow_dirty = false, bool $allow_primary_mutation = false, string $remote = 'origin', ?string $branch = null ): array|\WP_Error {
 		if ( WorkspaceAliasResolver::is_context_repository($handle) ) {
 			return WorkspaceAliasResolver::mutation_error($handle, 'git pull');
 		}
@@ -107,7 +107,18 @@ trait WorkspaceGitOperations {
 			return new \WP_Error('dirty_working_tree', 'Working tree is dirty. Commit/stash changes first or pass allow_dirty=true.', array( 'status' => 400 ));
 		}
 
-		$result = $this->run_git($repo_path, 'pull --ff-only');
+		$remote = trim($remote);
+		$branch = null !== $branch ? trim($branch) : null;
+		if ( '' === $remote ) {
+			$remote = 'origin';
+		}
+
+		$command = 'pull --ff-only';
+		if ( null !== $branch && '' !== $branch ) {
+			$command .= ' ' . escapeshellarg($remote) . ' ' . escapeshellarg($branch);
+		}
+
+		$result = $this->run_git($repo_path, $command);
 
 		if ( is_wp_error($result) ) {
 			return $result;


### PR DESCRIPTION
## Summary
- pass pull remote/branch options through the workspace git CLI and ability
- run explicit `git pull --ff-only <remote> <branch>` when a branch is supplied
- preserve existing pull behavior when no branch is provided

## Testing
- `php -l inc/Workspace/WorkspaceGitOperations.php`
- `php -l inc/Abilities/WorkspaceAbilities.php`
- `php -l inc/Cli/Commands/WorkspaceCommand.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the detached-primary pull failure, drafted the code change and validation commands for Chris to review.