### PR TITLE
Fix bulk abandoned worktree cleanup limits

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -3634,7 +3634,7 @@ class WorkspaceCommand extends BaseCommand {
 				return $reconcile;
 			}
 			$result['steps']['reconcile_metadata'] = $this->summarize_worktree_abandoned_step($reconcile);
-			$result['summary']['scanned']          += (int) ( $result['steps']['reconcile_metadata']['inspected'] ?? 0 );
+			$result['summary']['scanned']         += (int) ( $result['steps']['reconcile_metadata']['inspected'] ?? 0 );
 			$result['summary']['reconciled']       = (int) ( $reconcile['summary']['written'] ?? 0 );
 			$result['summary']['would_reconcile']  = (int) ( $reconcile['summary']['proposed'] ?? 0 );
 
@@ -3698,7 +3698,7 @@ class WorkspaceCommand extends BaseCommand {
 
 				$step_key                                      = sprintf('%s_pass_%d', $key, $pass);
 				$result['steps'][ $step_key ]                  = $this->summarize_worktree_abandoned_step($step);
-				$result['summary']['scanned']                  += (int) ( $result['steps'][ $step_key ]['inspected'] ?? 0 );
+				$result['summary']['scanned']                 += (int) ( $result['steps'][ $step_key ]['inspected'] ?? 0 );
 				$written                                       = (int) ( $step['summary']['written'] ?? 0 );
 				$planned                                       = (int) ( $step['summary']['planned'] ?? 0 );
 				$pass_marked                                  += $apply ? $written : $planned;

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -3519,7 +3519,7 @@ class WorkspaceCommand extends BaseCommand {
 	private function run_worktree_abandoned_orchestration( array $assoc_args ): array|\WP_Error {
 		$apply        = ! empty($assoc_args['apply']);
 		$force        = ! empty($assoc_args['force']);
-		$limit        = isset($assoc_args['limit']) ? max(1, min(100, (int) $assoc_args['limit'])) : 100;
+		$limit        = isset($assoc_args['limit']) ? max(1, min(1000, (int) $assoc_args['limit'])) : 100;
 		$passes       = isset($assoc_args['passes']) ? max(1, min(25, (int) $assoc_args['passes'])) : 5;
 		$offset       = isset($assoc_args['offset']) ? max(0, (int) $assoc_args['offset']) : 0;
 		$stage        = isset($assoc_args['stage']) ? strtolower( (string) preg_replace('/[^a-zA-Z0-9_-]/', '', (string) $assoc_args['stage']) ) : 'reconcile';
@@ -3580,6 +3580,7 @@ class WorkspaceCommand extends BaseCommand {
 			'steps'           => array(),
 			'blocked'         => array(),
 			'summary'         => array(
+				'scanned'                     => 0,
 				'reconciled'                  => 0,
 				'marked_cleanup_eligible'     => 0,
 				'would_mark_cleanup_eligible' => 0,
@@ -3633,6 +3634,7 @@ class WorkspaceCommand extends BaseCommand {
 				return $reconcile;
 			}
 			$result['steps']['reconcile_metadata'] = $this->summarize_worktree_abandoned_step($reconcile);
+			$result['summary']['scanned']          += (int) ( $result['steps']['reconcile_metadata']['inspected'] ?? 0 );
 			$result['summary']['reconciled']       = (int) ( $reconcile['summary']['written'] ?? 0 );
 			$result['summary']['would_reconcile']  = (int) ( $reconcile['summary']['proposed'] ?? 0 );
 
@@ -3696,6 +3698,7 @@ class WorkspaceCommand extends BaseCommand {
 
 				$step_key                                      = sprintf('%s_pass_%d', $key, $pass);
 				$result['steps'][ $step_key ]                  = $this->summarize_worktree_abandoned_step($step);
+				$result['summary']['scanned']                  += (int) ( $result['steps'][ $step_key ]['inspected'] ?? 0 );
 				$written                                       = (int) ( $step['summary']['written'] ?? 0 );
 				$planned                                       = (int) ( $step['summary']['planned'] ?? 0 );
 				$pass_marked                                  += $apply ? $written : $planned;
@@ -3837,6 +3840,7 @@ class WorkspaceCommand extends BaseCommand {
 		$result['summary']['removed']         += (int) ( $bounded['summary']['removed'] ?? 0 );
 		$result['summary']['would_remove']    += (int) ( $bounded['summary']['would_remove'] ?? 0 );
 		$result['summary']['bytes_reclaimed'] += (int) ( $bounded['summary']['bytes_reclaimed'] ?? 0 );
+		$result['summary']['scanned']         += (int) ( $result['steps'][ sprintf('bounded_apply_%s', $step_label) ]['inspected'] ?? 0 );
 		$result['blocked']                     = $this->merge_worktree_abandoned_blockers($result['blocked'], (array) ( $bounded['skipped'] ?? array() ));
 
 		return $bounded;
@@ -4088,6 +4092,10 @@ class WorkspaceCommand extends BaseCommand {
 				array(
 					'metric' => 'applied',
 					'value'  => ! empty($result['applied']) ? 'yes' : 'no',
+				),
+				array(
+					'metric' => 'scanned',
+					'value'  => (string) ( $summary['scanned'] ?? 0 ),
 				),
 				array(
 					'metric' => 'reconciled',

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -1644,6 +1644,15 @@ namespace {
     datamachine_code_cleanup_assert(2 === (int) ( $abandoned_json['summary']['removed'] ?? 0 ), 'abandoned summary reports removed rows from initial and post-classifier drains');
     datamachine_code_cleanup_assert(2 === (int) ( $abandoned_json['summary']['blocked'] ?? 0 ), 'abandoned summary reports blocked rows');
     datamachine_code_cleanup_assert(1 === (int) ( $abandoned_json['summary']['blocked_by_reason']['unpushed_commits'] ?? 0 ), 'abandoned preserves unpushed-commit blocker evidence');
+    datamachine_code_cleanup_assert(16 === (int) ( $abandoned_json['summary']['scanned'] ?? 0 ), 'abandoned summary reports aggregate scanned rows across classifier and bounded cleanup stages');
+
+    WP_CLI::$logs      = array();
+    WP_CLI::$successes = array();
+    $command->worktree(array( 'abandoned' ), array( 'apply' => true, 'force' => true, 'stage' => 'bounded', 'limit' => 500, 'passes' => 1, 'format' => 'json' ));
+    $abandoned_bulk_limit_json = json_decode(WP_CLI::$logs[0] ?? '', true);
+    datamachine_code_cleanup_assert(JSON_ERROR_NONE === json_last_error(), 'abandoned bulk-limit JSON output parses cleanly');
+    datamachine_code_cleanup_assert(500 === (int) ( $abandoned_bulk_limit_json['limit'] ?? 0 ), 'abandoned honors operator bulk limit above the old 100-row cap');
+    datamachine_code_cleanup_assert(500 === (int) ( $bounded_apply_ability->last_input['limit'] ?? 0 ), 'abandoned forwards operator bulk limit to bounded cleanup apply');
 
     $bounded_apply_ability->extra_skipped = 30;
     WP_CLI::$logs      = array();


### PR DESCRIPTION
## Summary
- Honors large operator page sizes for `workspace worktree abandoned` by raising the CLI orchestrator cap so `--limit=500` reaches classifier and bounded cleanup abilities.
- Adds aggregate `scanned` totals to abandoned cleanup summaries so large cleanup runs expose compact progress across classifier/removal stages.
- Covers the regression in the cleanup CLI smoke test, including forwarding a 500-row bulk limit to bounded cleanup apply.

Fixes #697.

## Verification
- `php tests/smoke-worktree-cleanup-cli.php`
- `php -l inc/Cli/Commands/WorkspaceCommand.php && php -l tests/smoke-worktree-cleanup-cli.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated issue #697, drafted the targeted CLI orchestration fix and smoke coverage, and ran verification for Chris to review.