### PR TITLE
Refactor git probe helpers

### DIFF
--- a/inc/Support/GitRunner.php
+++ b/inc/Support/GitRunner.php
@@ -134,4 +134,63 @@ final class GitRunner {
 			'output'  => $result['output'],
 		);
 	}
+
+	/**
+	 * Run a read-only git probe and return trimmed output, or null on failure.
+	 */
+	public static function probe_output( string $path, string $args ): ?string {
+		$result = self::run($path, $args);
+		if ( is_wp_error($result) ) {
+			return null;
+		}
+
+		$output = trim( (string) ( $result['output'] ?? '' ));
+		return '' !== $output ? $output : null;
+	}
+
+	/**
+	 * Get the current branch for a repository.
+	 */
+	public static function current_branch( string $path ): ?string {
+		return self::probe_output($path, 'rev-parse --abbrev-ref HEAD');
+	}
+
+	/**
+	 * Get a configured remote URL for a repository.
+	 */
+	public static function remote_url( string $path, string $remote_name = 'origin' ): ?string {
+		$remote_name = preg_replace('/[^A-Za-z0-9._-]/', '', $remote_name);
+		if ( '' === $remote_name ) {
+			return null;
+		}
+
+		return self::probe_output($path, 'config --get ' . escapeshellarg('remote.' . $remote_name . '.url'));
+	}
+
+	/**
+	 * Get the latest commit summary for a repository.
+	 */
+	public static function latest_commit_summary( string $path ): ?string {
+		return self::probe_output($path, 'log -1 --format="%h %s"');
+	}
+
+	/**
+	 * Count dirty status lines for a repository.
+	 */
+	public static function dirty_count( string $path ): int {
+		$output = self::probe_output($path, 'status --porcelain');
+		if ( null === $output ) {
+			return 0;
+		}
+
+		return count(array_filter(array_map('trim', explode("\n", $output))));
+	}
+
+	/**
+	 * Check whether an exact ref exists.
+	 */
+	public static function ref_exists( string $path, string $ref ): bool {
+		$result = self::run($path, 'show-ref --verify --quiet ' . escapeshellarg($ref));
+		return ! is_wp_error($result);
+	}
 }

--- a/inc/Workspace/WorkspaceGitOperations.php
+++ b/inc/Workspace/WorkspaceGitOperations.php
@@ -8,6 +8,7 @@
 namespace DataMachineCode\Workspace;
 
 use DataMachineCode\Support\GitHubRemote;
+use DataMachineCode\Support\GitRunner;
 use DataMachineCode\Support\PathSecurity;
 use DataMachineCode\Support\ProcessRunner;
 
@@ -41,10 +42,6 @@ trait WorkspaceGitOperations {
 			return $policy_attestation;
 		}
 
