### PR TITLE
Refactor worktree metadata inventory lookup

### DIFF
--- a/inc/Storage/WorktreeInventoryRepository.php
+++ b/inc/Storage/WorktreeInventoryRepository.php
@@ -144,10 +144,10 @@ class WorktreeInventoryRepository {
 
 		if ( method_exists($wpdb, 'get_row') && method_exists($wpdb, 'prepare') ) {
 			$table = self::table_name();
-			// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
-			$sql = $wpdb->prepare("SELECT * FROM {$table} WHERE handle = %s LIMIT 1", $handle);
-			// phpcs:enable WordPress.DB.PreparedSQL
-			$row = $wpdb->get_row($sql, ARRAY_A);
+			$row   = $wpdb->get_row(
+				$wpdb->prepare('SELECT * FROM %i WHERE handle = %s LIMIT 1', $table, $handle),
+				ARRAY_A
+			);
 			return is_array($row) ? $this->decode_row($row) : null;
 		}
 

--- a/inc/Storage/WorktreeInventoryRepository.php
+++ b/inc/Storage/WorktreeInventoryRepository.php
@@ -130,6 +130,37 @@ class WorktreeInventoryRepository {
 	}
 
 	/**
+	 * Fetch one inventory row by handle.
+	 *
+	 * @return array<string,mixed>|null
+	 */
+	public function get( string $handle ): ?array {
+		global $wpdb;
+
+		$handle = trim($handle);
+		if ( '' === $handle || ! isset($wpdb) ) {
+			return null;
+		}
+
+		if ( method_exists($wpdb, 'get_row') && method_exists($wpdb, 'prepare') ) {
+			$table = self::table_name();
+			// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
+			$sql = $wpdb->prepare("SELECT * FROM {$table} WHERE handle = %s LIMIT 1", $handle);
+			// phpcs:enable WordPress.DB.PreparedSQL
+			$row = $wpdb->get_row($sql, ARRAY_A);
+			return is_array($row) ? $this->decode_row($row) : null;
+		}
+
+		foreach ( $this->list() as $row ) {
+			if ( (string) ( $row['handle'] ?? '' ) === $handle ) {
+				return $row;
+			}
+		}
+
+		return null;
+	}
+
+	/**
 	 * Mark a known row as missing on disk instead of dropping it silently.
 	 */
 	public function mark_missing( string $handle ): bool {

--- a/inc/Workspace/WorktreeContextInjector.php
+++ b/inc/Workspace/WorktreeContextInjector.php
@@ -73,6 +73,8 @@ use DataMachineCode\Support\GitHubRemote;
 
 defined('ABSPATH') || exit;
 
+require_once __DIR__ . '/WorkspaceHandle.php';
+
 class WorktreeContextInjector {
 
 
@@ -1862,18 +1864,18 @@ class WorktreeContextInjector {
 			return;
 		}
 
-		$handle_parts = explode('@', $handle, 2);
-		$task         = is_array($metadata['origin_task'] ?? null) ? (array) $metadata['origin_task'] : array();
-		$session      = is_array($metadata['origin_session'] ?? null) ? self::summarize_session($metadata) : array();
+		$workspace_handle = WorkspaceHandle::parse($handle);
+		$task             = is_array($metadata['origin_task'] ?? null) ? (array) $metadata['origin_task'] : array();
+		$session          = is_array($metadata['origin_session'] ?? null) ? self::summarize_session($metadata) : array();
 
 		$repository->upsert(
 			array(
 				'handle'          => $handle,
-				'repo'            => (string) ( $metadata['repo'] ?? $handle_parts[0] ),
-				'branch'          => $metadata['branch'] ?? ( $handle_parts[1] ?? null ),
+				'repo'            => (string) ( $metadata['repo'] ?? $workspace_handle->repo() ),
+				'branch'          => $metadata['branch'] ?? $workspace_handle->branch_slug(),
 				'path'            => (string) ( $metadata['path'] ?? '' ),
 				'primary_path'    => $metadata['primary_path'] ?? null,
-				'is_primary'      => ! str_contains($handle, '@'),
+				'is_primary'      => ! $workspace_handle->is_worktree(),
 				'lifecycle_state' => $metadata['lifecycle_state'] ?? null,
 				'origin_site'     => $metadata['origin_site'] ?? null,
 				'origin_agent'    => $metadata['origin_agent'] ?? null,
@@ -1901,10 +1903,9 @@ class WorktreeContextInjector {
 			return null;
 		}
 
-		foreach ( $repository->list() as $row ) {
-			if ( (string) ( $row['handle'] ?? '' ) === $handle && is_array($row['metadata'] ?? null) ) {
-				return (array) $row['metadata'];
-			}
+		$row = $repository->get($handle);
+		if ( is_array($row) && is_array($row['metadata'] ?? null) ) {
+			return (array) $row['metadata'];
 		}
 
 		return null;

--- a/tests/worktree-add-lifecycle.php
+++ b/tests/worktree-add-lifecycle.php
@@ -82,6 +82,7 @@ final class Datamachine_Code_Test_Wpdb {
 	public string $last_error = '';
 	public int $insert_id = 0;
 	public int $rows_affected = 0;
+	public int $get_row_calls = 0;
 
 	/** @var array<string,array<string,mixed>> */
 	public array $rows = array();
@@ -130,6 +131,17 @@ final class Datamachine_Code_Test_Wpdb {
 
 	public function get_results( string $sql, string $output = ARRAY_A ): array {
 		return array_values($this->rows);
+	}
+
+	public function get_row( string $sql, string $output = ARRAY_A ): ?array {
+		++$this->get_row_calls;
+		foreach ( $this->rows as $handle => $row ) {
+			if ( str_contains($sql, (string) $handle) ) {
+				return $row;
+			}
+		}
+
+		return null;
 	}
 
 	public function prepare( string $query, mixed ...$args ): string {
@@ -225,6 +237,7 @@ try {
 
 	$show = $workspace->show_repo('homeboy@audit-primitives-20260616');
 	assert_true(! is_wp_error($show), 'persisted worktree is not visible to show_repo');
+	assert_true(0 < $wpdb->get_row_calls, 'persisted worktree metadata did not use direct inventory lookup');
 
 	$list    = $workspace->worktree_list('homeboy', null, array( 'include_status' => false, 'include_disk' => false ));
 	$handles = array_map(static fn( array $row ): string => (string) $row['handle'], $list['worktrees'] ?? array());


### PR DESCRIPTION
## Summary
- Add WorktreeInventoryRepository::get() for direct handle lookup with decoded row metadata.
- Use WorkspaceHandle in WorktreeContextInjector instead of local handle splitting.
- Fetch persisted injector metadata through the repository lookup instead of scanning the full inventory.

## Verification
- php -l inc/Storage/WorktreeInventoryRepository.php
- php -l inc/Workspace/WorktreeContextInjector.php
- php -l tests/worktree-add-lifecycle.php
- php tests/workspace-handle.php
- php tests/worktree-add-lifecycle.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, test update, and PR description for Chris to review.