### PR TITLE
Add argv command specs to process runner

### DIFF
--- a/inc/Support/CommandSpec.php
+++ b/inc/Support/CommandSpec.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Command Spec
+ *
+ * Explicit argv-based process contract for command execution that should not be
+ * interpreted by a shell.
+ *
+ * @package DataMachineCode\Support
+ */
+
+namespace DataMachineCode\Support;
+
+defined('ABSPATH') || exit;
+
+final class CommandSpec {
+
+	/** @var list<string> */
+	private array $argv;
+
+	/** @var string|null */
+	private ?string $cwd;
+
+	/** @var array<string,string>|null */
+	private ?array $env;
+
+	/**
+	 * @param list<string>               $argv Command argv. The first item is the executable.
+	 * @param array{cwd?: string|null, env?: array<string,mixed>|null} $options Execution policy.
+	 */
+	private function __construct( array $argv, array $options = array() ) {
+		$this->argv = $argv;
+		$this->cwd  = isset($options['cwd']) && is_string($options['cwd']) && '' !== $options['cwd'] ? $options['cwd'] : null;
+		$this->env  = isset($options['env']) && is_array($options['env']) ? self::normalize_env($options['env']) : null;
+	}
+
+	/**
+	 * Build a command spec from argv tokens.
+	 *
+	 * @param  array<int,mixed>          $argv Command argv. The first item is the executable.
+	 * @param  array{cwd?: string|null, env?: array<string,mixed>|null} $options Execution policy.
+	 * @return self|\WP_Error
+	 */
+	public static function from_argv( array $argv, array $options = array() ): self|\WP_Error {
+		$normalized = array();
+		foreach ( $argv as $arg ) {
+			if ( ! is_scalar($arg) ) {
+				return new \WP_Error('invalid_command_spec', 'Command argv entries must be scalar strings.', array( 'status' => 400 ));
+			}
+
+			$arg = (string) $arg;
+			if ( str_contains($arg, "\0") ) {
+				return new \WP_Error('invalid_command_spec', 'Command argv entries must not contain null bytes.', array( 'status' => 400 ));
+			}
+
+			$normalized[] = $arg;
+		}
+
+		if ( array() === $normalized || '' === $normalized[0] ) {
+			return new \WP_Error('invalid_command_spec', 'Command argv must include an executable.', array( 'status' => 400 ));
+		}
+
+		return new self($normalized, $options);
+	}
+
+	/**
+	 * @return list<string>
+	 */
+	public function argv(): array {
+		return $this->argv;
+	}
+
+	public function cwd(): ?string {
+		return $this->cwd;
+	}
+
+	/**
+	 * @return array<string,string>|null
+	 */
+	public function env(): ?array {
+		return $this->env;
+	}
+
+	/**
+	 * @return array<string,string>|null
+	 */
+	private static function normalize_env( array $env ): ?array {
+		$normalized = array();
+		foreach ( $env as $key => $value ) {
+			if ( is_scalar($value) ) {
+				$normalized[ (string) $key ] = (string) $value;
+			}
+		}
+
+		return array() === $normalized ? null : $normalized;
+	}
+}

--- a/inc/Support/ProcessRunner.php
+++ b/inc/Support/ProcessRunner.php
@@ -16,6 +16,9 @@ defined('ABSPATH') || exit;
 if ( ! class_exists(RuntimeCapabilities::class) ) {
 	require_once __DIR__ . '/RuntimeCapabilities.php';
 }
