### PR TITLE
Centralize GitHub repository descriptors

### DIFF
--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -19,6 +19,7 @@ use DataMachineCode\Support\PermissionHelper;
 use DataMachineCode\Support\PluginSettings;
 use DataMachineCode\GitHub\PrReviewEscalationPolicy;
 use DataMachineCode\Support\GitHubCredentialResolver;
+use DataMachineCode\Support\GitHubRemote;
 use DataMachineCode\Support\RunArtifactBundleFileWriter;
 use DataMachineCode\Support\RunArtifactPrSectionRenderer;
 use DataMachineCode\Workspace\Workspace;
@@ -31,6 +32,10 @@ if ( ! class_exists(AbilityRegistry::class) ) {
 
 if ( ! class_exists(GitHubCredentialResolver::class) ) {
 	include_once dirname(__DIR__) . '/Support/GitHubCredentialResolver.php';
+}
+
+if ( ! class_exists(GitHubRemote::class) ) {
+	include_once dirname(__DIR__) . '/Support/GitHubRemote.php';
 }
 
 if ( ! class_exists(PrReviewEscalationPolicy::class) ) {
@@ -69,9 +74,9 @@ class GitHubAbilities {
 	private static array $token_modes = array();
 
 	/**
-	 * GitHub API base URL.
+	 * GitHub API base URL for non-repository-scoped public GitHub requests.
 	 */
-	const API_BASE = 'https://api.github.com';
+	const API_BASE = GitHubRemote::PUBLIC_API_BASE_URL;
 
 	/**
 	 * Default per_page for API requests.
@@ -1377,7 +1382,7 @@ class GitHubAbilities {
 			$query_params['since'] = sanitize_text_field($input['since']);
 		}
 
-		$url      = sprintf('%s/repos/%s/issues', self::API_BASE, $repo);
+		$url      = GitHubRemote::apiUrl($repo, 'issues');
 		$response = self::apiGet($url, $query_params, $pat);
 
 		if ( is_wp_error($response) ) {
@@ -1410,7 +1415,7 @@ class GitHubAbilities {
 			return self::patError();
 		}
 
-		$url      = sprintf('%s/repos/%s/issues/%d', self::API_BASE, $repo, $issue_number);
+		$url      = GitHubRemote::apiUrl($repo, 'issues/' . $issue_number);
 		$response = self::apiGet($url, array(), $pat);
 
 		if ( is_wp_error($response) ) {
@@ -1472,7 +1477,7 @@ class GitHubAbilities {
 			return new \WP_Error('no_fields', 'No fields to update. Provide title, body, state, labels, or assignees.', array( 'status' => 400 ));
 		}
 
-		$url      = sprintf('%s/repos/%s/issues/%d', self::API_BASE, $repo, $issue_number);
+		$url      = GitHubRemote::apiUrl($repo, 'issues/' . $issue_number);
 		$response = self::apiRequest('PATCH', $url, $body, $pat);
 
 		if ( is_wp_error($response) ) {
@@ -1521,7 +1526,7 @@ class GitHubAbilities {
 			}
 		}
 
-		$url      = sprintf('%s/repos/%s/issues', self::API_BASE, $repo);
+		$url      = GitHubRemote::apiUrl($repo, 'issues');
 		$response = self::apiRequest('POST', $url, $body, $pat);
 
 		if ( is_wp_error($response) ) {
@@ -1661,7 +1666,7 @@ class GitHubAbilities {
 			$body['maintainer_can_modify'] = true;
 		}
 
-		$url      = sprintf('%s/repos/%s/pulls', self::API_BASE, $repo);
+		$url      = GitHubRemote::apiUrl($repo, 'pulls');
 		$response = self::apiRequest('POST', $url, $body, $pat);
 
 		if ( is_wp_error($response) ) {
@@ -1728,7 +1733,7 @@ class GitHubAbilities {
 		$head_query = str_contains($head, ':') ? $head : sprintf('%s:%s', $repo_owner, $head);
 		$head_ref   = str_contains($head, ':') ? substr($head, (int) strpos($head, ':') + 1) : $head;
 
-		$url      = sprintf('%s/repos/%s/pulls', self::API_BASE, $repo);
+		$url      = GitHubRemote::apiUrl($repo, 'pulls');
 		$response = self::apiGet(
 			$url,
 			array(
@@ -1988,7 +1993,7 @@ class GitHubAbilities {
 	 * @return array|\WP_Error
 	 */
 	private static function applyLabelsToNumber( string $repo, int $number, array $labels, string $pat ): array|\WP_Error {
-		$url      = sprintf('%s/repos/%s/issues/%d/labels', self::API_BASE, $repo, $number);
+		$url      = GitHubRemote::apiUrl($repo, 'issues/' . $number . '/labels');
 		$response = self::apiRequest('POST', $url, array( 'labels' => $labels ), $pat);
 
 		if ( is_wp_error($response) ) {
@@ -2057,7 +2062,7 @@ class GitHubAbilities {
 			return self::patError();
 		}
 
-		$url      = sprintf('%s/repos/%s/issues/%d/labels', self::API_BASE, $repo, $number);
+		$url      = GitHubRemote::apiUrl($repo, 'issues/' . $number . '/labels');
 		$response = self::apiRequest('POST', $url, array( 'labels' => $labels ), $pat);
 
 		if ( is_wp_error($response) ) {
@@ -2117,7 +2122,7 @@ class GitHubAbilities {
 			return self::patError();
 		}
 
-		$url      = sprintf('%s/repos/%s/issues/%d/labels/%s', self::API_BASE, $repo, $number, rawurlencode($label));
+		$url      = GitHubRemote::apiUrl($repo, 'issues/' . $number . '/labels/' . rawurlencode($label));
 		$response = self::apiRequest('DELETE', $url, null, $pat);
 
 		if ( is_wp_error($response) ) {
@@ -2149,7 +2154,7 @@ class GitHubAbilities {
 	 * @return string|\WP_Error Default branch name or error.
 	 */
 	private static function resolveDefaultBranch( string $repo, string $pat ): string|\WP_Error {
-		$response = self::apiGet(sprintf('%s/repos/%s', self::API_BASE, $repo), array(), $pat);
+		$response = self::apiGet(GitHubRemote::apiUrl($repo), array(), $pat);
 		if ( is_wp_error($response) ) {
 			return $response;
 		}
@@ -2185,7 +2190,7 @@ class GitHubAbilities {
 			}
 		}
 
-		$url      = sprintf('%s/repos/%s/issues/%d/comments', self::API_BASE, $repo, $issue_number);
+		$url      = GitHubRemote::apiUrl($repo, 'issues/' . $issue_number . '/comments');
 		$response = self::apiRequest('POST', $url, array( 'body' => $body ), $pat);
 
 		if ( is_wp_error($response) ) {
@@ -2212,7 +2217,7 @@ class GitHubAbilities {
 	 * @return true|\WP_Error True when a comment may be posted, or an error explaining why not.
 	 */
 	private static function checkIssueAutomationCommentTurn( string $repo, int $issue_number, string $pat ): true|\WP_Error {
-		$issue = self::apiGet(sprintf('%s/repos/%s/issues/%d', self::API_BASE, $repo, $issue_number), array(), $pat);
+		$issue = self::apiGet(GitHubRemote::apiUrl($repo, 'issues/' . $issue_number), array(), $pat);
 		if ( is_wp_error($issue) ) {
 			return $issue;
 		}
@@ -2228,7 +2233,7 @@ class GitHubAbilities {
 		}
 
 		$comments = self::apiGet(
-			sprintf('%s/repos/%s/issues/%d/comments', self::API_BASE, $repo, $issue_number),
+			GitHubRemote::apiUrl($repo, 'issues/' . $issue_number . '/comments'),
 			array(
 				'per_page' => self::MAX_PER_PAGE,
 				'page'     => (int) ceil($comment_count / self::MAX_PER_PAGE),
@@ -2326,7 +2331,7 @@ class GitHubAbilities {
 
 		$api_get     = $api_get ?? array( self::class, 'apiGet' );
 		$api_request = $api_request ?? array( self::class, 'apiRequest' );
-		$pull_url    = sprintf('%s/repos/%s/pulls/%d', self::API_BASE, $repo, $pull_number);
+		$pull_url    = GitHubRemote::apiUrl($repo, 'pulls/' . $pull_number);
 
 		$pull_response = $api_get($pull_url, array(), $pat);
 		if ( is_wp_error($pull_response) ) {
@@ -2343,7 +2348,7 @@ class GitHubAbilities {
 			return new \WP_Error('pull_request_head_sha_mismatch', 'Pull request head SHA does not match expected_head_sha.', array( 'status' => 409 ));
 		}
 
-		$merge_url = sprintf('%s/repos/%s/pulls/%d/merge', self::API_BASE, $repo, $pull_number);
+		$merge_url = GitHubRemote::apiUrl($repo, 'pulls/' . $pull_number . '/merge');
 		$response  = $api_request('PUT', $merge_url, array( 'merge_method' => $merge_method ), $pat);
 		if ( is_wp_error($response) ) {
 			return $response;
@@ -2406,7 +2411,7 @@ class GitHubAbilities {
 
 		$api_get     = $api_get ?? array( self::class, 'apiGet' );
 		$api_request = $api_request ?? array( self::class, 'apiRequest' );
-		$pull_url    = sprintf('%s/repos/%s/pulls/%d', self::API_BASE, $repo, $pull_number);
+		$pull_url    = GitHubRemote::apiUrl($repo, 'pulls/' . $pull_number);
 
 		$pull_response = $api_get($pull_url, array(), $pat);
 		if ( is_wp_error($pull_response) ) {
@@ -2470,7 +2475,7 @@ class GitHubAbilities {
 		}
 
 		$encoded_head_branch = implode('/', array_map('rawurlencode', explode('/', $head_branch)));
-		$delete_url          = sprintf('%s/repos/%s/git/refs/heads/%s', self::API_BASE, $repo, $encoded_head_branch);
+		$delete_url          = GitHubRemote::apiUrl($repo, 'git/refs/heads/' . $encoded_head_branch);
 		$deleted             = $api_request('DELETE', $delete_url, null, $pat);
 		if ( is_wp_error($deleted) ) {
 			$status = is_array($deleted->get_error_data()) ? (int) ( $deleted->get_error_data()['status'] ?? 0 ) : 0;
@@ -2570,7 +2575,7 @@ class GitHubAbilities {
 		$comments = array();
 		$page     = 1;
 		do {
-			$comments_url = sprintf('%s/repos/%s/issues/%d/comments', self::API_BASE, $repo, $pull_number);
+			$comments_url = GitHubRemote::apiUrl($repo, 'issues/' . $pull_number . '/comments');
 			$page_result  = $api_get(
 				$comments_url,
 				array(
@@ -2598,7 +2603,7 @@ class GitHubAbilities {
 
 			$response = $api_request(
 				'PATCH',
-				sprintf('%s/repos/%s/issues/comments/%d', self::API_BASE, $repo, $comment_id),
+				GitHubRemote::apiUrl($repo, 'issues/comments/' . $comment_id),
 				array( 'body' => $target_body ),
 				$pat
 			);
@@ -2611,7 +2616,7 @@ class GitHubAbilities {
 
 		$response = $api_request(
 			'POST',
-			sprintf('%s/repos/%s/issues/%d/comments', self::API_BASE, $repo, $pull_number),
+			GitHubRemote::apiUrl($repo, 'issues/' . $pull_number . '/comments'),
 			array( 'body' => $target_body ),
 			$pat
 		);
@@ -2731,7 +2736,7 @@ class GitHubAbilities {
 			'page'     => max(1, (int) ( $input['page'] ?? 1 )),
 		);
 
-		$url      = sprintf('%s/repos/%s/pulls', self::API_BASE, $repo);
+		$url      = GitHubRemote::apiUrl($repo, 'pulls');
 		$response = self::apiGet($url, $query_params, $pat);
 
 		if ( is_wp_error($response) ) {
@@ -3699,7 +3704,7 @@ class GitHubAbilities {
 			return self::patError();
 		}
 
-		$url      = sprintf('%s/repos/%s/pulls/%d', self::API_BASE, $repo, $pull_number);
+		$url      = GitHubRemote::apiUrl($repo, 'pulls/' . $pull_number);
 		$response = self::apiGet($url, array(), $pat);
 
 		if ( is_wp_error($response) ) {
@@ -3720,7 +3725,7 @@ class GitHubAbilities {
 	 */
 	private static function getLatestIssueComment( string $repo, int $issue_number, int $comment_count, string $pat ): array|\WP_Error|null {
 		$page = max(1, $comment_count);
-		$url  = sprintf('%s/repos/%s/issues/%d/comments', self::API_BASE, $repo, $issue_number);
+		$url  = GitHubRemote::apiUrl($repo, 'issues/' . $issue_number . '/comments');
 
 		$response = self::apiGet(
 			$url, array(
@@ -3765,7 +3770,7 @@ class GitHubAbilities {
 			'page'     => max(1, (int) ( $input['page'] ?? 1 )),
 		);
 
-		$url      = sprintf('%s/repos/%s/pulls/%d/files', self::API_BASE, $repo, $pull_number);
+		$url      = GitHubRemote::apiUrl($repo, 'pulls/' . $pull_number . '/files');
 		$response = self::apiGet($url, $query_params, $pat);
 
 		if ( is_wp_error($response) ) {
@@ -3804,7 +3809,7 @@ class GitHubAbilities {
 			'per_page' => self::clampPerPage($input['per_page'] ?? $input['max_check_runs'] ?? self::DEFAULT_PER_PAGE),
 		);
 
-		$url      = sprintf('%s/repos/%s/commits/%s/check-runs', self::API_BASE, $repo, $sha);
+		$url      = GitHubRemote::apiUrl($repo, 'commits/' . $sha . '/check-runs');
 		$response = self::apiGet($url, $query_params, $pat);
 
 		if ( is_wp_error($response) ) {
@@ -3845,7 +3850,7 @@ class GitHubAbilities {
 			return self::patError();
 		}
 
-		$url      = sprintf('%s/repos/%s/commits/%s/status', self::API_BASE, $repo, $sha);
+		$url      = GitHubRemote::apiUrl($repo, 'commits/' . $sha . '/status');
 		$response = self::apiGet($url, array(), $pat);
 
 		if ( is_wp_error($response) ) {
@@ -3898,7 +3903,7 @@ class GitHubAbilities {
 
 		$api_get = $api_get ?? static fn( string $url, array $query ) => self::apiGet($url, $query, $pat);
 		if ( '' === $head_sha ) {
-			$pull_response = $api_get(sprintf('%s/repos/%s/pulls/%d', self::API_BASE, $repo, $pull_number), array());
+			$pull_response = $api_get(GitHubRemote::apiUrl($repo, 'pulls/' . $pull_number), array());
 			if ( is_wp_error($pull_response) ) {
 				return $pull_response;
 			}
@@ -3910,7 +3915,7 @@ class GitHubAbilities {
 		}
 
 		$artifacts_response = $api_get(
-			sprintf('%s/repos/%s/actions/artifacts', self::API_BASE, $repo),
+			GitHubRemote::apiUrl($repo, 'actions/artifacts'),
 			array(
 				'name'     => $artifact_name,
 				'per_page' => self::MAX_PER_PAGE,
@@ -4170,7 +4175,7 @@ class GitHubAbilities {
 		}
 
 		// Check if the file already exists to get its SHA for update.
-		$get_url    = sprintf('%s/repos/%s/contents/%s', self::API_BASE, $repo, $file_path);
+		$get_url    = GitHubRemote::apiUrl($repo, 'contents/' . $file_path);
 		$get_params = array();
 		if ( ! empty($branch) ) {
 			$get_params['ref'] = $branch;
@@ -4198,7 +4203,7 @@ class GitHubAbilities {
 			$body['branch'] = $branch;
 		}
 
-		$put_url  = sprintf('%s/repos/%s/contents/%s', self::API_BASE, $repo, $file_path);
+		$put_url  = GitHubRemote::apiUrl($repo, 'contents/' . $file_path);
 		$response = self::apiRequest('PUT', $put_url, $body, $pat);
 
 		if ( is_wp_error($response) ) {
@@ -4314,7 +4319,7 @@ class GitHubAbilities {
 	 * @return true|\WP_Error True when the branch exists or was created.
 	 */
 	private static function ensureBranchExists( string $repo, string $branch, string $pat ): true|\WP_Error {
-		$branch_ref_url = sprintf('%s/repos/%s/git/ref/heads/%s', self::API_BASE, $repo, rawurlencode($branch));
+		$branch_ref_url = GitHubRemote::apiUrl($repo, 'git/ref/heads/' . rawurlencode($branch));
 		$response       = self::apiGet($branch_ref_url, array(), $pat);
 
 		if ( ! is_wp_error($response) ) {
@@ -4331,7 +4336,7 @@ class GitHubAbilities {
 			return $default_branch;
 		}
 
-		$default_ref_url = sprintf('%s/repos/%s/git/ref/heads/%s', self::API_BASE, $repo, rawurlencode($default_branch));
+		$default_ref_url = GitHubRemote::apiUrl($repo, 'git/ref/heads/' . rawurlencode($default_branch));
 		$default_ref     = self::apiGet($default_ref_url, array(), $pat);
 		if ( is_wp_error($default_ref) ) {
 			return $default_ref;
@@ -4342,7 +4347,7 @@ class GitHubAbilities {
 			return new \WP_Error('github_default_branch_sha_missing', 'GitHub did not return a SHA for the repository default branch.', array( 'status' => 500 ));
 		}
 
-		$create_ref_url = sprintf('%s/repos/%s/git/refs', self::API_BASE, $repo);
+		$create_ref_url = GitHubRemote::apiUrl($repo, 'git/refs');
 		$created        = self::apiRequest(
 			'POST',
 			$create_ref_url,
@@ -4385,7 +4390,7 @@ class GitHubAbilities {
 		$branch = sanitize_text_field($input['ref'] ?? $input['branch'] ?? '');
 		$ref    = ! empty($branch) ? $branch : 'HEAD';
 
-		$url      = sprintf('%s/repos/%s/git/trees/%s', self::API_BASE, $repo, $ref);
+		$url      = GitHubRemote::apiUrl($repo, 'git/trees/' . $ref);
 		$response = self::apiGet($url, array( 'recursive' => '1' ), $pat);
 
 		if ( is_wp_error($response) ) {
@@ -4527,7 +4532,7 @@ class GitHubAbilities {
 	 * @return array|\WP_Error Normalized file or error.
 	 */
 	private static function getSingleFileContent( string $repo, string $path, array $query_params, string $pat ): array|\WP_Error {
-		$url      = sprintf('%s/repos/%s/contents/%s', self::API_BASE, $repo, ltrim($path, '/'));
+		$url      = GitHubRemote::apiUrl($repo, 'contents/' . ltrim($path, '/'));
 		$response = self::apiGet($url, $query_params, $pat);
 
 		if ( is_wp_error($response) ) {

--- a/inc/CodeTask/CodeTaskCreator.php
+++ b/inc/CodeTask/CodeTaskCreator.php
@@ -7,6 +7,7 @@
 
 namespace DataMachineCode\CodeTask;
 
+use DataMachineCode\Support\GitHubRemote;
 use DataMachineCode\Workspace\Workspace;
 use DataMachineCode\Workspace\WorkspaceWriter;
 
@@ -122,25 +123,17 @@ class CodeTaskCreator {
 	 */
 	public static function resolve_repo( string $repo ): array|\WP_Error {
 		$repo = trim($repo);
-		if ( preg_match('#^([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)$#', $repo, $matches) ) {
-			$slug = $matches[1] . '/' . $matches[2];
+		$descriptor = GitHubRemote::descriptor($repo);
+		if ( null !== $descriptor ) {
+			$slug = $descriptor['slug'];
 			return array(
 				'slug' => $slug,
 				'name' => self::repo_name_from_slug($slug),
-				'url'  => 'https://github.com/' . $slug . '.git',
+				'url'  => $descriptor['https_clone_url'],
 			);
 		}
 
-		if ( preg_match('#^https://github\.com/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+?)(?:\.git)?/?$#', $repo, $matches) ) {
-			$slug = $matches[1] . '/' . $matches[2];
-			return array(
-				'slug' => $slug,
-				'name' => self::repo_name_from_slug($slug),
-				'url'  => 'https://github.com/' . $slug . '.git',
-			);
-		}
-
-		return new \WP_Error('invalid_repo', 'Repository must be a GitHub owner/repo slug or https://github.com/owner/repo URL.', array( 'status' => 400 ));
+		return new \WP_Error('invalid_repo', 'Repository must be a GitHub owner/repo slug or supported GitHub URL.', array( 'status' => 400 ));
 	}
 
 	public static function build_branch_name( EvidencePacket $packet ): string {

--- a/inc/Support/GitHubRemote.php
+++ b/inc/Support/GitHubRemote.php
@@ -2,13 +2,10 @@
 /**
  * GitHub Remote
  *
- * One place for GitHub-specific URL manipulation:
- *   - "is this a GitHub remote?"
- *   - "parse owner/repo out of the URL"
- *   - shared API URL helpers for authenticated GitHub operations
- *
- * Shared by Workspace GitHub lookups so the regex + host-detection logic has
- * a single source of truth.
+ * One place for GitHub-specific repository URL manipulation:
+ *   - detect supported GitHub/GitHub Enterprise remotes
+ *   - parse owner/repo/host descriptors out of clone or web URLs
+ *   - render clone, web, and API URLs from the same descriptor
  *
  * @package DataMachineCode\Support
  * @since   0.7.0
@@ -20,18 +17,83 @@ defined('ABSPATH') || exit;
 
 final class GitHubRemote {
 
+	public const PUBLIC_WEB_BASE_URL = 'https://github.com';
+	public const PUBLIC_API_BASE_URL = 'https://api.github.com';
+	public const PUBLIC_SSH_HOST     = 'github.com';
 
 
 	/**
-	 * Detect a GitHub remote. Matches https://github.com/... and
-	 * git@github.com:... Both forms count.
+	 * Detect a supported GitHub remote. Matches public GitHub and
+	 * GitHub Enterprise-style hosts such as github.a8c.com.
 	 */
 	public static function isGitHubRemote( string $url ): bool {
-		return (bool) preg_match('#(https?://github\.com/|git@github\.com:)#', $url);
+		return null !== self::descriptor($url);
 	}
 
 	/**
-	 * Extract `owner/repo` from a GitHub URL.
+	 * Build a repository descriptor from a slug, clone URL, or web URL.
+	 *
+	 * @return array{
+	 *     host:string,
+	 *     web_base_url:string,
+	 *     api_base_url:string,
+	 *     ssh_host:string,
+	 *     owner:string,
+	 *     repo:string,
+	 *     slug:string,
+	 *     https_clone_url:string,
+	 *     ssh_clone_url:string,
+	 *     web_url:string
+	 * }|null
+	 */
+	public static function descriptor( string $remote_or_slug ): ?array {
+		$value = trim($remote_or_slug);
+		if ( '' === $value ) {
+			return null;
+		}
+
+		$host  = self::PUBLIC_SSH_HOST;
+		$owner = '';
+		$repo  = '';
+
+		if ( preg_match('#^([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)$#', $value, $m) ) {
+			$owner = $m[1];
+			$repo  = $m[2];
+		} elseif ( preg_match('#^https?://([^/]+)/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+?)(?:\.git)?(?:/.*)?$#', $value, $m) ) {
+			$host  = strtolower($m[1]);
+			$owner = $m[2];
+			$repo  = $m[3];
+		} elseif ( preg_match('#^(?:ssh://)?git@([^:/]+)[:/]([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+?)(?:\.git)?/?$#', $value, $m) ) {
+			$host  = strtolower($m[1]);
+			$owner = $m[2];
+			$repo  = $m[3];
+		} else {
+			return null;
+		}
+
+		if ( ! self::isGitHubHost($host) || '' === $owner || '' === $repo ) {
+			return null;
+		}
+
+		$repo = preg_replace('/\.git$/', '', $repo) ?? $repo;
+		$slug = $owner . '/' . $repo;
+
+		return array(
+			'host'            => $host,
+			'web_base_url'    => self::webBaseUrl($host),
+			'api_base_url'    => self::apiBaseUrl($host),
+			'ssh_host'        => $host,
+			'owner'           => $owner,
+			'repo'            => $repo,
+			'slug'            => $slug,
+			'https_clone_url' => self::webBaseUrl($host) . '/' . $slug . '.git',
+			'ssh_clone_url'   => 'git@' . $host . ':' . $slug . '.git',
+			'web_url'         => self::webBaseUrl($host) . '/' . $slug,
+		);
+	}
+
+	/**
+	 * Extract `owner/repo` from a GitHub URL or slug.
 	 *
 	 * Accepts both `https://github.com/owner/repo(.git)(/)?` and
 	 * `git@github.com:owner/repo(.git)`. Returns null for any URL that
@@ -41,10 +103,43 @@ final class GitHubRemote {
 	 * @return string|null `owner/repo` or null.
 	 */
 	public static function slug( string $url ): ?string {
-		if ( preg_match('#github\.com[:/]([\w.-]+)/([\w.-]+?)(?:\.git)?/?$#', $url, $m) ) {
-			return $m[1] . '/' . $m[2];
+		$descriptor = self::descriptor($url);
+		return null !== $descriptor ? $descriptor['slug'] : null;
+	}
+
+	/**
+	 * Build a clone URL from a GitHub descriptor input.
+	 */
+	public static function cloneUrl( string $remote_or_slug, string $protocol = 'https' ): ?string {
+		$descriptor = self::descriptor($remote_or_slug);
+		if ( null === $descriptor ) {
+			return null;
 		}
-		return null;
+
+		return 'ssh' === $protocol ? $descriptor['ssh_clone_url'] : $descriptor['https_clone_url'];
+	}
+
+	/**
+	 * Build a GitHub web URL for a repo, optionally under a path.
+	 */
+	public static function webUrl( string $remote_or_slug, string $path = '' ): ?string {
+		$descriptor = self::descriptor($remote_or_slug);
+		if ( null === $descriptor ) {
+			return null;
+		}
+
+		if ( '' === $path ) {
+			return $descriptor['web_url'];
+		}
+
+		return $descriptor['web_url'] . '/' . ltrim($path, '/');
+	}
+
+	/**
+	 * Build a GitHub branch web URL for a repo.
+	 */
+	public static function branchUrl( string $remote_or_slug, string $branch ): ?string {
+		return self::webUrl($remote_or_slug, 'tree/' . rawurlencode($branch));
 	}
 
 	/**
@@ -58,11 +153,29 @@ final class GitHubRemote {
 	 * `slug()` or a value the caller already trusts). No sanitization
 	 * is attempted here beyond string concatenation.
 	 */
-	public static function apiUrl( string $slug, string $path = '' ): string {
-		$base = 'https://api.github.com/repos/' . $slug;
+	public static function apiUrl( string $remote_or_slug, string $path = '' ): string {
+		$descriptor = self::descriptor($remote_or_slug);
+		$slug       = null !== $descriptor ? $descriptor['slug'] : $remote_or_slug;
+		$base       = ( null !== $descriptor ? $descriptor['api_base_url'] : self::PUBLIC_API_BASE_URL ) . '/repos/' . $slug;
 		if ( '' === $path ) {
 			return $base;
 		}
 		return $base . '/' . ltrim($path, '/');
+	}
+
+	/**
+	 * Build a GitHub REST API URL not scoped to a repository.
+	 */
+	public static function apiBaseUrl( string $host = self::PUBLIC_SSH_HOST ): string {
+		return self::PUBLIC_SSH_HOST === strtolower($host) ? self::PUBLIC_API_BASE_URL : self::webBaseUrl($host) . '/api/v3';
+	}
+
+	private static function webBaseUrl( string $host ): string {
+		return 'https://' . strtolower($host);
+	}
+
+	private static function isGitHubHost( string $host ): bool {
+		$host = strtolower($host);
+		return self::PUBLIC_SSH_HOST === $host || str_starts_with($host, 'github.');
 	}
 }

--- a/inc/Workspace/RemoteWorkspaceBackend.php
+++ b/inc/Workspace/RemoteWorkspaceBackend.php
@@ -8,6 +8,7 @@
 namespace DataMachineCode\Workspace;
 
 use DataMachineCode\Abilities\GitHubAbilities;
+use DataMachineCode\Support\GitHubRemote;
 use DataMachineCode\Support\PathSecurity;
 
 defined('ABSPATH') || exit;
@@ -691,7 +692,7 @@ class RemoteWorkspaceBackend {
 			? '#' . $context['branch']
 			: '' ),
 			'branch'      => '' !== (string) $context['branch'] ? (string) $context['branch'] : null,
-			'remote'      => 'https://github.com/' . $context['repo'] . '.git',
+			'remote'      => GitHubRemote::cloneUrl((string) $context['repo']),
 			'commit'      => '' !== $context['last_commit_sha'] ? $context['last_commit_sha'] : null,
 			'dirty'       => count($files),
 			'files'       => $files,
@@ -784,7 +785,7 @@ class RemoteWorkspaceBackend {
 			'is_context'  => ! empty($context['read_only_context']),
 			'path'        => 'github://' . $context['repo'] . '#' . $context['branch'],
 			'branch'      => $context['branch'],
-			'remote'      => 'https://github.com/' . $context['repo'] . '.git',
+			'remote'      => GitHubRemote::cloneUrl((string) $context['repo']),
 			'commit'      => '' !== $context['last_commit_sha'] ? $context['last_commit_sha'] : null,
 			'dirty'       => count($files),
 			'files'       => $files,
@@ -1388,7 +1389,7 @@ class RemoteWorkspaceBackend {
 		}
 
 		$push_branch = null !== $branch && '' !== $branch ? $branch : $context['branch'];
-		$branch_url  = '' !== $push_branch ? 'https://github.com/' . $context['repo'] . '/tree/' . rawurlencode($push_branch) : null;
+		$branch_url  = '' !== $push_branch ? GitHubRemote::branchUrl((string) $context['repo'], (string) $push_branch) : null;
 
 		return array(
 			'success'        => true,

--- a/inc/Workspace/WorkspaceGitOperations.php
+++ b/inc/Workspace/WorkspaceGitOperations.php
@@ -659,7 +659,7 @@ trait WorkspaceGitOperations {
 		if ( null !== $remote_url ) {
 			$github_repo = GitHubRemote::slug($remote_url);
 			if ( null !== $github_repo ) {
-				$branch_url = 'https://github.com/' . $github_repo . '/tree/' . rawurlencode($target_branch);
+				$branch_url = GitHubRemote::branchUrl($remote_url, $target_branch);
 			}
 		}
 

--- a/inc/Workspace/WorkspaceRepositoryLifecycle.php
+++ b/inc/Workspace/WorkspaceRepositoryLifecycle.php
@@ -8,6 +8,7 @@
 namespace DataMachineCode\Workspace;
 
 use DataMachineCode\Support\GitRunner;
+use DataMachineCode\Support\GitHubRemote;
 use DataMachineCode\Support\ProcessRunner;
 
 defined('ABSPATH') || exit;
@@ -670,7 +671,7 @@ trait WorkspaceRepositoryLifecycle {
 					'is_context'       => true,
 					'path'             => null,
 					'branch'           => '' !== $ref ? $ref : null,
-					'remote'           => '' !== (string) ( $context_policy['repo'] ?? '' ) ? 'https://github.com/' . (string) $context_policy['repo'] . '.git' : null,
+					'remote'           => '' !== (string) ( $context_policy['repo'] ?? '' ) ? GitHubRemote::cloneUrl((string) $context_policy['repo']) : null,
 					'commit'           => null,
 					'dirty'            => 0,
 					'workspace_policy' => WorkspaceAliasResolver::policy_attestation($handle),

--- a/inc/Workspace/WorktreeContextInjector.php
+++ b/inc/Workspace/WorktreeContextInjector.php
@@ -69,6 +69,8 @@
 
 namespace DataMachineCode\Workspace;
 
+use DataMachineCode\Support\GitHubRemote;
+
 defined('ABSPATH') || exit;
 
 class WorktreeContextInjector {
@@ -870,10 +872,15 @@ class WorktreeContextInjector {
 		}
 
 		$metadata = array( 'pr_ref' => $pr );
-		if ( preg_match('~^https?://github\.com/([^/]+)/([^/]+)/pull/(\d+)(?:[/?#].*)?$~', $pr, $matches) ) {
-			$metadata['pr_url']    = sprintf('https://github.com/%s/%s/pull/%d', $matches[1], $matches[2], (int) $matches[3]);
-			$metadata['pr_number'] = (int) $matches[3];
-			$metadata['pr_repo']   = $matches[1] . '/' . $matches[2];
+		if ( preg_match('~^https?://([^/]+)/([^/]+)/([^/]+)/pull/(\d+)(?:[/?#].*)?$~', $pr, $matches) ) {
+			$descriptor = GitHubRemote::descriptor(sprintf('https://%s/%s/%s', $matches[1], $matches[2], $matches[3]));
+			if ( null === $descriptor ) {
+				return $metadata;
+			}
+
+			$metadata['pr_url']    = $descriptor['web_url'] . '/pull/' . (int) $matches[4];
+			$metadata['pr_number'] = (int) $matches[4];
+			$metadata['pr_repo']   = $descriptor['slug'];
 			return $metadata;
 		}
 

--- a/tests/github-remote.php
+++ b/tests/github-remote.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+if ( ! defined('ABSPATH') ) {
+	define('ABSPATH', __DIR__ . '/fixtures/');
+}
+
+require_once dirname(__DIR__) . '/inc/Support/GitHubRemote.php';
+require_once dirname(__DIR__) . '/inc/Workspace/WorktreeContextInjector.php';
+
+use DataMachineCode\Support\GitHubRemote;
+use DataMachineCode\Workspace\WorktreeContextInjector;
+
+function assert_same( mixed $expected, mixed $actual, string $message ): void {
+	if ( $expected !== $actual ) {
+		throw new RuntimeException(sprintf("%s\nExpected: %s\nActual: %s", $message, var_export($expected, true), var_export($actual, true)));
+	}
+}
+
+$public = GitHubRemote::descriptor('https://github.com/Extra-Chill/data-machine-code.git');
+assert_same('github.com', $public['host'] ?? null, 'Public GitHub host should parse.');
+assert_same('Extra-Chill/data-machine-code', $public['slug'] ?? null, 'Public GitHub slug should parse.');
+assert_same('https://github.com/Extra-Chill/data-machine-code.git', $public['https_clone_url'] ?? null, 'Public GitHub HTTPS clone URL should render.');
+assert_same('git@github.com:Extra-Chill/data-machine-code.git', $public['ssh_clone_url'] ?? null, 'Public GitHub SSH clone URL should render.');
+assert_same('https://api.github.com/repos/Extra-Chill/data-machine-code/pulls/1', GitHubRemote::apiUrl('Extra-Chill/data-machine-code', 'pulls/1'), 'Public GitHub repo API URL should render from a slug.');
+assert_same('https://github.com/Extra-Chill/data-machine-code/tree/refactor%2Fdescriptor', GitHubRemote::branchUrl('git@github.com:Extra-Chill/data-machine-code.git', 'refactor/descriptor'), 'Public GitHub branch URL should render from SSH remote.');
+
+$enterprise = GitHubRemote::descriptor('git@github.a8c.com:Automattic/data-machine-code.git');
+assert_same('github.a8c.com', $enterprise['host'] ?? null, 'GitHub Enterprise host should parse.');
+assert_same('Automattic/data-machine-code', $enterprise['slug'] ?? null, 'GitHub Enterprise slug should parse.');
+assert_same('https://github.a8c.com/api/v3', $enterprise['api_base_url'] ?? null, 'GitHub Enterprise API base URL should render.');
+assert_same('https://github.a8c.com/Automattic/data-machine-code.git', $enterprise['https_clone_url'] ?? null, 'GitHub Enterprise HTTPS clone URL should render.');
+assert_same('https://github.a8c.com/api/v3/repos/Automattic/data-machine-code/issues', GitHubRemote::apiUrl('https://github.a8c.com/Automattic/data-machine-code', 'issues'), 'GitHub Enterprise repo API URL should render from web URL.');
+assert_same('https://github.a8c.com/Automattic/data-machine-code/tree/feature%2Fbranch', GitHubRemote::branchUrl('git@github.a8c.com:Automattic/data-machine-code.git', 'feature/branch'), 'GitHub Enterprise branch URL should render from SSH remote.');
+
+$pr_metadata = WorktreeContextInjector::parse_pr_reference('https://github.a8c.com/Automattic/data-machine-code/pull/42');
+assert_same('https://github.a8c.com/Automattic/data-machine-code/pull/42', $pr_metadata['pr_url'] ?? null, 'GitHub Enterprise PR URL should round-trip.');
+assert_same(42, $pr_metadata['pr_number'] ?? null, 'GitHub Enterprise PR number should parse.');
+assert_same('Automattic/data-machine-code', $pr_metadata['pr_repo'] ?? null, 'GitHub Enterprise PR repo should parse.');
+
+assert_same(null, GitHubRemote::descriptor('https://gitlab.com/example/project.git'), 'Non-GitHub hosts should not parse.');
+
+echo "GitHubRemote descriptor tests passed.\n";


### PR DESCRIPTION
## Summary
- Expand GitHubRemote into a small repository descriptor for public GitHub and GitHub Enterprise-style hosts.
- Route repo-scoped API URL construction and clone/branch/PR URL rendering through the descriptor.
- Add focused descriptor tests for github.com and github.a8c.com remotes.

## Tests
- php -l inc/Support/GitHubRemote.php
- php -l inc/Abilities/GitHubAbilities.php
- php -l inc/CodeTask/CodeTaskCreator.php
- php -l inc/Workspace/RemoteWorkspaceBackend.php
- php -l inc/Workspace/WorkspaceRepositoryLifecycle.php
- php -l inc/Workspace/WorkspaceGitOperations.php
- php -l inc/Workspace/WorktreeContextInjector.php
- php tests/github-remote.php
- composer install
- php tests/worktree-add-lifecycle.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the descriptor primitive, routed the scoped URL construction changes, added tests, and ran local verification; Chris remains responsible for review and merge.