### PR TITLE
feat(workspace): accept repo@branch handle in worktree remove

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -3459,11 +3459,13 @@ class WorkspaceCommand extends BaseCommand {
 	 *     # Just dirty detection, skip size scan
 	 *     wp datamachine-code workspace worktree list --with-status
 	 *
-	 *     # Remove a worktree
+	 *     # Remove a worktree (two-arg form, or a single <repo>@<branch-slug> handle)
 	 *     wp datamachine-code workspace worktree remove data-machine fix/foo
+	 *     wp datamachine-code workspace worktree remove data-machine@fix-foo
 	 *
 	 *     # Force-remove a dirty worktree
 	 *     wp datamachine-code workspace worktree remove data-machine fix/foo --force
+	 *     wp datamachine-code workspace worktree remove data-machine@fix-foo --force
 	 *
 	 *     # Prune stale worktree registry entries across all primaries
 	 *     wp datamachine-code workspace worktree prune
@@ -3746,12 +3748,22 @@ class WorkspaceCommand extends BaseCommand {
 				break;
 
 			case 'remove':
-				if ( empty($args[1]) || empty($args[2]) ) {
-					WP_CLI::error('Usage: worktree remove <repo> <branch> [--force]');
+				// Accept either the two-arg `<repo> <branch>` form or a single
+				// `<repo>@<branch-slug>` handle (as printed by `list`/`path`/cleanup
+				// output). When both positionals are present, the two-arg form wins and
+				// acts as the disambiguator; a lone first arg containing `@` is split on
+				// the FIRST `@` into repo + branch-slug.
+				$remove_repo   = (string) ( $args[1] ?? '' );
+				$remove_branch = (string) ( $args[2] ?? '' );
+				if ( '' === $remove_branch && false !== strpos($remove_repo, '@') ) {
+					list( $remove_repo, $remove_branch ) = explode('@', $remove_repo, 2);
+				}
+				if ( '' === $remove_repo || '' === $remove_branch ) {
+					WP_CLI::error('Usage: worktree remove <repo> <branch> | <repo>@<branch-slug> [--force]');
 					return;
 				}
-				$input['repo']   = $args[1];
-				$input['branch'] = $args[2];
+				$input['repo']   = $remove_repo;
+				$input['branch'] = $remove_branch;
 				$input['force']  = ! empty($assoc_args['force']);
 				break;
 


### PR DESCRIPTION
## Summary

`workspace worktree remove` was the odd one out on the `workspace` CLI surface: it only accepted the two-arg `<repo> <branch>` form and rejected the `<repo>@<branch-slug>` **handle** that `list`, `show`, `path`, `finalize`, `mark-cleanup-eligible`, and the cleanup dry-run output all print/accept. Copying a handle out of `list`/cleanup output and pasting it into `remove` failed every time:

```
$ wp datamachine-code workspace worktree remove agents-api@fix-host-loaded-channel-smokes --force
Error: Usage: worktree remove <repo> <branch> [--force]
```

This PR closes the gap (scoped to it — no command redesign).

## Changes

- The `remove` case of the `worktree()` dispatcher in `inc/Cli/Commands/WorkspaceCommand.php` now accepts a single `<repo>@<branch-slug>` handle as the first positional, in addition to the existing two-arg `<repo> <branch>` form (kept for backward compat).
- When both positionals are present, the two-arg form wins and acts as the disambiguator. A lone first arg containing `@` is split on the **first** `@` into repo + branch-slug.
- `--force` behavior is unchanged.
- Updated the usage string and the `@subcommand` docblock examples so `--help` shows both forms.

The underlying ability (`datamachine-code/workspace-worktree-remove` → `WorkspaceWorktreeLifecycle::worktree_remove($repo, $branch, $force)`) already calls `slugify_branch()` internally, so passing the already-slugified branch half of a handle is safe and idempotent.

## Verification

- `php -l inc/Cli/Commands/WorkspaceCommand.php` → no syntax errors.
- Isolated arg-parsing unit test (7 cases, all pass) covering: two-arg form, handle form, multi-`@` slug (`data-machine@fix@weird` → branch `fix@weird`), two-arg-wins-over-`@`, and the missing-arg / empty error paths. No real worktrees were removed during testing — only the arg-parsing path was exercised.

Closes #745