+if ( ! class_exists(CommandSpec::class) ) {
+	require_once __DIR__ . '/CommandSpec.php';
+}
 
 final class ProcessRunner {
 
@@ -24,18 +27,23 @@ final class ProcessRunner {
 	/**
 	 * Execute a shell command and return a normalized result envelope.
 	 *
-	 * @param  string              $command Shell command to execute.
+	 * @param  string|CommandSpec $command Shell command or argv command spec to execute.
 	 * @param  array<string,mixed> $options Execution options.
 	 * @return array<string,mixed>|\WP_Error
 	 */
-	public static function run( string $command, array $options = array() ): array|\WP_Error {
+	public static function run( string|CommandSpec $command, array $options = array() ): array|\WP_Error {
 		$timeout_seconds = max(0, (int) ( $options['timeout_seconds'] ?? 0 ));
 		$output_cap      = max(0, (int) ( $options['output_cap_bytes'] ?? 0 ));
 		$on_output       = is_callable($options['on_output'] ?? null) ? $options['on_output'] : null;
-		$env             = isset($options['env']) && is_array($options['env']) ? $options['env'] : null;
-		$cwd             = isset($options['cwd']) && is_string($options['cwd']) && '' !== $options['cwd'] ? $options['cwd'] : null;
+		$env             = self::resolve_env($command, $options);
+		$cwd             = self::resolve_cwd($command, $options);
+		$is_command_spec = $command instanceof CommandSpec;
 
-		if ( 0 === $timeout_seconds && null === $on_output && null === $env && null === $cwd ) {
+		if ( $is_command_spec && null === $command->env() && isset($options['env']) && ! is_array($options['env']) ) {
+			return self::error($options, 'Process command environment must be an array.', array( 'status' => 400 ));
+		}
+
+		if ( ! $is_command_spec && 0 === $timeout_seconds && null === $on_output && null === $env && null === $cwd ) {
 			return self::run_via_exec($command, $options, $output_cap);
 		}
 
@@ -48,7 +56,9 @@ final class ProcessRunner {
 			);
 		}
 
-		return self::run_via_proc_open($command, $options, $timeout_seconds, $output_cap, $on_output, $cwd, $env);
+		$process_command = $is_command_spec ? $command->argv() : $command;
+
+		return self::run_via_proc_open($process_command, $options, $timeout_seconds, $output_cap, $on_output, $cwd, $env);
 	}
 
 	/**
@@ -89,7 +99,7 @@ final class ProcessRunner {
 	 * @param  array<string,mixed>|null $env
 	 * @return array<string,mixed>|\WP_Error
 	 */
-	private static function run_via_proc_open( string $command, array $options, int $timeout_seconds, int $output_cap, ?callable $on_output, ?string $cwd, ?array $env ): array|\WP_Error {
+	private static function run_via_proc_open( string|array $command, array $options, int $timeout_seconds, int $output_cap, ?callable $on_output, ?string $cwd, ?array $env ): array|\WP_Error {
 		$descriptor_spec = array(
 			1 => array( 'pipe', 'w' ),
 			2 => array( 'pipe', 'w' ),
@@ -193,6 +203,31 @@ final class ProcessRunner {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * @param string|CommandSpec   $command Shell command or argv command spec.
+	 * @param array<string,mixed> $options Execution options.
+	 */
+	private static function resolve_cwd( string|CommandSpec $command, array $options ): ?string {
+		if ( isset($options['cwd']) && is_string($options['cwd']) && '' !== $options['cwd'] ) {
+			return $options['cwd'];
+		}
+
+		return $command instanceof CommandSpec ? $command->cwd() : null;
+	}
+
+	/**
+	 * @param string|CommandSpec   $command Shell command or argv command spec.
+	 * @param array<string,mixed> $options Execution options.
+	 * @return array<string,mixed>|null
+	 */
+	private static function resolve_env( string|CommandSpec $command, array $options ): ?array {
+		if ( isset($options['env']) && is_array($options['env']) ) {
+			return $options['env'];
+		}
+
+		return $command instanceof CommandSpec ? $command->env() : null;
 	}
 
 	/**

--- a/inc/Workspace/WorkspaceRepositoryLifecycle.php
+++ b/inc/Workspace/WorkspaceRepositoryLifecycle.php
@@ -7,14 +7,18 @@
 
 namespace DataMachineCode\Workspace;
 
-use DataMachineCode\Support\GitRunner;
+use DataMachineCode\Support\CommandSpec;
 use DataMachineCode\Support\GitHubRemote;
+use DataMachineCode\Support\GitRunner;
 use DataMachineCode\Support\ProcessRunner;
 
 defined('ABSPATH') || exit;
 
 if ( ! class_exists(ProcessRunner::class) ) {
 	require_once dirname(__DIR__) . '/Support/ProcessRunner.php';
+}
+if ( ! class_exists(CommandSpec::class) ) {
+	require_once dirname(__DIR__) . '/Support/CommandSpec.php';
 }
 
 trait WorkspaceRepositoryLifecycle {
@@ -242,8 +246,12 @@ trait WorkspaceRepositoryLifecycle {
 			return $env;
 		}
 
-		$command = $this->build_clone_command($url, $repo_path, $partial_clone);
-		$result  = $this->run_clone_command($command, $progress_callback, $started_at, $env);
+		$command = $this->build_clone_command($url, $repo_path, $partial_clone, $env);
+		if ( is_wp_error($command) ) {
+			return $command;
+		}
+
+		$result = $this->run_clone_command($command, $progress_callback, $started_at);
 
 		if ( is_wp_error($result) ) {
 			return $this->clone_failed_error($result, $name, $repo_path, $url);
@@ -265,18 +273,23 @@ trait WorkspaceRepositoryLifecycle {
 	 * @param  string $url           Git clone URL.
 	 * @param  string $repo_path     Destination path.
 	 * @param  bool   $partial_clone Whether to request blobless partial clone.
-	 * @return string Shell command.
+	 * @param  array<string,string>|null $env Extra process environment.
+	 * @return CommandSpec|\WP_Error Command spec.
 	 */
-	private function build_clone_command( string $url, string $repo_path, bool $partial_clone ): string {
-		$args = array( 'clone', '--progress' );
+	private function build_clone_command( string $url, string $repo_path, bool $partial_clone, ?array $env ): CommandSpec|\WP_Error {
+		$args = array( 'git', 'clone', '--progress' );
 		if ( $partial_clone ) {
 			$args[] = '--filter=blob:none';
 		}
 
-		$args[] = escapeshellarg($url);
-		$args[] = escapeshellarg($repo_path);
+		$args[] = $url;
+		$args[] = $repo_path;
 
-		return 'GIT_TERMINAL_PROMPT=0 git ' . implode(' ', $args);
+		$env                        = $env ?? getenv();
+		$env                        = is_array($env) ? $env : array();
+		$env['GIT_TERMINAL_PROMPT'] = '0';
+
+		return CommandSpec::from_argv($args, array( 'env' => $env ));
 	}
 
 	/**
@@ -333,16 +346,15 @@ trait WorkspaceRepositoryLifecycle {
 	/**
 	 * Stream a clone command to an optional progress callback.
 	 *
-	 * @param  string        $command           Shell command.
+	 * @param  CommandSpec   $command           Command spec.
 	 * @param  callable|null $progress_callback Optional progress callback.
 	 * @param  float         $started_at        Clone start timestamp.
 	 * @return array{success: true, output: string}|\WP_Error
 	 */
-	private function run_clone_command( string $command, ?callable $progress_callback, float $started_at, ?array $env = null ): array|\WP_Error {
+	private function run_clone_command( CommandSpec $command, ?callable $progress_callback, float $started_at ): array|\WP_Error {
 		$result = ProcessRunner::run(
 			$command,
 			array(
-				'env'                        => $env,
 				'error_code'                 => 'clone_failed',
 				'poll_interval_microseconds' => 100000,
 				'on_output'                  => function ( string $chunk ) use ( $progress_callback, $started_at ): void {

--- a/tests/process-runner-command-spec.php
+++ b/tests/process-runner-command-spec.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+if ( ! defined('ABSPATH') ) {
+	define('ABSPATH', __DIR__ . '/fixtures/');
+}
+
+if ( ! class_exists('WP_Error') ) {
+	class WP_Error {
+		private string $code;
+		private string $message;
+		private array $data;
+
+		public function __construct( string $code = '', string $message = '', array $data = array() ) {
+			$this->code    = $code;
+			$this->message = $message;
+			$this->data    = $data;
+		}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+
+		public function get_error_data(): array {
+			return $this->data;
+		}
+	}
+}
+
+require_once dirname(__DIR__) . '/inc/Support/CommandSpec.php';
+require_once dirname(__DIR__) . '/inc/Support/RuntimeCapabilities.php';
+require_once dirname(__DIR__) . '/inc/Support/ProcessRunner.php';
+
+use DataMachineCode\Support\CommandSpec;
+use DataMachineCode\Support\ProcessRunner;
+
+function process_runner_assert_same( mixed $expected, mixed $actual, string $message ): void {
+	if ( $expected !== $actual ) {
+		throw new RuntimeException(sprintf('%s Expected %s, got %s.', $message, var_export($expected, true), var_export($actual, true)));
+	}
+}
+
+function process_runner_assert_not_error( mixed $result, string $message ): void {
+	if ( $result instanceof WP_Error ) {
+		throw new RuntimeException(sprintf('%s %s', $message, $result->get_error_message()));
+	}
+}
+
+$cwd = sys_get_temp_dir();
+
+$spec = CommandSpec::from_argv(
+	array( PHP_BINARY, '-r', 'fwrite(STDOUT, getenv("DMC_COMMAND_SPEC_TEST") . "|" . basename(getcwd()));' ),
+	array(
+		'cwd' => $cwd,
+		'env' => array_merge(
+			getenv() ?: array(),
+			array( 'DMC_COMMAND_SPEC_TEST' => 'argv-ok' )
+		),
+	)
+);
+process_runner_assert_not_error($spec, 'CommandSpec should accept argv.');
+
+$result = ProcessRunner::run($spec, array( 'separate_streams' => true ));
+process_runner_assert_not_error($result, 'ProcessRunner should execute argv specs.');
+process_runner_assert_same('argv-ok|' . basename($cwd), $result['stdout'], 'CommandSpec preserves argv, cwd, and env policy.');
+process_runner_assert_same('', $result['stderr'], 'CommandSpec captures stderr separately.');
+
+$invalid = CommandSpec::from_argv(array());
+process_runner_assert_same(true, $invalid instanceof WP_Error, 'CommandSpec rejects empty argv.');
+
+echo "process-runner-command-spec: ok\n";


### PR DESCRIPTION
## Summary
- Add a small CommandSpec value object for argv-based process execution with cwd/env policy.
- Extend ProcessRunner to accept CommandSpec while preserving legacy shell-string execution.
- Convert git clone command construction to argv execution and keep auth/non-interactive env handling intact.
- Add focused coverage for argv execution, cwd/env propagation, separate stderr capture, and invalid argv rejection.

## Verification
- php -l inc/Support/CommandSpec.php inc/Support/ProcessRunner.php inc/Workspace/WorkspaceRepositoryLifecycle.php tests/process-runner-command-spec.php
- git diff --cached --check
- php tests/process-runner-command-spec.php
- php tests/worktree-add-lifecycle.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the CommandSpec/ProcessRunner implementation, clone callsite conversion, focused test, and local verification. Chris remains responsible for review and final acceptance.
