### PR TITLE
Fix disk-budget refusal cleanup guidance

### DIFF
--- a/inc/Workspace/WorkspaceWorktreeLifecycle.php
+++ b/inc/Workspace/WorkspaceWorktreeLifecycle.php
@@ -114,13 +114,30 @@ trait WorkspaceWorktreeLifecycle {
 		$disk_budget = WorktreeDiskBudget::inspect($this->workspace_path, WorktreeDiskBudget::thresholds($repo, $branch), $force);
 		if ( 'refused' === ( $disk_budget['status'] ?? '' ) ) {
 			$recommendations = array_map(
-				fn( $row ) => sprintf(
-					'%d. %s: %s (target reclaim: %s)',
-					(int) ( $row['priority'] ?? 0 ),
-					(string) ( $row['action'] ?? 'cleanup' ),
-					(string) ( $row['command'] ?? '' ),
-					(string) ( $row['expected_reclaim'] ?? 'unknown' )
-				),
+				static function ( $row ): string {
+					$commands = array_filter(
+						array(
+							'preview' => (string) ( $row['preview_command'] ?? $row['command'] ?? '' ),
+							'apply'   => (string) ( $row['apply_command'] ?? '' ),
+						)
+					);
+					$command_text = implode(
+						'; ',
+						array_map(
+							static fn( string $label, string $command ): string => sprintf('%s: %s', $label, $command),
+							array_keys($commands),
+							array_values($commands)
+						)
+					);
+
+					return sprintf(
+						'%d. %s: %s (target reclaim: %s)',
+						(int) ( $row['priority'] ?? 0 ),
+						(string) ( $row['action'] ?? 'cleanup' ),
+						$command_text,
+						(string) ( $row['expected_reclaim'] ?? 'unknown' )
+					);
+				},
 				(array) ( $disk_budget['cleanup_recommendations'] ?? array() )
 			);
 			return new \WP_Error(

--- a/inc/Workspace/WorkspaceWorktreeLifecycle.php
+++ b/inc/Workspace/WorkspaceWorktreeLifecycle.php
@@ -115,7 +115,7 @@ trait WorkspaceWorktreeLifecycle {
 		if ( 'refused' === ( $disk_budget['status'] ?? '' ) ) {
 			$recommendations = array_map(
 				static function ( $row ): string {
-					$commands = array_filter(
+					$commands     = array_filter(
 						array(
 							'preview' => (string) ( $row['preview_command'] ?? $row['command'] ?? '' ),
 							'apply'   => (string) ( $row['apply_command'] ?? '' ),

--- a/inc/Workspace/WorktreeDiskBudget.php
+++ b/inc/Workspace/WorktreeDiskBudget.php
@@ -199,20 +199,24 @@ final class WorktreeDiskBudget {
 				'expected_reclaim_bytes' => $target_reclaim,
 				'expected_reclaim'       => $target_human,
 				'command'                => 'studio wp datamachine-code workspace worktree cleanup-artifacts --dry-run --sort=size',
+				'preview_command'        => 'studio wp datamachine-code workspace worktree cleanup-artifacts --dry-run --sort=size',
 			),
 			array(
 				'priority'               => 2,
-				'action'                 => 'apply reviewed cleanup-eligible worktrees',
+				'action'                 => 'review and apply bounded cleanup-eligible worktrees',
 				'expected_reclaim_bytes' => $target_reclaim,
 				'expected_reclaim'       => $target_human,
 				'command'                => 'studio wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --dry-run --limit=25',
+				'preview_command'        => 'studio wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --dry-run --limit=25',
+				'apply_command'          => 'studio wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --limit=25',
 			),
 			array(
 				'priority'               => 3,
-				'action'                 => 'generate combined emergency plan',
+				'action'                 => 'generate combined emergency cleanup report',
 				'expected_reclaim_bytes' => $target_reclaim,
 				'expected_reclaim'       => $target_human,
 				'command'                => 'studio wp datamachine-code workspace worktree emergency-cleanup --format=json',
+				'preview_command'        => 'studio wp datamachine-code workspace worktree emergency-cleanup --format=json',
 			),
 		);
 	}

--- a/tests/worktree-disk-budget.php
+++ b/tests/worktree-disk-budget.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+if ( ! defined('ABSPATH') ) {
+	define('ABSPATH', __DIR__ . '/fixtures/');
+}
+
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+
+use DataMachineCode\Workspace\WorktreeDiskBudget;
+
+function assert_true( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		throw new RuntimeException($message);
+	}
+}
+
+$gib = 1073741824;
+
+try {
+	$budget = WorktreeDiskBudget::evaluate(
+		array(
+			'workspace_path' => '/tmp/dmc-test-workspace',
+			'free_bytes'     => 2 * $gib,
+			'total_bytes'    => 100 * $gib,
+			'worktree_count' => 12,
+		),
+		array(
+			'warn_free_bytes'     => 20 * $gib,
+			'refuse_free_bytes'   => 10 * $gib,
+			'warn_free_percent'   => 15.0,
+			'refuse_free_percent' => 10.0,
+			'warn_worktree_count' => 100,
+		)
+	);
+
+	assert_true('refused' === $budget['status'], 'low free space should refuse worktree creation');
+	assert_true(8 * $gib === $budget['cleanup_recommendations'][0]['expected_reclaim_bytes'], 'recommendations should include the bytes needed to clear the effective floor');
+	assert_true(str_contains(WorktreeDiskBudget::format_summary($budget), '2.0 GiB (2.0%) free'), 'summary should include current free GiB and percent');
+
+	$commands = array_column($budget['cleanup_recommendations'], 'command');
+	assert_true(in_array('studio wp datamachine-code workspace worktree cleanup-artifacts --dry-run --sort=size', $commands, true), 'artifact cleanup preview command is missing');
+	assert_true(in_array('studio wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --dry-run --limit=25', $commands, true), 'bounded cleanup-eligible dry-run command is missing');
+	assert_true(in_array('studio wp datamachine-code workspace worktree emergency-cleanup --format=json', $commands, true), 'emergency cleanup report command is missing');
+
+	$bounded = $budget['cleanup_recommendations'][1];
+	assert_true('studio wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --dry-run --limit=25' === $bounded['preview_command'], 'bounded cleanup preview command is missing');
+	assert_true('studio wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --limit=25' === $bounded['apply_command'], 'bounded cleanup apply command is missing');
+
+	fwrite(STDOUT, "worktree-disk-budget ok\n");
+} catch (Throwable $e) {
+	fwrite(STDERR, $e->getMessage() . "\n");
+	exit(1);
+}


### PR DESCRIPTION
## Summary
- Add explicit preview/apply command fields to disk-budget cleanup recommendations.
- Render disk-budget refusal guidance as review-first remediation steps with bounded cleanup-eligible dry-run/apply and artifact/emergency previews.
- Add a focused standalone test for low-disk recommendation numbers and commands.

## Tests
- `php tests/worktree-disk-budget.php`
- `php tests/worktree-add-lifecycle.php`
- `php -l inc/Workspace/WorkspaceWorktreeLifecycle.php && php -l inc/Workspace/WorktreeDiskBudget.php && php -l tests/worktree-disk-budget.php`
- `for test in tests/*.php; do php "$test" || exit 1; done`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation and tests drafted by coding agent for Chris to review