### PR TITLE
Refactor shared worktree cleanup primitives

### DIFF
--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -24,6 +24,8 @@ require_once __DIR__ . '/WorkspaceMetadataReconciliation.php';
 require_once __DIR__ . '/WorkspaceRepositoryLifecycle.php';
 require_once __DIR__ . '/WorkspaceRowTriage.php';
 require_once __DIR__ . '/WorkspaceWorktreeLifecycle.php';
+require_once __DIR__ . '/WorktreeAgeFilter.php';
+require_once __DIR__ . '/WorktreeCleanupSignal.php';
 require_once __DIR__ . '/WorkspaceWorktreeCleanupEngine.php';
 require_once __DIR__ . '/WorkspaceWorktreeInventoryCleanup.php';
 require_once __DIR__ . '/WorkspaceWorktreeEmergencyCleanup.php';

--- a/inc/Workspace/WorkspaceWorktreeCleanupEngine.php
+++ b/inc/Workspace/WorkspaceWorktreeCleanupEngine.php
@@ -124,16 +124,7 @@ trait WorkspaceWorktreeCleanupEngine {
 				return $duration_seconds;
 			}
 
-			$threshold_ts = time() - $duration_seconds;
-			$age_filter   = array(
-				'type'             => 'older_than',
-				'older_than'       => $older_than,
-				'duration_seconds' => $duration_seconds,
-				'threshold'        => gmdate('c', $threshold_ts),
-				'threshold_unix'   => $threshold_ts,
-				'excluded'         => 0,
-				'unknown_age'      => 0,
-			);
+			$age_filter = WorktreeAgeFilter::build($older_than, $duration_seconds);
 		}
 
 		$listing = $this->worktree_list(
@@ -482,21 +473,8 @@ trait WorkspaceWorktreeCleanupEngine {
 				$fetched[ $repo ] = true;
 			}
 
-			$signal = null;
-			if ( is_array($metadata) && WorktreeContextInjector::has_cleanup_signal($metadata) ) {
-				$signal = array(
-					'signal' => 'cleanup_eligible',
-					'reason' => 'worktree finalized or explicitly marked cleanup_eligible',
-				);
-				if ( ! empty($metadata['pr_url']) ) {
-					$signal['pr_url'] = (string) $metadata['pr_url'];
-				}
-			} elseif ( $include_repaired_metadata && is_array($metadata) && ! empty($metadata['metadata_repaired']) ) {
-				$signal = array(
-					'signal' => 'repaired_metadata',
-					'reason' => 'operator-approved cleanup of repaired metadata',
-				);
-			} else {
+			$signal = is_array($metadata) ? WorktreeCleanupSignal::from_metadata($metadata, $include_repaired_metadata) : null;
+			if ( null === $signal ) {
 				$signal = $this->detect_merge_signal($primary_path, $repo, $branch, $skip_github, $github_cache);
 			}
 			if ( null === $signal ) {
@@ -559,58 +537,34 @@ trait WorkspaceWorktreeCleanupEngine {
 
 			$age_decision = null;
 			if ( null !== $age_filter ) {
-				$created_ts = is_string($created_at) && '' !== $created_at ? strtotime($created_at) : false;
-				if ( false === $created_ts ) {
-					++$age_filter['unknown_age'];
+				$age_decision = WorktreeAgeFilter::decide($created_at, $age_filter);
+				if ( 'unknown_age' === $age_decision['decision'] ) {
 					$skipped[] = array_merge(
 						array(
 							'handle'      => $handle,
 							'repo'        => $repo,
 							'branch'      => $branch,
 							'path'        => $wt_path,
-							'reason_code' => 'unknown_age',
-							'reason'      => 'missing or invalid created_at metadata - age filter cannot decide safely',
 							'created_at'  => $created_at,
 							'metadata'    => $metadata,
-							'age_filter'  => array(
-								'type'       => 'older_than',
-								'older_than' => $age_filter['older_than'],
-								'threshold'  => $age_filter['threshold'],
-								'decision'   => 'unknown_age',
-							),
-						), $disk_fields
+						), WorktreeAgeFilter::skip_fields($age_decision), $disk_fields
 					);
 					continue;
 				}
 
-				$age_seconds  = time() - $created_ts;
-				$age_decision = array(
-					'type'        => 'older_than',
-					'older_than'  => $age_filter['older_than'],
-					'threshold'   => $age_filter['threshold'],
-					'created_at'  => $created_at,
-					'age_seconds' => $age_seconds,
-				);
-
-				if ( $created_ts > $age_filter['threshold_unix'] ) {
-					++$age_filter['excluded'];
+				if ( 'excluded' === $age_decision['decision'] ) {
 					$skipped[] = array_merge(
 						array(
 							'handle'      => $handle,
 							'repo'        => $repo,
 							'branch'      => $branch,
 							'path'        => $wt_path,
-							'reason_code' => 'age_filter',
-							'reason'      => sprintf('created_at %s is newer than --older-than=%s threshold %s', $created_at, $age_filter['older_than'], $age_filter['threshold']),
 							'created_at'  => $created_at,
 							'metadata'    => $metadata,
-							'age_filter'  => array_merge($age_decision, array( 'decision' => 'excluded' )),
-						), $disk_fields
+						), WorktreeAgeFilter::skip_fields($age_decision), $disk_fields
 					);
 					continue;
 				}
-
-				$age_decision['decision'] = 'included';
 			}
 
 			$candidate = array_merge(
@@ -620,18 +574,14 @@ trait WorkspaceWorktreeCleanupEngine {
 					'branch'          => $branch,
 					'path'            => $wt_path,
 					'dirty'           => $dirty_count,
-					'signal'          => $signal['signal'],
-					'reason_code'     => $signal['signal'],
-					'reason'          => $signal['reason'],
 					'cleanup_reasons' => array_values(array_filter(array( $signal['signal'], $signal['reason'] ))),
-					'pr_url'          => $signal['pr_url'] ?? null,
 					'created_at'      => $created_at,
 					'liveness'        => $liveness,
 					'metadata'        => $metadata,
-				), $disk_fields
+				), WorktreeCleanupSignal::candidate_fields($signal, true), $disk_fields
 			);
 			if ( null !== $age_decision ) {
-				$candidate['age_filter'] = $age_decision;
+				$candidate['age_filter'] = $age_decision['age_filter'];
 			}
 			$candidates[] = $candidate;
 		}

--- a/inc/Workspace/WorkspaceWorktreeCleanupEngine.php
+++ b/inc/Workspace/WorkspaceWorktreeCleanupEngine.php
@@ -541,13 +541,15 @@ trait WorkspaceWorktreeCleanupEngine {
 				if ( 'unknown_age' === $age_decision['decision'] ) {
 					$skipped[] = array_merge(
 						array(
-							'handle'      => $handle,
-							'repo'        => $repo,
-							'branch'      => $branch,
-							'path'        => $wt_path,
-							'created_at'  => $created_at,
-							'metadata'    => $metadata,
-						), WorktreeAgeFilter::skip_fields($age_decision), $disk_fields
+							'handle'     => $handle,
+							'repo'       => $repo,
+							'branch'     => $branch,
+							'path'       => $wt_path,
+							'created_at' => $created_at,
+							'metadata'   => $metadata,
+						),
+						WorktreeAgeFilter::skip_fields($age_decision),
+						$disk_fields
 					);
 					continue;
 				}
@@ -555,13 +557,15 @@ trait WorkspaceWorktreeCleanupEngine {
 				if ( 'excluded' === $age_decision['decision'] ) {
 					$skipped[] = array_merge(
 						array(
-							'handle'      => $handle,
-							'repo'        => $repo,
-							'branch'      => $branch,
-							'path'        => $wt_path,
-							'created_at'  => $created_at,
-							'metadata'    => $metadata,
-						), WorktreeAgeFilter::skip_fields($age_decision), $disk_fields
+							'handle'     => $handle,
+							'repo'       => $repo,
+							'branch'     => $branch,
+							'path'       => $wt_path,
+							'created_at' => $created_at,
+							'metadata'   => $metadata,
+						),
+						WorktreeAgeFilter::skip_fields($age_decision),
+						$disk_fields
 					);
 					continue;
 				}

--- a/inc/Workspace/WorkspaceWorktreeInventoryCleanup.php
+++ b/inc/Workspace/WorkspaceWorktreeInventoryCleanup.php
@@ -36,16 +36,7 @@ trait WorkspaceWorktreeInventoryCleanup {
 				return $duration_seconds;
 			}
 
-			$threshold_ts = time() - $duration_seconds;
-			$age_filter   = array(
-				'type'             => 'older_than',
-				'older_than'       => $older_than,
-				'duration_seconds' => $duration_seconds,
-				'threshold'        => gmdate('c', $threshold_ts),
-				'threshold_unix'   => $threshold_ts,
-				'excluded'         => 0,
-				'unknown_age'      => 0,
-			);
+			$age_filter = WorktreeAgeFilter::build($older_than, $duration_seconds);
 		}
 
 		$candidates = array();
@@ -117,56 +108,33 @@ trait WorkspaceWorktreeInventoryCleanup {
 				if ( $include_repaired_metadata && $repaired ) {
 					$age_decision = null;
 					if ( null !== $age_filter ) {
-						$created_ts = is_string($created_at) && '' !== $created_at ? strtotime($created_at) : false;
-						if ( false === $created_ts ) {
-							++$age_filter['unknown_age'];
+						$age_decision = WorktreeAgeFilter::decide($created_at, $age_filter);
+						if ( 'unknown_age' === $age_decision['decision'] ) {
 							$skipped[] = array_merge(
-								$base_row, array(
-									'reason_code' => 'unknown_age',
-									'reason'      => 'missing or invalid created_at metadata - age filter cannot decide safely',
-									'age_filter'  => array(
-										'type'       => 'older_than',
-										'older_than' => $age_filter['older_than'],
-										'threshold'  => $age_filter['threshold'],
-										'decision'   => 'unknown_age',
-									),
-								)
+								$base_row,
+								WorktreeAgeFilter::skip_fields($age_decision)
 							);
 							continue;
 						}
 
-						$age_decision = array(
-							'type'        => 'older_than',
-							'older_than'  => $age_filter['older_than'],
-							'threshold'   => $age_filter['threshold'],
-							'created_at'  => $created_at,
-							'age_seconds' => time() - $created_ts,
-						);
-						if ( $created_ts > $age_filter['threshold_unix'] ) {
-							++$age_filter['excluded'];
+						if ( 'excluded' === $age_decision['decision'] ) {
 							$skipped[] = array_merge(
-								$base_row, array(
-									'reason_code' => 'age_filter',
-									'reason'      => sprintf('created_at %s is newer than --older-than=%s threshold %s', $created_at, $age_filter['older_than'], $age_filter['threshold']),
-									'age_filter'  => array_merge($age_decision, array( 'decision' => 'excluded' )),
-								)
+								$base_row,
+								WorktreeAgeFilter::skip_fields($age_decision)
 							);
 							continue;
 						}
-						$age_decision['decision'] = 'included';
 					}
 
+					$signal    = WorktreeCleanupSignal::from_metadata($metadata, true);
 					$candidate = array_merge(
 						$base_row, array(
 							'dirty'         => 0,
-							'signal'        => 'repaired_metadata',
-							'reason_code'   => 'repaired_metadata',
-							'reason'        => 'operator-approved cleanup of repaired metadata',
 							'repair_status' => 'repaired_metadata',
-						)
+						), WorktreeCleanupSignal::candidate_fields($signal ?? array())
 					);
 					if ( null !== $age_decision ) {
-									$candidate['age_filter'] = $age_decision;
+						$candidate['age_filter'] = $age_decision['age_filter'];
 					}
 					$candidates[] = $candidate;
 					continue;
@@ -181,63 +149,34 @@ trait WorkspaceWorktreeInventoryCleanup {
 				continue;
 			}
 
+			$age_decision = null;
 			if ( null !== $age_filter ) {
-				$created_ts = is_string($created_at) && '' !== $created_at ? strtotime($created_at) : false;
-				if ( false === $created_ts ) {
-					++$age_filter['unknown_age'];
+				$age_decision = WorktreeAgeFilter::decide($created_at, $age_filter);
+				if ( 'unknown_age' === $age_decision['decision'] ) {
 					$skipped[] = array_merge(
-						$base_row, array(
-							'reason_code' => 'unknown_age',
-							'reason'      => 'missing or invalid created_at metadata - age filter cannot decide safely',
-							'age_filter'  => array(
-								'type'       => 'older_than',
-								'older_than' => $age_filter['older_than'],
-								'threshold'  => $age_filter['threshold'],
-								'decision'   => 'unknown_age',
-							),
-						)
+						$base_row,
+						WorktreeAgeFilter::skip_fields($age_decision)
 					);
 					continue;
 				}
 
-				if ( $created_ts > $age_filter['threshold_unix'] ) {
-					++$age_filter['excluded'];
+				if ( 'excluded' === $age_decision['decision'] ) {
 					$skipped[] = array_merge(
-						$base_row, array(
-							'reason_code' => 'age_filter',
-							'reason'      => sprintf('created_at %s is newer than --older-than=%s threshold %s', $created_at, $age_filter['older_than'], $age_filter['threshold']),
-							'age_filter'  => array(
-								'type'        => 'older_than',
-								'older_than'  => $age_filter['older_than'],
-								'threshold'   => $age_filter['threshold'],
-								'created_at'  => $created_at,
-								'age_seconds' => time() - $created_ts,
-								'decision'    => 'excluded',
-							),
-						)
+						$base_row,
+						WorktreeAgeFilter::skip_fields($age_decision)
 					);
 					continue;
 				}
 			}
 
+			$signal    = WorktreeCleanupSignal::from_metadata($metadata);
 			$candidate = array_merge(
 				$base_row, array(
 					'dirty'       => 0,
-					'signal'      => 'cleanup_eligible',
-					'reason_code' => 'cleanup_eligible',
-					'reason'      => 'worktree finalized or explicitly marked cleanup_eligible',
-					'pr_url'      => $metadata['pr_url'] ?? null,
-				)
+				), WorktreeCleanupSignal::candidate_fields($signal ?? array(), true)
 			);
-			if ( null !== $age_filter && is_string($created_at) && '' !== $created_at ) {
-				$candidate['age_filter'] = array(
-					'type'        => 'older_than',
-					'older_than'  => $age_filter['older_than'],
-					'threshold'   => $age_filter['threshold'],
-					'created_at'  => $created_at,
-					'age_seconds' => time() - (int) strtotime($created_at),
-					'decision'    => 'included',
-				);
+			if ( null !== $age_decision ) {
+				$candidate['age_filter'] = $age_decision['age_filter'];
 			}
 
 			$candidates[] = $candidate;

--- a/inc/Workspace/WorkspaceWorktreeInventoryCleanup.php
+++ b/inc/Workspace/WorkspaceWorktreeInventoryCleanup.php
@@ -171,9 +171,11 @@ trait WorkspaceWorktreeInventoryCleanup {
 
 			$signal    = WorktreeCleanupSignal::from_metadata($metadata);
 			$candidate = array_merge(
-				$base_row, array(
-					'dirty'       => 0,
-				), WorktreeCleanupSignal::candidate_fields($signal ?? array(), true)
+				$base_row,
+				array(
+					'dirty' => 0,
+				),
+				WorktreeCleanupSignal::candidate_fields($signal ?? array(), true)
 			);
 			if ( null !== $age_decision ) {
 				$candidate['age_filter'] = $age_decision['age_filter'];

--- a/inc/Workspace/WorktreeAgeFilter.php
+++ b/inc/Workspace/WorktreeAgeFilter.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Shared worktree cleanup age filtering helpers.
+ *
+ * @package DataMachineCode\Workspace
+ */
+
+namespace DataMachineCode\Workspace;
+
+defined('ABSPATH') || exit;
+
+final class WorktreeAgeFilter {
+
+	/**
+	 * Build an age filter summary/counter array from a parsed duration.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public static function build( string $older_than, int $duration_seconds, ?int $now = null ): array {
+		$threshold_ts = ( $now ?? time() ) - $duration_seconds;
+
+		return array(
+			'type'             => 'older_than',
+			'older_than'       => $older_than,
+			'duration_seconds' => $duration_seconds,
+			'threshold'        => gmdate('c', $threshold_ts),
+			'threshold_unix'   => $threshold_ts,
+			'excluded'         => 0,
+			'unknown_age'      => 0,
+		);
+	}
+
+	/**
+	 * Decide whether a row passes the age filter and update summary counters.
+	 *
+	 * @param  mixed               $created_at Worktree creation timestamp.
+	 * @param  array<string,mixed> $age_filter Mutable filter summary/counter array.
+	 * @return array<string,mixed>
+	 */
+	public static function decide( mixed $created_at, array &$age_filter, ?int $now = null ): array {
+		$created_ts = is_string($created_at) && '' !== $created_at ? strtotime($created_at) : false;
+		if ( false === $created_ts ) {
+			++$age_filter['unknown_age'];
+			return array(
+				'decision'   => 'unknown_age',
+				'age_filter' => array(
+					'type'       => 'older_than',
+					'older_than' => $age_filter['older_than'],
+					'threshold'  => $age_filter['threshold'],
+					'decision'   => 'unknown_age',
+				),
+			);
+		}
+
+		$decision = array(
+			'type'        => 'older_than',
+			'older_than'  => $age_filter['older_than'],
+			'threshold'   => $age_filter['threshold'],
+			'created_at'  => $created_at,
+			'age_seconds' => ( $now ?? time() ) - $created_ts,
+		);
+
+		if ( $created_ts > $age_filter['threshold_unix'] ) {
+			++$age_filter['excluded'];
+			$decision['decision'] = 'excluded';
+			return array(
+				'decision'   => 'excluded',
+				'age_filter' => $decision,
+			);
+		}
+
+		$decision['decision'] = 'included';
+		return array(
+			'decision'   => 'included',
+			'age_filter' => $decision,
+		);
+	}
+
+	/**
+	 * Build the standard skip row fragment for an age filter decision.
+	 *
+	 * @param  array<string,mixed> $decision Age decision from decide().
+	 * @return array<string,mixed>
+	 */
+	public static function skip_fields( array $decision ): array {
+		if ( 'unknown_age' === (string) ( $decision['decision'] ?? '' ) ) {
+			return array(
+				'reason_code' => 'unknown_age',
+				'reason'      => 'missing or invalid created_at metadata - age filter cannot decide safely',
+				'age_filter'  => $decision['age_filter'],
+			);
+		}
+
+		$age_filter = is_array($decision['age_filter'] ?? null) ? $decision['age_filter'] : array();
+		return array(
+			'reason_code' => 'age_filter',
+			'reason'      => sprintf('created_at %s is newer than --older-than=%s threshold %s', (string) ( $age_filter['created_at'] ?? '' ), (string) ( $age_filter['older_than'] ?? '' ), (string) ( $age_filter['threshold'] ?? '' )),
+			'age_filter'  => $age_filter,
+		);
+	}
+}

--- a/inc/Workspace/WorktreeCleanupSignal.php
+++ b/inc/Workspace/WorktreeCleanupSignal.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Shared worktree cleanup signal helpers.
+ *
+ * @package DataMachineCode\Workspace
+ */
+
+namespace DataMachineCode\Workspace;
+
+defined('ABSPATH') || exit;
+
+final class WorktreeCleanupSignal {
+
+	/**
+	 * Build a cleanup signal from lifecycle metadata when one is explicit enough.
+	 *
+	 * @param  array<string,mixed>|null $metadata Lifecycle metadata.
+	 * @return array<string,mixed>|null
+	 */
+	public static function from_metadata( ?array $metadata, bool $include_repaired_metadata = false ): ?array {
+		if ( is_array($metadata) && WorktreeContextInjector::has_cleanup_signal($metadata) ) {
+			$signal = array(
+				'signal' => 'cleanup_eligible',
+				'reason' => 'worktree finalized or explicitly marked cleanup_eligible',
+			);
+			if ( ! empty($metadata['pr_url']) ) {
+				$signal['pr_url'] = (string) $metadata['pr_url'];
+			}
+
+			return $signal;
+		}
+
+		if ( $include_repaired_metadata && is_array($metadata) && ! empty($metadata['metadata_repaired']) ) {
+			return array(
+				'signal' => 'repaired_metadata',
+				'reason' => 'operator-approved cleanup of repaired metadata',
+			);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Build the common cleanup candidate fields for a cleanup signal.
+	 *
+	 * @param  array<string,mixed> $signal Cleanup signal.
+	 * @return array<string,mixed>
+	 */
+	public static function candidate_fields( array $signal, bool $include_null_pr_url = false ): array {
+		$fields = array(
+			'signal'      => (string) ( $signal['signal'] ?? '' ),
+			'reason_code' => (string) ( $signal['signal'] ?? '' ),
+			'reason'      => (string) ( $signal['reason'] ?? '' ),
+		);
+
+		if ( $include_null_pr_url || array_key_exists('pr_url', $signal) ) {
+			$fields['pr_url'] = $signal['pr_url'] ?? null;
+		}
+
+		return $fields;
+	}
+}


### PR DESCRIPTION
## Summary
- Add shared `WorktreeAgeFilter` helper for cleanup age filter construction, decisions, and skip fields.
- Add shared `WorktreeCleanupSignal` helper for lifecycle cleanup signal and candidate field construction.
- Use the helpers in full worktree cleanup and inventory-only cleanup without changing cleanup policy.

## Verification
- `php -l inc/Workspace/WorktreeAgeFilter.php && php -l inc/Workspace/WorktreeCleanupSignal.php && php -l inc/Workspace/Workspace.php && php -l inc/Workspace/WorkspaceWorktreeCleanupEngine.php && php -l inc/Workspace/WorkspaceWorktreeInventoryCleanup.php`
- `for test in tests/*.php; do php "$test" || exit $?; done`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the cleanup primitive refactor and ran local verification; Chris remains responsible for review and merge.