### PR TITLE
Centralize workspace writable-root policy

### DIFF
--- a/inc/Workspace/RemoteWorkspaceBackend.php
+++ b/inc/Workspace/RemoteWorkspaceBackend.php
@@ -195,10 +195,10 @@ class RemoteWorkspaceBackend {
 			if ( ! is_array($worktree) ) {
 				continue;
 			}
-			if ( $repo_name !== (string) ( $worktree['repo_name'] ?? '' ) ) {
+			if ( (string) ( $worktree['repo_name'] ?? '' ) !== $repo_name ) {
 				continue;
 			}
-			if ( $branch !== (string) ( $worktree['branch'] ?? '' ) ) {
+			if ( (string) ( $worktree['branch'] ?? '' ) !== $branch ) {
 				continue;
 			}
 
@@ -492,7 +492,7 @@ class RemoteWorkspaceBackend {
 			return $path;
 		}
 
-		$policy_check = $this->policy->assert_paths_writable((string) $context['repo_name'], array( $path ));
+		$policy_check = $this->policy->assert_paths_writable( (string) $context['repo_name'], array( $path ) );
 		if ( is_wp_error($policy_check) ) {
 			return $policy_check;
 		}
@@ -532,7 +532,7 @@ class RemoteWorkspaceBackend {
 			return $normalized_path;
 		}
 
-		$policy_check = $this->policy->assert_paths_writable((string) $context['repo_name'], array( $normalized_path ));
+		$policy_check = $this->policy->assert_paths_writable( (string) $context['repo_name'], array( $normalized_path ) );
 		if ( is_wp_error($policy_check) ) {
 			return $policy_check;
 		}
@@ -605,7 +605,7 @@ class RemoteWorkspaceBackend {
 			? '#' . $context['branch']
 			: '' ),
 			'branch'      => '' !== (string) $context['branch'] ? (string) $context['branch'] : null,
-			'remote'      => GitHubRemote::cloneUrl((string) $context['repo']),
+			'remote'      => GitHubRemote::cloneUrl( (string) $context['repo'] ),
 			'commit'      => '' !== $context['last_commit_sha'] ? $context['last_commit_sha'] : null,
 			'dirty'       => count($files),
 			'files'       => $files,
@@ -698,7 +698,7 @@ class RemoteWorkspaceBackend {
 			'is_context'  => ! empty($context['read_only_context']),
 			'path'        => 'github://' . $context['repo'] . '#' . $context['branch'],
 			'branch'      => $context['branch'],
-			'remote'      => GitHubRemote::cloneUrl((string) $context['repo']),
+			'remote'      => GitHubRemote::cloneUrl( (string) $context['repo'] ),
 			'commit'      => '' !== $context['last_commit_sha'] ? $context['last_commit_sha'] : null,
 			'dirty'       => count($files),
 			'files'       => $files,
@@ -1262,7 +1262,7 @@ class RemoteWorkspaceBackend {
 		}
 
 		$push_branch = null !== $branch && '' !== $branch ? $branch : $context['branch'];
-		$branch_url  = '' !== $push_branch ? GitHubRemote::branchUrl((string) $context['repo'], (string) $push_branch) : null;
+		$branch_url  = '' !== $push_branch ? GitHubRemote::branchUrl( (string) $context['repo'], (string) $push_branch ) : null;
 
 		return array(
 			'success'        => true,

--- a/inc/Workspace/RemoteWorkspaceBackend.php
+++ b/inc/Workspace/RemoteWorkspaceBackend.php
@@ -9,11 +9,19 @@ namespace DataMachineCode\Workspace;
 
 use DataMachineCode\Abilities\GitHubAbilities;
 use DataMachineCode\Support\GitHubRemote;
-use DataMachineCode\Support\PathSecurity;
 
 defined('ABSPATH') || exit;
 
 class RemoteWorkspaceBackend {
+
+	/**
+	 * @var WorkspacePolicy
+	 */
+	private WorkspacePolicy $policy;
+
+	public function __construct( ?WorkspacePolicy $policy = null ) {
+		$this->policy = $policy ?? new WorkspacePolicy();
+	}
 
 
 
@@ -484,7 +492,7 @@ class RemoteWorkspaceBackend {
 			return $path;
 		}
 
-		$policy_check = $this->ensure_writable_roots_allow_paths((string) $context['repo_name'], array( $path ));
+		$policy_check = $this->policy->assert_paths_writable((string) $context['repo_name'], array( $path ));
 		if ( is_wp_error($policy_check) ) {
 			return $policy_check;
 		}
@@ -502,101 +510,6 @@ class RemoteWorkspaceBackend {
 			'size'    => strlen($content),
 			'created' => true,
 		);
-	}
-
-	/**
-	 * Enforce configured writable roots before a remote mutation is staged.
-	 *
-	 * @param  string            $repo_name Repository name.
-	 * @param  array<int,string> $paths     Repo-relative paths.
-	 * @return true|\WP_Error
-	 */
-	private function ensure_writable_roots_allow_paths( string $repo_name, array $paths ): true|\WP_Error {
-		$writable_roots = $this->get_repo_writable_roots($repo_name);
-		if ( empty($writable_roots) ) {
-			return true;
-		}
-
-		$rejected = array();
-		foreach ( $paths as $path ) {
-			$relative = $this->normalize_policy_path($path);
-			if ( '' !== $relative && ! PathSecurity::isPathAllowed($relative, $writable_roots) ) {
-				$rejected[] = $relative;
-			}
-		}
-
-		$rejected = array_values(array_unique($rejected));
-		if ( empty($rejected) ) {
-			return true;
-		}
-
-		return new \WP_Error(
-			'path_not_allowed',
-			sprintf(
-				'Path(s) outside configured writable_roots: %s. Allowed writable_roots: %s.',
-				implode(', ', $rejected),
-				implode(', ', $writable_roots)
-			),
-			array(
-				'status'         => 403,
-				'rejected_paths' => $rejected,
-				'writable_roots' => $writable_roots,
-			)
-		);
-	}
-
-	/**
-	 * @return array<int,string>
-	 */
-	private function get_repo_writable_roots( string $repo_name ): array {
-		$policies = $this->get_workspace_git_policies();
-		$repo     = $policies['repos'][ $repo_name ] ?? array();
-		$paths    = $repo['writable_roots'] ?? $repo['allowed_paths'] ?? array();
-
-		return $this->normalize_policy_paths($paths);
-	}
-
-	/**
-	 * @return array{repos: array<string, array<string, mixed>>}
-	 */
-	private function get_workspace_git_policies(): array {
-		$defaults = array( 'repos' => array() );
-		$settings = function_exists('get_option') ? get_option('datamachine_workspace_git_policies', $defaults) : $defaults;
-		if ( ! is_array($settings) ) {
-			$settings = $defaults;
-		}
-		if ( ! isset($settings['repos']) || ! is_array($settings['repos']) ) {
-			$settings['repos'] = array();
-		}
-		if ( function_exists('apply_filters') ) {
-			$settings = apply_filters('datamachine_workspace_git_policies', $settings);
-		}
-
-		return isset($settings['repos']) && is_array($settings['repos']) ? $settings : $defaults;
-	}
-
-	/**
-	 * @param  mixed $paths Raw policy value.
-	 * @return array<int,string>
-	 */
-	private function normalize_policy_paths( mixed $paths ): array {
-		if ( ! is_array($paths) ) {
-			return array();
-		}
-
-		$clean = array();
-		foreach ( $paths as $path ) {
-			$normalized = $this->normalize_policy_path((string) $path);
-			if ( '' !== $normalized ) {
-				$clean[] = $normalized;
-			}
-		}
-
-		return array_values(array_unique($clean));
-	}
-
-	private function normalize_policy_path( string $path ): string {
-		return rtrim(ltrim(str_replace('\\', '/', trim($path)), '/'), '/');
 	}
 
 	/**
@@ -619,7 +532,7 @@ class RemoteWorkspaceBackend {
 			return $normalized_path;
 		}
 
-		$policy_check = $this->ensure_writable_roots_allow_paths((string) $context['repo_name'], array( $normalized_path ));
+		$policy_check = $this->policy->assert_paths_writable((string) $context['repo_name'], array( $normalized_path ));
 		if ( is_wp_error($policy_check) ) {
 			return $policy_check;
 		}

--- a/inc/Workspace/WorkspaceGitOperations.php
+++ b/inc/Workspace/WorkspaceGitOperations.php
@@ -1272,11 +1272,7 @@ trait WorkspaceGitOperations {
 	 * @return array<int,string>
 	 */
 	private function get_repo_writable_roots( string $repo_name ): array {
-		$policies = $this->get_workspace_git_policies();
-		$repo     = $policies['repos'][ $repo_name ] ?? array();
-		$paths    = $repo['writable_roots'] ?? $repo['allowed_paths'] ?? array();
-
-		return $this->normalize_policy_paths($paths);
+		return ( new WorkspacePolicy() )->writable_roots_for_repo($repo_name);
 	}
 
 	/**
@@ -1286,10 +1282,7 @@ trait WorkspaceGitOperations {
 	 * @return array<int,string>
 	 */
 	private function get_repo_hidden_paths( string $repo_name ): array {
-		$policies = $this->get_workspace_git_policies();
-		$repo     = $policies['repos'][ $repo_name ] ?? array();
-
-		return $this->normalize_policy_paths($repo['hidden_paths'] ?? array());
+		return ( new WorkspacePolicy() )->hidden_paths_for_repo($repo_name);
 	}
 
 	/**
@@ -1299,23 +1292,7 @@ trait WorkspaceGitOperations {
 	 * @return array<int,string>
 	 */
 	private function normalize_policy_paths( mixed $paths ): array {
-		if ( ! is_array($paths) ) {
-			return array();
-		}
-
-		$clean = array();
-		foreach ( $paths as $path ) {
-			$normalized = trim( (string) $path);
-			if ( '' === $normalized ) {
-				continue;
-			}
-
-			$normalized = ltrim(str_replace('\\', '/', $normalized), '/');
-			$normalized = rtrim($normalized, '/');
-			$clean[]    = $normalized;
-		}
-
-		return array_values(array_unique($clean));
+		return ( new WorkspacePolicy() )->normalize_paths($paths);
 	}
 
 	/**
@@ -1357,10 +1334,8 @@ trait WorkspaceGitOperations {
 	 * @return array<string,mixed>|null|\WP_Error
 	 */
 	private function build_workspace_policy_attestation( string $repo_name, string $repo_path, ?array $paths = null ): array|null|\WP_Error {
-		$writable_roots = $this->get_repo_writable_roots($repo_name);
-		$hidden_paths   = $this->get_repo_hidden_paths($repo_name);
-
-		if ( empty($writable_roots) && empty($hidden_paths) ) {
+		$policy = new WorkspacePolicy();
+		if ( empty($policy->writable_roots_for_repo($repo_name)) && empty($policy->hidden_paths_for_repo($repo_name)) ) {
 			return null;
 		}
 
@@ -1374,47 +1349,15 @@ trait WorkspaceGitOperations {
 			return $ignored_files;
 		}
 
-		$changed_files = array_values(array_unique(array_merge($changed_files, $ignored_files)));
-		sort($changed_files);
-
-		$policy = array(
-			'writable_roots' => $writable_roots,
-			'hidden_paths'   => $hidden_paths,
-		);
-
-		$real_repo = realpath($repo_path);
-		if ( false === $real_repo ) {
-			return new \WP_Error('repo_path_unavailable', 'Repository path cannot be resolved for workspace policy attestation.', array( 'status' => 500 ));
-		}
-
-		$violations = array();
-		foreach ( $changed_files as $path ) {
-			$violations = array_merge($violations, $this->workspace_policy_path_violations($repo_path, $real_repo, $path, $writable_roots, $hidden_paths, $ignored_files));
-		}
-
-     // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- fallback for standalone smoke tests outside WordPress.
-		$policy_json = function_exists('wp_json_encode') ? wp_json_encode($policy) : json_encode($policy);
-
-		return array(
-			'policy_hash'      => hash('sha256', (string) $policy_json),
-			'checked_roots'    => array(
-				'repository'     => $real_repo,
-				'writable_roots' => $writable_roots,
-				'hidden_paths'   => $hidden_paths,
-			),
-			'changed_files'    => $changed_files,
-			'violations'       => $violations,
-			'supported_checks' => array(
-				'writable_roots',
-				'hidden_paths',
-				'symlink',
-				'gitlink',
-				'nested_git',
-				'non_regular',
-				'outside_realpath',
-				'ignored',
-				'hardlink',
-			),
+		return $policy->attest_changed_paths(
+			$repo_name,
+			$repo_path,
+			$changed_files,
+			$ignored_files,
+			function ( string $path ) use ( $repo_path ): string {
+				$stage = $this->run_git($repo_path, 'ls-files --stage -- ' . escapeshellarg($path));
+				return is_wp_error($stage) ? '' : (string) ( $stage['output'] ?? '' );
+			}
 		);
 	}
 
@@ -1496,89 +1439,6 @@ trait WorkspaceGitOperations {
 		}
 
 		return array_values(array_unique($files));
-	}
-
-	/**
-	 * Build all policy violations for a single relative path.
-	 *
-	 * @param  string            $repo_path      Repository path.
-	 * @param  string            $real_repo      Real repository path.
-	 * @param  string            $path           Relative path.
-	 * @param  array<int,string> $writable_roots Writable roots.
-	 * @param  array<int,string> $hidden_paths   Hidden paths.
-	 * @param  array<int,string> $ignored_files  Ignored files.
-	 * @return array<int,array<string,string>>
-	 */
-	private function workspace_policy_path_violations( string $repo_path, string $real_repo, string $path, array $writable_roots, array $hidden_paths, array $ignored_files ): array {
-		$violations = array();
-		$path       = ltrim(str_replace('\\', '/', $path), '/');
-		$absolute   = $repo_path . '/' . $path;
-
-		$add_violation = static function ( string $reason, string $detail = '' ) use ( &$violations, $path ): void {
-			$violation = array(
-				'path'   => $path,
-				'reason' => $reason,
-			);
-			if ( '' !== $detail ) {
-				$violation['detail'] = $detail;
-			}
-			$violations[] = $violation;
-		};
-
-		if ( ! empty($writable_roots) && ! $this->is_path_allowed($path, $writable_roots) ) {
-			$add_violation('outside_writable_roots', 'Changed path is outside configured writable_roots.');
-		}
-
-		if ( ! empty($hidden_paths) && $this->is_path_allowed($path, $hidden_paths) ) {
-			$add_violation('hidden_path', 'Changed path is under configured hidden_paths.');
-		}
-
-		if ( '.git' === $path || str_starts_with($path, '.git/') || str_contains($path, '/.git/') || str_ends_with($path, '/.git') ) {
-			$add_violation('nested_git', 'Changed path includes a .git directory or file.');
-		}
-
-		if ( in_array($path, $ignored_files, true) ) {
-			$add_violation('ignored', 'Changed path is ignored by git exclude rules.');
-		}
-
-		if ( is_link($absolute) ) {
-			$add_violation('symlink', 'Changed path is a symlink.');
-			$target = readlink($absolute);
-			if ( false !== $target ) {
-				$target_path = str_starts_with($target, '/') ? $target : dirname($absolute) . '/' . $target;
-				$real_target = realpath($target_path);
-				if ( false === $real_target || ( $real_target !== $real_repo && ! str_starts_with($real_target, $real_repo . '/') ) ) {
-					$add_violation('outside_realpath', 'Symlink target resolves outside the repository.');
-				}
-				foreach ( $hidden_paths as $hidden_path ) {
-					$hidden_real = realpath($repo_path . '/' . $hidden_path);
-					if ( false !== $hidden_real && false !== $real_target && ( $real_target === $hidden_real || str_starts_with($real_target, $hidden_real . '/') ) ) {
-						$add_violation('hidden_path_exposure', 'Symlink target resolves under hidden_paths.');
-					}
-				}
-			}
-		} elseif ( file_exists($absolute) ) {
-			$real_path = realpath($absolute);
-			if ( false === $real_path || ( $real_path !== $real_repo && ! str_starts_with($real_path, $real_repo . '/') ) ) {
-				$add_violation('outside_realpath', 'Changed path resolves outside the repository.');
-			}
-
-			if ( ! is_file($absolute) && ! is_dir($absolute) ) {
-				$add_violation('non_regular', 'Changed path is neither a regular file nor a directory.');
-			}
-
-			$stat = @lstat($absolute); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
-			if ( is_array($stat) && is_file($absolute) && (int) ( $stat['nlink'] ?? 1 ) > 1 ) {
-				$add_violation('hardlink', 'Changed file has more than one hardlink.');
-			}
-		}
-
-		$stage = $this->run_git($repo_path, 'ls-files --stage -- ' . escapeshellarg($path));
-		if ( ! is_wp_error($stage) && preg_match('/^160000\s/', (string) ( $stage['output'] ?? '' )) ) {
-			$add_violation('gitlink', 'Changed path is a gitlink/submodule entry.');
-		}
-
-		return $violations;
 	}
 
 	/**

--- a/inc/Workspace/WorkspacePolicy.php
+++ b/inc/Workspace/WorkspacePolicy.php
@@ -1,0 +1,285 @@
+<?php
+/**
+ * Workspace policy service.
+ *
+ * Centralizes workspace writable-root policy loading, path normalization,
+ * enforcement, and attestation construction for local and remote backends.
+ *
+ * @package DataMachineCode\Workspace
+ */
+
+namespace DataMachineCode\Workspace;
+
+use DataMachineCode\Support\PathSecurity;
+
+defined('ABSPATH') || exit;
+
+final class WorkspacePolicy {
+
+
+
+	/**
+	 * Return writable roots for a repository.
+	 *
+	 * `writable_roots` is the runner-facing contract. `allowed_paths` remains
+	 * supported as the existing workspace git policy name and fallback.
+	 *
+	 * @param  string $repo_name Repository name.
+	 * @return array<int,string>
+	 */
+	public function writable_roots_for_repo( string $repo_name ): array {
+		$policies = $this->workspace_git_policies();
+		$repo     = $policies['repos'][ $repo_name ] ?? array();
+		$paths    = $repo['writable_roots'] ?? $repo['allowed_paths'] ?? array();
+
+		return $this->normalize_paths($paths);
+	}
+
+	/**
+	 * Return hidden roots for a repository.
+	 *
+	 * @param  string $repo_name Repository name.
+	 * @return array<int,string>
+	 */
+	public function hidden_paths_for_repo( string $repo_name ): array {
+		$policies = $this->workspace_git_policies();
+		$repo     = $policies['repos'][ $repo_name ] ?? array();
+
+		return $this->normalize_paths($repo['hidden_paths'] ?? array());
+	}
+
+	/**
+	 * Normalize one repo-relative path.
+	 */
+	public function normalize_path( string $path ): string {
+		return rtrim(ltrim(str_replace('\\', '/', trim($path)), '/'), '/');
+	}
+
+	/**
+	 * Normalize repo-relative path lists.
+	 *
+	 * @param  mixed $paths Raw policy/path value.
+	 * @return array<int,string>
+	 */
+	public function normalize_paths( mixed $paths ): array {
+		if ( ! is_array($paths) ) {
+			return array();
+		}
+
+		$clean = array();
+		foreach ( $paths as $path ) {
+			$normalized = $this->normalize_path((string) $path);
+			if ( '' !== $normalized ) {
+				$clean[] = $normalized;
+			}
+		}
+
+		return array_values(array_unique($clean));
+	}
+
+	/**
+	 * Enforce configured writable roots for repo-relative paths.
+	 *
+	 * @param  string            $repo_name Repository name.
+	 * @param  array<int,string> $paths     Repo-relative paths.
+	 * @return true|\WP_Error
+	 */
+	public function assert_paths_writable( string $repo_name, array $paths ): true|\WP_Error {
+		$writable_roots = $this->writable_roots_for_repo($repo_name);
+		if ( empty($writable_roots) ) {
+			return true;
+		}
+
+		$rejected = array();
+		foreach ( $paths as $path ) {
+			$relative = $this->normalize_path($path);
+			if ( '' !== $relative && ! PathSecurity::isPathAllowed($relative, $writable_roots) ) {
+				$rejected[] = $relative;
+			}
+		}
+
+		$rejected = array_values(array_unique($rejected));
+		if ( empty($rejected) ) {
+			return true;
+		}
+
+		return new \WP_Error(
+			'path_not_allowed',
+			sprintf(
+				'Path(s) outside configured writable_roots: %s. Allowed writable_roots: %s.',
+				implode(', ', $rejected),
+				implode(', ', $writable_roots)
+			),
+			array(
+				'status'         => 403,
+				'rejected_paths' => $rejected,
+				'writable_roots' => $writable_roots,
+			)
+		);
+	}
+
+	/**
+	 * Build a machine-readable workspace policy attestation.
+	 *
+	 * @param  string            $repo_name     Repository name.
+	 * @param  string            $repo_path     Repository path.
+	 * @param  array<int,string> $changed_files Changed repo-relative paths.
+	 * @param  array<int,string> $ignored_files Ignored repo-relative paths.
+	 * @param  callable|null     $git_stage     Optional callback returning `git ls-files --stage` output for one path.
+	 * @return array<string,mixed>|null|\WP_Error
+	 */
+	public function attest_changed_paths( string $repo_name, string $repo_path, array $changed_files, array $ignored_files = array(), ?callable $git_stage = null ): array|null|\WP_Error {
+		$writable_roots = $this->writable_roots_for_repo($repo_name);
+		$hidden_paths   = $this->hidden_paths_for_repo($repo_name);
+
+		if ( empty($writable_roots) && empty($hidden_paths) ) {
+			return null;
+		}
+
+		$changed_files = array_values(array_unique(array_merge($this->normalize_paths($changed_files), $this->normalize_paths($ignored_files))));
+		$ignored_files = $this->normalize_paths($ignored_files);
+		sort($changed_files);
+
+		$policy = array(
+			'writable_roots' => $writable_roots,
+			'hidden_paths'   => $hidden_paths,
+		);
+
+		$real_repo = realpath($repo_path);
+		if ( false === $real_repo ) {
+			return new \WP_Error('repo_path_unavailable', 'Repository path cannot be resolved for workspace policy attestation.', array( 'status' => 500 ));
+		}
+
+		$violations = array();
+		foreach ( $changed_files as $path ) {
+			$violations = array_merge($violations, $this->path_violations($repo_path, $real_repo, $path, $writable_roots, $hidden_paths, $ignored_files, $git_stage));
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- fallback for standalone smoke tests outside WordPress.
+		$policy_json = function_exists('wp_json_encode') ? wp_json_encode($policy) : json_encode($policy);
+
+		return array(
+			'policy_hash'      => hash('sha256', (string) $policy_json),
+			'checked_roots'    => array(
+				'repository'     => $real_repo,
+				'writable_roots' => $writable_roots,
+				'hidden_paths'   => $hidden_paths,
+			),
+			'changed_files'    => $changed_files,
+			'violations'       => $violations,
+			'supported_checks' => array(
+				'writable_roots',
+				'hidden_paths',
+				'symlink',
+				'gitlink',
+				'nested_git',
+				'non_regular',
+				'outside_realpath',
+				'ignored',
+				'hardlink',
+			),
+		);
+	}
+
+	/**
+	 * @return array{repos: array<string, array<string, mixed>>}
+	 */
+	private function workspace_git_policies(): array {
+		$defaults = array( 'repos' => array() );
+		$settings = function_exists('get_option') ? get_option('datamachine_workspace_git_policies', $defaults) : $defaults;
+		if ( ! is_array($settings) ) {
+			$settings = $defaults;
+		}
+		if ( ! isset($settings['repos']) || ! is_array($settings['repos']) ) {
+			$settings['repos'] = array();
+		}
+		if ( function_exists('apply_filters') ) {
+			$settings = apply_filters('datamachine_workspace_git_policies', $settings);
+		}
+
+		return isset($settings['repos']) && is_array($settings['repos']) ? $settings : $defaults;
+	}
+
+	/**
+	 * Build all policy violations for a single relative path.
+	 *
+	 * @param  string            $repo_path      Repository path.
+	 * @param  string            $real_repo      Real repository path.
+	 * @param  string            $path           Relative path.
+	 * @param  array<int,string> $writable_roots Writable roots.
+	 * @param  array<int,string> $hidden_paths   Hidden paths.
+	 * @param  array<int,string> $ignored_files  Ignored files.
+	 * @return array<int,array<string,string>>
+	 */
+	private function path_violations( string $repo_path, string $real_repo, string $path, array $writable_roots, array $hidden_paths, array $ignored_files, ?callable $git_stage = null ): array {
+		$violations = array();
+		$path       = ltrim(str_replace('\\', '/', $path), '/');
+		$absolute   = $repo_path . '/' . $path;
+
+		$add_violation = static function ( string $reason, string $detail = '' ) use ( &$violations, $path ): void {
+			$violation = array(
+				'path'   => $path,
+				'reason' => $reason,
+			);
+			if ( '' !== $detail ) {
+				$violation['detail'] = $detail;
+			}
+			$violations[] = $violation;
+		};
+
+		if ( ! empty($writable_roots) && ! PathSecurity::isPathAllowed($path, $writable_roots) ) {
+			$add_violation('outside_writable_roots', 'Changed path is outside configured writable_roots.');
+		}
+
+		if ( ! empty($hidden_paths) && PathSecurity::isPathAllowed($path, $hidden_paths) ) {
+			$add_violation('hidden_path', 'Changed path is under configured hidden_paths.');
+		}
+
+		if ( '.git' === $path || str_starts_with($path, '.git/') || str_contains($path, '/.git/') || str_ends_with($path, '/.git') ) {
+			$add_violation('nested_git', 'Changed path includes a .git directory or file.');
+		}
+
+		if ( in_array($path, $ignored_files, true) ) {
+			$add_violation('ignored', 'Changed path is ignored by git exclude rules.');
+		}
+
+		if ( is_link($absolute) ) {
+			$add_violation('symlink', 'Changed path is a symlink.');
+			$target = readlink($absolute);
+			if ( false !== $target ) {
+				$target_path = str_starts_with($target, '/') ? $target : dirname($absolute) . '/' . $target;
+				$real_target = realpath($target_path);
+				if ( false === $real_target || ( $real_target !== $real_repo && ! str_starts_with($real_target, $real_repo . '/') ) ) {
+					$add_violation('outside_realpath', 'Symlink target resolves outside the repository.');
+				}
+				foreach ( $hidden_paths as $hidden_path ) {
+					$hidden_real = realpath($repo_path . '/' . $hidden_path);
+					if ( false !== $hidden_real && false !== $real_target && ( $real_target === $hidden_real || str_starts_with($real_target, $hidden_real . '/') ) ) {
+						$add_violation('hidden_path_exposure', 'Symlink target resolves under hidden_paths.');
+					}
+				}
+			}
+		} elseif ( file_exists($absolute) ) {
+			$real_path = realpath($absolute);
+			if ( false === $real_path || ( $real_path !== $real_repo && ! str_starts_with($real_path, $real_repo . '/') ) ) {
+				$add_violation('outside_realpath', 'Changed path resolves outside the repository.');
+			}
+
+			if ( ! is_file($absolute) && ! is_dir($absolute) ) {
+				$add_violation('non_regular', 'Changed path is neither a regular file nor a directory.');
+			}
+
+			$stat = @lstat($absolute); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+			if ( is_array($stat) && is_file($absolute) && (int) ( $stat['nlink'] ?? 1 ) > 1 ) {
+				$add_violation('hardlink', 'Changed file has more than one hardlink.');
+			}
+		}
+
+		$stage_output = null !== $git_stage ? $git_stage($path) : '';
+		if ( is_string($stage_output) && preg_match('/^160000\s/', trim($stage_output)) ) {
+			$add_violation('gitlink', 'Changed path is a gitlink/submodule entry.');
+		}
+
+		return $violations;
+	}
+}

--- a/inc/Workspace/WorkspacePolicy.php
+++ b/inc/Workspace/WorkspacePolicy.php
@@ -68,7 +68,7 @@ final class WorkspacePolicy {
 
 		$clean = array();
 		foreach ( $paths as $path ) {
-			$normalized = $this->normalize_path((string) $path);
+			$normalized = $this->normalize_path( (string) $path );
 			if ( '' !== $normalized ) {
 				$clean[] = $normalized;
 			}
@@ -270,7 +270,7 @@ final class WorkspacePolicy {
 			}
 
 			$stat = @lstat($absolute); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
-			if ( is_array($stat) && is_file($absolute) && (int) ( $stat['nlink'] ?? 1 ) > 1 ) {
+			if ( is_array($stat) && is_file($absolute) && (int) $stat[3] > 1 ) {
 				$add_violation('hardlink', 'Changed file has more than one hardlink.');
 			}
 		}

--- a/inc/Workspace/WorkspaceWriter.php
+++ b/inc/Workspace/WorkspaceWriter.php
@@ -30,10 +30,16 @@ class WorkspaceWriter {
 	private Workspace $workspace;
 
 	/**
+	 * @var WorkspacePolicy
+	 */
+	private WorkspacePolicy $policy;
+
+	/**
 	 * @param Workspace $workspace Workspace instance for path resolution and validation.
 	 */
-	public function __construct( Workspace $workspace ) {
+	public function __construct( Workspace $workspace, ?WorkspacePolicy $policy = null ) {
 		$this->workspace = $workspace;
+		$this->policy    = $policy ?? new WorkspacePolicy();
 	}
 
 	/**
@@ -71,7 +77,7 @@ class WorkspaceWriter {
 			return new \WP_Error('path_traversal', 'Path traversal detected. Access denied.', array( 'status' => 403 ));
 		}
 
-		$policy_check = $this->ensure_writable_roots_allow_paths($name, array( $path ));
+		$policy_check = $this->policy->assert_paths_writable($this->workspace->parse_handle($name)['repo'], array( $path ));
 		if ( is_wp_error($policy_check) ) {
 			return $policy_check;
 		}
@@ -153,7 +159,7 @@ class WorkspaceWriter {
 			return new \WP_Error('path_traversal', (string) ( $validation['message'] ?? 'Path traversal detected. Access denied.' ), array( 'status' => 403 ));
 		}
 
-		$policy_check = $this->ensure_writable_roots_allow_paths($name, array( $path ));
+		$policy_check = $this->policy->assert_paths_writable($this->workspace->parse_handle($name)['repo'], array( $path ));
 		if ( is_wp_error($policy_check) ) {
 			return $policy_check;
 		}
@@ -269,7 +275,7 @@ class WorkspaceWriter {
 			}
 		}
 
-		$policy_check = $this->ensure_writable_roots_allow_paths($name, $patch_paths);
+		$policy_check = $this->policy->assert_paths_writable($this->workspace->parse_handle($name)['repo'], $patch_paths);
 		if ( is_wp_error($policy_check) ) {
 			return $policy_check;
 		}
@@ -441,116 +447,6 @@ class WorkspaceWriter {
 		}
 
 		return array_values(array_unique($files));
-	}
-
-	/**
-	 * Enforce configured writable roots before a writer mutation touches disk.
-	 *
-	 * @param  string            $name  Workspace handle.
-	 * @param  array<int,string> $paths Repo-relative paths the mutation would touch.
-	 * @return true|\WP_Error
-	 */
-	private function ensure_writable_roots_allow_paths( string $name, array $paths ): true|\WP_Error {
-		$parsed         = $this->workspace->parse_handle($name);
-		$writable_roots = $this->get_repo_writable_roots($parsed['repo']);
-		if ( empty($writable_roots) ) {
-			return true;
-		}
-
-		$rejected = array();
-		foreach ( $paths as $path ) {
-			$relative = $this->normalize_policy_path($path);
-			if ( '' === $relative ) {
-				continue;
-			}
-
-			if ( ! PathSecurity::isPathAllowed($relative, $writable_roots) ) {
-				$rejected[] = $relative;
-			}
-		}
-
-		$rejected = array_values(array_unique($rejected));
-		if ( empty($rejected) ) {
-			return true;
-		}
-
-		return new \WP_Error(
-			'path_not_allowed',
-			sprintf(
-				'Path(s) outside configured writable_roots: %s. Allowed writable_roots: %s.',
-				implode(', ', $rejected),
-				implode(', ', $writable_roots)
-			),
-			array(
-				'status'         => 403,
-				'rejected_paths' => $rejected,
-				'writable_roots' => $writable_roots,
-			)
-		);
-	}
-
-	/**
-	 * Return writable roots for a repo from datamachine_workspace_git_policies.
-	 *
-	 * @param  string $repo_name Repository name.
-	 * @return array<int,string>
-	 */
-	private function get_repo_writable_roots( string $repo_name ): array {
-		$policies = $this->get_workspace_git_policies();
-		$repo     = $policies['repos'][ $repo_name ] ?? array();
-		$paths    = $repo['writable_roots'] ?? $repo['allowed_paths'] ?? array();
-
-		return $this->normalize_policy_paths($paths);
-	}
-
-	/**
-	 * Read workspace git policy settings.
-	 *
-	 * @return array{repos: array<string, array<string, mixed>>}
-	 */
-	private function get_workspace_git_policies(): array {
-		$defaults = array( 'repos' => array() );
-		$settings = function_exists('get_option') ? get_option('datamachine_workspace_git_policies', $defaults) : $defaults;
-		if ( ! is_array($settings) ) {
-			$settings = $defaults;
-		}
-		if ( ! isset($settings['repos']) || ! is_array($settings['repos']) ) {
-			$settings['repos'] = array();
-		}
-		if ( function_exists('apply_filters') ) {
-			$settings = apply_filters('datamachine_workspace_git_policies', $settings);
-		}
-
-		return isset($settings['repos']) && is_array($settings['repos']) ? $settings : $defaults;
-	}
-
-	/**
-	 * Normalize policy path lists.
-	 *
-	 * @param  mixed $paths Raw policy value.
-	 * @return array<int,string>
-	 */
-	private function normalize_policy_paths( mixed $paths ): array {
-		if ( ! is_array($paths) ) {
-			return array();
-		}
-
-		$clean = array();
-		foreach ( $paths as $path ) {
-			$normalized = $this->normalize_policy_path((string) $path);
-			if ( '' !== $normalized ) {
-				$clean[] = $normalized;
-			}
-		}
-
-		return array_values(array_unique($clean));
-	}
-
-	/**
-	 * Normalize a repo-relative policy path.
-	 */
-	private function normalize_policy_path( string $path ): string {
-		return rtrim(ltrim(str_replace('\\', '/', trim($path)), '/'), '/');
 	}
 
 	/**

--- a/inc/Workspace/WorkspaceWriter.php
+++ b/inc/Workspace/WorkspaceWriter.php
@@ -507,6 +507,6 @@ class WorkspaceWriter {
 			$path = substr($path, 2);
 		}
 
-		return $this->normalize_policy_path($path);
+		return $this->policy->normalize_path($path);
 	}
 }

--- a/tests/smoke-workspace-file-policy.php
+++ b/tests/smoke-workspace-file-policy.php
@@ -55,6 +55,7 @@ namespace {
 
 	require_once dirname(__DIR__) . '/inc/Support/PathSecurity.php';
 	require_once dirname(__DIR__) . '/inc/Workspace/WorkspaceAliasResolver.php';
+	require_once dirname(__DIR__) . '/inc/Workspace/WorkspacePolicy.php';
 	require_once dirname(__DIR__) . '/inc/Workspace/Workspace.php';
 	require_once dirname(__DIR__) . '/inc/Workspace/WorkspaceReader.php';
 	require_once dirname(__DIR__) . '/inc/Workspace/WorkspaceWriter.php';

--- a/tests/workspace-policy.php
+++ b/tests/workspace-policy.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+if ( ! defined('ABSPATH') ) {
+	define('ABSPATH', __DIR__ . '/fixtures/');
+}
+
+final class WP_Error {
+	private string $code;
+	private string $message;
+	private mixed $data;
+
+	public function __construct( string $code = '', string $message = '', mixed $data = null ) {
+		$this->code    = $code;
+		$this->message = $message;
+		$this->data    = $data;
+	}
+
+	public function get_error_code(): string {
+		return $this->code;
+	}
+
+	public function get_error_message(): string {
+		return $this->message;
+	}
+
+	public function get_error_data(): mixed {
+		return $this->data;
+	}
+}
+
+function is_wp_error( mixed $value ): bool {
+	return $value instanceof WP_Error;
+}
+
+function apply_filters( string $hook_name, mixed $value, mixed ...$args ): mixed {
+	return $value;
+}
+
+$GLOBALS['datamachine_code_test_options'] = array();
+function get_option( string $name, mixed $default = false ): mixed {
+	return $GLOBALS['datamachine_code_test_options'][ $name ] ?? $default;
+}
+
+require_once dirname(__DIR__) . '/inc/Support/PathSecurity.php';
+require_once dirname(__DIR__) . '/inc/Workspace/WorkspacePolicy.php';
+
+use DataMachineCode\Workspace\WorkspacePolicy;
+
+function assert_true( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		throw new RuntimeException($message);
+	}
+}
+
+$policy = new WorkspacePolicy();
+
+$GLOBALS['datamachine_code_test_options']['datamachine_workspace_git_policies'] = array(
+	'repos' => array(
+		'example' => array(
+			'writable_roots' => array( '/src/', 'docs\\guides', '', 'src' ),
+		),
+		'legacy'  => array(
+			'allowed_paths' => array( 'legacy' ),
+		),
+	),
+);
+
+assert_true(
+	array( 'src', 'docs/guides' ) === $policy->writable_roots_for_repo('example'),
+	'writable_roots should be normalized and de-duplicated.'
+);
+
+assert_true(
+	array( 'legacy' ) === $policy->writable_roots_for_repo('legacy'),
+	'allowed_paths should remain the fallback writable-root policy.'
+);
+
+assert_true(
+	true === $policy->assert_paths_writable('example', array( 'src/File.php', '/docs/guides/index.md' )),
+	'Paths under writable_roots should pass.'
+);
+
+$blocked = $policy->assert_paths_writable('example', array( 'README.md', 'other/file.php' ));
+assert_true(is_wp_error($blocked), 'Paths outside writable_roots should fail.');
+assert_true('path_not_allowed' === $blocked->get_error_code(), 'Blocked paths should use the existing error code.');
+
+$data = $blocked->get_error_data();
+assert_true(
+	is_array($data) && array( 'README.md', 'other/file.php' ) === $data['rejected_paths'],
+	'Blocked paths should report normalized rejected paths.'
+);
+
+echo "workspace-policy ok\n";


### PR DESCRIPTION
## Summary
- Add a shared `WorkspacePolicy` service for workspace policy loading, path normalization, writable-root enforcement, and changed-path attestation.
- Route local writer, remote backend, and git attestation helpers through the shared service while preserving existing policy option shape and error responses.
- Add a focused standalone test for writable-root normalization and enforcement.

## Tests
- `php -l inc/Workspace/WorkspacePolicy.php`
- `php -l inc/Workspace/WorkspaceGitOperations.php`
- `php -l inc/Workspace/WorkspaceWriter.php`
- `php -l inc/Workspace/RemoteWorkspaceBackend.php`
- `php tests/workspace-policy.php`
- `git diff --check`

Not run: existing standalone worktree lifecycle test because this skip-bootstrap worktree does not have `vendor/autoload.php` installed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the shared policy extraction, caller updates, focused test, and local verification; Chris remains responsible for review and acceptance.