### PR TITLE
Fix workspace file ability handle and mutation policy

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -263,7 +263,7 @@ class WorkspaceAbilities {
 								'description' => 'Explicitly allow reading from a stale, diverged, detached, or otherwise unsafe primary checkout. Worktree reads are unaffected.',
 							),
 						),
-						'required'   => array( 'path' ),
+						'required'   => array( 'repo', 'path' ),
 					),
 					'output_schema'       => array(
 						'type'       => 'object',
@@ -304,7 +304,7 @@ class WorkspaceAbilities {
 								'description' => 'Explicitly allow listing a stale, diverged, detached, or otherwise unsafe primary checkout. Worktree reads are unaffected.',
 							),
 						),
-						'required'   => array(),
+						'required'   => array( 'repo' ),
 					),
 					'output_schema'       => array(
 						'type'       => 'object',
@@ -369,7 +369,7 @@ class WorkspaceAbilities {
 								'description' => 'Explicitly allow grepping a stale, diverged, detached, or otherwise unsafe primary checkout. Worktree reads are unaffected.',
 							),
 						),
-						'required'   => array( 'pattern' ),
+						'required'   => array( 'repo', 'pattern' ),
 					),
 					'output_schema'       => array(
 						'type'       => 'object',
@@ -575,8 +575,12 @@ class WorkspaceAbilities {
 								'type'        => 'string',
 								'description' => 'File content to write.',
 							),
+							'allow_primary_mutation' => array(
+								'type'        => 'boolean',
+								'description' => 'Permit mutation on the primary checkout (default false). Worktrees are always allowed.',
+							),
 						),
-						'required'   => array( 'path', 'content' ),
+						'required'   => array( 'repo', 'path', 'content' ),
 					),
 					'output_schema'       => array(
 						'type'       => 'object',
@@ -638,8 +642,12 @@ class WorkspaceAbilities {
 								'type'        => 'boolean',
 								'description' => 'Replace all occurrences (default false).',
 							),
+							'allow_primary_mutation' => array(
+								'type'        => 'boolean',
+								'description' => 'Permit mutation on the primary checkout (default false). Worktrees are always allowed.',
+							),
 						),
-						'required'   => array( 'path' ),
+						'required'   => array( 'repo', 'path' ),
 					),
 					'output_schema'       => array(
 						'type'       => 'object',
@@ -951,7 +959,7 @@ class WorkspaceAbilities {
 								'description' => 'Permit mutation on the primary checkout (default false). Worktrees are always allowed.',
 							),
 						),
