### PR TITLE
Refactor contained recursive directory removal

### DIFF
--- a/inc/Workspace/WorkspaceCoreUtilities.php
+++ b/inc/Workspace/WorkspaceCoreUtilities.php
@@ -850,6 +850,75 @@ trait WorkspaceCoreUtilities {
 	}
 
 	/**
+	 * Recursively remove an existing directory after validating containment.
+	 *
+	 * The target must be a real directory inside, but not equal to, the container.
+	 * Symlinks are unlinked as entries and never traversed.
+	 *
+	 * @param  string      $absolute      Absolute directory path to remove.
+	 * @param  string      $container     Parent directory that must contain the target.
+	 * @param  string|null $relative_base Base path used to report deleted relative paths.
+	 * @return array<int,string>|\WP_Error
+	 */
+	protected function remove_contained_directory_recursive( string $absolute, string $container, ?string $relative_base = null ): array|\WP_Error {
+		$validation = $this->validate_containment($absolute, $container);
+		if ( ! $validation['valid'] ) {
+			return new \WP_Error('path_traversal', (string) ( $validation['message'] ?? 'Path traversal detected. Access denied.' ), array( 'status' => 403 ));
+		}
+
+		$container_real = realpath($container);
+		$target_real    = (string) ( $validation['real_path'] ?? '' );
+		if ( false === $container_real || '' === $target_real || $target_real === $container_real ) {
+			return new \WP_Error('unsafe_delete_root', sprintf('Refusing to recursively delete container root: %s', $absolute), array( 'status' => 403 ));
+		}
+
+		if ( ! is_dir($target_real) || is_link($absolute) ) {
+			return new \WP_Error('not_a_directory', sprintf('Recursive delete target is not a directory: %s', $absolute), array( 'status' => 400 ));
+		}
+
+		$relative_base_real = realpath($relative_base ?? $container);
+		if ( false === $relative_base_real ) {
+			$relative_base_real = $container_real;
+		}
+
+		$deleted = array();
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Failure is converted into a WP_Error below.
+		$entries = @scandir($target_real);
+		if ( false === $entries ) {
+			return new \WP_Error('scandir_failed', sprintf('Failed to read directory: %s', $target_real), array( 'status' => 500 ));
+		}
+
+		foreach ( $entries as $entry ) {
+			if ( '.' === $entry || '..' === $entry ) {
+				continue;
+			}
+
+			$child = $target_real . '/' . $entry;
+			if ( is_dir($child) && ! is_link($child) ) {
+				$nested = $this->remove_contained_directory_recursive($child, $container_real, $relative_base_real);
+				if ( is_wp_error($nested) ) {
+					return $nested;
+				}
+				$deleted = array_merge($deleted, $nested);
+			} else {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+				if ( ! unlink($child) ) {
+					return new \WP_Error('delete_failed', sprintf('Failed to delete file: %s', $child), array( 'status' => 500 ));
+				}
+				$deleted[] = ltrim(substr($child, strlen($relative_base_real)), '/');
+			}
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir
+		if ( ! rmdir($target_real) ) {
+			return new \WP_Error('delete_failed', sprintf('Failed to remove directory: %s', $target_real), array( 'status' => 500 ));
+		}
+
+		$deleted[] = ltrim(substr($target_real, strlen($relative_base_real)), '/');
+		return $deleted;
+	}
+
+	/**
 	 * Derive a repo name from a git URL.
 	 *
 	 * @param  string $url Git URL.

--- a/inc/Workspace/WorkspaceGitOperations.php
+++ b/inc/Workspace/WorkspaceGitOperations.php
@@ -427,7 +427,7 @@ trait WorkspaceGitOperations {
 				$deleted[] = $relative;
 			}
 		} elseif ( $is_dir ) {
-			$removed = $this->remove_directory_recursive($absolute, $repo_path);
+			$removed = $this->remove_contained_directory_recursive($absolute, $repo_path, $repo_path);
 			if ( is_wp_error($removed) ) {
 				return $removed;
 			}
@@ -448,48 +448,6 @@ trait WorkspaceGitOperations {
 			'deleted'     => $deleted,
 			'was_tracked' => $is_tracked,
 		);
-	}
-
-	/**
-	 * Recursively remove an untracked directory under a repo, returning the
-	 * list of relative paths removed (deepest first).
-	 *
-	 * @param  string $absolute  Absolute path to remove.
-	 * @param  string $repo_path Repo root for relative-path computation.
-	 * @return array<int,string>|\WP_Error
-	 */
-	private function remove_directory_recursive( string $absolute, string $repo_path ): array|\WP_Error {
-		$deleted = array();
-        // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Failure is converted into a WP_Error below.
-		$entries = @scandir($absolute);
-		if ( false === $entries ) {
-			return new \WP_Error('scandir_failed', sprintf('Failed to read directory: %s', $absolute), array( 'status' => 500 ));
-		}
-		foreach ( $entries as $entry ) {
-			if ( '.' === $entry || '..' === $entry ) {
-				continue;
-			}
-			$child = $absolute . '/' . $entry;
-			if ( is_dir($child) && ! is_link($child) ) {
-				$nested = $this->remove_directory_recursive($child, $repo_path);
-				if ( is_wp_error($nested) ) {
-					return $nested;
-				}
-				$deleted = array_merge($deleted, $nested);
-			} else {
-                // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
-				if ( ! unlink($child) ) {
-					return new \WP_Error('delete_failed', sprintf('Failed to delete file: %s', $child), array( 'status' => 500 ));
-				}
-				$deleted[] = ltrim(substr($child, strlen($repo_path)), '/');
-			}
-		}
-     // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir
-		if ( ! rmdir($absolute) ) {
-			return new \WP_Error('delete_failed', sprintf('Failed to remove directory: %s', $absolute), array( 'status' => 500 ));
-		}
-		$deleted[] = ltrim(substr($absolute, strlen($repo_path)), '/');
-		return $deleted;
 	}
 
 	/**

--- a/inc/Workspace/WorkspaceRepositoryLifecycle.php
+++ b/inc/Workspace/WorkspaceRepositoryLifecycle.php
@@ -613,13 +613,9 @@ trait WorkspaceRepositoryLifecycle {
 			}
 		}
 
-		// Remove recursively.
-		$escaped = escapeshellarg($validation['real_path']);
-     // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
-		exec(sprintf('rm -rf %s 2>&1', $escaped), $output, $exit_code);
-
-		if ( 0 !== $exit_code ) {
-			return new \WP_Error('remove_failed', sprintf('Failed to remove (exit %d): %s', $exit_code, implode("\n", $output)), array( 'status' => 500 ));
+		$removed = $this->remove_contained_directory_recursive($validation['real_path'], $this->workspace_path, $this->workspace_path);
+		if ( is_wp_error($removed) ) {
+			return $removed;
 		}
 
 		// If we removed a worktree directory but didn't go through `git worktree remove`,

--- a/inc/Workspace/WorkspaceRepositoryLifecycle.php
+++ b/inc/Workspace/WorkspaceRepositoryLifecycle.php
@@ -667,7 +667,7 @@ trait WorkspaceRepositoryLifecycle {
 					'is_context'       => true,
 					'path'             => null,
 					'branch'           => '' !== $ref ? $ref : null,
-					'remote'           => '' !== (string) ( $context_policy['repo'] ?? '' ) ? GitHubRemote::cloneUrl((string) $context_policy['repo']) : null,
+					'remote'           => '' !== (string) ( $context_policy['repo'] ?? '' ) ? GitHubRemote::cloneUrl( (string) $context_policy['repo'] ) : null,
 					'commit'           => null,
 					'dirty'            => 0,
 					'workspace_policy' => WorkspaceAliasResolver::policy_attestation($handle),

--- a/inc/Workspace/WorkspaceWorktreeCleanupEngine.php
+++ b/inc/Workspace/WorkspaceWorktreeCleanupEngine.php
@@ -2823,7 +2823,7 @@ trait WorkspaceWorktreeCleanupEngine {
 
 		$broken_marker = $this->classify_broken_orphan_worktree_marker($real_path);
 		if ( null !== $broken_marker ) {
-			$removed_paths = $this->remove_directory_recursive($real_path, $this->workspace_path);
+			$removed_paths = $this->remove_contained_directory_recursive($real_path, $this->workspace_path, $this->workspace_path);
 			if ( is_wp_error($removed_paths) ) {
 				return $removed_paths;
 			}

--- a/inc/Workspace/WorkspaceWorktreeLifecycle.php
+++ b/inc/Workspace/WorkspaceWorktreeLifecycle.php
@@ -1365,7 +1365,7 @@ trait WorkspaceWorktreeLifecycle {
 			return null;
 		}
 
-		$removed_paths = $this->remove_directory_recursive($path, $this->workspace_path);
+		$removed_paths = $this->remove_contained_directory_recursive($path, $this->workspace_path, $this->workspace_path);
 		if ( $removed_paths instanceof \WP_Error ) {
 			return $removed_paths;
 		}


### PR DESCRIPTION
## Summary
- Promote recursive directory removal into a shared contained workspace primitive.
- Replace repository lifecycle shell deletion with the contained PHP primitive.
- Route existing workspace recursive deletion callers through the shared primitive.

## Verification
- php -l inc/Workspace/WorkspaceCoreUtilities.php inc/Workspace/WorkspaceGitOperations.php inc/Workspace/WorkspaceRepositoryLifecycle.php inc/Workspace/WorkspaceWorktreeLifecycle.php inc/Workspace/WorkspaceWorktreeCleanupEngine.php
- for file in tests/*.php; do php "$file" || exit 1; done
- composer validate --no-check-publish (valid with existing warning about version field)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the contained recursive deletion refactor, updated callsites, and ran local verification. Chris remains responsible for review and testing.