### PR TITLE
Verify worktree add persistence before success

### DIFF
--- a/inc/Workspace/WorkspaceWorktreeLifecycle.php
+++ b/inc/Workspace/WorkspaceWorktreeLifecycle.php
@@ -160,7 +160,33 @@ trait WorkspaceWorktreeLifecycle {
 			$response['bootstrap'] = WorktreeBootstrapper::bootstrap($wt_path);
 		}
 
-		$this->worktree_inventory()->upsert($this->build_worktree_inventory_row_from_handle($wt_handle));
+		if ( ! is_dir($wt_path) || ! file_exists($wt_path . '/.git') ) {
+			return new \WP_Error(
+				'worktree_not_materialized',
+				sprintf('Git reported worktree "%s" was added at %s, but the checkout is not accessible after creation.', $wt_handle, $wt_path),
+				array(
+					'status' => 500,
+					'handle' => $wt_handle,
+					'path'   => $wt_path,
+				)
+			);
+		}
+
+		$persisted = $this->worktree_inventory()->upsert($this->build_worktree_inventory_row_from_handle($wt_handle));
+		if ( ! $persisted ) {
+			$this->rollback_rejected_worktree($primary_path, $wt_path, $branch, ! empty($response['created_branch']));
+			WorktreeContextInjector::forget_metadata($wt_handle);
+
+			return new \WP_Error(
+				'worktree_inventory_persist_failed',
+				sprintf('Worktree "%s" was created but could not be persisted to the workspace inventory; rolled back the checkout instead of reporting success.', $wt_handle),
+				array(
+					'status' => 500,
+					'handle' => $wt_handle,
+					'path'   => $wt_path,
+				)
+			);
+		}
 
 		$this->emit_workspace_changed('worktree_add', $repo, $wt_handle, $wt_path);
 

