### PR TITLE
Fix remote workspace commits to publish atomically

### DIFF
--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -4227,6 +4227,207 @@ class GitHubAbilities {
 	}
 
 	/**
+	 * Commit multiple file writes atomically by creating Git objects and moving one ref.
+	 *
+	 * Unlike the Contents API, this publishes all file changes in one commit or leaves
+	 * the branch ref unchanged when any pre-publication step fails.
+	 *
+	 * @param  array $input {
+	 *                      Required: repo, files, commit_message.
+	 *                      Optional: branch.
+	 *                      }
+	 * @return array|\WP_Error Success payload or error.
+	 */
+	public static function commitFiles( array $input ): array|\WP_Error {
+		$repo = self::resolveRepo(sanitize_text_field($input['repo'] ?? ''));
+		if ( empty($repo) ) {
+			return new \WP_Error('missing_repo', 'Repository (owner/repo) is required or configure a default repo.', array( 'status' => 400 ));
+		}
+
+		$commit_message = sanitize_text_field($input['commit_message'] ?? '');
+		if ( empty($commit_message) ) {
+			return new \WP_Error('missing_commit_message', 'Commit message is required.', array( 'status' => 400 ));
+		}
+
+		$files = self::normalizeCommitFiles($input['files'] ?? array());
+		if ( is_wp_error($files) ) {
+			return $files;
+		}
+		if ( empty($files) ) {
+			return new \WP_Error('missing_files', 'At least one file is required for an atomic GitHub commit.', array( 'status' => 400 ));
+		}
+
+		$pat = self::getPatForRepo($repo);
+		if ( empty($pat) ) {
+			return self::patError();
+		}
+
+		$branch = sanitize_text_field($input['branch'] ?? '');
+		if ( '' === $branch ) {
+			$branch = self::resolveDefaultBranch($repo, $pat);
+			if ( is_wp_error($branch) ) {
+				return $branch;
+			}
+		} else {
+			$branch_result = self::ensureBranchExists($repo, $branch, $pat);
+			if ( is_wp_error($branch_result) ) {
+				return $branch_result;
+			}
+		}
+
+		$ref_url = sprintf('%s/repos/%s/git/ref/heads/%s', self::API_BASE, $repo, rawurlencode($branch));
+		$ref     = self::apiGet($ref_url, array(), $pat);
+		if ( is_wp_error($ref) ) {
+			return $ref;
+		}
+
+		$base_commit_sha = (string) ( $ref['data']['object']['sha'] ?? '' );
+		if ( '' === $base_commit_sha ) {
+			return new \WP_Error('github_ref_sha_missing', 'GitHub did not return a SHA for the target branch ref.', array( 'status' => 500 ));
+		}
+
+		$base_commit = self::apiGet(sprintf('%s/repos/%s/git/commits/%s', self::API_BASE, $repo, rawurlencode($base_commit_sha)), array(), $pat);
+		if ( is_wp_error($base_commit) ) {
+			return $base_commit;
+		}
+
+		$base_tree_sha = (string) ( $base_commit['data']['tree']['sha'] ?? '' );
+		if ( '' === $base_tree_sha ) {
+			return new \WP_Error('github_base_tree_sha_missing', 'GitHub did not return a tree SHA for the target branch commit.', array( 'status' => 500 ));
+		}
+
+		$tree_entries = array();
+		foreach ( $files as $file ) {
+			$blob = self::apiRequest(
+				'POST',
+				sprintf('%s/repos/%s/git/blobs', self::API_BASE, $repo),
+				array(
+					'content'  => (string) $file['content'],
+					'encoding' => 'utf-8',
+				),
+				$pat
+			);
+			if ( is_wp_error($blob) ) {
+				return $blob;
+			}
+
+			$blob_sha = (string) ( $blob['data']['sha'] ?? '' );
+			if ( '' === $blob_sha ) {
+				return new \WP_Error('github_blob_sha_missing', sprintf('GitHub did not return a blob SHA for %s.', $file['path']), array( 'status' => 500 ));
+			}
+
+			$tree_entries[] = array(
+				'path' => $file['path'],
+				'mode' => '100644',
+				'type' => 'blob',
+				'sha'  => $blob_sha,
+			);
+		}
+
+		$tree = self::apiRequest(
+			'POST',
+			sprintf('%s/repos/%s/git/trees', self::API_BASE, $repo),
+			array(
+				'base_tree' => $base_tree_sha,
+				'tree'      => $tree_entries,
+			),
+			$pat
+		);
+		if ( is_wp_error($tree) ) {
+			return $tree;
+		}
+
+		$new_tree_sha = (string) ( $tree['data']['sha'] ?? '' );
+		if ( '' === $new_tree_sha ) {
+			return new \WP_Error('github_tree_sha_missing', 'GitHub did not return a tree SHA for the atomic commit.', array( 'status' => 500 ));
+		}
+
+		$commit = self::apiRequest(
+			'POST',
+			sprintf('%s/repos/%s/git/commits', self::API_BASE, $repo),
+			array(
+				'message' => $commit_message,
+				'tree'    => $new_tree_sha,
+				'parents' => array( $base_commit_sha ),
+			),
+			$pat
+		);
+		if ( is_wp_error($commit) ) {
+			return $commit;
+		}
+
+		$new_commit_sha = (string) ( $commit['data']['sha'] ?? '' );
+		if ( '' === $new_commit_sha ) {
+			return new \WP_Error('github_commit_sha_missing', 'GitHub did not return a SHA for the atomic commit.', array( 'status' => 500 ));
+		}
+
+		$updated_ref = self::apiRequest(
+			'PATCH',
+			$ref_url,
+			array(
+				'sha'   => $new_commit_sha,
+				'force' => false,
+			),
+			$pat
+		);
+		if ( is_wp_error($updated_ref) ) {
+			return $updated_ref;
+		}
+
+		return array(
+			'success' => true,
+			'commit'  => array(
+				'sha'      => $new_commit_sha,
+				'html_url' => $commit['data']['html_url'] ?? '',
+				'message'  => $commit['data']['message'] ?? $commit_message,
+			),
+			'branch'  => $branch,
+			'files'   => array_map(static fn( array $file ): string => (string) $file['path'], $files),
+			'message' => sprintf('Committed %d file(s) to %s in %s.', count($files), $branch, $repo),
+		);
+	}
+
+	/**
+	 * Normalize an atomic commit file set.
+	 *
+	 * @param  mixed $files Associative path => content map or list of path/content arrays.
+	 * @return array<int,array{path:string,content:string}>|\WP_Error
+	 */
+	private static function normalizeCommitFiles( mixed $files ): array|\WP_Error {
+		if ( ! is_array($files) ) {
+			return new \WP_Error('invalid_files', 'Files must be an array.', array( 'status' => 400 ));
+		}
+
+		$normalized = array();
+		foreach ( $files as $key => $value ) {
+			if ( is_array($value) ) {
+				$path    = self::normalizeRepoWritePath($value['path'] ?? $key);
+				$content = $value['content'] ?? '';
+			} else {
+				$path    = self::normalizeRepoWritePath($key);
+				$content = $value;
+			}
+
+			if ( is_wp_error($path) ) {
+				return $path;
+			}
+			if ( '' === $path ) {
+				return new \WP_Error('missing_file_path', 'Each file in an atomic GitHub commit requires a path.', array( 'status' => 400 ));
+			}
+			if ( ! is_scalar($content) && null !== $content ) {
+				return new \WP_Error('invalid_file_content', sprintf('File content for %s must be scalar.', $path), array( 'status' => 400 ));
+			}
+
+			$normalized[ $path ] = array(
+				'path'    => $path,
+				'content' => (string) $content,
+			);
+		}
+
+		return array_values($normalized);
+	}
+
+	/**
 	 * Normalize a repository write path without allowing traversal outside the repo.
 	 *
 	 * @param  mixed $path Candidate repository-relative path.

--- a/inc/Workspace/RemoteWorkspaceBackend.php
+++ b/inc/Workspace/RemoteWorkspaceBackend.php
@@ -877,7 +877,7 @@ class RemoteWorkspaceBackend {
 	}
 
 	/**
-	 * Commit pending remote workspace changes through GitHub Contents API.
+	 * Commit pending remote workspace changes through one GitHub Git-data commit.
 	 *
 	 * @return array<string,mixed>|\WP_Error
 	 */
