### PR TITLE
Refactor cleanup evidence behind DMC boundary

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -565,15 +565,15 @@ class WorkspaceAbilities {
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
-							'repo'    => array(
+							'repo'                   => array(
 								'type'        => 'string',
 								'description' => 'Workspace handle: `<repo>` (primary) or `<repo>@<branch-slug>` (worktree).',
 							),
-							'path'    => array(
+							'path'                   => array(
 								'type'        => 'string',
 								'description' => 'Relative file path within the repo.',
 							),
-							'content' => array(
+							'content'                => array(
 								'type'        => 'string',
 								'description' => 'File content to write.',
 							),
@@ -608,39 +608,39 @@ class WorkspaceAbilities {
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
-							'repo'        => array(
+							'repo'                   => array(
 								'type'        => 'string',
 								'description' => 'Workspace handle: `<repo>` (primary) or `<repo>@<branch-slug>` (worktree).',
 							),
-							'path'        => array(
+							'path'                   => array(
 								'type'        => 'string',
 								'description' => 'Relative file path within the repo.',
 							),
-							'old_string'  => array(
+							'old_string'             => array(
 								'type'        => 'string',
 								'description' => 'Text to find.',
 							),
-							'new_string'  => array(
+							'new_string'             => array(
 								'type'        => 'string',
 								'description' => 'Replacement text.',
 							),
-							'search'      => array(
+							'search'                 => array(
 								'type'        => 'string',
 								'description' => 'Alias for old_string.',
 							),
-							'replace'     => array(
+							'replace'                => array(
 								'type'        => 'string',
 								'description' => 'Alias for new_string.',
 							),
-							'old'         => array(
+							'old'                    => array(
 								'type'        => 'string',
 								'description' => 'Alias for old_string.',
 							),
-							'new'         => array(
+							'new'                    => array(
 								'type'        => 'string',
 								'description' => 'Alias for new_string.',
 							),
-							'replace_all' => array(
+							'replace_all'            => array(
 								'type'        => 'boolean',
 								'description' => 'Replace all occurrences (default false).',
 							),
@@ -1298,27 +1298,27 @@ class WorkspaceAbilities {
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
-							'repo'           => array(
+							'repo'                       => array(
 								'type'        => 'string',
 								'description' => 'Primary repo name (no @-suffix).',
 							),
-							'branch'         => array(
+							'branch'                     => array(
 								'type'        => 'string',
 								'description' => 'Branch to check out in the worktree (e.g. fix/foo-bar). Slashes become dashes in the on-disk slug.',
 							),
-							'from'           => array(
+							'from'                       => array(
 								'type'        => 'string',
 								'description' => 'Base ref when creating the branch (default origin/HEAD).',
 							),
-							'inject_context' => array(
+							'inject_context'             => array(
 								'type'        => 'boolean',
 								'description' => 'Inject the originating site\'s agent context (MEMORY.md, USER.md, RULES.md) into the new worktree. Default true. Set false to create a bare worktree.',
 							),
-							'bootstrap'      => array(
+							'bootstrap'                  => array(
 								'type'        => 'boolean',
 								'description' => 'Run detected bootstrap steps (submodule init plus root or one-level nested package-manager/composer installs) after creating the worktree. Default true. Steps are skipped gracefully when their trigger file or tool is missing. Set false for a bare checkout (e.g. when only reading code).',
 							),
-							'allow_stale'    => array(
+							'allow_stale'                => array(
 								'type'        => 'boolean',
 								'description' => 'Bypass the staleness gate. When false (default), any branch/base behind the remote default branch is refused, and a new worktree more than `datamachine_worktree_stale_threshold` commits behind upstream is rolled back with a staleness error. Set true to opt in to a known-stale checkout.',
 							),
@@ -1326,19 +1326,19 @@ class WorkspaceAbilities {
 								'type'        => 'boolean',
 								'description' => 'Bypass the fetch-failure freshness gate. When false (default), worktree creation is refused if remote freshness cannot be verified. Set true only for intentional offline work with local refs.',
 							),
-							'rebase_base'    => array(
+							'rebase_base'                => array(
 								'type'        => 'boolean',
 								'description' => 'After creating the worktree, rebase onto the upstream tip (the branch\'s @{upstream} for existing branches, origin/<base> for new branches off a local base). Default false. On rebase conflicts the rebase is aborted; the worktree stays at its pre-rebase state and `rebase_succeeded: false` is surfaced.',
 							),
-							'force'          => array(
+							'force'                      => array(
 								'type'        => 'boolean',
 								'description' => 'Explicitly bypass the disk-budget refusal threshold. The disk-budget report still appears in output so the override is visible.',
 							),
-							'task_url'       => array(
+							'task_url'                   => array(
 								'type'        => 'string',
 								'description' => 'Optional task/issue URL (e.g. GitHub issue link) to record on the worktree for ownership/duplicate detection. Falls back to DATAMACHINE_TASK_URL env when omitted.',
 							),
-							'task_ref'       => array(
+							'task_ref'                   => array(
 								'type'        => 'string',
 								'description' => 'Optional short task/issue reference (e.g. `org/repo#123`) recorded alongside task_url. Falls back to DATAMACHINE_TASK_REF env when omitted.',
 							),
@@ -2666,7 +2666,7 @@ class WorkspaceAbilities {
 		if ( is_wp_error($handle_check) ) {
 			return $handle_check;
 		}
-		$reader       = new WorkspaceReader($workspace);
+		$reader = new WorkspaceReader($workspace);
 		if ( RemoteWorkspaceBackend::should_handle() && null !== self::showLocalWorkspaceHandleIfPresent($workspace, (string) ( $input['repo'] ?? '' )) ) {
 			return $reader->read_file(
 				$input['repo'] ?? '',
@@ -2714,7 +2714,7 @@ class WorkspaceAbilities {
 		if ( is_wp_error($handle_check) ) {
 			return $handle_check;
 		}
-		$reader       = new WorkspaceReader($workspace);
+		$reader = new WorkspaceReader($workspace);
 		if ( RemoteWorkspaceBackend::should_handle() && null !== self::showLocalWorkspaceHandleIfPresent($workspace, (string) ( $input['repo'] ?? '' )) ) {
 			return $reader->list_directory(
 				$input['repo'] ?? '',
@@ -2753,7 +2753,7 @@ class WorkspaceAbilities {
 		if ( is_wp_error($handle_check) ) {
 			return $handle_check;
 		}
-		$reader       = new WorkspaceReader($workspace);
+		$reader = new WorkspaceReader($workspace);
 		if ( RemoteWorkspaceBackend::should_handle() && null !== self::showLocalWorkspaceHandleIfPresent($workspace, (string) ( $input['repo'] ?? '' )) ) {
 			return $reader->grep(
 				$input['repo'] ?? '',

--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -15,6 +15,7 @@
 namespace DataMachineCode\Abilities;
 
 use DataMachineCode\Support\PermissionHelper;
+use DataMachineCode\Cleanup\WorkspaceCleanupRunEvidenceStore;
 use DataMachineCode\Workspace\CleanupRunService;
 use DataMachineCode\Workspace\RemoteWorkspaceBackend;
 use DataMachineCode\Workspace\RunnerWorkspacePublisher;
@@ -4389,7 +4390,7 @@ class WorkspaceAbilities {
 	 * @return array<string,mixed>|\WP_Error
 	 */
 	public static function workspaceCleanupStatus( array $input ): array|\WP_Error {
-		return ( new CleanupRunService() )->status( (string) ( $input['run_id'] ?? '' ));
+		return ( new WorkspaceCleanupRunEvidenceStore() )->read( (string) ( $input['run_id'] ?? '' ));
 	}
 
 	/**
@@ -4399,7 +4400,7 @@ class WorkspaceAbilities {
 	 * @return array<string,mixed>|\WP_Error
 	 */
 	public static function workspaceCleanupEvidence( array $input ): array|\WP_Error {
-		return ( new CleanupRunService() )->evidence( (string) ( $input['run_id'] ?? '' ));
+		return ( new WorkspaceCleanupRunEvidenceStore() )->read( (string) ( $input['run_id'] ?? '' ), true );
 	}
 
 	/**

--- a/inc/Cleanup/CompositeCleanupRunEvidenceStore.php
+++ b/inc/Cleanup/CompositeCleanupRunEvidenceStore.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Cleanup run evidence store that routes across DMC-owned storage adapters.
+ *
+ * @package DataMachineCode\Cleanup
+ */
+
+namespace DataMachineCode\Cleanup;
+
+defined('ABSPATH') || exit;
+
+class CompositeCleanupRunEvidenceStore implements CleanupRunEvidenceStoreInterface {
+
+
+
+	public function __construct(
+		private ?CleanupRunEvidenceStoreInterface $workspace_store = null,
+		private ?CleanupRunEvidenceStoreInterface $job_store = null
+	) {
+		$this->workspace_store ??= new WorkspaceCleanupRunEvidenceStore();
+		$this->job_store       ??= new DataMachineJobCleanupRunEvidenceStore();
+	}
+
+	/**
+	 * Read one cleanup run from the store implied by its identifier.
+	 *
+	 * @param  string $run_id           Stable cleanup run identifier.
+	 * @param  bool   $include_evidence Whether to include raw evidence records.
+	 * @param  bool   $include_details  Whether to include verbose diagnostic details.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function read( string $run_id, bool $include_evidence = false, bool $include_details = false ): array|\WP_Error {
+		if ( $this->is_job_cleanup_run_id($run_id) ) {
+			return $this->job_store->read($run_id, $include_evidence, $include_details);
+		}
+
+		return $this->workspace_store->read($run_id, $include_evidence, $include_details);
+	}
+
+	private function is_job_cleanup_run_id( string $run_id ): bool {
+		$run_id = trim($run_id);
+		return is_numeric($run_id) || 1 === preg_match('/^cleanup-run-\d+$/', $run_id);
+	}
+}

--- a/inc/Cleanup/WorkspaceCleanupRunEvidenceStore.php
+++ b/inc/Cleanup/WorkspaceCleanupRunEvidenceStore.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Cleanup run evidence store backed by DMC workspace cleanup rows.
+ *
+ * @package DataMachineCode\Cleanup
+ */
+
+namespace DataMachineCode\Cleanup;
+
+use DataMachineCode\Workspace\CleanupRunService;
+
+defined('ABSPATH') || exit;
+
+class WorkspaceCleanupRunEvidenceStore implements CleanupRunEvidenceStoreInterface {
+
+
+
+	public function __construct(
+		private ?CleanupRunService $cleanup_run_service = null
+	) {
+		$this->cleanup_run_service ??= new CleanupRunService();
+	}
+
+	/**
+	 * Read one DMC workspace cleanup run.
+	 *
+	 * @param  string $run_id           Stable cleanup run identifier.
+	 * @param  bool   $include_evidence Whether to include raw evidence records.
+	 * @param  bool   $include_details  Whether to include verbose diagnostic details.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function read( string $run_id, bool $include_evidence = false, bool $include_details = false ): array|\WP_Error {
+		unset($include_details);
+
+		return $include_evidence ? $this->cleanup_run_service->evidence($run_id) : $this->cleanup_run_service->status($run_id);
+	}
+}

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -19,8 +19,8 @@ use WP_CLI;
 use DataMachine\Cli\BaseCommand;
 use DataMachineCode\Cli\CliResponseRenderer;
 use DataMachineCode\Cli\CliRepeatableOptionParser;
+use DataMachineCode\Cleanup\CompositeCleanupRunEvidenceStore;
 use DataMachineCode\Cleanup\CleanupRunEvidenceStoreInterface;
-use DataMachineCode\Cleanup\DataMachineJobCleanupRunEvidenceStore;
 use DataMachineCode\Workspace\Workspace;
 use DataMachineCode\Workspace\WorktreeContextInjector;
 use DataMachineCode\Workspace\WorkspaceMutationLock;
@@ -751,16 +751,12 @@ class WorkspaceCommand extends BaseCommand {
 
 			case 'status':
 			case 'evidence':
-				if ( ! $this->is_job_cleanup_run_id( (string) ( $args[1] ?? '' )) ) {
-					$this->run_cleanup_control_ability($operation, (string) ( $args[1] ?? '' ), $assoc_args);
-					return;
-				}
-				$job_id = $this->cleanup_run_job_id( (string) ( $args[1] ?? '' ));
-				if ( $job_id <= 0 ) {
+				$run_id = (string) ( $args[1] ?? '' );
+				if ( '' === trim($run_id) ) {
 					WP_CLI::error('Usage: wp datamachine-code workspace cleanup ' . $operation . ' <run-id>');
 					return;
 				}
-				$this->render_cleanup_run_status($job_id, $assoc_args, 'evidence' === $operation);
+				$this->render_cleanup_run_status($run_id, $assoc_args, 'evidence' === $operation);
 				return;
 
 			case 'resume':
@@ -1229,8 +1225,8 @@ class WorkspaceCommand extends BaseCommand {
 		$this->render_worktree_emergency_cleanup_result($result, $assoc_args);
 	}
 
-	private function render_cleanup_run_status( int $job_id, array $assoc_args, bool $evidence ): void {
-		$output = $this->cleanup_run_evidence_store()->read($this->cleanup_run_id($job_id), $evidence, ! empty($assoc_args['verbose']));
+	private function render_cleanup_run_status( string $run_id, array $assoc_args, bool $evidence ): void {
+		$output = $this->cleanup_run_evidence_store()->read($run_id, $evidence, ! empty($assoc_args['verbose']));
 		if ( $output instanceof \WP_Error ) {
 			WP_CLI::error($output->get_error_message());
 			return;
@@ -1241,7 +1237,7 @@ class WorkspaceCommand extends BaseCommand {
 
 	private function cleanup_run_evidence_store(): CleanupRunEvidenceStoreInterface {
 		if ( null === $this->cleanup_run_evidence_store ) {
-			$this->cleanup_run_evidence_store = new DataMachineJobCleanupRunEvidenceStore();
+			$this->cleanup_run_evidence_store = new CompositeCleanupRunEvidenceStore();
 		}
 
 		return $this->cleanup_run_evidence_store;

--- a/tests/cleanup-run-evidence-store-boundary.php
+++ b/tests/cleanup-run-evidence-store-boundary.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+	if ( ! defined('ABSPATH') ) {
+		define('ABSPATH', __DIR__ . '/fixtures/');
+	}
+
+	require_once dirname(__DIR__) . '/inc/Cleanup/CleanupRunEvidenceStoreInterface.php';
+	require_once dirname(__DIR__) . '/inc/Cleanup/CompositeCleanupRunEvidenceStore.php';
+
+	use DataMachineCode\Cleanup\CleanupRunEvidenceStoreInterface;
+	use DataMachineCode\Cleanup\CompositeCleanupRunEvidenceStore;
+
+	final class FakeCleanupRunEvidenceStore implements CleanupRunEvidenceStoreInterface {
+		/** @var array<int,array<string,mixed>> */
+		public array $calls = array();
+
+		public function __construct(
+			private string $source
+		) {}
+
+		public function read( string $run_id, bool $include_evidence = false, bool $include_details = false ): array|\WP_Error {
+			$this->calls[] = compact('run_id', 'include_evidence', 'include_details');
+
+			return array(
+				'source'           => $this->source,
+				'run_id'           => $run_id,
+				'include_evidence' => $include_evidence,
+				'include_details'  => $include_details,
+			);
+		}
+	}
+
+	function cleanup_boundary_assert_same( mixed $expected, mixed $actual, string $message ): void {
+		if ( $expected !== $actual ) {
+			throw new RuntimeException(sprintf("%s\nExpected: %s\nActual: %s", $message, var_export($expected, true), var_export($actual, true)));
+		}
+	}
+
+	$workspace = new FakeCleanupRunEvidenceStore('workspace');
+	$job       = new FakeCleanupRunEvidenceStore('job');
+	$store     = new CompositeCleanupRunEvidenceStore($workspace, $job);
+
+	$result = $store->read('cleanup-run-20260504120000-abc123', true, true);
+	cleanup_boundary_assert_same('workspace', $result['source'] ?? null, 'Timestamp cleanup run IDs should route to the DMC workspace evidence store.');
+	cleanup_boundary_assert_same(true, $workspace->calls[0]['include_evidence'] ?? null, 'Workspace evidence flag should pass through.');
+
+	$result = $store->read('cleanup-run-123', false, true);
+	cleanup_boundary_assert_same('job', $result['source'] ?? null, 'Job cleanup run IDs should route to the Data Machine job adapter.');
+	cleanup_boundary_assert_same(true, $job->calls[0]['include_details'] ?? null, 'Job details flag should pass through.');
+
+	$result = $store->read('123');
+	cleanup_boundary_assert_same('job', $result['source'] ?? null, 'Numeric cleanup run IDs should route to the Data Machine job adapter.');
+
+	echo "cleanup run evidence store boundary test passed.\n";
+}


### PR DESCRIPTION
## Summary
- Add DMC-owned cleanup run evidence store adapters for workspace rows and Data Machine job-backed cleanup runs.
- Route CLI cleanup status/evidence through the composite evidence boundary instead of branching directly on job IDs.
- Route cleanup status/evidence abilities through the workspace evidence adapter.
- Add a focused boundary test for adapter routing.

## Verification
- `php -l inc/Cleanup/WorkspaceCleanupRunEvidenceStore.php && php -l inc/Cleanup/CompositeCleanupRunEvidenceStore.php && php -l inc/Cli/Commands/WorkspaceCommand.php && php -l inc/Abilities/WorkspaceAbilities.php && php -l tests/cleanup-run-evidence-store-boundary.php`
- `git diff --check`
- `php tests/cleanup-run-evidence-store-boundary.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the small boundary/adapter refactor, focused test, and verification commands for Chris to review.