### PR TITLE
Fix release lint formatting

### DIFF
--- a/inc/Cleanup/CleanupRemainingWorkSummary.php
+++ b/inc/Cleanup/CleanupRemainingWorkSummary.php
@@ -13,7 +13,7 @@ class CleanupRemainingWorkSummary {
 
 
 
-	private const EXAMPLE_LIMIT = 3;
+	private const EXAMPLE_LIMIT              = 3;
 	private const METADATA_RECONCILE_COMMAND = 'studio wp datamachine-code workspace worktree reconcile-metadata --dry-run --limit=25 --offset=0 --until-budget=30s --format=json';
 
 	/**

--- a/inc/CodeTask/CodeTaskCreator.php
+++ b/inc/CodeTask/CodeTaskCreator.php
@@ -122,7 +122,7 @@ class CodeTaskCreator {
 	 * @return array{slug:string,name:string,url:string}|\WP_Error
 	 */
 	public static function resolve_repo( string $repo ): array|\WP_Error {
-		$repo = trim($repo);
+		$repo       = trim($repo);
 		$descriptor = GitHubRemote::descriptor($repo);
 		if ( null !== $descriptor ) {
 			$slug = $descriptor['slug'];

--- a/inc/Workspace/WorkspaceMutationLock.php
+++ b/inc/Workspace/WorkspaceMutationLock.php
@@ -195,7 +195,7 @@ final class WorkspaceMutationLock {
 	 */
 	public static function prune_stale( string $workspace_path, bool $dry_run = false ): array {
 		$before    = self::status($workspace_path);
-		$protected = self::active_filesystem_lock_keys((array) ( $before['filesystem'] ?? array() ));
+		$protected = self::active_filesystem_lock_keys( (array) ( $before['filesystem'] ?? array() ) );
 		$db_pruned = $dry_run ? array(
 			'dry_run'          => true,
 			'protected_active' => count($protected),
@@ -282,24 +282,24 @@ final class WorkspaceMutationLock {
 			$live_flock_present = in_array($lock_key, $active_filesystem_keys, true);
 			$owner_context      = (array) ( $lock['metadata']['owner_context'] ?? array() );
 			$database_rows[]    = array(
-				'source'                  => 'database',
-				'lock_key'                => $lock_key,
-				'scope'                   => (string) ( $lock['scope'] ?? '' ),
-				'state'                   => 'stale',
-				'owner'                   => (string) ( $lock['owner'] ?? '' ),
-				'session'                 => self::owner_context_session_id($owner_context),
-				'run_id'                  => (string) ( $lock['run_id'] ?? '' ),
-				'job_id'                  => $lock['job_id'] ?? null,
-				'acquired_at'             => (string) ( $lock['acquired_at'] ?? '' ),
-				'heartbeat_at'            => (string) ( $lock['heartbeat_at'] ?? '' ),
-				'expires_at'              => (string) ( $lock['expires_at'] ?? '' ),
-				'age_seconds'             => $lock['age_seconds'] ?? null,
-				'heartbeat_age_seconds'   => $lock['heartbeat_age_seconds'] ?? null,
-				'expires_age_seconds'     => $lock['expires_age_seconds'] ?? null,
-				'live_flock_present'      => $live_flock_present,
-				'safe_to_prune'           => ! $live_flock_present,
-				'preview_command'         => 'wp datamachine-code workspace worktree locks --prune-stale --dry-run --format=json',
-				'apply_command'           => 'wp datamachine-code workspace worktree locks --prune-stale --format=json',
+				'source'                   => 'database',
+				'lock_key'                 => $lock_key,
+				'scope'                    => (string) ( $lock['scope'] ?? '' ),
+				'state'                    => 'stale',
+				'owner'                    => (string) ( $lock['owner'] ?? '' ),
+				'session'                  => self::owner_context_session_id($owner_context),
+				'run_id'                   => (string) ( $lock['run_id'] ?? '' ),
+				'job_id'                   => $lock['job_id'] ?? null,
+				'acquired_at'              => (string) ( $lock['acquired_at'] ?? '' ),
+				'heartbeat_at'             => (string) ( $lock['heartbeat_at'] ?? '' ),
+				'expires_at'               => (string) ( $lock['expires_at'] ?? '' ),
+				'age_seconds'              => $lock['age_seconds'] ?? null,
+				'heartbeat_age_seconds'    => $lock['heartbeat_age_seconds'] ?? null,
+				'expires_age_seconds'      => $lock['expires_age_seconds'] ?? null,
+				'live_flock_present'       => $live_flock_present,
+				'safe_to_prune'            => ! $live_flock_present,
+				'preview_command'          => 'wp datamachine-code workspace worktree locks --prune-stale --dry-run --format=json',
+				'apply_command'            => 'wp datamachine-code workspace worktree locks --prune-stale --format=json',
 				'active_lock_refusal_note' => $live_flock_present ? 'Matching filesystem lock has a live flock; DB row is reported but protected from stale pruning.' : '',
 			);
 		}

--- a/inc/Workspace/WorkspaceRowTriage.php
+++ b/inc/Workspace/WorkspaceRowTriage.php
@@ -34,7 +34,7 @@ trait WorkspaceRowTriage {
 		$rows             = array_merge($this->workspace_top_level_triage_rows(), $this->workspace_external_worktree_triage_rows());
 
 		if ( '' !== $status_filter ) {
-			$rows = array_values(array_filter($rows, static fn( array $row ): bool => $status_filter === (string) ( $row['triage_status'] ?? '' )));
+			$rows = array_values(array_filter($rows, static fn( array $row ): bool => (string) ( $row['triage_status'] ?? '' ) === $status_filter));
 		} elseif ( ! $include_resolved ) {
 			$rows = array_values(array_filter($rows, static fn( array $row ): bool => 'unresolved' === (string) ( $row['triage_status'] ?? '' )));
 		}
@@ -42,8 +42,8 @@ trait WorkspaceRowTriage {
 		usort(
 			$rows,
 			static function ( array $a, array $b ): int {
-				$status_cmp = strcmp((string) ( $a['triage_status'] ?? '' ), (string) ( $b['triage_status'] ?? '' ));
-				return 0 !== $status_cmp ? $status_cmp : strcmp((string) ( $a['row_id'] ?? '' ), (string) ( $b['row_id'] ?? '' ));
+				$status_cmp = strcmp( (string) ( $a['triage_status'] ?? '' ), (string) ( $b['triage_status'] ?? '' ) );
+				return 0 !== $status_cmp ? $status_cmp : strcmp( (string) ( $a['row_id'] ?? '' ), (string) ( $b['row_id'] ?? '' ) );
 			}
 		);
 
@@ -104,7 +104,7 @@ trait WorkspaceRowTriage {
 			$metadata['triage_created_at'] = $now;
 		}
 
-		WorktreeContextInjector::store_lifecycle_metadata((string) ( $row['metadata_key'] ?? $row_id ), $metadata);
+		WorktreeContextInjector::store_lifecycle_metadata( (string) ( $row['metadata_key'] ?? $row_id ), $metadata );
 
 		$updated = $this->workspace_row_triage_find($row_id, true);
 		if ( is_wp_error($updated) ) {
@@ -145,7 +145,7 @@ trait WorkspaceRowTriage {
 			return new \WP_Error('triage_adopt_linked_worktree_unsupported', 'Linked worktree rows cannot be adopted as primary checkouts.', array( 'status' => 400 ));
 		}
 
-		$adopt = $this->adopt_repo((string) ( $row['path'] ?? '' ), $name);
+		$adopt = $this->adopt_repo( (string) ( $row['path'] ?? '' ), $name );
 		if ( is_wp_error($adopt) ) {
 			return $adopt;
 		}
@@ -346,7 +346,7 @@ trait WorkspaceRowTriage {
 		$triage_status = $this->workspace_row_triage_status_from_metadata($metadata);
 
 		$created_at = isset($metadata['created_at']) ? (string) $metadata['created_at'] : null;
-		$mtime      = @filemtime((string) ( $row['path'] ?? '' )); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Best-effort provenance for local workspace rows.
+		$mtime      = @filemtime( (string) ( $row['path'] ?? '' ) ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Best-effort provenance for local workspace rows.
 		if ( null === $created_at && false !== $mtime ) {
 			$created_at = gmdate('c', $mtime);
 		}
@@ -409,7 +409,7 @@ trait WorkspaceRowTriage {
 		}
 
 		foreach ( (array) ( $result['rows'] ?? array() ) as $row ) {
-			if ( $row_id === (string) ( $row['row_id'] ?? '' ) ) {
+			if ( (string) ( $row['row_id'] ?? '' ) === $row_id ) {
 				return $row;
 			}
 		}
@@ -425,15 +425,15 @@ trait WorkspaceRowTriage {
 	 */
 	private function workspace_row_triage_summary( array $rows ): array {
 		$summary = array(
-			'total'              => count($rows),
-			'unresolved'         => 0,
-			'ignored'            => 0,
-			'quarantined'        => 0,
-			'adopted'            => 0,
-			'external_worktree'  => 0,
+			'total'               => count($rows),
+			'unresolved'          => 0,
+			'ignored'             => 0,
+			'quarantined'         => 0,
+			'adopted'             => 0,
+			'external_worktree'   => 0,
 			'noncanonical_handle' => 0,
-			'non_git'            => 0,
-			'by_issue'           => array(),
+			'non_git'             => 0,
+			'by_issue'            => array(),
 		);
 
 		foreach ( $rows as $row ) {

--- a/inc/Workspace/WorktreeCleanupClassifier.php
+++ b/inc/Workspace/WorktreeCleanupClassifier.php
@@ -143,7 +143,7 @@ final class WorktreeCleanupClassifier {
 		$buckets['metadata_reconciliation_candidates']  = (int) ( $skipped_by_reason['needs_metadata_reconcile'] ?? 0 ) + (int) ( $skipped_by_reason['requires_full_scan'] ?? 0 ) + (int) ( $skipped_by_reason['missing_metadata'] ?? 0 );
 		$buckets['dirty_unpushed']                      = $buckets[ self::BUCKET_BLOCKED_BY_DIRTY_OR_UNPUSHED ];
 		$buckets['active_no_signal']                    = (int) ( $skipped_by_reason['active_no_signal'] ?? 0 ) + (int) ( $skipped_by_reason['no_inventory_cleanup_signal'] ?? 0 );
-		$buckets['intentional_triage']                   = (int) ( $skipped_by_reason['triage_ignored'] ?? 0 ) + (int) ( $skipped_by_reason['triage_quarantined'] ?? 0 );
+		$buckets['intentional_triage']                  = (int) ( $skipped_by_reason['triage_ignored'] ?? 0 ) + (int) ( $skipped_by_reason['triage_quarantined'] ?? 0 );
 
 		ksort($buckets);
 		return $buckets;


### PR DESCRIPTION
## Summary
- Fix release-blocking PHPCS formatting findings in workspace cleanup, row triage, mutation lock, code task, and cleanup summary code.
- Keep changes limited to assignment alignment, array arrow alignment, cast spacing, and Yoda comparisons.
- Leave CHANGELOG.md untouched.

## Verification
- php -l inc/Workspace/WorktreeCleanupClassifier.php && php -l inc/CodeTask/CodeTaskCreator.php && php -l inc/Workspace/WorkspaceMutationLock.php && php -l inc/Workspace/WorkspaceRowTriage.php && php -l inc/Cleanup/CleanupRemainingWorkSummary.php
- git diff --check
- homeboy lint data-machine-code --path /Users/chubes/Developer/data-machine-code@release-main-20260617

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused lint-formatting patch and ran local verification; Chris remains responsible for review and merge.