@@ -899,36 +899,23 @@ class RemoteWorkspaceBackend {
 			return new \WP_Error('nothing_to_commit', 'No remote workspace changes to commit.', array( 'status' => 400 ));
 		}
 
-		$last_sha = '';
-		foreach ( $pending as $path => $content ) {
-			$current_sha = $this->file_sha_for_commit($context, (string) $path);
-			if ( is_wp_error($current_sha) ) {
-				return $current_sha;
-			}
-
-			$input = array(
+		$result = GitHubAbilities::commitFiles(
+			array(
 				'repo'           => $context['repo'],
-				'file_path'      => $path,
-				'content'        => (string) $content,
+				'files'          => $pending,
 				'commit_message' => $message,
 				'branch'         => $context['branch'],
-			);
-			if ( '' !== $current_sha ) {
-				$input['sha'] = $current_sha;
-			}
-
-			$result = GitHubAbilities::createOrUpdateFile(
-				$input
-			);
-			if ( is_wp_error($result) ) {
-				return $result;
-			}
-			$last_sha = (string) ( $result['commit']['sha'] ?? $last_sha );
+			)
+		);
+		if ( is_wp_error($result) ) {
+			return $result;
 		}
+
+		$commit_sha = (string) ( $result['commit']['sha'] ?? '' );
 
 		$state = $this->state();
 		$state['worktrees'][ $context['handle'] ]['pending_files']   = array();
-		$state['worktrees'][ $context['handle'] ]['last_commit_sha'] = $last_sha;
+		$state['worktrees'][ $context['handle'] ]['last_commit_sha'] = $commit_sha;
 		$this->save_state($state);
 
 		return array(
@@ -936,36 +923,9 @@ class RemoteWorkspaceBackend {
 			'backend' => 'github_api',
 			'name'    => $handle,
 			'branch'  => $context['branch'],
-			'commit'  => $last_sha,
+			'commit'  => $commit_sha,
 			'message' => sprintf('Committed remote workspace changes to %s.', $context['branch']),
 		);
-	}
-
-	/**
-	 * Resolve the current file SHA for a Contents API update.
-	 *
-	 * @param array<string,mixed> $context Remote workspace context.
-	 */
-	private function file_sha_for_commit( array $context, string $path ): string|\WP_Error {
-		$file = $this->get_file_contents_with_fallback($context, $path);
-		if ( is_wp_error($file) ) {
-			$status = (int) ( $file->get_error_data()['status'] ?? 0 );
-			if ( 404 === $status ) {
-				return '';
-			}
-
-			return $file;
-		}
-		if ( empty($file['files'][0]) ) {
-			$status = (int) ( $file['errors'][0]['status'] ?? 0 );
-			if ( 404 === $status ) {
-				return '';
-			}
-
-			return new \WP_Error('remote_workspace_file_unavailable', $file['errors'][0]['message'] ?? sprintf('File not found: %s.', $path), array( 'status' => 404 ));
-		}
-
-		return (string) ( $file['files'][0]['sha'] ?? '' );
 	}
 
 	/**

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -12,6 +12,7 @@ php tests/smoke-worktree-handles.php                          # pure-unit, fast
 php tests/smoke-worktree-cleanup.php                          # spawns a real git workspace
 php tests/smoke-worktree-cleanup-merged-obsolete-dirty.php    # merged + obsolete-on-default classifier
 php tests/smoke-worktree-bootstrap.php                        # fixture + real git, no WP required
+php tests/github-atomic-commit.php                            # GitHub API stubs, no network
 ```
 
 Expected: `32/32 passed`, `131/131 passed`, `14/14 passed`, and `30/30 passed`

--- a/tests/github-atomic-commit.php
+++ b/tests/github-atomic-commit.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+if ( ! defined('ABSPATH') ) {
+	define('ABSPATH', __DIR__ . '/fixtures/');
+}
+
+final class WP_Error {
+	private string $code;
+	private string $message;
+	private mixed $data;
+
+	public function __construct( string $code = '', string $message = '', mixed $data = null ) {
+		$this->code    = $code;
+		$this->message = $message;
+		$this->data    = $data;
+	}
+
+	public function get_error_code(): string {
+		return $this->code;
+	}
+
+	public function get_error_message(): string {
+		return $this->message;
+	}
+
+	public function get_error_data(): mixed {
+		return $this->data;
+	}
+}
+
+function is_wp_error( mixed $value ): bool {
+	return $value instanceof WP_Error;
+}
+
+function apply_filters( string $hook_name, mixed $value, mixed ...$args ): mixed {
+	return $value;
+}
+
+function get_option( string $name, mixed $default = false ): mixed {
+	return $default;
+}
+
+function sanitize_text_field( mixed $value ): string {
+	return trim((string) $value);
+}
+
+function wp_json_encode( mixed $value, int $flags = 0, int $depth = 512 ): string|false {
+	return json_encode($value, $flags, $depth);
+}
+
+function wp_remote_retrieve_response_code( array $response ): int {
+	return (int) ( $response['response']['code'] ?? 0 );
+}
+
+function wp_remote_retrieve_body( array $response ): string {
+	return (string) ( $response['body'] ?? '' );
+}
+
+function datamachine_code_test_response( int $status, array $body ): array {
+	return array(
+		'response' => array( 'code' => $status ),
+		'body'     => json_encode($body),
+	);
+}
+
+$GLOBALS['datamachine_code_github_requests']        = array();
+$GLOBALS['datamachine_code_github_fail_blob_index'] = null;
+$GLOBALS['datamachine_code_github_blob_count']      = 0;
+
+function wp_remote_get( string $url, array $args = array() ): array {
+	$GLOBALS['datamachine_code_github_requests'][] = array(
+		'method' => 'GET',
+		'url'    => $url,
+		'body'   => null,
+	);
+
+	if ( str_contains($url, '/repos/owner/repo/git/ref/heads/main') ) {
+		return datamachine_code_test_response(200, array( 'object' => array( 'sha' => 'base-commit' ) ));
+	}
+
+	if ( str_contains($url, '/repos/owner/repo/git/commits/base-commit') ) {
+		return datamachine_code_test_response(200, array( 'tree' => array( 'sha' => 'base-tree' ) ));
+	}
+
+	if ( str_ends_with($url, '/repos/owner/repo') ) {
+		return datamachine_code_test_response(200, array( 'default_branch' => 'main' ));
+	}
+
+	return datamachine_code_test_response(404, array( 'message' => 'not found' ));
+}
+
+function wp_remote_request( string $url, array $args = array() ): array {
+	$body = isset($args['body']) ? json_decode((string) $args['body'], true) : null;
+	$GLOBALS['datamachine_code_github_requests'][] = array(
+		'method' => (string) ( $args['method'] ?? 'GET' ),
+		'url'    => $url,
+		'body'   => $body,
+	);
+
+	if ( str_contains($url, '/git/blobs') ) {
+		++$GLOBALS['datamachine_code_github_blob_count'];
+		if ( $GLOBALS['datamachine_code_github_fail_blob_index'] === $GLOBALS['datamachine_code_github_blob_count'] ) {
+			return datamachine_code_test_response(500, array( 'message' => 'blob failed' ));
+		}
+
+		return datamachine_code_test_response(201, array( 'sha' => 'blob-' . $GLOBALS['datamachine_code_github_blob_count'] ));
+	}
+
+	if ( str_contains($url, '/git/trees') ) {
+		return datamachine_code_test_response(201, array( 'sha' => 'new-tree' ));
+	}
+
+	if ( str_contains($url, '/git/commits') ) {
+		return datamachine_code_test_response(
+			201,
+			array(
+				'sha'      => 'new-commit',
+				'html_url' => 'https://github.com/owner/repo/commit/new-commit',
+				'message'  => (string) ( $body['message'] ?? '' ),
+			)
+		);
+	}
+
+	if ( str_contains($url, '/git/ref/heads/main') && 'PATCH' === ( $args['method'] ?? '' ) ) {
+		return datamachine_code_test_response(200, array( 'object' => array( 'sha' => $body['sha'] ?? '' ) ));
+	}
+
+	return datamachine_code_test_response(404, array( 'message' => 'not found' ));
+}
+
+function assert_true( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		throw new RuntimeException($message);
+	}
+}
+
+function matching_requests( string $method, string $needle ): array {
+	return array_values(
+		array_filter(
+			$GLOBALS['datamachine_code_github_requests'],
+			static fn( array $request ): bool => $method === $request['method'] && str_contains($request['url'], $needle)
+		)
+	);
+}
+
+function reset_github_stubs( ?int $fail_blob_index = null ): void {
+	$GLOBALS['datamachine_code_github_requests']        = array();
+	$GLOBALS['datamachine_code_github_fail_blob_index'] = $fail_blob_index;
+	$GLOBALS['datamachine_code_github_blob_count']      = 0;
+}
+
+putenv('GITHUB_TOKEN=stub-token');
+
+require_once dirname(__DIR__) . '/inc/Support/PluginSettings.php';
+require_once dirname(__DIR__) . '/inc/Support/GitHubCredentialResolver.php';
+require_once dirname(__DIR__) . '/inc/Abilities/GitHubAbilities.php';
+
+use DataMachineCode\Abilities\GitHubAbilities;
+
+try {
+	reset_github_stubs();
+	$result = GitHubAbilities::commitFiles(
+		array(
+			'repo'           => 'owner/repo',
+			'branch'         => 'main',
+			'commit_message' => 'test: atomic commit',
+			'files'          => array(
+				'a.txt' => 'alpha',
+				'b.txt' => 'bravo',
+			),
+		)
+	);
+
+	assert_true(! is_wp_error($result), is_wp_error($result) ? $result->get_error_message() : 'atomic commit failed');
+	assert_true('new-commit' === ( $result['commit']['sha'] ?? '' ), 'atomic commit did not return the new commit SHA');
+	assert_true(2 === count(matching_requests('POST', '/git/blobs')), 'expected one blob per file');
+	assert_true(1 === count(matching_requests('POST', '/git/trees')), 'expected one tree creation');
+	assert_true(1 === count(matching_requests('POST', '/git/commits')), 'expected one commit creation');
+	assert_true(1 === count(matching_requests('PATCH', '/git/ref/heads/main')), 'expected one branch ref update');
+	assert_true(0 === count(matching_requests('PUT', '/contents/')), 'must not use Contents API writes');
+
+	$tree_request = matching_requests('POST', '/git/trees')[0];
+	assert_true('base-tree' === ( $tree_request['body']['base_tree'] ?? '' ), 'tree must be based on the branch base tree');
+	assert_true(array( 'a.txt', 'b.txt' ) === array_column($tree_request['body']['tree'] ?? array(), 'path'), 'tree must contain both file paths');
+
+	reset_github_stubs(2);
+	$failed = GitHubAbilities::commitFiles(
+		array(
+			'repo'           => 'owner/repo',
+			'branch'         => 'main',
+			'commit_message' => 'test: atomic failure',
+			'files'          => array(
+				'a.txt' => 'alpha',
+				'b.txt' => 'bravo',
+			),
+		)
+	);
+
+	assert_true(is_wp_error($failed), 'blob failure should fail the atomic commit');
+	assert_true(0 === count(matching_requests('POST', '/git/trees')), 'failure before tree creation must not create a tree');
+	assert_true(0 === count(matching_requests('POST', '/git/commits')), 'failure before commit creation must not create a commit');
+	assert_true(0 === count(matching_requests('PATCH', '/git/ref/heads/main')), 'failure before ref update must not publish changes');
+
+	fwrite(STDOUT, "github-atomic-commit ok\n");
+} catch (Throwable $e) {
+	fwrite(STDERR, $e->getMessage() . "\n");
+	exit(1);
+}


### PR DESCRIPTION
## Summary
- Add a reusable GitHub atomic multi-file commit primitive using blobs, trees, commits, and one ref update.
- Switch remote workspace git commits from per-file Contents API writes to the atomic primitive.
- Add a network-free smoke test covering multi-file atomic publish behavior and pre-publication failure semantics.

## Testing
- `php -l inc/Abilities/GitHubAbilities.php`
- `php -l inc/Workspace/RemoteWorkspaceBackend.php`
- `php -l tests/github-atomic-commit.php`
- `php tests/github-atomic-commit.php`
- `composer install`
- `php tests/worktree-add-lifecycle.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the GitHub atomic commit primitive, wired the remote workspace commit path, and drafted the focused smoke coverage. Chris remains responsible for review and testing.