### PR TITLE
docs: neutralize active workspace examples

### DIFF
--- a/inc/Runtime/ActiveWorkspaceProjector.php
+++ b/inc/Runtime/ActiveWorkspaceProjector.php
@@ -51,7 +51,7 @@
  *       'flow_id'      => $flow_id,
  *       'initial_data' => array(
  *           'active_workspace' => array(
- *               'handle' => 'extrachill-artist-platform@docs/agent-run-123',
+ *               'handle' => 'example-plugin@docs/agent-run-123',
  *           ),
  *       ),
  *   ) );
@@ -62,7 +62,7 @@
  * == Layer purity ==
  *
  * This class talks about workspaces, not docs, voice, or any consumer
- * concept. Downstream plugins (e.g. extrachill-docs) consume the
+ * concept. Downstream plugins (e.g. example-docs) consume the
  * active_workspace entry to make their own routing decisions. DMC stays
  * generic.
  *


### PR DESCRIPTION
## Summary
- Replace project-specific active workspace examples with neutral names.
- Keep the generic DMC layering guidance intact without behavior changes.

## Tests
- php -l inc/Runtime/ActiveWorkspaceProjector.php

## AI assistance
- No substantive AI code changes.
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Trivial comment-only documentation/example cleanup and verification.