### PR TITLE
Refactor CLI rendering helpers

### DIFF
--- a/inc/Cli/CliRepeatableOptionParser.php
+++ b/inc/Cli/CliRepeatableOptionParser.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Repeatable WP-CLI option parser.
+ *
+ * @package DataMachineCode\Cli
+ */
+
+namespace DataMachineCode\Cli;
+
+defined('ABSPATH') || exit;
+
+final class CliRepeatableOptionParser {
+
+	/**
+	 * Collect every occurrence of a repeatable assoc flag from raw argv.
+	 *
+	 * WP-CLI's parsed assoc args are last-wins for repeated flags, so commands
+	 * that accept repeatable options need to inspect raw argv to preserve order.
+	 * Supports both `--flag=value` and `--flag value` forms.
+	 *
+	 * @param  string              $flag Flag name without leading `--`.
+	 * @param  array<int,mixed>|null $argv Raw argv tokens. Defaults to `$GLOBALS['argv']`.
+	 * @return string[] Values in argv order, with empty values omitted.
+	 */
+	public static function collect( string $flag, ?array $argv = null ): array {
+		$argv = $argv ?? ( is_array($GLOBALS['argv'] ?? null) ? $GLOBALS['argv'] : array() );
+
+		$flag       = ltrim($flag, '-');
+		$long_flag  = '--' . $flag;
+		$assignment = $long_flag . '=';
+		$values     = array();
+		$count      = count($argv);
+
+		for ( $i = 0; $i < $count; ++$i ) {
+			$token = $argv[ $i ];
+			if ( ! is_string($token) ) {
+				continue;
+			}
+
+			if ( 0 === strpos($token, $assignment) ) {
+				$value = substr($token, strlen($assignment));
+				if ( '' !== $value ) {
+					$values[] = $value;
+				}
+				continue;
+			}
+
+			if ( $long_flag !== $token ) {
+				continue;
+			}
+
+			$next = $argv[ $i + 1 ] ?? null;
+			if ( ! is_string($next) || '' === $next || str_starts_with($next, '--') ) {
+				continue;
+			}
+
+			$values[] = $next;
+			++$i;
+		}
+
+		return $values;
+	}
+}

--- a/inc/Cli/CliResponseRenderer.php
+++ b/inc/Cli/CliResponseRenderer.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Shared WP-CLI response rendering helpers.
+ *
+ * @package DataMachineCode\Cli
+ */
+
+namespace DataMachineCode\Cli;
+
+use WP_CLI;
+
+defined('ABSPATH') || exit;
+
+final class CliResponseRenderer {
+
+	/**
+	 * Render a payload as pretty JSON.
+	 *
+	 * @param mixed $payload Response payload.
+	 */
+	public function json( mixed $payload ): void {
+		WP_CLI::line( (string) wp_json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) );
+	}
+
+	/**
+	 * Render rows with WP-CLI's native item formatter.
+	 *
+	 * @param array<int,array<string,mixed>> $items Rows to render.
+	 * @param string[]                       $fields Field order.
+	 * @param array<string,mixed>            $assoc_args CLI assoc args.
+	 * @param string                         $default_format Default format.
+	 */
+	public function items( array $items, array $fields, array $assoc_args, string $default_format = 'table' ): void {
+		$format = (string) ( $assoc_args['format'] ?? $default_format );
+
+		if ( function_exists('WP_CLI\\Utils\\format_items') ) {
+			\WP_CLI\Utils\format_items($format, $items, $fields);
+			return;
+		}
+
+		foreach ( $items as $item ) {
+			WP_CLI::line(implode("\t", array_map(static fn( string $field ): string => (string) ( $item[ $field ] ?? '' ), $fields)));
+		}
+	}
+}

--- a/inc/Cli/Commands/CodeTaskCommand.php
+++ b/inc/Cli/Commands/CodeTaskCommand.php
@@ -7,6 +7,7 @@
 
 namespace DataMachineCode\Cli\Commands;
 
+use DataMachineCode\Cli\CliResponseRenderer;
 use DataMachine\Cli\BaseCommand;
 use WP_CLI;
 
