### PR TITLE
Centralize PR label handling

### DIFF
--- a/inc/Abilities/GitHubAbilities.php
+++ b/inc/Abilities/GitHubAbilities.php
@@ -1606,27 +1606,7 @@ class GitHubAbilities {
 
 		if ( null !== $existing_pull ) {
 			$pull     = self::normalizePull($existing_pull);
-			$labels   = self::mergeProvenanceLabels(isset($input['labels']) && is_array($input['labels']) ? $input['labels'] : array());
-			$labeling = null;
-
-			if ( ! empty($labels) && ! empty($pull['number']) ) {
-				$label_response = self::applyLabelsToNumber($repo, (int) $pull['number'], $labels, $pat);
-				if ( is_wp_error($label_response) ) {
-					$labeling = array(
-						'success'    => false,
-						'labels'     => $labels,
-						'error_code' => $label_response->get_error_code(),
-						'error'      => $label_response->get_error_message(),
-						'status'     => is_array($label_response->get_error_data()) ? ( $label_response->get_error_data()['status'] ?? null ) : null,
-					);
-				} else {
-					$labeling = array(
-						'success'        => true,
-						'labels'         => $labels,
-						'applied_labels' => $label_response['applied_labels'] ?? array(),
-					);
-				}
-			}
+			$labeling = self::labelPullRequest($repo, (int) ( $pull['number'] ?? 0 ), $input, $pat);
 
 			$result = array(
 				'success'      => true,
@@ -1674,27 +1654,7 @@ class GitHubAbilities {
 		}
 
 		$pull     = self::normalizePull($response['data']);
-		$labels   = self::mergeProvenanceLabels(isset($input['labels']) && is_array($input['labels']) ? $input['labels'] : array());
-		$labeling = null;
-
-		if ( ! empty($labels) && ! empty($pull['number']) ) {
-			$label_response = self::applyLabelsToNumber($repo, (int) $pull['number'], $labels, $pat);
-			if ( is_wp_error($label_response) ) {
-				$labeling = array(
-					'success'    => false,
-					'labels'     => $labels,
-					'error_code' => $label_response->get_error_code(),
-					'error'      => $label_response->get_error_message(),
-					'status'     => is_array($label_response->get_error_data()) ? ( $label_response->get_error_data()['status'] ?? null ) : null,
-				);
-			} else {
-				$labeling = array(
-					'success'        => true,
-					'labels'         => $labels,
-					'applied_labels' => $label_response['applied_labels'] ?? array(),
-				);
-			}
-		}
+		$labeling = self::labelPullRequest($repo, (int) ( $pull['number'] ?? 0 ), $input, $pat);
 
 		$result = array(
 			'success'      => true,
@@ -1929,6 +1889,41 @@ class GitHubAbilities {
 		}
 
 		return $merged;
+	}
+
+	/**
+	 * Apply PR labels and normalize the result for every PR creation path.
+	 *
+	 * @param  string $repo   Repository owner/name.
+	 * @param  int    $number Pull request number.
+	 * @param  array  $input  Pull request input.
+	 * @param  string $pat    GitHub token.
+	 * @return array<string,mixed>|null
+	 */
+	private static function labelPullRequest( string $repo, int $number, array $input, string $pat ): ?array {
+		$labels = self::mergeProvenanceLabels(isset($input['labels']) && is_array($input['labels']) ? $input['labels'] : array());
+		if ( empty($labels) || $number <= 0 ) {
+			return null;
+		}
+
+		$label_response = self::applyLabelsToNumber($repo, $number, $labels, $pat);
+		if ( is_wp_error($label_response) ) {
+			$error_data = $label_response->get_error_data();
+
+			return array(
+				'success'    => false,
+				'labels'     => $labels,
+				'error_code' => $label_response->get_error_code(),
+				'error'      => $label_response->get_error_message(),
+				'status'     => is_array($error_data) ? ( $error_data['status'] ?? null ) : null,
+			);
+		}
+
+		return array(
+			'success'        => true,
+			'labels'         => $labels,
+			'applied_labels' => $label_response['applied_labels'] ?? array(),
+		);
 	}
 
 	/**

--- a/inc/Handlers/GitHub/GitHubPullRequestPublish.php
+++ b/inc/Handlers/GitHub/GitHubPullRequestPublish.php
@@ -220,33 +220,21 @@ class GitHubPullRequestPublish extends PublishHandler {
 		$pull_number = (int) ( $result['pull_number'] ?? 0 );
 
 		$labels         = $this->resolveListParameter($parameters['labels'] ?? null, $handler_config['labels'] ?? '');
-		$applied_labels = array();
-		$label_error    = null;
+		$labeling       = is_array($result['labeling'] ?? null) ? $result['labeling'] : null;
+		$applied_labels = is_array($labeling['applied_labels'] ?? null) ? $labeling['applied_labels'] : array();
+		$label_error    = is_array($labeling) && false === ( $labeling['success'] ?? true ) ? (string) ( $labeling['error'] ?? '' ) : null;
 
-		if ( ! empty($labels) && $pull_number > 0 ) {
-			$label_result = GitHubAbilities::addLabels(
+		if ( null !== $label_error ) {
+			$this->log(
+				'warning',
+				'GitHub Pull Request opened but failed to apply labels: ' . $label_error,
 				array(
+					'job_id'      => $parameters['job_id'] ?? null,
 					'repo'        => $repo,
 					'pull_number' => $pull_number,
-					'labels'      => $labels,
+					'labels'      => $labeling['labels'] ?? $labels,
 				)
 			);
-
-			if ( is_wp_error($label_result) ) {
-				$label_error = $label_result->get_error_message();
-				$this->log(
-					'warning',
-					'GitHub Pull Request opened but failed to apply labels: ' . $label_error,
-					array(
-						'job_id'      => $parameters['job_id'] ?? null,
-						'repo'        => $repo,
-						'pull_number' => $pull_number,
-						'labels'      => $labels,
-					)
-				);
-			} else {
-				$applied_labels = $label_result['applied_labels'] ?? array();
-			}
 		}
 
 		$response_data = array(


### PR DESCRIPTION
## Summary
- Centralizes pull request label application result normalization inside `GitHubAbilities`.
- Reuses the normalized `labeling` result in `GitHubPullRequestPublish` instead of applying labels a second time.
- Keeps PR open/reuse behavior unchanged while reducing duplicated label handling.

## Verification
- `php -l inc/Abilities/GitHubAbilities.php`
- `php -l inc/Handlers/GitHub/GitHubPullRequestPublish.php`
- `php tests/github-remote.php`
- `php tests/runner-workspace-publisher-target.php`
- `php tests/github-atomic-commit.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the small PR-label handling refactor and ran local syntax/smoke verification; Chris remains responsible for review and merge.