### PR TITLE
Add artifact cleanup until-empty runner

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -2387,6 +2387,29 @@ class WorkspaceAbilities {
 				)
 			);
 
+			AbilityRegistry::register(
+				'datamachine-code/workspace-cleanup-until-empty',
+				array(
+					'label'               => 'Run Artifact Cleanup Until Empty',
+					'description'         => 'Repeatedly plan and apply DB-backed artifact cleanup until no safe rows remain, a budget is hit, or candidates repeat.',
+					'category'            => 'datamachine-code-workspace',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'mode'           => array( 'type' => 'string' ),
+							'force'          => array( 'type' => 'boolean' ),
+							'limit'          => array( 'type' => 'integer' ),
+							'max_passes'     => array( 'type' => 'integer' ),
+							'budget_seconds' => array( 'type' => 'integer' ),
+						),
+					),
+					'output_schema'       => array( 'type' => 'object' ),
+					'execute_callback'    => array( self::class, 'workspaceCleanupUntilEmpty' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
 			foreach ( array( 'status', 'evidence', 'resume', 'cancel' ) as $cleanup_operation ) {
 				AbilityRegistry::register(
 					'datamachine-code/workspace-cleanup-' . $cleanup_operation,
@@ -4139,6 +4162,22 @@ class WorkspaceAbilities {
 	 */
 	public static function workspaceCleanupApply( array $input ): array|\WP_Error {
 		return ( new CleanupRunService() )->apply( (string) ( $input['run_id'] ?? '' ), self::cleanupRunApplyOptions($input));
+	}
+
+	/**
+	 * Run artifact cleanup until no rows remain or progress stalls.
+	 *
+	 * @param  array $input Input parameters.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public static function workspaceCleanupUntilEmpty( array $input ): array|\WP_Error {
+		$options = self::cleanupRunApplyOptions($input);
+		foreach ( array( 'mode', 'max_passes', 'budget_seconds' ) as $key ) {
+			if ( isset($input[ $key ]) ) {
+				$options[ $key ] = 'mode' === $key ? (string) $input[ $key ] : (int) $input[ $key ];
+			}
+		}
+		return ( new CleanupRunService() )->until_empty($options);
 	}
 
 	/**

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -567,7 +567,7 @@ class WorkspaceCommand extends BaseCommand {
 	 * ## OPTIONS
 	 *
 	 * <operation>
-	 * : Cleanup operation. One of: <plan|apply|run|status|resume|cancel|evidence>.
+	 * : Cleanup operation. One of: <plan|apply|until-empty|run|status|resume|cancel|evidence>.
 	 *   Existing task-backed controls remain: <run|status|resume|cancel|evidence>.
 	 *
 	 * [<run-id>]
@@ -637,6 +637,14 @@ class WorkspaceCommand extends BaseCommand {
 	 * : For `cleanup run`, drain the queued parent job, drain active child cleanup
 	 *   jobs discovered from cleanup status, then print verified bytes reclaimed.
 	 *
+	 * [--max-passes=<count>]
+	 * : For `cleanup until-empty --mode=artifacts`, maximum plan/apply passes before
+	 *   stopping. Defaults to 10, max 25.
+	 *
+	 * [--budget-seconds=<seconds>]
+	 * : For `cleanup until-empty --mode=artifacts`, stop before starting another
+	 *   pass after this many seconds.
+	 *
 	 * [--format=<format>]
 	 * : Output format.
 	 * ---
@@ -669,6 +677,9 @@ class WorkspaceCommand extends BaseCommand {
 	 *     wp datamachine-code workspace cleanup run --mode=artifacts --dry-run --format=json
 	 *     wp datamachine-code workspace cleanup apply cleanup-run-20260504120000-abc123
 	 *
+	 *     # Repeatedly apply reviewed safe artifact rows until none remain
+	 *     wp datamachine-code workspace cleanup until-empty --mode=artifacts --format=json
+	 *
 	 *     # Full audit (slow on huge workspaces)
 	 *     wp datamachine-code workspace cleanup run --mode=artifacts --dry-run --exhaustive --format=json
 	 *
@@ -700,6 +711,10 @@ class WorkspaceCommand extends BaseCommand {
 
 			case 'apply':
 				$this->run_cleanup_control_ability('apply', (string) ( $args[1] ?? '' ), $assoc_args);
+				return;
+
+			case 'until-empty':
+				$this->run_cleanup_until_empty($assoc_args);
 				return;
 
 			case 'run':
@@ -772,6 +787,45 @@ class WorkspaceCommand extends BaseCommand {
 				$this->flush_cli_output();
 			}
 			$result = $this->drain_cleanup_run_to_status($result, $assoc_args);
+		}
+
+		$this->render_cleanup_control_result($result, $assoc_args);
+	}
+
+	private function run_cleanup_until_empty( array $assoc_args ): void {
+		$mode = strtolower(preg_replace('/[^a-z0-9_\-]/', '', (string) ( $assoc_args['mode'] ?? 'artifacts' )));
+		if ( 'artifacts' !== $mode ) {
+			WP_CLI::error('cleanup until-empty currently supports --mode=artifacts only.');
+			return;
+		}
+
+		$ability = wp_get_ability('datamachine-code/workspace-cleanup-until-empty');
+		if ( ! $ability ) {
+			WP_CLI::error('Workspace cleanup until-empty ability not registered.');
+			return;
+		}
+
+		$input = array( 'mode' => $mode );
+		foreach ( array( 'force', 'limit' ) as $key ) {
+			if ( isset($assoc_args[ $key ]) ) {
+				$input[ $key ] = 'force' === $key ? (bool) $assoc_args[ $key ] : (int) $assoc_args[ $key ];
+			}
+		}
+		foreach (
+			array(
+				'max-passes'     => 'max_passes',
+				'budget-seconds' => 'budget_seconds',
+			) as $cli_key => $input_key
+		) {
+			if ( isset($assoc_args[ $cli_key ]) ) {
+				$input[ $input_key ] = (int) $assoc_args[ $cli_key ];
+			}
+		}
+
+		$result = $ability->execute($input);
+		if ( is_wp_error($result) ) {
+			WP_CLI::error($result->get_error_message());
+			return;
 		}
 
 		$this->render_cleanup_control_result($result, $assoc_args);

--- a/inc/Workspace/CleanupRunService.php
+++ b/inc/Workspace/CleanupRunService.php
@@ -311,6 +311,146 @@ class CleanupRunService {
 		return $this->apply($run_id, $opts);
 	}
 
+	/**
+	 * Repeatedly plan/apply artifact cleanup until no safe rows remain or progress stalls.
+	 *
+	 * @param  array<string,mixed> $opts Loop options.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function until_empty( array $opts = array() ): array|\WP_Error {
+		$mode = (string) ( $opts['mode'] ?? 'artifacts' );
+		if ( 'artifacts' !== $mode ) {
+			return new \WP_Error('cleanup_until_empty_unsupported_mode', 'Cleanup until-empty currently supports mode=artifacts only.', array( 'status' => 400 ));
+		}
+
+		$max_passes     = max(1, min(25, (int) ( $opts['max_passes'] ?? 10 )));
+		$limit          = $this->apply_limit($opts);
+		$started        = microtime(true);
+		$budget_seconds = isset($opts['budget_seconds']) ? max(1, (int) $opts['budget_seconds']) : 0;
+		$seen           = array();
+		$passes         = array();
+		$total_bytes    = 0;
+		$total_applied  = 0;
+		$total_skipped  = 0;
+
+		for ( $pass = 1; $pass <= $max_passes; ++$pass ) {
+			if ( $budget_seconds > 0 && microtime(true) - $started >= $budget_seconds ) {
+				return $this->until_empty_result('budget_exhausted', $passes, $total_bytes, $total_applied, $total_skipped, array( 'budget_seconds' => $budget_seconds ));
+			}
+
+			$plan = $this->plan(
+				array(
+					'mode'                   => 'artifacts',
+					'include_artifacts'      => true,
+					'include_worktrees'      => false,
+					'include_resolvers'      => false,
+					'force_artifact_cleanup' => ! empty($opts['force']),
+				)
+			);
+			if ( $plan instanceof \WP_Error ) {
+				return $plan;
+			}
+
+			$rows        = (array) ( $plan['rows']['artifact_cleanup'] ?? array() );
+			$fingerprint = $this->cleanup_rows_fingerprint($rows);
+			if ( array() === $rows ) {
+				return $this->until_empty_result('completed', $passes, $total_bytes, $total_applied, $total_skipped, array( 'final_run_id' => $plan['run_id'] ?? null ));
+			}
+			if ( isset($seen[ $fingerprint ]) ) {
+				return $this->until_empty_result(
+					'repeated_candidates',
+					$passes,
+					$total_bytes,
+					$total_applied,
+					$total_skipped,
+					array(
+						'run_id'      => $plan['run_id'] ?? null,
+						'fingerprint' => $fingerprint,
+						'reason'      => 'The same artifact candidate set appeared after a previous apply; stopping to avoid a cleanup loop.',
+					)
+				);
+			}
+			$seen[ $fingerprint ] = true;
+
+			$run_id        = (string) ( $plan['run_id'] ?? '' );
+			$run_applied   = 0;
+			$run_skipped   = 0;
+			$run_reclaimed = 0;
+			$status        = null;
+			do {
+				$apply = $this->apply(
+					$run_id,
+					array(
+						'force' => ! empty($opts['force']),
+						'limit' => $limit,
+					)
+				);
+				if ( $apply instanceof \WP_Error ) {
+					return $apply;
+				}
+				$run_applied  += (int) ( $apply['applied'] ?? 0 );
+				$run_skipped  += (int) ( $apply['skipped'] ?? 0 );
+				$run_reclaimed = (int) ( $apply['summary']['bytes_reclaimed'] ?? $run_reclaimed );
+				$status        = (string) ( $apply['status'] ?? '' );
+			} while ( 'needs_resume' === $status );
+
+			$total_applied += $run_applied;
+			$total_skipped += $run_skipped;
+			$total_bytes   += $run_reclaimed;
+			$passes[]       = array(
+				'pass'            => $pass,
+				'run_id'          => $run_id,
+				'planned_rows'    => count($rows),
+				'applied'         => $run_applied,
+				'skipped'         => $run_skipped,
+				'bytes_reclaimed' => $run_reclaimed,
+				'fingerprint'     => $fingerprint,
+			);
+
+			if ( 0 === $run_applied ) {
+				return $this->until_empty_result('no_progress', $passes, $total_bytes, $total_applied, $total_skipped, array( 'run_id' => $run_id ));
+			}
+		}
+
+		return $this->until_empty_result('max_passes_reached', $passes, $total_bytes, $total_applied, $total_skipped, array( 'max_passes' => $max_passes ));
+	}
+
+	/**
+	 * @param array<int,array<string,mixed>> $rows Cleanup rows.
+	 */
+	private function cleanup_rows_fingerprint( array $rows ): string {
+		$parts = array();
+		foreach ( $rows as $row ) {
+			$artifacts = array();
+			foreach ( (array) ( $row['artifacts'] ?? array() ) as $artifact ) {
+				if ( is_array($artifact) ) {
+					$artifacts[] = (string) ( $artifact['path'] ?? '' );
+				}
+			}
+			sort($artifacts);
+			$parts[] = implode('|', array( (string) ( $row['handle'] ?? '' ), (string) ( $row['path'] ?? '' ), implode(',', $artifacts) ));
+		}
+		sort($parts);
+		return sha1(implode("\n", $parts));
+	}
+
+	/**
+	 * @param array<int,array<string,mixed>> $passes Loop pass summaries.
+	 * @param array<string,mixed>            $extra  Extra result fields.
+	 */
+	private function until_empty_result( string $state, array $passes, int $bytes, int $applied, int $skipped, array $extra = array() ): array {
+		return array(
+			'success'         => in_array($state, array( 'completed', 'budget_exhausted', 'max_passes_reached' ), true),
+			'state'           => $state,
+			'status'          => $state,
+			'passes'          => $passes,
+			'pass_count'      => count($passes),
+			'applied'         => $applied,
+			'skipped'         => $skipped,
+			'bytes_reclaimed' => $bytes,
+		) + $extra;
+	}
+
 	private function plan_items( array $plan ): array {
 		$items = array();
 		foreach ( (array) ( $plan['rows'] ?? array() ) as $type => $rows ) {

--- a/inc/Workspace/WorkspaceArtifactCleanup.php
+++ b/inc/Workspace/WorkspaceArtifactCleanup.php
@@ -176,7 +176,7 @@ trait WorkspaceArtifactCleanup {
 					break;
 				}
 
-				$removed_artifacts[] = $artifact;
+				$removed_artifacts[] = is_array($remove) ? array_merge($artifact, array( 'removal' => $remove )) : $artifact;
 			}
 
 			if ( $failed ) {
@@ -678,9 +678,9 @@ trait WorkspaceArtifactCleanup {
 	 *
 	 * @param  string $worktree_path Worktree root path.
 	 * @param  string $relative      Profile-relative artifact path.
-	 * @return true|\WP_Error
+	 * @return array<string,mixed>|\WP_Error
 	 */
-	private function remove_worktree_artifact_path( string $worktree_path, string $relative ): true|\WP_Error {
+	private function remove_worktree_artifact_path( string $worktree_path, string $relative ): array|\WP_Error {
 		$relative = trim($relative, '/');
 		if ( '' === $relative || str_contains($relative, '..') ) {
 			return new \WP_Error('invalid_artifact_path', sprintf('Invalid artifact path: %s', $relative), array( 'status' => 400 ));
@@ -728,7 +728,12 @@ trait WorkspaceArtifactCleanup {
 			return new \WP_Error('artifact_remove_failed', sprintf('Artifact path still exists after removal: %s', $relative), array( 'status' => 500 ));
 		}
 
-		return true;
+		return array(
+			'resolved_path' => $artifact_real,
+			'exit_code'     => $exit,
+			'exists_after'  => false,
+			'verified_at'   => gmdate('c'),
+		);
 	}
 
 	/**

--- a/tests/smoke-cleanup-run-storage.php
+++ b/tests/smoke-cleanup-run-storage.php
@@ -211,6 +211,59 @@ class DataMachineCodeCleanupRunFakeWorkspace extends \DataMachineCode\Workspace\
     }
 }
 
+class DataMachineCodeCleanupUntilEmptyWorkspace extends DataMachineCodeCleanupRunFakeWorkspace
+{
+    public int $plan_calls = 0;
+    public bool $repeat = false;
+
+    public function workspace_cleanup_plan( array $opts = array() ): array|WP_Error
+    {
+        ++$this->plan_calls;
+        if (! $this->repeat && $this->plan_calls > 2 ) {
+            return array(
+            'success' => true,
+            'mode'    => 'cleanup_plan',
+            'plan_id' => 'cleanup-plan-empty-' . $this->plan_calls,
+            'rows'    => array( 'artifact_cleanup' => array(), 'worktree_removal' => array(), 'resolver' => array() ),
+            'summary' => array( 'total_rows' => 0, 'recommended_commands' => array() ),
+            );
+        }
+
+        return array(
+        'success' => true,
+        'mode'    => 'cleanup_plan',
+        'plan_id' => 'cleanup-plan-until-' . $this->plan_calls,
+        'rows'    => array(
+        'artifact_cleanup' => array(
+        array(
+        'handle'              => 'demo@artifact-' . ( $this->repeat ? 'repeat' : $this->plan_calls ),
+        'repo'                => 'demo',
+        'branch'              => 'main',
+        'path'                => '/tmp/demo@artifact',
+        'row_type'            => 'artifact_cleanup',
+        'reason_code'         => 'profile_artifact',
+        'artifact_size_bytes' => 10,
+        'artifacts'           => array( array( 'path' => 'target', 'size_bytes' => 10 ) ),
+        ),
+        ),
+        'worktree_removal' => array(),
+        'resolver'         => array(),
+        ),
+        'summary' => array( 'total_rows' => 1, 'recommended_commands' => array() ),
+        );
+    }
+
+    public function worktree_cleanup_artifacts( array $opts = array() ): array|WP_Error
+    {
+        $this->artifact_calls[] = $opts;
+        $removed = array();
+        foreach ( (array) ( $opts['apply_plan']['candidates'] ?? array() ) as $candidate ) {
+            $removed[] = is_array($candidate) ? $candidate : array();
+        }
+        return array( 'removed' => $removed, 'skipped' => array(), 'summary' => array() );
+    }
+}
+
 function datamachine_code_cleanup_run_assert( bool $condition, string $message ): void
 {
     if (! $condition ) {
@@ -314,5 +367,22 @@ $bounded_done = $bounded_service->resume($bounded_plan['run_id'], array( 'limit'
 datamachine_code_cleanup_run_assert('completed' === (string) ( $bounded_done['status'] ?? '' ), 'bounded resume completes final batch');
 datamachine_code_cleanup_run_assert(2 === count($bounded_workspace->artifact_calls), 'bounded resume drains artifact batches before worktrees');
 datamachine_code_cleanup_run_assert(2 === count($bounded_workspace->worktree_calls), 'bounded resume drains worktree batches after artifacts');
+
+$until_workspace = new DataMachineCodeCleanupUntilEmptyWorkspace();
+$until_service = new \DataMachineCode\Workspace\CleanupRunService(new \DataMachineCode\Storage\CleanupRunRepository(), $until_workspace);
+$until_result = $until_service->until_empty(array( 'mode' => 'artifacts', 'limit' => 1, 'max_passes' => 5 ));
+datamachine_code_cleanup_run_assert(! is_wp_error($until_result), 'until-empty succeeds');
+datamachine_code_cleanup_run_assert('completed' === (string) ( $until_result['state'] ?? '' ), 'until-empty stops when artifact plan is empty');
+datamachine_code_cleanup_run_assert(2 === (int) ( $until_result['pass_count'] ?? 0 ), 'until-empty records two cleanup passes before empty plan');
+datamachine_code_cleanup_run_assert(2 === (int) ( $until_result['applied'] ?? 0 ), 'until-empty aggregates applied rows');
+datamachine_code_cleanup_run_assert(20 === (int) ( $until_result['bytes_reclaimed'] ?? 0 ), 'until-empty aggregates reclaimed bytes');
+
+$repeat_workspace = new DataMachineCodeCleanupUntilEmptyWorkspace();
+$repeat_workspace->repeat = true;
+$repeat_service = new \DataMachineCode\Workspace\CleanupRunService(new \DataMachineCode\Storage\CleanupRunRepository(), $repeat_workspace);
+$repeat_result = $repeat_service->until_empty(array( 'mode' => 'artifacts', 'limit' => 1, 'max_passes' => 5 ));
+datamachine_code_cleanup_run_assert('repeated_candidates' === (string) ( $repeat_result['state'] ?? '' ), 'until-empty stops when candidate fingerprint repeats');
+datamachine_code_cleanup_run_assert(false === (bool) ( $repeat_result['success'] ?? true ), 'repeated candidate loop is not reported as clean success');
+datamachine_code_cleanup_run_assert(1 === (int) ( $repeat_result['pass_count'] ?? 0 ), 'repeat detection stops before applying the repeated pass');
 
 echo "DB-backed cleanup run storage smoke passed.\n";

--- a/tests/smoke-worktree-cleanup-artifacts.php
+++ b/tests/smoke-worktree-cleanup-artifacts.php
@@ -304,6 +304,8 @@ namespace {
     $assert(false, is_wp_error($apply), 'apply-plan returns report');
     $assert(false, (bool) ( $apply['dry_run'] ?? true ), 'apply-plan is destructive mode');
     $assert(1, (int) ( $apply['summary']['removed_artifacts'] ?? 0 ), 'apply-plan from bounded plan only removes safe-revalidated rows');
+    $apply_removed_by_handle = array_column($apply['removed'] ?? array(), null, 'handle');
+    $assert(false, (bool) ( $apply_removed_by_handle['demo@clean']['artifacts'][0]['removal']['exists_after'] ?? true ), 'apply-plan records verified artifact absence evidence');
     $assert(false, is_dir($tmp . '/demo@clean/target'), 'apply-plan removes clean artifact directory');
     $assert(true, is_dir($tmp . '/demo@dirty/target'), 'apply-plan revalidation skips dirty worktree even when bounded plan flagged it');
     $assert(true, is_dir($tmp . '/demo@unpushed/target'), 'apply-plan revalidation skips unpushed worktree even when bounded plan flagged it');

--- a/tests/smoke-worktree-cleanup-cli.php
+++ b/tests/smoke-worktree-cleanup-cli.php
@@ -1177,6 +1177,7 @@ namespace {
 	$cleanup_run_ability = new FakeCleanupRunAbility();
 	$cleanup_plan_ability = new FakeCleanupPlanAbility();
 	$cleanup_status_ability = new FakeCleanupStatusAbility();
+	$cleanup_until_empty_ability = new FakeCleanupStatusAbility();
     $hygiene_ability = new FakeHygieneAbility();
     $get_jobs_ability = new FakeGetJobsAbility();
     $retry_job_ability = new FakeRetryJobAbility();
@@ -1185,6 +1186,7 @@ namespace {
 	'datamachine-code/workspace-list'                        => $workspace_list_ability,
 	'datamachine-code/workspace-cleanup-plan'                => $cleanup_plan_ability,
 	'datamachine-code/workspace-cleanup-run'                 => $cleanup_run_ability,
+	'datamachine-code/workspace-cleanup-until-empty'         => $cleanup_until_empty_ability,
     'datamachine-code/workspace-cleanup-apply'               => $cleanup_status_ability,
     'datamachine-code/workspace-cleanup-status'              => $cleanup_status_ability,
     'datamachine-code/workspace-cleanup-resume'              => $cleanup_status_ability,
@@ -1221,9 +1223,11 @@ namespace {
     datamachine_code_cleanup_assert(str_contains($doc_comment, "\n\t * [--stage=<stage>]"), 'worktree synopsis declares abandoned --stage at top level');
     datamachine_code_cleanup_assert(! str_contains($doc_comment, "\n\t\t * [--apply-plan=<file>]"), 'cleanup flags are not hidden behind nested docblock indentation');
     datamachine_code_cleanup_assert(str_contains($cleanup_doc_comment, 'Control task-backed workspace cleanup runs.'), 'workspace cleanup command documents task-backed controller surface');
-    datamachine_code_cleanup_assert(str_contains($cleanup_doc_comment, '<plan|apply|run|status|resume|cancel|evidence>'), 'workspace cleanup synopsis exposes DB-backed and task-backed cleanup operations');
+    datamachine_code_cleanup_assert(str_contains($cleanup_doc_comment, '<plan|apply|until-empty|run|status|resume|cancel|evidence>'), 'workspace cleanup synopsis exposes DB-backed and task-backed cleanup operations');
     datamachine_code_cleanup_assert(str_contains($cleanup_doc_comment, '[--dry-run]'), 'task-backed cleanup synopsis keeps synchronous dry-run review');
     datamachine_code_cleanup_assert(str_contains($cleanup_doc_comment, '[--drain]'), 'task-backed cleanup synopsis exposes drain option');
+	datamachine_code_cleanup_assert(str_contains($cleanup_doc_comment, '[--max-passes=<count>]'), 'workspace cleanup synopsis exposes until-empty pass budget');
+	datamachine_code_cleanup_assert(str_contains($cleanup_doc_comment, 'workspace cleanup until-empty --mode=artifacts'), 'workspace cleanup examples include artifact until-empty loop');
 	datamachine_code_cleanup_assert(str_contains($cleanup_doc_comment, 'stale-worktrees'), 'workspace cleanup synopsis exposes stale-worktrees destructive profile');
     datamachine_code_cleanup_assert(str_contains($cleanup_doc_comment, 'apply runs freeze eligible candidates'), 'workspace cleanup limit help clarifies artifact apply scoping');
     datamachine_code_cleanup_assert(str_contains($doc_comment, 'positive maximum worktrees to scan'), 'worktree limit help requires positive page sizes');
@@ -1334,6 +1338,15 @@ namespace {
 	datamachine_code_cleanup_assert(true === ( $cleanup_plan_ability->last_input['include_artifacts'] ?? false ), 'cleanup run --dry-run artifact review includes artifact scan');
 	datamachine_code_cleanup_assert(false === ( $cleanup_plan_ability->last_input['include_worktrees'] ?? true ), 'cleanup run --dry-run artifact review skips worktree removal rows');
 	datamachine_code_cleanup_assert($last_scheduled_cleanup_run === $cleanup_run_ability->last_input, 'cleanup run --dry-run does not schedule cleanup run ability');
+
+	WP_CLI::$logs      = array();
+	WP_CLI::$successes = array();
+	$command->cleanup(array( 'until-empty' ), array( 'mode' => 'artifacts', 'limit' => 11, 'max-passes' => 3, 'budget-seconds' => 60, 'force' => true, 'format' => 'json' ));
+	datamachine_code_cleanup_assert('artifacts' === ( $cleanup_until_empty_ability->last_input['mode'] ?? '' ), 'cleanup until-empty forwards artifact mode');
+	datamachine_code_cleanup_assert(11 === (int) ( $cleanup_until_empty_ability->last_input['limit'] ?? 0 ), 'cleanup until-empty forwards apply limit');
+	datamachine_code_cleanup_assert(3 === (int) ( $cleanup_until_empty_ability->last_input['max_passes'] ?? 0 ), 'cleanup until-empty forwards pass cap');
+	datamachine_code_cleanup_assert(60 === (int) ( $cleanup_until_empty_ability->last_input['budget_seconds'] ?? 0 ), 'cleanup until-empty forwards time budget');
+	datamachine_code_cleanup_assert(true === (bool) ( $cleanup_until_empty_ability->last_input['force'] ?? false ), 'cleanup until-empty forwards force flag');
 
     WP_CLI::$logs      = array();
     WP_CLI::$successes = array();


### PR DESCRIPTION
## Summary
- Add a DB-backed artifact cleanup `until-empty` operation that repeatedly plans and applies safe artifact cleanup until no rows remain, a budget is reached, or candidates repeat.
- Record per-artifact removal evidence after deletion so successful cleanup includes resolved path, exit code, absence verification, and timestamp.
- Expose the loop through the workspace cleanup ability and WP-CLI, with smoke coverage for convergence, repeat detection, CLI forwarding, and removal evidence.

Fixes #713
Refs #710

## Testing
- `php tests/smoke-cleanup-run-storage.php`
- `php tests/smoke-worktree-cleanup-artifacts.php`
- `php tests/smoke-worktree-cleanup-cli.php`
- `php -l inc/Workspace/CleanupRunService.php && php -l inc/Workspace/WorkspaceArtifactCleanup.php && php -l inc/Abilities/WorkspaceAbilities.php && php -l inc/Cli/Commands/WorkspaceCommand.php`
- `homeboy lint data-machine-code --changed-only --force-hot`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and tested the cleanup loop, CLI/ability wiring, and smoke coverage for Chris to review.