-						'required'   => array( 'path' ),
+						'required'   => array( 'repo', 'path' ),
 					),
 					'output_schema'       => array(
 						'type'       => 'object',
@@ -2583,9 +2591,13 @@ class WorkspaceAbilities {
 	 * @return array Result.
 	 */
 	public static function readFile( array $input ): array|\WP_Error {
-		$input     = self::normalize_mounted_workspace_path_input($input, array( 'repo' ));
-		$workspace = new Workspace();
-		$reader    = new WorkspaceReader($workspace);
+		$input        = self::normalize_mounted_workspace_path_input($input, array( 'repo' ));
+		$workspace    = new Workspace();
+		$handle_check = $workspace->require_explicit_workspace_handle($input['repo'] ?? '');
+		if ( is_wp_error($handle_check) ) {
+			return $handle_check;
+		}
+		$reader       = new WorkspaceReader($workspace);
 		if ( RemoteWorkspaceBackend::should_handle() && null !== self::showLocalWorkspaceHandleIfPresent($workspace, (string) ( $input['repo'] ?? '' )) ) {
 			return $reader->read_file(
 				$input['repo'] ?? '',
@@ -2627,9 +2639,13 @@ class WorkspaceAbilities {
 	 * @return array Result.
 	 */
 	public static function listDirectory( array $input ): array|\WP_Error {
-		$input     = self::normalize_mounted_workspace_path_input($input, array( 'repo' ));
-		$workspace = new Workspace();
-		$reader    = new WorkspaceReader($workspace);
+		$input        = self::normalize_mounted_workspace_path_input($input, array( 'repo' ));
+		$workspace    = new Workspace();
+		$handle_check = $workspace->require_explicit_workspace_handle($input['repo'] ?? '');
+		if ( is_wp_error($handle_check) ) {
+			return $handle_check;
+		}
+		$reader       = new WorkspaceReader($workspace);
 		if ( RemoteWorkspaceBackend::should_handle() && null !== self::showLocalWorkspaceHandleIfPresent($workspace, (string) ( $input['repo'] ?? '' )) ) {
 			return $reader->list_directory(
 				$input['repo'] ?? '',
@@ -2662,9 +2678,13 @@ class WorkspaceAbilities {
 	 * @return array Result.
 	 */
 	public static function grepFiles( array $input ): array|\WP_Error {
-		$input     = self::normalize_mounted_workspace_path_input($input, array( 'repo' ));
-		$workspace = new Workspace();
-		$reader    = new WorkspaceReader($workspace);
+		$input        = self::normalize_mounted_workspace_path_input($input, array( 'repo' ));
+		$workspace    = new Workspace();
+		$handle_check = $workspace->require_explicit_workspace_handle($input['repo'] ?? '');
+		if ( is_wp_error($handle_check) ) {
+			return $handle_check;
+		}
+		$reader       = new WorkspaceReader($workspace);
 		if ( RemoteWorkspaceBackend::should_handle() && null !== self::showLocalWorkspaceHandleIfPresent($workspace, (string) ( $input['repo'] ?? '' )) ) {
 			return $reader->grep(
 				$input['repo'] ?? '',
@@ -2954,7 +2974,13 @@ class WorkspaceAbilities {
 	 * @return array Result.
 	 */
 	public static function writeFile( array $input ): array|\WP_Error {
-		$input = self::normalize_mounted_workspace_path_input($input, array( 'repo' ));
+		$input        = self::normalize_mounted_workspace_path_input($input, array( 'repo' ));
+		$workspace    = new Workspace();
+		$handle_check = $workspace->ensure_workspace_mutation_allowed($input['repo'] ?? '', ! empty($input['allow_primary_mutation']));
+		if ( is_wp_error($handle_check) ) {
+			return $handle_check;
+		}
+
 		if ( RemoteWorkspaceBackend::should_handle() ) {
 			$result = ( new RemoteWorkspaceBackend() )->write_file(
 				$input['repo'] ?? '',
@@ -2964,13 +2990,13 @@ class WorkspaceAbilities {
 			return self::decorate_remote_workspace_result('write_file', $result);
 		}
 
-		$workspace = new Workspace();
-		$writer    = new WorkspaceWriter($workspace);
+		$writer = new WorkspaceWriter($workspace);
 
 		return $writer->write_file(
 			$input['repo'] ?? '',
 			$input['path'] ?? '',
-			$input['content'] ?? ''
+			$input['content'] ?? '',
+			! empty($input['allow_primary_mutation'])
 		);
 	}
 
@@ -2981,7 +3007,12 @@ class WorkspaceAbilities {
 	 * @return array Result.
 	 */
 	public static function editFile( array $input ): array|\WP_Error {
-		$input      = self::normalize_mounted_workspace_path_input($input, array( 'repo' ));
+		$input        = self::normalize_mounted_workspace_path_input($input, array( 'repo' ));
+		$workspace    = new Workspace();
+		$handle_check = $workspace->ensure_workspace_mutation_allowed($input['repo'] ?? '', ! empty($input['allow_primary_mutation']));
+		if ( is_wp_error($handle_check) ) {
+			return $handle_check;
+		}
 		$old_string = (string) ( $input['old_string'] ?? $input['search'] ?? $input['old'] ?? '' );
 		$new_string = (string) ( $input['new_string'] ?? $input['replace'] ?? $input['new'] ?? '' );
 
@@ -3004,15 +3035,15 @@ class WorkspaceAbilities {
 			return self::decorate_remote_workspace_result('edit_file', $result);
 		}
 
-		$workspace = new Workspace();
-		$writer    = new WorkspaceWriter($workspace);
+		$writer = new WorkspaceWriter($workspace);
 
 		return $writer->edit_file(
 			$input['repo'] ?? '',
 			$input['path'] ?? '',
 			$old_string,
 			$new_string,
-			! empty($input['replace_all'])
+			! empty($input['replace_all']),
+			! empty($input['allow_primary_mutation'])
 		);
 	}
 

--- a/inc/Workspace/WorkspaceCoreUtilities.php
+++ b/inc/Workspace/WorkspaceCoreUtilities.php
@@ -253,6 +253,63 @@ trait WorkspaceCoreUtilities {
 	}
 
 	/**
+	 * Require file-operation callers to name a workspace handle explicitly.
+	 *
+	 * @param  string $handle Workspace handle from ability input.
+	 * @return array{repo: string, branch_slug: string|null, is_worktree: bool, dir_name: string}|\WP_Error
+	 */
+	public function require_explicit_workspace_handle( string $handle ): array|\WP_Error {
+		$handle = trim($handle);
+		if ( '' === $handle ) {
+			return new \WP_Error(
+				'missing_workspace_handle',
+				'Workspace file operations require an explicit repo/worktree handle; workspace-root access is not allowed.',
+				array( 'status' => 400 )
+			);
+		}
+
+		$parsed = $this->parse_handle($handle);
+		if ( '' === $parsed['dir_name'] || '' === $parsed['repo'] ) {
+			return new \WP_Error(
+				'invalid_workspace_handle',
+				'Workspace file operations require a valid repo/worktree handle; workspace-root access is not allowed.',
+				array( 'status' => 400 )
+			);
+		}
+
+		return $parsed;
+	}
+
+	/**
+	 * Enforce the default read-only policy for primary checkout mutations.
+	 *
+	 * @param  string $handle Workspace handle.
+	 * @param  bool   $allow  Whether primary checkout mutation is explicitly allowed.
+	 * @return array{repo: string, branch_slug: string|null, is_worktree: bool, dir_name: string}|\WP_Error
+	 */
+	public function ensure_workspace_mutation_allowed( string $handle, bool $allow = false, string $allow_guidance = 'Pass allow_primary_mutation=true to operate on it' ): array|\WP_Error {
+		$parsed = $this->require_explicit_workspace_handle($handle);
+		if ( is_wp_error($parsed) ) {
+			return $parsed;
+		}
+
+		if ( $parsed['is_worktree'] || $allow ) {
+			return $parsed;
+		}
+
+		return new \WP_Error(
+			'primary_mutation_blocked',
+			sprintf(
+				'Primary checkout "%s" is read-only by default. %s, or use a worktree handle (e.g. %s@<branch-slug>).',
+				$parsed['repo'],
+				$allow_guidance,
+				$parsed['repo']
+			),
+			array( 'status' => 403 )
+		);
+	}
+
+	/**
 	 * Convert a branch name to a filesystem-safe slug.
 	 *
 	 * Slashes become dashes (`fix/foo-bar` → `fix-foo-bar`). Anything else

--- a/inc/Workspace/WorkspaceGitOperations.php
+++ b/inc/Workspace/WorkspaceGitOperations.php
@@ -354,7 +354,11 @@ trait WorkspaceGitOperations {
 			return WorkspaceAliasResolver::mutation_error($handle, 'delete');
 		}
 
-		$parsed    = $this->parse_handle($handle);
+		$parsed = $this->require_explicit_workspace_handle($handle);
+		if ( is_wp_error($parsed) ) {
+			return $parsed;
+		}
+
 		$repo_name = $parsed['repo'];
 		$repo_path = $this->resolve_repo_path($handle);
 		if ( is_wp_error($repo_path) ) {

--- a/inc/Workspace/WorkspaceReader.php
+++ b/inc/Workspace/WorkspaceReader.php
@@ -40,6 +40,11 @@ class WorkspaceReader {
 	 * @return array{success: bool, content?: string, path?: string, size?: int, lines_read?: int, offset?: int}|\WP_Error
 	 */
 	public function read_file( string $name, string $path, int $max_size = Workspace::MAX_READ_SIZE, ?int $offset = null, ?int $limit = null, bool $allow_stale_primary = false ): array|\WP_Error {
+		$handle_check = $this->workspace->require_explicit_workspace_handle($name);
+		if ( is_wp_error($handle_check) ) {
+			return $handle_check;
+		}
+
 		$policy_error = WorkspaceAliasResolver::read_error_if_disallowed($name, $path);
 		if ( null !== $policy_error ) {
 			return $policy_error;
@@ -150,6 +155,11 @@ class WorkspaceReader {
 	 * @return array{success: bool, repo?: string, path?: string, entries?: array}|\WP_Error
 	 */
 	public function list_directory( string $name, ?string $path = null, bool $allow_stale_primary = false ): array|\WP_Error {
+		$handle_check = $this->workspace->require_explicit_workspace_handle($name);
+		if ( is_wp_error($handle_check) ) {
+			return $handle_check;
+		}
+
 		$policy_error = WorkspaceAliasResolver::read_error_if_disallowed($name, $path ?? '');
 		if ( null !== $policy_error ) {
 			return $policy_error;
@@ -250,6 +260,11 @@ class WorkspaceReader {
 	 * @return array{success: bool, repo?: string, path?: string, pattern?: string, matches?: array, count?: int, truncated?: bool}|\WP_Error
 	 */
 	public function grep( string $name, string $pattern, ?string $path = null, ?string $include_pattern = null, int $max_results = 100, int $context_lines = 0, bool $allow_stale_primary = false ): array|\WP_Error {
+		$handle_check = $this->workspace->require_explicit_workspace_handle($name);
+		if ( is_wp_error($handle_check) ) {
+			return $handle_check;
+		}
+
 		$policy_error = WorkspaceAliasResolver::read_error_if_disallowed($name, $path ?? '');
 		if ( null !== $policy_error ) {
 			return $policy_error;

--- a/inc/Workspace/WorkspaceWriter.php
+++ b/inc/Workspace/WorkspaceWriter.php
@@ -45,12 +45,14 @@ class WorkspaceWriter {
 	 *
 	 * @param  string $name    Repository directory name.
 	 * @param  string $path    Relative file path within the repo.
-	 * @param  string $content File content to write.
+	 * @param  string $content                File content to write.
+	 * @param  bool   $allow_primary_mutation Permit mutation on a primary checkout.
 	 * @return array{success: bool, path?: string, size?: int, created?: bool}|\WP_Error
 	 */
-	public function write_file( string $name, string $path, string $content ): array|\WP_Error {
-		if ( WorkspaceAliasResolver::is_context_repository($name) ) {
-			return WorkspaceAliasResolver::mutation_error($name, 'write');
+	public function write_file( string $name, string $path, string $content, bool $allow_primary_mutation = false ): array|\WP_Error {
+		$mutation_check = $this->ensure_workspace_mutation_allowed($name, 'write', $allow_primary_mutation);
+		if ( is_wp_error($mutation_check) ) {
+			return $mutation_check;
 		}
 
 		$repo_path = $this->workspace->get_repo_path($name);
@@ -127,12 +129,14 @@ class WorkspaceWriter {
 	 * @param  string $path        Relative file path within the repo.
 	 * @param  string $old_string  Text to find.
 	 * @param  string $new_string  Replacement text.
-	 * @param  bool   $replace_all Replace all occurrences (default false).
+	 * @param  bool   $replace_all            Replace all occurrences (default false).
+	 * @param  bool   $allow_primary_mutation Permit mutation on a primary checkout.
 	 * @return array{success: bool, path?: string, replacements?: int}|\WP_Error
 	 */
-	public function edit_file( string $name, string $path, string $old_string, string $new_string, bool $replace_all = false ): array|\WP_Error {
-		if ( WorkspaceAliasResolver::is_context_repository($name) ) {
-			return WorkspaceAliasResolver::mutation_error($name, 'edit');
+	public function edit_file( string $name, string $path, string $old_string, string $new_string, bool $replace_all = false, bool $allow_primary_mutation = false ): array|\WP_Error {
+		$mutation_check = $this->ensure_workspace_mutation_allowed($name, 'edit', $allow_primary_mutation);
+		if ( is_wp_error($mutation_check) ) {
+			return $mutation_check;
 		}
 
 		$repo_path = $this->workspace->get_repo_path($name);
@@ -234,27 +238,15 @@ class WorkspaceWriter {
 	 * @return array{success: bool, name: string, path: string, changed_files: string[], diff: string, status: string, check_output: string, apply_output: string}|\WP_Error
 	 */
 	public function apply_patch( string $name, string $patch, bool $allow_primary_mutation = false ): array|\WP_Error {
-		if ( WorkspaceAliasResolver::is_context_repository($name) ) {
-			return WorkspaceAliasResolver::mutation_error($name, 'apply-patch');
+		$mutation_check = $this->ensure_workspace_mutation_allowed($name, 'apply-patch', $allow_primary_mutation);
+		if ( is_wp_error($mutation_check) ) {
+			return $mutation_check;
 		}
 
 		$repo_path = $this->workspace->get_repo_path($name);
-		$parsed    = $this->workspace->parse_handle($name);
 
 		if ( ! is_dir($repo_path) ) {
 			return new \WP_Error('repo_not_found', sprintf('Repository "%s" not found in workspace.', $name), array( 'status' => 404 ));
-		}
-
-		if ( empty($parsed['is_worktree']) && ! $allow_primary_mutation ) {
-			return new \WP_Error(
-				'primary_mutation_blocked',
-				sprintf(
-					'Primary checkout "%s" is read-only by default. Pass allow_primary_mutation=true to operate on it, or use a worktree handle (e.g. %s@<branch-slug>).',
-					$parsed['repo'],
-					$parsed['repo']
-				),
-				array( 'status' => 403 )
-			);
 		}
 
 		$patch = str_replace("\r\n", "\n", $patch);
@@ -346,6 +338,19 @@ class WorkspaceWriter {
 				unlink($temp);
 			}
 		}
+	}
+
+	private function ensure_workspace_mutation_allowed( string $name, string $operation, bool $allow_primary_mutation ): true|\WP_Error {
+		if ( WorkspaceAliasResolver::is_context_repository($name) ) {
+			return WorkspaceAliasResolver::mutation_error($name, $operation);
+		}
+
+		$allowed = $this->workspace->ensure_workspace_mutation_allowed($name, $allow_primary_mutation);
+		if ( is_wp_error($allowed) ) {
+			return $allowed;
+		}
+
+		return true;
 	}
 
 	/**

--- a/tests/smoke-workspace-file-policy.php
+++ b/tests/smoke-workspace-file-policy.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace DataMachine\Core\FilesRepository {
+	class FilesystemHelper {
+		public static function get() {
+			return null;
+		}
+	}
+}
+
+namespace {
+	define('ABSPATH', __DIR__ . '/');
+	$workspace_root = sys_get_temp_dir() . '/datamachine-code-file-policy-' . getmypid();
+	define('DATAMACHINE_WORKSPACE_PATH', $workspace_root);
+
+	class WP_Error {
+		private string $code;
+		private string $message;
+		private mixed $data;
+
+		public function __construct( string $code = '', string $message = '', mixed $data = null ) {
+			$this->code    = $code;
+			$this->message = $message;
+			$this->data    = $data;
+		}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+
+		public function get_error_data(): mixed {
+			return $this->data;
+		}
+	}
+
+	function is_wp_error( mixed $value ): bool {
+		return $value instanceof WP_Error;
+	}
+
+	function get_option( string $name, mixed $default = false ): mixed {
+		return $default;
+	}
+
+	function apply_filters( string $hook_name, mixed $value ): mixed {
+		return $value;
+	}
+
+	function size_format( int|float $bytes ): string {
+		return (string) $bytes . ' B';
+	}
+
+	require_once dirname(__DIR__) . '/inc/Support/PathSecurity.php';
+	require_once dirname(__DIR__) . '/inc/Workspace/WorkspaceAliasResolver.php';
+	require_once dirname(__DIR__) . '/inc/Workspace/Workspace.php';
+	require_once dirname(__DIR__) . '/inc/Workspace/WorkspaceReader.php';
+	require_once dirname(__DIR__) . '/inc/Workspace/WorkspaceWriter.php';
+
+	$passed = 0;
+	$total  = 0;
+
+	$assert = function ( bool $condition, string $label ) use ( &$passed, &$total ): void {
+		++$total;
+		if ( $condition ) {
+			++$passed;
+			return;
+		}
+
+		fwrite(STDERR, "FAIL: {$label}\n");
+	};
+
+	$remove_tree = function ( string $path ) use ( &$remove_tree ): void {
+		if ( ! file_exists($path) ) {
+			return;
+		}
+		if ( is_file($path) || is_link($path) ) {
+			unlink($path);
+			return;
+		}
+		foreach ( scandir($path) ?: array() as $entry ) {
+			if ( '.' === $entry || '..' === $entry ) {
+				continue;
+			}
+			$remove_tree($path . '/' . $entry);
+		}
+		rmdir($path);
+	};
+
+	$remove_tree($workspace_root);
+	mkdir($workspace_root . '/demo', 0777, true);
+	mkdir($workspace_root . '/demo@feature-policy', 0777, true);
+	file_put_contents($workspace_root . '/demo/existing.txt', 'hello primary');
+	file_put_contents($workspace_root . '/demo@feature-policy/existing.txt', 'hello worktree');
+
+	$workspace = new DataMachineCode\Workspace\Workspace();
+	$reader    = new DataMachineCode\Workspace\WorkspaceReader($workspace);
+	$writer    = new DataMachineCode\Workspace\WorkspaceWriter($workspace);
+
+	$missing = $workspace->require_explicit_workspace_handle('');
+	$assert(is_wp_error($missing) && 'missing_workspace_handle' === $missing->get_error_code(), 'empty handles are rejected centrally');
+
+	$read_root = $reader->read_file('', 'demo/existing.txt');
+	$assert(is_wp_error($read_root) && 'missing_workspace_handle' === $read_root->get_error_code(), 'read_file rejects workspace-root handle');
+
+	$write_primary = $writer->write_file('demo', 'new.txt', 'primary');
+	$assert(is_wp_error($write_primary) && 'primary_mutation_blocked' === $write_primary->get_error_code(), 'write_file blocks primary mutation by default');
+	$assert(! file_exists($workspace_root . '/demo/new.txt'), 'blocked primary write does not create file');
+
+	$edit_primary = $writer->edit_file('demo', 'existing.txt', 'hello', 'goodbye');
+	$assert(is_wp_error($edit_primary) && 'primary_mutation_blocked' === $edit_primary->get_error_code(), 'edit_file blocks primary mutation by default');
+	$assert('hello primary' === file_get_contents($workspace_root . '/demo/existing.txt'), 'blocked primary edit leaves file unchanged');
+
+	$patch_primary = $writer->apply_patch('demo', "diff --git a/new.txt b/new.txt\nnew file mode 100644\n--- /dev/null\n+++ b/new.txt\n@@ -0,0 +1 @@\n+patched\n");
+	$assert(is_wp_error($patch_primary) && 'primary_mutation_blocked' === $patch_primary->get_error_code(), 'apply_patch uses the shared primary mutation preflight');
+
+	$write_worktree = $writer->write_file('demo@feature-policy', 'new.txt', 'worktree');
+	$assert(is_array($write_worktree) && ! empty($write_worktree['success']), 'write_file allows worktree mutation');
+	$assert('worktree' === file_get_contents($workspace_root . '/demo@feature-policy/new.txt'), 'worktree write lands in the worktree handle');
+
+	$write_primary_allowed = $writer->write_file('demo', 'allowed.txt', 'allowed', true);
+	$assert(is_array($write_primary_allowed) && ! empty($write_primary_allowed['success']), 'write_file honors explicit primary mutation override');
+
+	$remove_tree($workspace_root);
+
+	fprintf(STDOUT, "%d/%d passed\n", $passed, $total);
+	exit($passed === $total ? 0 : 1);
+}


### PR DESCRIPTION
## Summary
- Require explicit workspace handles for workspace file abilities and reject workspace-root file access centrally.
- Apply the primary checkout mutation guard to workspace write/edit through the same shared policy used by patch/delete-style mutations.
- Add focused smoke coverage for missing handles, primary write/edit/patch blocks, worktree writes, and explicit primary override.

## Tests
- `php tests/smoke-workspace-file-policy.php`
- `php tests/worktree-add-lifecycle.php`
- `php -l inc/Workspace/WorkspaceCoreUtilities.php && php -l inc/Workspace/WorkspaceReader.php && php -l inc/Workspace/WorkspaceWriter.php && php -l inc/Workspace/WorkspaceGitOperations.php && php -l inc/Abilities/WorkspaceAbilities.php && php -l tests/smoke-workspace-file-policy.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the scoped workspace file policy fix, added focused smoke coverage, and ran verification. Chris remains responsible for review and final acceptance.