### PR TITLE
Refactor workspace handle parsing

### DIFF
--- a/inc/Runtime/ActiveWorkspaceProjector.php
+++ b/inc/Runtime/ActiveWorkspaceProjector.php
@@ -72,9 +72,12 @@
 
 namespace DataMachineCode\Runtime;
 
+use DataMachineCode\Workspace\WorkspaceHandle;
 use DataMachineCode\Workspace\WorktreeContextInjector;
 
 defined('ABSPATH') || exit;
+
+require_once dirname(__DIR__) . '/Workspace/WorkspaceHandle.php';
 
 class ActiveWorkspaceProjector {
 
@@ -143,22 +146,20 @@ class ActiveWorkspaceProjector {
 	 * @return array<string,mixed>
 	 */
 	private static function build_entry( string $handle, array $overrides ): array {
-		$metadata   = WorktreeContextInjector::get_metadata($handle);
-		$is_primary = ! str_contains($handle, '@');
+		$metadata         = WorktreeContextInjector::get_metadata($handle);
+		$workspace_handle = WorkspaceHandle::parse($handle);
+		$is_primary       = ! $workspace_handle->is_worktree();
 
 		$entry = array(
 			'handle'  => $handle,
 			'primary' => $is_primary,
 		);
 
-		// Derive repo + branch from handle.
-		$handle_parts = explode('@', $handle, 2);
-		$repo_slug    = $handle_parts[0] ?? '';
-		if ( '' !== $repo_slug ) {
-			$entry['repo'] = $repo_slug;
+		if ( '' !== $workspace_handle->repo() ) {
+			$entry['repo'] = $workspace_handle->repo();
 		}
-		if ( ! $is_primary && isset($handle_parts[1]) && '' !== $handle_parts[1] ) {
-			$entry['branch'] = $handle_parts[1];
+		if ( null !== $workspace_handle->branch_slug() && '' !== $workspace_handle->branch_slug() ) {
+			$entry['branch'] = $workspace_handle->branch_slug();
 		}
 
 		// Enrich from persisted metadata.

--- a/inc/Workspace/RunnerWorkspacePublisher.php
+++ b/inc/Workspace/RunnerWorkspacePublisher.php
@@ -43,13 +43,13 @@ class RunnerWorkspacePublisher {
 			return new \WP_Error('runner_workspace_publish_missing_pr_title', 'pr_title is required.', array( 'status' => 400 ));
 		}
 
-		$base = trim( (string) ( $input['base'] ?? $input['base_branch'] ?? $input['base_ref'] ?? '' ) );
+		$base   = trim( (string) ( $input['base'] ?? $input['base_branch'] ?? $input['base_ref'] ?? '' ) );
 		$target = $this->resolve_publication_target($input, $handle, $target_repo, $base);
 		if ( is_wp_error($target) ) {
 			return $target;
 		}
 		$branch = $target['push_branch'];
-		$body = $this->build_pull_request_body( (string) ( $input['pr_body'] ?? $input['body'] ?? '' ), $input );
+		$body   = $this->build_pull_request_body( (string) ( $input['pr_body'] ?? $input['body'] ?? '' ), $input );
 
 		$status = WorkspaceAbilities::gitStatus(array( 'name' => $handle ));
 		if ( is_wp_error($status) ) {
@@ -177,7 +177,8 @@ class RunnerWorkspacePublisher {
 			return $head;
 		}
 
-		$base_owner = strtolower(strtok($base_repo, '/') ?: '');
+		$base_owner = strtok($base_repo, '/');
+		$base_owner = false === $base_owner ? '' : strtolower($base_owner);
 		$head_owner = $head['owner'];
 		$head_repo  = null === $head_owner ? $base_repo : $head_owner . '/' . substr($base_repo, (int) strpos($base_repo, '/') + 1);
 
@@ -200,12 +201,12 @@ class RunnerWorkspacePublisher {
 		$head_ref    = null === $head_owner ? $push_branch : $head_owner . ':' . $head['branch'];
 
 		return array(
-			'base_repo'    => $base_repo,
-			'base_ref'     => $base,
-			'head_repo'    => $head_repo,
-			'head_ref'     => $head_ref,
-			'push_remote'  => $push_remote,
-			'push_branch'  => $push_branch,
+			'base_repo'   => $base_repo,
+			'base_ref'    => $base,
+			'head_repo'   => $head_repo,
+			'head_ref'    => $head_ref,
+			'push_remote' => $push_remote,
+			'push_branch' => $push_branch,
 		);
 	}
 
@@ -222,16 +223,25 @@ class RunnerWorkspacePublisher {
 					if ( '' === $owner || '' === $head_branch ) {
 						return new \WP_Error('runner_workspace_publish_invalid_head_branch', 'Head must be a branch or owner:branch.', array( 'status' => 400 ));
 					}
-					return array( 'owner' => $owner, 'branch' => $head_branch );
+					return array(
+						'owner'  => $owner,
+						'branch' => $head_branch,
+					);
 				}
 
-				return array( 'owner' => null, 'branch' => $branch );
+				return array(
+					'owner'  => null,
+					'branch' => $branch,
+				);
 			}
 		}
 
 		$workspace_handle = WorkspaceHandle::parse($handle);
 		if ( null !== $workspace_handle->branch_slug() && '' !== $workspace_handle->branch_slug() ) {
-			return array( 'owner' => null, 'branch' => $workspace_handle->branch_slug() );
+			return array(
+				'owner'  => null,
+				'branch' => $workspace_handle->branch_slug(),
+			);
 		}
 
 		return new \WP_Error('runner_workspace_publish_missing_head_branch', 'A head branch/ref or branch context is required.', array( 'status' => 400 ));

--- a/inc/Workspace/RunnerWorkspacePublisher.php
+++ b/inc/Workspace/RunnerWorkspacePublisher.php
@@ -12,6 +12,8 @@ use DataMachineCode\Abilities\WorkspaceAbilities;
 
 defined('ABSPATH') || exit;
 
+require_once __DIR__ . '/WorkspaceHandle.php';
+
 class RunnerWorkspacePublisher {
 
 	/**
@@ -227,11 +229,9 @@ class RunnerWorkspacePublisher {
 			}
 		}
 
-		if ( str_contains($handle, '@') ) {
-			$slug = substr($handle, (int) strpos($handle, '@') + 1);
-			if ( '' !== $slug ) {
-				return array( 'owner' => null, 'branch' => $slug );
-			}
+		$workspace_handle = WorkspaceHandle::parse($handle);
+		if ( null !== $workspace_handle->branch_slug() && '' !== $workspace_handle->branch_slug() ) {
+			return array( 'owner' => null, 'branch' => $workspace_handle->branch_slug() );
 		}
 
 		return new \WP_Error('runner_workspace_publish_missing_head_branch', 'A head branch/ref or branch context is required.', array( 'status' => 400 ));

--- a/inc/Workspace/WorkspaceAliasResolver.php
+++ b/inc/Workspace/WorkspaceAliasResolver.php
@@ -349,8 +349,8 @@ class WorkspaceAliasResolver {
 			return $value;
 		}
 
-		$sanitized = self::sanitize_scoped_string($value, $root);
-		$sanitized = str_replace($handle, $alias, $sanitized);
+		$sanitized        = self::sanitize_scoped_string($value, $root);
+		$sanitized        = str_replace($handle, $alias, $sanitized);
 		$workspace_handle = WorkspaceHandle::parse($handle);
 		if ( $workspace_handle->is_worktree() ) {
 			$sanitized = str_replace(array( $workspace_handle->repo(), (string) $workspace_handle->branch_slug() ), array( $alias, $alias ), $sanitized);

--- a/inc/Workspace/WorkspaceAliasResolver.php
+++ b/inc/Workspace/WorkspaceAliasResolver.php
@@ -9,6 +9,8 @@ namespace DataMachineCode\Workspace;
 
 defined('ABSPATH') || exit;
 
+require_once __DIR__ . '/WorkspaceHandle.php';
+
 class WorkspaceAliasResolver {
 
 
@@ -349,9 +351,9 @@ class WorkspaceAliasResolver {
 
 		$sanitized = self::sanitize_scoped_string($value, $root);
 		$sanitized = str_replace($handle, $alias, $sanitized);
-		if ( str_contains($handle, '@') ) {
-			list( $repo, $slug ) = explode('@', $handle, 2);
-			$sanitized           = str_replace(array( $repo, $slug ), array( $alias, $alias ), $sanitized);
+		$workspace_handle = WorkspaceHandle::parse($handle);
+		if ( $workspace_handle->is_worktree() ) {
+			$sanitized = str_replace(array( $workspace_handle->repo(), (string) $workspace_handle->branch_slug() ), array( $alias, $alias ), $sanitized);
 		}
 
 		return $sanitized;

--- a/inc/Workspace/WorkspaceCoreUtilities.php
+++ b/inc/Workspace/WorkspaceCoreUtilities.php
@@ -14,6 +14,8 @@ use DataMachineCode\Storage\WorktreeInventoryRepository;
 
 defined('ABSPATH') || exit;
 
+require_once __DIR__ . '/WorkspaceHandle.php';
+
 trait WorkspaceCoreUtilities {
 
 	/**
@@ -225,31 +227,7 @@ trait WorkspaceCoreUtilities {
 	 * @return array{repo: string, branch_slug: string|null, is_worktree: bool, dir_name: string}
 	 */
 	public function parse_handle( string $handle ): array {
-		$handle = trim($handle);
-
-		if ( str_contains($handle, '@') ) {
-			$parts = explode('@', $handle, 2);
-			$repo  = $this->sanitize_name($parts[0]);
-			$slug  = $this->sanitize_slug($parts[1]);
-
-			if ( '' !== $repo && '' !== $slug ) {
-				return array(
-					'repo'        => $repo,
-					'branch_slug' => $slug,
-					'is_worktree' => true,
-					'dir_name'    => $repo . '@' . $slug,
-				);
-			}
-		}
-
-		$repo = $this->sanitize_name($handle);
-
-		return array(
-			'repo'        => $repo,
-			'branch_slug' => null,
-			'is_worktree' => false,
-			'dir_name'    => $repo,
-		);
+		return WorkspaceHandle::parse($handle)->to_array();
 	}
 
 	/**

--- a/inc/Workspace/WorkspaceHandle.php
+++ b/inc/Workspace/WorkspaceHandle.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Workspace handle value helper.
+ *
+ * @package DataMachineCode\Workspace
+ */
+
+namespace DataMachineCode\Workspace;
+
+defined('ABSPATH') || exit;
+
+/**
+ * Parsed workspace handle identity.
+ */
+final class WorkspaceHandle {
+
+	private function __construct(
+		private readonly string $repo,
+		private readonly ?string $branch_slug,
+		private readonly bool $is_worktree,
+		private readonly string $dir_name
+	) {}
+
+	/**
+	 * Parse a workspace handle into its canonical components.
+	 */
+	public static function parse( string $handle ): self {
+		$handle = trim($handle);
+
+		if ( str_contains($handle, '@') ) {
+			$parts = explode('@', $handle, 2);
+			$repo  = self::sanitize_name($parts[0] ?? '');
+			$slug  = self::sanitize_slug($parts[1] ?? '');
+
+			if ( '' !== $repo && '' !== $slug ) {
+				return new self($repo, $slug, true, $repo . '@' . $slug);
+			}
+		}
+
+		$repo = self::sanitize_name($handle);
+
+		return new self($repo, null, false, $repo);
+	}
+
+	public function repo(): string {
+		return $this->repo;
+	}
+
+	public function branch_slug(): ?string {
+		return $this->branch_slug;
+	}
+
+	public function is_worktree(): bool {
+		return $this->is_worktree;
+	}
+
+	public function dir_name(): string {
+		return $this->dir_name;
+	}
+
+	/**
+	 * @return array{repo: string, branch_slug: string|null, is_worktree: bool, dir_name: string}
+	 */
+	public function to_array(): array {
+		return array(
+			'repo'        => $this->repo,
+			'branch_slug' => $this->branch_slug,
+			'is_worktree' => $this->is_worktree,
+			'dir_name'    => $this->dir_name,
+		);
+	}
+
+	private static function sanitize_slug( string $slug ): string {
+		$slug = preg_replace('/[^a-zA-Z0-9._-]/', '', $slug);
+		$slug = preg_replace('/-{2,}/', '-', (string) $slug);
+		return trim( (string) $slug, '-.');
+	}
+
+	private static function sanitize_name( string $name ): string {
+		return (string) preg_replace('/[^a-zA-Z0-9._-]/', '', $name);
+	}
+}

--- a/tests/workspace-handle.php
+++ b/tests/workspace-handle.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+if ( ! defined('ABSPATH') ) {
+	define('ABSPATH', __DIR__ . '/fixtures/');
+}
+
+require_once dirname(__DIR__) . '/inc/Workspace/WorkspaceHandle.php';
+
+use DataMachineCode\Workspace\WorkspaceHandle;
+
+function assert_same( mixed $expected, mixed $actual, string $message ): void {
+	if ( $expected !== $actual ) {
+		throw new RuntimeException(sprintf('%s Expected %s, got %s.', $message, var_export($expected, true), var_export($actual, true)));
+	}
+}
+
+$primary = WorkspaceHandle::parse(' data-machine-code ');
+assert_same('data-machine-code', $primary->repo(), 'primary repo parses');
+assert_same(null, $primary->branch_slug(), 'primary has no branch slug');
+assert_same(false, $primary->is_worktree(), 'primary is not worktree');
+assert_same('data-machine-code', $primary->dir_name(), 'primary dir name matches repo');
+
+$worktree = WorkspaceHandle::parse('data-machine-code@cook-workspace-identity-primitives');
+assert_same('data-machine-code', $worktree->repo(), 'worktree repo parses');
+assert_same('cook-workspace-identity-primitives', $worktree->branch_slug(), 'worktree branch slug parses');
+assert_same(true, $worktree->is_worktree(), 'worktree is worktree');
+assert_same('data-machine-code@cook-workspace-identity-primitives', $worktree->dir_name(), 'worktree dir name is canonical');
+assert_same(
+	array(
+		'repo'        => 'data-machine-code',
+		'branch_slug' => 'cook-workspace-identity-primitives',
+		'is_worktree' => true,
+		'dir_name'    => 'data-machine-code@cook-workspace-identity-primitives',
+	),
+	$worktree->to_array(),
+	'worktree array shape matches parse_handle contract'
+);
+
+$fallback = WorkspaceHandle::parse('data-machine-code@');
+assert_same('data-machine-code', $fallback->repo(), 'invalid worktree falls back to primary parsing');
+assert_same(false, $fallback->is_worktree(), 'invalid worktree fallback is primary');
+
+echo "workspace-handle: ok\n";


### PR DESCRIPTION
## Summary
- Add a reusable WorkspaceHandle value helper for canonical workspace handle parsing.
- Route Workspace::parse_handle() through the helper to preserve the existing array contract.
- Replace small duplicated handle splits in active workspace projection, alias sanitization, and runner workspace publication.

## Verification
- php -l inc/Workspace/WorkspaceHandle.php inc/Workspace/WorkspaceCoreUtilities.php inc/Runtime/ActiveWorkspaceProjector.php inc/Workspace/WorkspaceAliasResolver.php inc/Workspace/RunnerWorkspacePublisher.php tests/workspace-handle.php
- php tests/workspace-handle.php
- php tests/runner-workspace-publisher-target.php
- php tests/smoke-workspace-file-policy.php
- for test in tests/*.php; do php "$test" || exit 1; done

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the workspace handle helper refactor, updated the targeted call sites, added lightweight helper coverage, and ran verification. Chris remains responsible for review and merge.