@@ -81,11 +82,11 @@ class CodeTaskCommand extends BaseCommand {
 		}
 
 		if ( 'json' === ( $assoc_args['format'] ?? 'table' ) ) {
-			WP_CLI::log(wp_json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+			$this->renderer()->json($result);
 			return;
 		}
 
-		$this->format_items(
+		$this->renderer()->items(
 			array(
 				array(
 					'repo'        => $result['repo'] ?? '',
@@ -96,9 +97,12 @@ class CodeTaskCommand extends BaseCommand {
 				),
 			),
 			array( 'repo', 'branch', 'handle', 'prompt_path', 'source_url' ),
-			$assoc_args,
-			'repo'
+			$assoc_args
 		);
+	}
+
+	private function renderer(): CliResponseRenderer {
+		return new CliResponseRenderer();
 	}
 
 	/**

--- a/inc/Cli/Commands/GitHubCommand.php
+++ b/inc/Cli/Commands/GitHubCommand.php
@@ -13,6 +13,7 @@ namespace DataMachineCode\Cli\Commands;
 
 use WP_CLI;
 use DataMachine\Cli\BaseCommand;
+use DataMachineCode\Cli\CliResponseRenderer;
 use DataMachineCode\Abilities\GitHubAbilities;
 use DataMachineCode\GitHub\PrReviewFlowInstaller;
 use DataMachineCode\GitHub\PrReviewFlowScaffold;
@@ -86,7 +87,7 @@ class GitHubCommand extends BaseCommand {
 		$format = $assoc_args['format'] ?? 'table';
 
 		if ( 'json' === $format ) {
-			WP_CLI::line( (string) \wp_json_encode($result, JSON_PRETTY_PRINT));
+			$this->renderer()->json($result);
 			return;
 		}
 
@@ -110,7 +111,7 @@ class GitHubCommand extends BaseCommand {
 			);
 		}
 
-		$this->format_items($items, array( 'number', 'state', 'title', 'labels', 'comments', 'created_at' ), $assoc_args);
+		$this->renderer()->items($items, array( 'number', 'state', 'title', 'labels', 'comments', 'created_at' ), $assoc_args);
 		WP_CLI::log(sprintf('%d issue(s) returned.', count($items)));
 	}
 
@@ -163,7 +164,7 @@ class GitHubCommand extends BaseCommand {
 		$format = $assoc_args['format'] ?? 'table';
 
 		if ( 'json' === $format ) {
-			WP_CLI::line( (string) \wp_json_encode($result, JSON_PRETTY_PRINT));
+			$this->renderer()->json($result);
 			return;
 		}
 
@@ -351,7 +352,7 @@ class GitHubCommand extends BaseCommand {
 		$format = $assoc_args['format'] ?? 'table';
 
 		if ( 'json' === $format ) {
-			WP_CLI::line( (string) \wp_json_encode($result, JSON_PRETTY_PRINT));
+			$this->renderer()->json($result);
 			return;
 		}
 
@@ -381,7 +382,7 @@ class GitHubCommand extends BaseCommand {
 			);
 		}
 
-		$this->format_items($items, array( 'number', 'status', 'title', 'branch', 'user', 'created_at' ), $assoc_args);
+		$this->renderer()->items($items, array( 'number', 'status', 'title', 'branch', 'user', 'created_at' ), $assoc_args);
 		WP_CLI::log(sprintf('%d PR(s) returned.', count($items)));
 	}
 
@@ -568,7 +569,7 @@ class GitHubCommand extends BaseCommand {
 		$format = $assoc_args['format'] ?? 'table';
 
 		if ( 'json' === $format ) {
-			WP_CLI::line( (string) \wp_json_encode($result, JSON_PRETTY_PRINT));
+			$this->renderer()->json($result);
 			return;
 		}
 
@@ -591,8 +592,12 @@ class GitHubCommand extends BaseCommand {
 			);
 		}
 
-		$this->format_items($items, array( 'repo', 'language', 'stars', 'open_issues', 'private', 'last_push' ), $assoc_args);
+		$this->renderer()->items($items, array( 'repo', 'language', 'stars', 'open_issues', 'private', 'last_push' ), $assoc_args);
 		WP_CLI::log(sprintf('%d repo(s) returned.', count($items)));
+	}
+
+	private function renderer(): CliResponseRenderer {
+		return new CliResponseRenderer();
 	}
 
 	/**

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -17,6 +17,7 @@ namespace DataMachineCode\Cli\Commands;
 
 use WP_CLI;
 use DataMachine\Cli\BaseCommand;
+use DataMachineCode\Cli\CliRepeatableOptionParser;
 use DataMachineCode\Cleanup\CleanupRunEvidenceStoreInterface;
 use DataMachineCode\Cleanup\DataMachineJobCleanupRunEvidenceStore;
 use DataMachineCode\Workspace\Workspace;
@@ -2821,46 +2822,6 @@ class WorkspaceCommand extends BaseCommand {
 	}
 
 	/**
-	 * Collect every `--<flag>=<value>` occurrence from the raw process argv.
-	 *
-	 * WP-CLI's parsed `$assoc_args` is last-wins for repeated assoc flags —
-	 * it never returns an array, even when the synopsis declares the flag as
-	 * repeatable (`...`). For commands that document a flag as repeatable
-	 * (`--rel`, `--include`, etc.), we walk $GLOBALS['argv'] directly so
-	 * every occurrence is preserved in argv order.
-	 *
-	 * Empty values are filtered out. Bare `--<flag>` (no value) is ignored
-	 * because it's ambiguous in the assoc-flag context.
-	 *
-	 * @param  string $flag Flag name without the leading `--` (e.g. 'rel').
-	 * @return string[] Every value, in argv order, for the named flag.
-	 */
-	private function collectRepeatableFlag( string $flag ): array {
-		$argv = $GLOBALS['argv'] ?? array();
-		if ( ! is_array($argv) ) {
-			return array();
-		}
-
-		$prefix     = '--' . $flag . '=';
-		$prefix_len = strlen($prefix);
-		$values     = array();
-
-		foreach ( $argv as $token ) {
-			if ( ! is_string($token) ) {
-				continue;
-			}
-			if ( 0 === strpos($token, $prefix) ) {
-				$value = substr($token, $prefix_len);
-				if ( '' !== $value ) {
-					$values[] = $value;
-				}
-			}
-		}
-
-		return $values;
-	}
-
-	/**
 	 * Resolve @file syntax — if a string starts with @, read file contents.
 	 *
 	 * Mirrors curl's -d @filename convention. If the value doesn't start
@@ -3026,7 +2987,7 @@ class WorkspaceCommand extends BaseCommand {
 		}
 
 		if ( 'add' === $operation ) {
-			$input['paths'] = $this->collectRepeatableFlag('rel');
+			$input['paths'] = CliRepeatableOptionParser::collect('rel');
 
 			if ( empty($input['paths']) ) {
 				WP_CLI::error('git add requires at least one --rel=<relative/path>.');
@@ -3094,7 +3055,7 @@ class WorkspaceCommand extends BaseCommand {
 			if ( ! empty($assoc_args['squash']) ) {
 				$input['squash'] = true;
 			}
-			$drop_paths = $this->collectRepeatableFlag('drop-path');
+			$drop_paths = CliRepeatableOptionParser::collect('drop-path');
 			if ( ! empty($drop_paths) ) {
 				$input['drop_paths'] = $drop_paths;
 			}
@@ -3116,7 +3077,7 @@ class WorkspaceCommand extends BaseCommand {
 			if ( ! empty($assoc_args['staged']) ) {
 				$input['staged'] = true;
 			}
-			$diff_paths = $this->collectRepeatableFlag('rel');
+			$diff_paths = CliRepeatableOptionParser::collect('rel');
 			if ( ! empty($diff_paths) ) {
 				$input['path'] = (string) $diff_paths[0];
 			}

--- a/tests/cli-repeatable-option-parser.php
+++ b/tests/cli-repeatable-option-parser.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+if ( ! defined('ABSPATH') ) {
+	define('ABSPATH', __DIR__ . '/fixtures/');
+}
+
+require_once dirname(__DIR__) . '/inc/Cli/CliRepeatableOptionParser.php';
+
+use DataMachineCode\Cli\CliRepeatableOptionParser;
+
+function assert_same( array $expected, array $actual, string $message ): void {
+	if ( $expected !== $actual ) {
+		throw new RuntimeException(
+			sprintf(
+				"%s\nExpected: %s\nActual:   %s",
+				$message,
+				json_encode($expected),
+				json_encode($actual)
+			)
+		);
+	}
+}
+
+assert_same(
+	array( 'one.php', 'two.php', 'three.php' ),
+	CliRepeatableOptionParser::collect(
+		'rel',
+		array( 'wp', 'datamachine-code', 'workspace', 'git', 'add', 'repo', '--rel=one.php', '--rel', 'two.php', '--other=value', '--rel=three.php' )
+	),
+	'Collects both assignment and separated repeatable option forms in order.'
+);
+
+assert_same(
+	array( 'kept' ),
+	CliRepeatableOptionParser::collect('rel', array( '--rel=', '--rel', '--next=value', '--rel', '', '--rel', 'kept' )),
+	'Ignores empty values and bare flags without a following value.'
+);
+
+$GLOBALS['argv'] = array( 'wp', 'cmd', '--drop-path', 'a.txt', '--drop-path=b.txt' );
+assert_same(
+	array( 'a.txt', 'b.txt' ),
+	CliRepeatableOptionParser::collect('drop-path'),
+	'Defaults to global argv when no argv is provided.'
+);
+
+echo "cli-repeatable-option-parser: ok\n";


### PR DESCRIPTION
## Summary
- Add shared CLI response rendering helpers for JSON and item output.
- Add a shared repeatable option parser that preserves repeated flags in raw argv order.
- Support both `--flag=value` and `--flag value` forms for workspace repeatable options.
- Route focused GitHub/code-task output paths through the shared renderer without broad CLI churn.

## Tests
- `php -l inc/Cli/CliRepeatableOptionParser.php`
- `php -l inc/Cli/CliResponseRenderer.php`
- `php -l inc/Cli/Commands/WorkspaceCommand.php`
- `php -l inc/Cli/Commands/GitHubCommand.php`
- `php -l inc/Cli/Commands/CodeTaskCommand.php`
- `php tests/cli-repeatable-option-parser.php`
- `composer install --no-interaction`
- `php tests/worktree-add-lifecycle.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the small CLI helper refactor, parser test coverage, and verification commands for Chris to review.