--- a/tests/worktree-add-lifecycle.php
+++ b/tests/worktree-add-lifecycle.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+const ARRAY_A = 'ARRAY_A';
+
+if ( ! defined('ABSPATH') ) {
+	define('ABSPATH', __DIR__ . '/fixtures/');
+}
+
+$temp_root      = realpath(sys_get_temp_dir()) ?: sys_get_temp_dir();
+$workspace_root = rtrim($temp_root, '/') . '/datamachine-code-worktree-add-' . getmypid();
+if ( ! defined('DATAMACHINE_WORKSPACE_PATH') ) {
+	define('DATAMACHINE_WORKSPACE_PATH', $workspace_root);
+}
+
+final class WP_Error {
+	private string $code;
+	private string $message;
+	private mixed $data;
+
+	public function __construct( string $code = '', string $message = '', mixed $data = null ) {
+		$this->code    = $code;
+		$this->message = $message;
+		$this->data    = $data;
+	}
+
+	public function get_error_code(): string {
+		return $this->code;
+	}
+
+	public function get_error_message(): string {
+		return $this->message;
+	}
+
+	public function get_error_data(): mixed {
+		return $this->data;
+	}
+}
+
+function is_wp_error( mixed $value ): bool {
+	return $value instanceof WP_Error;
+}
+
+function apply_filters( string $hook_name, mixed $value, mixed ...$args ): mixed {
+	return $value;
+}
+
+function current_time( string $type, bool $gmt = false ): string {
+	return gmdate('Y-m-d H:i:s');
+}
+
+function wp_json_encode( mixed $value, int $flags = 0, int $depth = 512 ): string|false {
+	return json_encode($value, $flags, $depth);
+}
+
+$GLOBALS['datamachine_code_test_options'] = array();
+function get_option( string $name, mixed $default = false ): mixed {
+	return $GLOBALS['datamachine_code_test_options'][ $name ] ?? $default;
+}
+
+function update_option( string $name, mixed $value, mixed $autoload = null ): bool {
+	$GLOBALS['datamachine_code_test_options'][ $name ] = $value;
+	return true;
+}
+
+function home_url(): string {
+	return 'https://example.test';
+}
+
+function get_bloginfo( string $show = '' ): string {
+	return 'DMC Test';
+}
+
+function dbDelta( string $sql ): array {
+	return array();
+}
+
+final class Datamachine_Code_Test_Wpdb {
+	public string $prefix = 'wp_';
+	public bool $fail_replace = false;
+	public string $last_error = '';
+	public int $insert_id = 0;
+	public int $rows_affected = 0;
+
+	/** @var array<string,array<string,mixed>> */
+	public array $rows = array();
+
+	/** @var array<int,array<string,mixed>> */
+	public array $lock_rows = array();
+
+	public function get_charset_collate(): string {
+		return '';
+	}
+
+	public function replace( string $table, array $data ): int|false {
+		if ( $this->fail_replace ) {
+			return false;
+		}
+
+		$this->rows[ (string) $data['handle'] ] = $data;
+		$this->rows_affected = 1;
+		return 1;
+	}
+
+	public function insert( string $table, array $data, array $format = array() ): int|false {
+		++$this->insert_id;
+		$data['id'] = $this->insert_id;
+		$this->lock_rows[ $this->insert_id ] = $data;
+		$this->rows_affected = 1;
+		return 1;
+	}
+
+	public function delete( string $table, array $where ): int|false {
+		unset($this->rows[ (string) ( $where['handle'] ?? '' ) ]);
+		return 1;
+	}
+
+	public function update( string $table, array $data, array $where ): int|false {
+		$handle = (string) ( $where['handle'] ?? '' );
+		if ( isset($this->rows[ $handle ]) ) {
+			$this->rows[ $handle ] = array_merge($this->rows[ $handle ], $data);
+		}
+		if ( isset($where['id'], $this->lock_rows[ (int) $where['id'] ]) ) {
+			$this->lock_rows[ (int) $where['id'] ] = array_merge($this->lock_rows[ (int) $where['id'] ], $data);
+		}
+		$this->rows_affected = 1;
+		return 1;
+	}
+
+	public function get_results( string $sql, string $output = ARRAY_A ): array {
+		return array_values($this->rows);
+	}
+
+	public function prepare( string $query, mixed ...$args ): string {
+		foreach ( $args as $arg ) {
+			$query = preg_replace('/%s/', addslashes((string) $arg), $query, 1) ?? $query;
+		}
+		return $query;
+	}
+
+	public function query( string $sql ): int|false {
+		$this->rows_affected = 0;
+		return 1;
+	}
+
+	public function get_var( string $sql ): string|int|null {
+		if ( str_contains($sql, 'SHOW TABLES LIKE') ) {
+			return str_contains($sql, 'datamachine_code_locks') ? $this->prefix . 'datamachine_code_locks' : $this->prefix . 'datamachine_code_worktrees';
+		}
+		return 0;
+	}
+
+	public function get_col( string $sql ): array {
+		return array();
+	}
+}
+
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+require_once dirname(__DIR__) . '/inc/Workspace/Workspace.php';
+
+use DataMachineCode\Workspace\Workspace;
+
+function run_command( string $command, ?string $cwd = null ): string {
+	$prefix = null === $cwd ? '' : 'cd ' . escapeshellarg($cwd) . ' && ';
+	$output = array();
+	$code   = 0;
+	exec($prefix . $command . ' 2>&1', $output, $code);
+	if ( 0 !== $code ) {
+		throw new RuntimeException(sprintf("Command failed (%d): %s\n%s", $code, $command, implode("\n", $output)));
+	}
+	return implode("\n", $output);
+}
+
+function remove_tree( string $path ): void {
+	if ( ! file_exists($path) ) {
+		return;
+	}
+	$iterator = new RecursiveIteratorIterator(
+		new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+		RecursiveIteratorIterator::CHILD_FIRST
+	);
+	foreach ( $iterator as $item ) {
+		$item->isDir() && ! $item->isLink() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+	}
+	rmdir($path);
+}
+
+function assert_true( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		throw new RuntimeException($message);
+	}
+}
+
+function create_primary_checkout( string $workspace_root ): void {
+	$source = $workspace_root . '/source';
+	$origin = $workspace_root . '/origin.git';
+	mkdir($workspace_root, 0777, true);
+	mkdir($source, 0777, true);
+	run_command('git init -b main', $source);
+	run_command('git config user.email test@example.test', $source);
+	run_command('git config user.name "DMC Test"', $source);
+	file_put_contents($source . '/README.md', "fixture\n");
+	run_command('git add README.md', $source);
+	run_command('git commit -m initial', $source);
+	run_command('git init --bare ' . escapeshellarg($origin));
+	run_command('git remote add origin ' . escapeshellarg($origin), $source);
+	run_command('git push -u origin main', $source);
+	run_command('git clone ' . escapeshellarg($origin) . ' ' . escapeshellarg($workspace_root . '/homeboy'));
+	run_command('git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main', $workspace_root . '/homeboy');
+}
+
+remove_tree($workspace_root);
+
+try {
+	create_primary_checkout($workspace_root);
+	$wpdb = new Datamachine_Code_Test_Wpdb();
+	$GLOBALS['wpdb'] = $wpdb;
+
+	$workspace = new Workspace();
+	$result    = $workspace->worktree_add('homeboy', 'audit-primitives-20260616', 'origin/main', false, false, false, false, true);
+	assert_true(! is_wp_error($result), is_wp_error($result) ? $result->get_error_message() : 'worktree_add failed');
+	assert_true(is_dir($result['path']), 'successful worktree_add path is not accessible');
+	assert_true(isset($wpdb->rows['homeboy@audit-primitives-20260616']), 'successful worktree_add was not persisted');
+
+	$show = $workspace->show_repo('homeboy@audit-primitives-20260616');
+	assert_true(! is_wp_error($show), 'persisted worktree is not visible to show_repo');
+
+	$list    = $workspace->worktree_list('homeboy', null, array( 'include_status' => false, 'include_disk' => false ));
+	$handles = array_map(static fn( array $row ): string => (string) $row['handle'], $list['worktrees'] ?? array());
+	assert_true(in_array('homeboy@audit-primitives-20260616', $handles, true), 'persisted worktree is not visible to worktree_list');
+
+	$failure_wpdb = new Datamachine_Code_Test_Wpdb();
+	$failure_wpdb->fail_replace = true;
+	$GLOBALS['wpdb'] = $failure_wpdb;
+	$failed = $workspace->worktree_add('homeboy', 'audit-primitives-persist-fails', 'origin/main', false, false, false, false, true);
+	assert_true(is_wp_error($failed), 'inventory persistence failure reported success');
+	assert_true('worktree_inventory_persist_failed' === $failed->get_error_code(), 'unexpected persistence failure error code');
+	assert_true(! is_dir($workspace_root . '/homeboy@audit-primitives-persist-fails'), 'failed persistence left a worktree directory behind');
+
+	remove_tree($workspace_root);
+	fwrite(STDOUT, "worktree-add-lifecycle ok\n");
+} catch (Throwable $e) {
+	remove_tree($workspace_root);
+	fwrite(STDERR, $e->getMessage() . "\n");
+	exit(1);
+}


### PR DESCRIPTION
## Summary
- Require local worktree add results to still be accessible before returning success.
- Require the new worktree to persist to the workspace inventory; roll back the checkout if persistence fails.
- Add a standalone regression test that creates a real temporary git primary and proves successful add is visible via show/list while persistence failures return WP_Error.

## Tests
- php tests/worktree-add-lifecycle.php
- php -l inc/Workspace/WorkspaceWorktreeLifecycle.php
- php -l tests/worktree-add-lifecycle.php
- composer validate --no-check-publish

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated the workspace lifecycle path, drafted the persistence guard and regression test, and ran local verification. Chris remains responsible for review and merge.