### PR TITLE
Refactor worktree cleanup candidate classification

### DIFF
--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -26,6 +26,7 @@ require_once __DIR__ . '/WorkspaceRowTriage.php';
 require_once __DIR__ . '/WorkspaceWorktreeLifecycle.php';
 require_once __DIR__ . '/WorktreeAgeFilter.php';
 require_once __DIR__ . '/WorktreeCleanupSignal.php';
+require_once __DIR__ . '/WorktreeCleanupCandidateClassifier.php';
 require_once __DIR__ . '/WorkspaceWorktreeCleanupEngine.php';
 require_once __DIR__ . '/WorkspaceWorktreeInventoryCleanup.php';
 require_once __DIR__ . '/WorkspaceWorktreeEmergencyCleanup.php';

--- a/inc/Workspace/WorkspaceWorktreeCleanupEngine.php
+++ b/inc/Workspace/WorkspaceWorktreeCleanupEngine.php
@@ -477,117 +477,30 @@ trait WorkspaceWorktreeCleanupEngine {
 			if ( null === $signal ) {
 				$signal = $this->detect_merge_signal($primary_path, $repo, $branch, $skip_github, $github_cache);
 			}
-			if ( null === $signal ) {
-				$skipped[] = array_merge(
-					array(
-						'handle'                 => $handle,
-						'repo'                   => $repo,
-						'branch'                 => $branch,
-						'path'                   => $wt_path,
-						'reason_code'            => 'no_merge_signal',
-						'reason'                 => 'no merge signal — leaving in place',
-						'merge_signal_evidence'  => $this->build_no_merge_signal_evidence($primary_path, $branch, $skip_github),
-						'active_review_command'  => 'studio wp datamachine-code workspace worktree active-no-signal-report --limit=25 --offset=0 --format=json',
-						'active_review_commands' => $this->build_active_no_signal_next_commands(25, 0),
-						'created_at'             => $created_at,
-						'metadata'               => $metadata,
-					), $disk_fields
-				);
-				continue;
-			}
-
-			if ( 'probe-timeout' === $signal['signal'] ) {
-				$skipped[] = array_merge(
-					array(
-						'handle'      => $handle,
-						'repo'        => $repo,
-						'branch'      => $branch,
-						'path'        => $wt_path,
-						'reason_code' => 'probe_timeout',
-						'reason'      => $signal['reason'],
-						'created_at'  => $created_at,
-						'metadata'    => $metadata,
-					), $disk_fields
-				);
-				continue;
-			}
-
-			if ( 'github-unknown' === $signal['signal'] ) {
-				$skipped[] = array_merge(
-					array(
-						'handle'                 => $handle,
-						'repo'                   => $repo,
-						'branch'                 => $branch,
-						'path'                   => $wt_path,
-						'reason_code'            => 'github_unknown',
-						'reason'                 => $signal['reason'],
-						'merge_signal_evidence'  => array(
-							'classification' => 'github_signal_unavailable',
-							'github_signal'  => 'unavailable',
-							'reason'         => $signal['reason'],
-						),
-						'active_review_command'  => 'studio wp datamachine-code workspace worktree active-no-signal-report --limit=25 --offset=0 --format=json',
-						'active_review_commands' => $this->build_active_no_signal_next_commands(25, 0),
-						'created_at'             => $created_at,
-						'metadata'               => $metadata,
-					), $disk_fields
-				);
-				continue;
-			}
-
-			$age_decision = null;
-			if ( null !== $age_filter ) {
-				$age_decision = WorktreeAgeFilter::decide($created_at, $age_filter);
-				if ( 'unknown_age' === $age_decision['decision'] ) {
-					$skipped[] = array_merge(
-						array(
-							'handle'     => $handle,
-							'repo'       => $repo,
-							'branch'     => $branch,
-							'path'       => $wt_path,
-							'created_at' => $created_at,
-							'metadata'   => $metadata,
-						),
-						WorktreeAgeFilter::skip_fields($age_decision),
-						$disk_fields
-					);
-					continue;
-				}
-
-				if ( 'excluded' === $age_decision['decision'] ) {
-					$skipped[] = array_merge(
-						array(
-							'handle'     => $handle,
-							'repo'       => $repo,
-							'branch'     => $branch,
-							'path'       => $wt_path,
-							'created_at' => $created_at,
-							'metadata'   => $metadata,
-						),
-						WorktreeAgeFilter::skip_fields($age_decision),
-						$disk_fields
-					);
-					continue;
-				}
-			}
-
-			$candidate = array_merge(
+			$classification = WorktreeCleanupCandidateClassifier::classify_merge_signal_path(
 				array(
-					'handle'          => $wt['handle'],
-					'repo'            => $repo,
-					'branch'          => $branch,
-					'path'            => $wt_path,
-					'dirty'           => $dirty_count,
-					'cleanup_reasons' => array_values(array_filter(array( $signal['signal'], $signal['reason'] ))),
-					'created_at'      => $created_at,
-					'liveness'        => $liveness,
-					'metadata'        => $metadata,
-				), WorktreeCleanupSignal::candidate_fields($signal, true), $disk_fields
+					'handle'      => $handle,
+					'repo'        => $repo,
+					'branch'      => $branch,
+					'path'        => $wt_path,
+					'dirty_count' => $dirty_count,
+					'created_at'  => $created_at,
+					'liveness'    => $liveness,
+					'metadata'    => $metadata,
+					'disk_fields' => $disk_fields,
+				),
+				$signal,
+				$age_filter,
+				fn() => $this->build_no_merge_signal_evidence($primary_path, $branch, $skip_github),
+				$this->build_active_no_signal_next_commands(25, 0)
 			);
-			if ( null !== $age_decision ) {
-				$candidate['age_filter'] = $age_decision['age_filter'];
+
+			if ( 'candidate' === $classification['type'] ) {
+				$candidates[] = $classification['row'];
+				continue;
 			}
-			$candidates[] = $candidate;
+
+			$skipped[] = $classification['row'];
 		}
 
 		$candidates = $this->dedupe_worktree_cleanup_rows($candidates);

--- a/inc/Workspace/WorktreeCleanupCandidateClassifier.php
+++ b/inc/Workspace/WorktreeCleanupCandidateClassifier.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Worktree cleanup candidate classification.
+ *
+ * @package DataMachineCode\Workspace
+ */
+
+namespace DataMachineCode\Workspace;
+
+defined('ABSPATH') || exit;
+
+final class WorktreeCleanupCandidateClassifier {
+
+	/**
+	 * Classify one clean, non-primary worktree after safety probes and signal detection.
+	 *
+	 * @param  array<string,mixed>      $context                   Normalized worktree context.
+	 * @param  array<string,mixed>|null $signal                    Cleanup signal, if any.
+	 * @param  array<string,mixed>|null $age_filter                Mutable age filter summary.
+	 * @param  callable                 $no_merge_signal_evidence  Lazy evidence callback for no-signal rows.
+	 * @param  array<string,string>     $active_review_commands    Review/apply commands for no-signal rows.
+	 * @return array{type:string,row:array<string,mixed>}
+	 */
+	public static function classify_merge_signal_path( array $context, ?array $signal, ?array &$age_filter, callable $no_merge_signal_evidence, array $active_review_commands ): array {
+		$base        = self::base_row($context);
+		$disk_fields = is_array($context['disk_fields'] ?? null) ? $context['disk_fields'] : array();
+
+		if ( null === $signal ) {
+			return self::skip(
+				array_merge(
+					$base,
+					array(
+						'reason_code'            => 'no_merge_signal',
+						'reason'                 => 'no merge signal — leaving in place',
+						'merge_signal_evidence'  => $no_merge_signal_evidence(),
+						'active_review_command'  => 'studio wp datamachine-code workspace worktree active-no-signal-report --limit=25 --offset=0 --format=json',
+						'active_review_commands' => $active_review_commands,
+					),
+					$disk_fields
+				)
+			);
+		}
+
+		if ( 'probe-timeout' === (string) ( $signal['signal'] ?? '' ) ) {
+			return self::skip(
+				array_merge(
+					$base,
+					array(
+						'reason_code' => 'probe_timeout',
+						'reason'      => (string) ( $signal['reason'] ?? '' ),
+					),
+					$disk_fields
+				)
+			);
+		}
+
+		if ( 'github-unknown' === (string) ( $signal['signal'] ?? '' ) ) {
+			return self::skip(
+				array_merge(
+					$base,
+					array(
+						'reason_code'            => 'github_unknown',
+						'reason'                 => (string) ( $signal['reason'] ?? '' ),
+						'merge_signal_evidence'  => array(
+							'classification' => 'github_signal_unavailable',
+							'github_signal'  => 'unavailable',
+							'reason'         => (string) ( $signal['reason'] ?? '' ),
+						),
+						'active_review_command'  => 'studio wp datamachine-code workspace worktree active-no-signal-report --limit=25 --offset=0 --format=json',
+						'active_review_commands' => $active_review_commands,
+					),
+					$disk_fields
+				)
+			);
+		}
+
+		$age_decision = null;
+		if ( null !== $age_filter ) {
+			$age_decision = WorktreeAgeFilter::decide($context['created_at'] ?? null, $age_filter);
+			if ( in_array((string) ( $age_decision['decision'] ?? '' ), array( 'unknown_age', 'excluded' ), true) ) {
+				return self::skip(
+					array_merge(
+						$base,
+						WorktreeAgeFilter::skip_fields($age_decision),
+						$disk_fields
+					)
+				);
+			}
+		}
+
+		$candidate = array_merge(
+			$base,
+			array(
+				'dirty'           => (int) ( $context['dirty_count'] ?? 0 ),
+				'cleanup_reasons' => array_values(array_filter(array( $signal['signal'] ?? '', $signal['reason'] ?? '' ))),
+				'liveness'        => (string) ( $context['liveness'] ?? '' ),
+			),
+			WorktreeCleanupSignal::candidate_fields($signal, true),
+			$disk_fields
+		);
+		if ( null !== $age_decision ) {
+			$candidate['age_filter'] = $age_decision['age_filter'];
+		}
+
+		return array(
+			'type' => 'candidate',
+			'row'  => $candidate,
+		);
+	}
+
+	/**
+	 * Build common row fields used by this cleanup path.
+	 *
+	 * @param  array<string,mixed> $context Normalized worktree context.
+	 * @return array<string,mixed>
+	 */
+	private static function base_row( array $context ): array {
+		return array(
+			'handle'     => (string) ( $context['handle'] ?? '' ),
+			'repo'       => (string) ( $context['repo'] ?? '' ),
+			'branch'     => (string) ( $context['branch'] ?? '' ),
+			'path'       => (string) ( $context['path'] ?? '' ),
+			'created_at' => $context['created_at'] ?? null,
+			'metadata'   => $context['metadata'] ?? null,
+		);
+	}
+
+	/**
+	 * Wrap a skip row in the classifier result shape.
+	 *
+	 * @param  array<string,mixed> $row Skip row.
+	 * @return array{type:string,row:array<string,mixed>}
+	 */
+	private static function skip( array $row ): array {
+		return array(
+			'type' => 'skip',
+			'row'  => $row,
+		);
+	}
+}

--- a/inc/Workspace/WorktreeCleanupCandidateClassifier.php
+++ b/inc/Workspace/WorktreeCleanupCandidateClassifier.php
@@ -77,7 +77,7 @@ final class WorktreeCleanupCandidateClassifier {
 		$age_decision = null;
 		if ( null !== $age_filter ) {
 			$age_decision = WorktreeAgeFilter::decide($context['created_at'] ?? null, $age_filter);
-			if ( in_array((string) ( $age_decision['decision'] ?? '' ), array( 'unknown_age', 'excluded' ), true) ) {
+			if ( in_array( (string) ( $age_decision['decision'] ?? '' ), array( 'unknown_age', 'excluded' ), true) ) {
 				return self::skip(
 					array_merge(
 						$base,

--- a/tests/worktree-cleanup-candidate-classifier.php
+++ b/tests/worktree-cleanup-candidate-classifier.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+if ( ! defined('ABSPATH') ) {
+	define('ABSPATH', __DIR__ . '/fixtures/');
+}
+
+require_once dirname(__DIR__) . '/inc/Workspace/WorktreeAgeFilter.php';
+require_once dirname(__DIR__) . '/inc/Workspace/WorktreeCleanupSignal.php';
+require_once dirname(__DIR__) . '/inc/Workspace/WorktreeCleanupCandidateClassifier.php';
+
+use DataMachineCode\Workspace\WorktreeAgeFilter;
+use DataMachineCode\Workspace\WorktreeCleanupCandidateClassifier;
+
+function worktree_cleanup_candidate_assert_same( mixed $expected, mixed $actual, string $message ): void {
+	if ( $expected !== $actual ) {
+		throw new RuntimeException(sprintf('%s Expected %s, got %s.', $message, var_export($expected, true), var_export($actual, true)));
+	}
+}
+
+$context = array(
+	'handle'      => 'repo@merged-branch',
+	'repo'        => 'repo',
+	'branch'      => 'merged-branch',
+	'path'        => '/tmp/repo@merged-branch',
+	'dirty_count' => 0,
+	'created_at'  => '2026-01-01T00:00:00+00:00',
+	'liveness'    => 'stale',
+	'metadata'    => array( 'created_at' => '2026-01-01T00:00:00+00:00' ),
+	'disk_fields' => array( 'size_bytes' => 123 ),
+);
+
+$age_filter       = null;
+$evidence_called  = false;
+$candidate_result = WorktreeCleanupCandidateClassifier::classify_merge_signal_path(
+	$context,
+	array(
+		'signal' => 'github-merged-pr',
+		'reason' => 'GitHub reports merged PR',
+		'pr_url' => 'https://example.com/pr/1',
+	),
+	$age_filter,
+	function () use ( &$evidence_called ): array {
+		$evidence_called = true;
+		return array( 'classification' => 'no_cleanup_signal' );
+	},
+	array( 'review_command' => 'review' )
+);
+
+worktree_cleanup_candidate_assert_same('candidate', $candidate_result['type'], 'merged signal is a candidate');
+worktree_cleanup_candidate_assert_same('github-merged-pr', $candidate_result['row']['signal'], 'candidate signal is preserved');
+worktree_cleanup_candidate_assert_same('github-merged-pr', $candidate_result['row']['reason_code'], 'candidate reason_code matches signal');
+worktree_cleanup_candidate_assert_same(false, $evidence_called, 'no-signal evidence stays lazy for candidates');
+
+$no_signal_filter = null;
+$no_signal        = WorktreeCleanupCandidateClassifier::classify_merge_signal_path(
+	$context,
+	null,
+	$no_signal_filter,
+	function (): array {
+		return array( 'classification' => 'no_cleanup_signal' );
+	},
+	array( 'review_command' => 'review' )
+);
+
+worktree_cleanup_candidate_assert_same('skip', $no_signal['type'], 'missing signal is skipped');
+worktree_cleanup_candidate_assert_same('no_merge_signal', $no_signal['row']['reason_code'], 'missing signal reason_code matches cleanup contract');
+worktree_cleanup_candidate_assert_same(array( 'classification' => 'no_cleanup_signal' ), $no_signal['row']['merge_signal_evidence'], 'missing signal includes evidence');
+
+$recent_context               = $context;
+$recent_context['created_at'] = '2026-06-16T00:00:00+00:00';
+$recent_age_filter           = WorktreeAgeFilter::build('30d', 30 * 24 * 60 * 60, strtotime('2026-06-17T00:00:00+00:00'));
+$age_skip                    = WorktreeCleanupCandidateClassifier::classify_merge_signal_path(
+	$recent_context,
+	array(
+		'signal' => 'upstream-gone',
+		'reason' => 'upstream branch is gone',
+	),
+	$recent_age_filter,
+	fn(): array => array(),
+	array()
+);
+
+worktree_cleanup_candidate_assert_same('skip', $age_skip['type'], 'recent worktree is skipped by age filter');
+worktree_cleanup_candidate_assert_same('age_filter', $age_skip['row']['reason_code'], 'age skip reason_code matches cleanup contract');
+worktree_cleanup_candidate_assert_same(1, $recent_age_filter['excluded'], 'age filter excluded counter is updated');
+
+echo "worktree-cleanup-candidate-classifier: ok\n";


### PR DESCRIPTION
## Summary
- Extract the post-safety worktree cleanup candidate/skip decision into WorktreeCleanupCandidateClassifier.
- Keep worktree_cleanup_merged() responsible for scanning, probes, signal discovery, and destructive apply behavior.
- Add standalone coverage for candidate, no-signal skip, and age-filter skip classification.

## Verification
- php -l inc/Workspace/WorktreeCleanupCandidateClassifier.php
- php -l inc/Workspace/Workspace.php
- php -l inc/Workspace/WorkspaceWorktreeCleanupEngine.php
- php -l tests/worktree-cleanup-candidate-classifier.php
- php tests/worktree-cleanup-candidate-classifier.php
- for test in tests/*.php; do php "$test" || exit 1; done
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the classifier extraction, test coverage, and PR description; Chris remains responsible for review and merge.