-		$branch_result = $this->run_git($repo_path, 'rev-parse --abbrev-ref HEAD');
-		$remote_result = $this->run_git($repo_path, 'config --get remote.origin.url');
-		$latest_result = $this->run_git($repo_path, 'log -1 --format="%h %s"');
-
 		$files = array_filter(array_map('trim', explode("\n", $status_result['output'] ?? '')));
 
 		$response = array(
@@ -53,9 +50,9 @@ trait WorkspaceGitOperations {
 			'repo'        => $parsed['repo'],
 			'is_worktree' => $parsed['is_worktree'],
 			'path'        => $repo_path,
-			'branch'      => ! is_wp_error($branch_result) ? trim( (string) $branch_result['output']) : null,
-			'remote'      => ! is_wp_error($remote_result) ? trim( (string) $remote_result['output']) : null,
-			'commit'      => ! is_wp_error($latest_result) ? trim( (string) $latest_result['output']) : null,
+			'branch'      => GitRunner::current_branch($repo_path),
+			'remote'      => GitRunner::remote_url($repo_path),
+			'commit'      => GitRunner::latest_commit_summary($repo_path),
 			'dirty'       => count($files),
 			'files'       => array_values($files),
 		);
@@ -1751,14 +1748,7 @@ trait WorkspaceGitOperations {
 	 * @return string|null Remote URL or null.
 	 */
 	private function git_get_remote( string $repo_path, string $remote_name = 'origin' ): ?string {
-		$escaped     = escapeshellarg($repo_path);
-		$remote_name = preg_replace('/[^A-Za-z0-9._-]/', '', $remote_name);
-		if ( '' === $remote_name ) {
-			return null;
-		}
-     // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
-		$remote = exec(sprintf('git -C %s config --get %s 2>/dev/null', $escaped, escapeshellarg('remote.' . $remote_name . '.url')));
-		return ( '' !== $remote ) ? $remote : null;
+		return GitRunner::remote_url($repo_path, $remote_name);
 	}
 
 	/**
@@ -1768,9 +1758,6 @@ trait WorkspaceGitOperations {
 	 * @return string|null Branch name or null.
 	 */
 	private function git_get_branch( string $repo_path ): ?string {
-		$escaped = escapeshellarg($repo_path);
-        // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
-		$branch = exec(sprintf('git -C %s rev-parse --abbrev-ref HEAD 2>/dev/null', $escaped));
-		return ( '' !== $branch ) ? $branch : null;
+		return GitRunner::current_branch($repo_path);
 	}
 }

--- a/inc/Workspace/WorkspaceRepositoryLifecycle.php
+++ b/inc/Workspace/WorkspaceRepositoryLifecycle.php
@@ -671,7 +671,7 @@ trait WorkspaceRepositoryLifecycle {
 					'is_context'       => true,
 					'path'             => null,
 					'branch'           => '' !== $ref ? $ref : null,
-					'remote'           => '' !== (string) ( $context_policy['repo'] ?? '' ) ? GitHubRemote::cloneUrl((string) $context_policy['repo']) : null,
+					'remote'           => '' !== (string) ( $context_policy['repo'] ?? '' ) ? GitHubRemote::cloneUrl( (string) $context_policy['repo'] ) : null,
 					'commit'           => null,
 					'dirty'            => 0,
 					'workspace_policy' => WorkspaceAliasResolver::policy_attestation($handle),

--- a/inc/Workspace/WorkspaceRepositoryLifecycle.php
+++ b/inc/Workspace/WorkspaceRepositoryLifecycle.php
@@ -692,14 +692,10 @@ trait WorkspaceRepositoryLifecycle {
 			return new \WP_Error('repo_not_found', sprintf('Workspace handle "%s" not found.', $parsed['dir_name']), array( 'status' => 404 ));
 		}
 
-		$escaped = escapeshellarg($repo_path);
-
-     // phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
-		$branch = trim( (string) exec(sprintf('git -C %s rev-parse --abbrev-ref HEAD 2>/dev/null', $escaped)));
-		$remote = trim( (string) exec(sprintf('git -C %s config --get remote.origin.url 2>/dev/null', $escaped)));
-		$commit = trim( (string) exec(sprintf('git -C %s log -1 --format="%%h %%s" 2>/dev/null', $escaped)));
-		$status = trim( (string) exec(sprintf('git -C %s status --porcelain 2>/dev/null | wc -l', $escaped)));
-     // phpcs:enable
+		$branch = GitRunner::current_branch($repo_path);
+		$remote = GitRunner::remote_url($repo_path);
+		$commit = GitRunner::latest_commit_summary($repo_path);
+		$status = GitRunner::dirty_count($repo_path);
 
 		$result = array(
 			'success'           => true,
@@ -708,10 +704,10 @@ trait WorkspaceRepositoryLifecycle {
 			'is_worktree'       => $parsed['is_worktree'],
 			'is_context'        => null !== $context_policy,
 			'path'              => $repo_path,
-			'branch'            => $branch ? $branch : null,
-			'remote'            => $remote ? $remote : null,
-			'commit'            => $commit ? $commit : null,
-			'dirty'             => (int) $status,
+			'branch'            => $branch,
+			'remote'            => $remote,
+			'commit'            => $commit,
+			'dirty'             => $status,
 			'primary_freshness' => ! $parsed['is_worktree'] ? $this->build_primary_freshness_report($repo_path, $parsed['dir_name']) : null,
 		);
 		if ( null !== $context_policy ) {

--- a/inc/Workspace/WorkspaceWorktreeLifecycle.php
+++ b/inc/Workspace/WorkspaceWorktreeLifecycle.php
@@ -7,6 +7,8 @@
 
 namespace DataMachineCode\Workspace;
 
+use DataMachineCode\Support\GitRunner;
+
 defined('ABSPATH') || exit;
 
 trait WorkspaceWorktreeLifecycle {
@@ -256,12 +258,11 @@ trait WorkspaceWorktreeLifecycle {
 		}
 
 		// Does the branch already exist locally?
-     // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
-		exec(sprintf('git -C %s show-ref --verify --quiet %s 2>&1', escapeshellarg($primary_path), escapeshellarg('refs/heads/' . $branch)), $_unused, $exists_local);
+		$exists_local   = GitRunner::ref_exists($primary_path, 'refs/heads/' . $branch);
 		$created_branch = false;
 		$resolved_base  = null;
 
-		if ( 0 === $exists_local ) {
+		if ( $exists_local ) {
 			if ( ! $allow_stale && ! $rebase_base && ! $fetch_failed ) {
 				$default_guard = $this->assert_ref_current_with_default_branch($primary_path, $branch, $repo, $branch, 'branch');
 				if ( is_wp_error($default_guard) ) {


### PR DESCRIPTION
## Summary
- Centralizes small read-only git probes in `GitRunner`.
- Replaces scoped raw branch, remote, commit, dirty-count, and local-ref probes in workspace lifecycle/git operations code.

## Verification
- `php -l inc/Support/GitRunner.php && php -l inc/Workspace/WorkspaceRepositoryLifecycle.php && php -l inc/Workspace/WorkspaceWorktreeLifecycle.php && php -l inc/Workspace/WorkspaceGitOperations.php`
- `composer validate --strict` (valid; existing warning about the `version` field)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the small refactor, ran local syntax/package validation, and prepared the PR; Chris remains responsible for review and acceptance.