### PR TITLE
Refactor PR run artifact access behind boundary

### DIFF
--- a/inc/Handlers/GitHub/GitHubPullRequestPublish.php
+++ b/inc/Handlers/GitHub/GitHubPullRequestPublish.php
@@ -10,6 +10,8 @@ namespace DataMachineCode\Handlers\GitHub;
 use DataMachine\Core\Steps\HandlerRegistrationTrait;
 use DataMachine\Core\Steps\Publish\Handlers\PublishHandler;
 use DataMachineCode\Abilities\GitHubAbilities;
+use DataMachineCode\RunArtifacts\DataMachineRunArtifactRepository;
+use DataMachineCode\RunArtifacts\RunArtifactRepositoryInterface;
 use DataMachineCode\Support\RunArtifactBundleFileWriter;
 use DataMachineCode\Support\RunArtifactPrSectionRenderer;
 
@@ -23,8 +25,11 @@ class GitHubPullRequestPublish extends PublishHandler {
 
 	use HandlerRegistrationTrait;
 
-	public function __construct() {
+	private RunArtifactRepositoryInterface $run_artifact_repository;
+
+	public function __construct( ?RunArtifactRepositoryInterface $run_artifact_repository = null ) {
 		parent::__construct('github_pull_request');
+		$this->run_artifact_repository = $run_artifact_repository ?? new DataMachineRunArtifactRepository();
 
 		self::registerHandler(
 			'github_pull_request',
@@ -317,7 +322,7 @@ class GitHubPullRequestPublish extends PublishHandler {
 			return array();
 		}
 
-		$artifacts = $this->jobArtifactsForPublish($job_id);
+		$artifacts = $this->run_artifact_repository->artifacts_for_job($job_id);
 		if ( empty($artifacts) ) {
 			return array();
 		}
@@ -343,7 +348,7 @@ class GitHubPullRequestPublish extends PublishHandler {
 	 * @return array<int,array<string,mixed>> File records accepted by the normal files loop.
 	 */
 	private function bundleFileArtifactsForPublish( array $parameters, array $handler_config ): array {
-		$artifacts = is_array($parameters['run_artifacts'] ?? null) ? $parameters['run_artifacts'] : $this->jobArtifactsForPublish( (int) ( $parameters['job_id'] ?? 0 ));
+		$artifacts = is_array($parameters['run_artifacts'] ?? null) ? $parameters['run_artifacts'] : $this->run_artifact_repository->artifacts_for_job( (int) ( $parameters['job_id'] ?? 0 ));
 		if ( empty($artifacts) ) {
 			return array();
 		}
@@ -371,7 +376,7 @@ class GitHubPullRequestPublish extends PublishHandler {
 			}
 		}
 
-		return $this->jobRunArtifactEgressPolicy( (int) ( $parameters['job_id'] ?? 0 ));
+		return $this->run_artifact_repository->egress_policy_for_job( (int) ( $parameters['job_id'] ?? 0 ));
 	}
 
 	/**
@@ -427,39 +432,6 @@ class GitHubPullRequestPublish extends PublishHandler {
 		$mode   = sanitize_text_field( (string) ( $config['mode'] ?? $handler_config['run_artifact_attachment_mode'] ?? RunArtifactPrSectionRenderer::MODE_BODY_SECTION ));
 
 		return RunArtifactPrSectionRenderer::MODE_COMMENT === $mode ? RunArtifactPrSectionRenderer::MODE_COMMENT : RunArtifactPrSectionRenderer::MODE_BODY_SECTION;
-	}
-
-	/**
-	 * @return array<string,mixed>
-	 */
-	private function jobArtifactsForPublish( int $job_id ): array {
-		if ( $job_id <= 0 || ! class_exists('\\DataMachine\\Core\\JobArtifacts') ) {
-			return array();
-		}
-
-		$result = ( new \DataMachine\Core\JobArtifacts() )->get($job_id);
-		if ( empty($result['success']) || ! is_array($result['artifacts'] ?? null) ) {
-			return array();
-		}
-
-		return $result['artifacts'];
-	}
-
-	/**
-	 * @return array<string,mixed>
-	 */
-	private function jobRunArtifactEgressPolicy( int $job_id ): array {
-		if ( $job_id <= 0 || ! class_exists('\\DataMachine\\Core\\Database\\Jobs\\Jobs') ) {
-			return array();
-		}
-
-		$jobs = new \DataMachine\Core\Database\Jobs\Jobs();
-		if ( ! method_exists($jobs, 'retrieve_engine_data') ) {
-			return array();
-		}
-
-		$engine_data = $jobs->retrieve_engine_data($job_id);
-		return is_array($engine_data['run_artifact_egress_policy'] ?? null) ? $engine_data['run_artifact_egress_policy'] : array();
 	}
 
 	/**

--- a/inc/RunArtifacts/DataMachineRunArtifactRepository.php
+++ b/inc/RunArtifacts/DataMachineRunArtifactRepository.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Data Machine-backed run artifact repository.
+ *
+ * @package DataMachineCode\RunArtifacts
+ */
+
+namespace DataMachineCode\RunArtifacts;
+
+defined('ABSPATH') || exit;
+
+class DataMachineRunArtifactRepository implements RunArtifactRepositoryInterface {
+
+
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	public function artifacts_for_job( int $job_id ): array {
+		if ( $job_id <= 0 || ! class_exists('\\DataMachine\\Core\\JobArtifacts') ) {
+			return array();
+		}
+
+		$result = ( new \DataMachine\Core\JobArtifacts() )->get($job_id);
+		if ( empty($result['success']) || ! is_array($result['artifacts'] ?? null) ) {
+			return array();
+		}
+
+		return $result['artifacts'];
+	}
+
+	/**
+	 * @return array<string,array<string,mixed>>
+	 */
+	public function egress_policy_for_job( int $job_id ): array {
+		if ( $job_id <= 0 || ! class_exists('\\DataMachine\\Core\\Database\\Jobs\\Jobs') ) {
+			return array();
+		}
+
+		$jobs = new \DataMachine\Core\Database\Jobs\Jobs();
+		if ( ! method_exists($jobs, 'retrieve_engine_data') ) {
+			return array();
+		}
+
+		$engine_data = $jobs->retrieve_engine_data($job_id);
+		return is_array($engine_data['run_artifact_egress_policy'] ?? null) ? $engine_data['run_artifact_egress_policy'] : array();
+	}
+}

--- a/inc/RunArtifacts/RunArtifactRepositoryInterface.php
+++ b/inc/RunArtifacts/RunArtifactRepositoryInterface.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Run artifact repository contract.
+ *
+ * @package DataMachineCode\RunArtifacts
+ */
+
+namespace DataMachineCode\RunArtifacts;
+
+defined('ABSPATH') || exit;
+
+interface RunArtifactRepositoryInterface {
+
+
+
+	/**
+	 * Read the artifact payload for a completed runtime job.
+	 *
+	 * @param  int $job_id Runtime job identifier.
+	 * @return array<string,mixed>
+	 */
+	public function artifacts_for_job( int $job_id ): array;
+
+	/**
+	 * Read the artifact egress policy captured with a runtime job.
+	 *
+	 * @param  int $job_id Runtime job identifier.
+	 * @return array<string,array<string,mixed>>
+	 */
+	public function egress_policy_for_job( int $job_id ): array;
+}

--- a/tests/run-artifact-repository-boundary.php
+++ b/tests/run-artifact-repository-boundary.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DataMachine\Core\Steps {
+	trait HandlerRegistrationTrait {
+		public static function registerHandler( mixed ...$args ): void {}
+	}
+}
+
+namespace DataMachine\Core\Steps\Publish\Handlers {
+	class PublishHandler {
+		public function __construct( string $slug ) {}
+	}
+}
+
+namespace {
+	if ( ! defined('ABSPATH') ) {
+		define('ABSPATH', __DIR__ . '/fixtures/');
+	}
+
+	if ( ! function_exists('sanitize_key') ) {
+		function sanitize_key( string $key ): string {
+			return strtolower(preg_replace('/[^a-zA-Z0-9_\-]/', '', $key) ?? '');
+		}
+	}
+
+	if ( ! function_exists('sanitize_title') ) {
+		function sanitize_title( string $title ): string {
+			$title = strtolower(trim($title));
+			$title = preg_replace('/[^a-z0-9]+/', '-', $title) ?? '';
+			return trim($title, '-');
+		}
+	}
+
+	require_once dirname(__DIR__) . '/inc/RunArtifacts/RunArtifactRepositoryInterface.php';
+	require_once dirname(__DIR__) . '/inc/Support/RunArtifactBundleFileWriter.php';
+	require_once dirname(__DIR__) . '/inc/Handlers/GitHub/GitHubPullRequestPublish.php';
+
+	use DataMachineCode\Handlers\GitHub\GitHubPullRequestPublish;
+	use DataMachineCode\RunArtifacts\RunArtifactRepositoryInterface;
+
+	final class FakeRunArtifactRepository implements RunArtifactRepositoryInterface {
+		public int $artifact_job_id = 0;
+		public int $policy_job_id   = 0;
+
+		public function artifacts_for_job( int $job_id ): array {
+			$this->artifact_job_id = $job_id;
+
+			return array(
+				'daily_memory_artifacts' => array(
+					array(
+						'type'                 => 'daily_memory',
+						'agent_slug'           => 'boundary agent',
+						'bundle_relative_path' => 'memory.md',
+						'content'              => '# Boundary evidence',
+					),
+				),
+			);
+		}
+
+		public function egress_policy_for_job( int $job_id ): array {
+			$this->policy_job_id = $job_id;
+
+			return array(
+				'daily_memory' => array(
+					'egress' => array( 'bundle-file' ),
+				),
+			);
+		}
+	}
+
+	function boundary_assert_same( mixed $expected, mixed $actual, string $message ): void {
+		if ( $expected !== $actual ) {
+			throw new RuntimeException(sprintf("%s\nExpected: %s\nActual: %s", $message, var_export($expected, true), var_export($actual, true)));
+		}
+	}
+
+	$repository = new FakeRunArtifactRepository();
+	$handler    = new GitHubPullRequestPublish($repository);
+	$method     = new ReflectionMethod($handler, 'bundleFileArtifactsForPublish');
+
+	$files = $method->invoke($handler, array( 'job_id' => 42 ), array( 'bundle_root' => 'bundles/{agent_slug}' ));
+
+	boundary_assert_same(42, $repository->artifact_job_id, 'Handler should read artifacts through the injected repository.');
+	boundary_assert_same(42, $repository->policy_job_id, 'Handler should read egress policy through the injected repository.');
+	boundary_assert_same('bundles/boundary-agent/memory.md', $files[0]['file_path'] ?? null, 'Injected repository artifacts should still become bundle-file writes.');
+	boundary_assert_same('# Boundary evidence', $files[0]['content'] ?? null, 'Artifact content should be preserved.');
+
+	echo "run artifact repository boundary test passed.\n";
+}


### PR DESCRIPTION
## Summary
- Add a DMC-owned run artifact repository interface.
- Move Data Machine job artifact/job engine-data reads into a Data Machine-specific adapter.
- Inject the boundary into `GitHubPullRequestPublish` so the handler no longer directly instantiates Data Machine artifact/job classes.
- Add a focused standalone boundary test for PR bundle-file artifact handling.

## Verification
- `php -l inc/RunArtifacts/RunArtifactRepositoryInterface.php`
- `php -l inc/RunArtifacts/DataMachineRunArtifactRepository.php`
- `php -l inc/Handlers/GitHub/GitHubPullRequestPublish.php`
- `php -l tests/run-artifact-repository-boundary.php`
- `php tests/run-artifact-repository-boundary.php`
- `php tests/github-remote.php`
- `php tests/smoke-abandoned-cleanup-orchestrator.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the small boundary abstraction, adapter wiring, and focused verification test for Chris to review.