### PR TITLE
Add active no-signal triage preview

### DIFF
--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -3635,7 +3635,7 @@ class WorkspaceCommand extends BaseCommand {
 
 		$input         = array();
 		$input_builder = (string) ( $operation_config['input_builder'] ?? '' );
-		if ( '' !== $input_builder && method_exists($this, $input_builder) ) {
+		if ( '' !== $input_builder ) {
 			$input = $this->{$input_builder}($operation, $assoc_args);
 		}
 
@@ -5998,7 +5998,7 @@ class WorkspaceCommand extends BaseCommand {
 			}
 		}
 
-		$this->render_active_no_signal_triage_preview((array) ( $result['active_no_signal_triage'] ?? array() ));
+		$this->render_active_no_signal_triage_preview( (array) ( $result['active_no_signal_triage'] ?? array() ) );
 
 		WP_CLI::log('');
 		$remaining = (int) ( $continuation['remaining_total'] ?? 0 );

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -6049,20 +6049,20 @@ class WorkspaceCommand extends BaseCommand {
 		);
 
 		$report = array(
-			'success'         => (bool) ( $result['success'] ?? true ),
-			'mode'            => (string) ( $result['mode'] ?? 'bounded_cleanup_eligible_apply' ),
-			'dry_run'         => ! empty($result['dry_run']),
-			'destructive'     => ! empty($result['destructive']),
-			'workspace_path'  => $result['workspace_path'] ?? null,
-			'generated_at'    => $result['generated_at'] ?? null,
-			'summary'         => $compact_summary,
-			'blocker_buckets' => $buckets,
-			'next_actions'    => $actions,
+			'success'                 => (bool) ( $result['success'] ?? true ),
+			'mode'                    => (string) ( $result['mode'] ?? 'bounded_cleanup_eligible_apply' ),
+			'dry_run'                 => ! empty($result['dry_run']),
+			'destructive'             => ! empty($result['destructive']),
+			'workspace_path'          => $result['workspace_path'] ?? null,
+			'generated_at'            => $result['generated_at'] ?? null,
+			'summary'                 => $compact_summary,
+			'blocker_buckets'         => $buckets,
+			'next_actions'            => $actions,
 			'active_no_signal_triage' => (array) ( $result['active_no_signal_triage'] ?? array() ),
-			'candidates'      => $this->compact_cleanup_rows($candidates, 25),
-			'removed'         => $this->compact_cleanup_rows($removed, 25),
-			'continuation'    => $this->compact_cleanup_continuation( (array) ( $result['continuation'] ?? $result['pagination'] ?? array() ) ),
-			'evidence'        => $this->compact_cleanup_evidence( (array) ( $result['evidence'] ?? array() ), $skipped ),
+			'candidates'              => $this->compact_cleanup_rows($candidates, 25),
+			'removed'                 => $this->compact_cleanup_rows($removed, 25),
+			'continuation'            => $this->compact_cleanup_continuation( (array) ( $result['continuation'] ?? $result['pagination'] ?? array() ) ),
+			'evidence'                => $this->compact_cleanup_evidence( (array) ( $result['evidence'] ?? array() ), $skipped ),
 		);
 
 		if ( ! empty($result['job_backed']) ) {

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -5998,6 +5998,8 @@ class WorkspaceCommand extends BaseCommand {
 			}
 		}
 
+		$this->render_active_no_signal_triage_preview((array) ( $result['active_no_signal_triage'] ?? array() ));
+
 		WP_CLI::log('');
 		$remaining = (int) ( $continuation['remaining_total'] ?? 0 );
 		if ( $remaining > 0 ) {
@@ -6056,6 +6058,7 @@ class WorkspaceCommand extends BaseCommand {
 			'summary'         => $compact_summary,
 			'blocker_buckets' => $buckets,
 			'next_actions'    => $actions,
+			'active_no_signal_triage' => (array) ( $result['active_no_signal_triage'] ?? array() ),
 			'candidates'      => $this->compact_cleanup_rows($candidates, 25),
 			'removed'         => $this->compact_cleanup_rows($removed, 25),
 			'continuation'    => $this->compact_cleanup_continuation( (array) ( $result['continuation'] ?? $result['pagination'] ?? array() ) ),
@@ -6067,6 +6070,55 @@ class WorkspaceCommand extends BaseCommand {
 		}
 
 		return array_filter($report, fn( $value ) => null !== $value);
+	}
+
+	/**
+	 * Render concise active/no-signal triage preview from bounded cleanup output.
+	 *
+	 * @param  array<string,mixed> $preview Triage preview payload.
+	 * @return void
+	 */
+	private function render_active_no_signal_triage_preview( array $preview ): void {
+		$total = (int) ( $preview['total'] ?? 0 );
+		if ( $total <= 0 ) {
+			return;
+		}
+
+		WP_CLI::log('');
+		WP_CLI::log(sprintf('Active/no-signal triage preview: %d unresolved active worktree(s).', $total));
+		$summary_rows = array();
+		foreach ( (array) ( $preview['by_age'] ?? array() ) as $bucket => $count ) {
+			if ( (int) $count > 0 ) {
+				$summary_rows[] = array(
+					'dimension' => 'age',
+					'bucket'    => (string) $bucket,
+					'count'     => (int) $count,
+				);
+			}
+		}
+		foreach ( (array) ( $preview['by_liveness'] ?? array() ) as $bucket => $count ) {
+			$summary_rows[] = array(
+				'dimension' => 'liveness',
+				'bucket'    => (string) $bucket,
+				'count'     => (int) $count,
+			);
+		}
+		foreach ( (array) ( $preview['by_repo'] ?? array() ) as $bucket => $count ) {
+			$summary_rows[] = array(
+				'dimension' => 'repo',
+				'bucket'    => (string) $bucket,
+				'count'     => (int) $count,
+			);
+		}
+		$this->format_items($summary_rows, array( 'dimension', 'bucket', 'count' ), array( 'format' => 'table' ), 'dimension');
+
+		WP_CLI::log('Non-destructive next commands:');
+		foreach ( (array) ( $preview['commands'] ?? array() ) as $label => $command ) {
+			WP_CLI::log(sprintf('  %s: %s', (string) $label, (string) $command));
+		}
+		if ( ! empty($preview['safety']) ) {
+			WP_CLI::log('Safety: ' . (string) $preview['safety']);
+		}
 	}
 
 	/**

--- a/inc/Workspace/Workspace.php
+++ b/inc/Workspace/Workspace.php
@@ -15,6 +15,7 @@ namespace DataMachineCode\Workspace;
 defined('ABSPATH') || exit;
 
 require_once __DIR__ . '/WorkspaceCoreUtilities.php';
+require_once __DIR__ . '/WorktreeActiveNoSignalTriagePreview.php';
 require_once __DIR__ . '/WorkspaceActiveNoSignalCleanup.php';
 require_once __DIR__ . '/WorkspaceArtifactCleanup.php';
 require_once __DIR__ . '/WorkspaceCleanupPlan.php';

--- a/inc/Workspace/WorkspaceWorktreeCleanupEngine.php
+++ b/inc/Workspace/WorkspaceWorktreeCleanupEngine.php
@@ -697,7 +697,7 @@ trait WorkspaceWorktreeCleanupEngine {
 			}
 
 			$parsed = $this->parse_handle($entry);
-			if ( empty($parsed['is_worktree']) || '' === (string) ( $parsed['repo'] ?? '' ) ) {
+			if ( empty($parsed['is_worktree']) || '' === (string) $parsed['repo'] ) {
 				continue;
 			}
 

--- a/inc/Workspace/WorkspaceWorktreeCleanupEngine.php
+++ b/inc/Workspace/WorkspaceWorktreeCleanupEngine.php
@@ -1012,7 +1012,7 @@ trait WorkspaceWorktreeCleanupEngine {
 		$batch    = array_slice($all_candidates, 0, $limit);
 		$deferred = array_slice($all_candidates, $limit);
 
-		$continuation = array(
+		$continuation            = array(
 			'remaining_total'   => count($deferred),
 			'remaining_handles' => array_values(array_filter(array_map(fn( $row ) => is_array($row) ? (string) ( $row['handle'] ?? '' ) : '', $deferred))),
 			'next_call_hint'    => count($deferred) > 0 ? sprintf('Run the bounded cleanup-eligible apply again to drain the next %d candidate(s).', min($limit, count($deferred))) : null,
@@ -1024,25 +1024,25 @@ trait WorkspaceWorktreeCleanupEngine {
 
 		if ( $dry_run ) {
 			return array(
-				'success'        => true,
-				'mode'           => 'bounded_cleanup_eligible_apply',
-				'dry_run'        => true,
-				'destructive'    => false,
-				'workspace_path' => $this->workspace_path,
-				'generated_at'   => gmdate('c'),
-				'candidates'     => $batch,
-				'removed'        => array(),
-				'skipped'        => $inventory_skipped,
-				'summary'        => array(
+				'success'                 => true,
+				'mode'                    => 'bounded_cleanup_eligible_apply',
+				'dry_run'                 => true,
+				'destructive'             => false,
+				'workspace_path'          => $this->workspace_path,
+				'generated_at'            => gmdate('c'),
+				'candidates'              => $batch,
+				'removed'                 => array(),
+				'skipped'                 => $inventory_skipped,
+				'summary'                 => array(
 					'processed'       => count($batch),
 					'removed'         => 0,
 					'skipped'         => count($inventory_skipped),
 					'bytes_reclaimed' => 0,
 					'limit'           => $limit,
 				),
-				'continuation'   => $continuation,
+				'continuation'            => $continuation,
 				'active_no_signal_triage' => $active_no_signal_triage,
-				'evidence'       => array(
+				'evidence'                => array(
 					'elapsed_ms'       => (int) round(( microtime(true) - $started_at ) * 1000),
 					'inventory_total'  => count($all_candidates),
 					'planned_handles'  => array_values(array_filter(array_map(fn( $row ) => is_array($row) ? (string) ( $row['handle'] ?? '' ) : '', $batch))),
@@ -1154,16 +1154,16 @@ trait WorkspaceWorktreeCleanupEngine {
 		$this->worktree_prune();
 
 		return array(
-			'success'        => true,
-			'mode'           => 'bounded_cleanup_eligible_apply',
-			'dry_run'        => false,
-			'destructive'    => true,
-			'workspace_path' => $this->workspace_path,
-			'generated_at'   => gmdate('c'),
-			'candidates'     => $batch,
-			'removed'        => $removed,
-			'skipped'        => $skipped,
-			'summary'        => array(
+			'success'                 => true,
+			'mode'                    => 'bounded_cleanup_eligible_apply',
+			'dry_run'                 => false,
+			'destructive'             => true,
+			'workspace_path'          => $this->workspace_path,
+			'generated_at'            => gmdate('c'),
+			'candidates'              => $batch,
+			'removed'                 => $removed,
+			'skipped'                 => $skipped,
+			'summary'                 => array(
 				'processed'          => $processed,
 				'removed'            => count($removed),
 				'skipped'            => count($skipped),
@@ -1171,9 +1171,9 @@ trait WorkspaceWorktreeCleanupEngine {
 				'limit'              => $limit,
 				'discarded_unpushed' => count($discarded_unpushed),
 			),
-			'continuation'   => $continuation,
+			'continuation'            => $continuation,
 			'active_no_signal_triage' => $active_no_signal_triage,
-			'evidence'       => array(
+			'evidence'                => array(
 				'elapsed_ms'         => (int) round(( microtime(true) - $started_at ) * 1000),
 				'inventory_total'    => count($all_candidates),
 				'removed_handles'    => array_values(array_filter(array_map(fn( $row ) => (string) $row['handle'], $removed))),

--- a/inc/Workspace/WorkspaceWorktreeCleanupEngine.php
+++ b/inc/Workspace/WorkspaceWorktreeCleanupEngine.php
@@ -1020,6 +1020,7 @@ trait WorkspaceWorktreeCleanupEngine {
 			'limit_applied'     => $limit,
 			'remove_timeout'    => $remove_timeout_seconds,
 		);
+		$active_no_signal_triage = WorktreeActiveNoSignalTriagePreview::build($inventory_skipped, min($limit, 25));
 
 		if ( $dry_run ) {
 			return array(
@@ -1040,6 +1041,7 @@ trait WorkspaceWorktreeCleanupEngine {
 					'limit'           => $limit,
 				),
 				'continuation'   => $continuation,
+				'active_no_signal_triage' => $active_no_signal_triage,
 				'evidence'       => array(
 					'elapsed_ms'       => (int) round(( microtime(true) - $started_at ) * 1000),
 					'inventory_total'  => count($all_candidates),
@@ -1170,6 +1172,7 @@ trait WorkspaceWorktreeCleanupEngine {
 				'discarded_unpushed' => count($discarded_unpushed),
 			),
 			'continuation'   => $continuation,
+			'active_no_signal_triage' => $active_no_signal_triage,
 			'evidence'       => array(
 				'elapsed_ms'         => (int) round(( microtime(true) - $started_at ) * 1000),
 				'inventory_total'    => count($all_candidates),

--- a/inc/Workspace/WorktreeActiveNoSignalTriagePreview.php
+++ b/inc/Workspace/WorktreeActiveNoSignalTriagePreview.php
@@ -44,7 +44,7 @@ final class WorktreeActiveNoSignalTriagePreview {
 		);
 
 		foreach ( $rows as $row ) {
-			if ( ! is_array($row) || ! in_array((string) ( $row['reason_code'] ?? '' ), self::ACTIVE_REASON_CODES, true) ) {
+			if ( ! in_array( (string) ( $row['reason_code'] ?? '' ), self::ACTIVE_REASON_CODES, true ) ) {
 				continue;
 			}
 

--- a/inc/Workspace/WorktreeActiveNoSignalTriagePreview.php
+++ b/inc/Workspace/WorktreeActiveNoSignalTriagePreview.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Concise active/no-signal triage preview for bounded cleanup output.
+ *
+ * @package DataMachineCode\Workspace
+ */
+
+namespace DataMachineCode\Workspace;
+
+defined('ABSPATH') || exit;
+
+final class WorktreeActiveNoSignalTriagePreview {
+
+	private const ACTIVE_REASON_CODES = array(
+		'active_no_signal',
+		'no_inventory_cleanup_signal',
+		'lifecycle_reconciliation_candidate',
+	);
+
+	/**
+	 * Build a bounded operator preview for unresolved active/no-signal rows.
+	 *
+	 * @param  array<int,array<string,mixed>> $rows Skipped cleanup rows.
+	 * @param  int                           $limit Suggested command page size.
+	 * @param  int                           $now   Current timestamp for age buckets.
+	 * @return array<string,mixed>
+	 */
+	public static function build( array $rows, int $limit = 25, ?int $now = null ): array {
+		$now     = $now ?? time();
+		$limit   = max(1, min(200, $limit));
+		$preview = array(
+			'total'       => 0,
+			'by_age'      => array(
+				'lt_1d'   => 0,
+				'1_7d'    => 0,
+				'7_30d'   => 0,
+				'gte_30d' => 0,
+				'unknown' => 0,
+			),
+			'by_liveness' => array(),
+			'by_repo'     => array(),
+			'commands'    => self::commands($limit),
+			'safety'      => 'Commands classify active/no-signal rows into cleanup_eligible metadata only; they do not remove worktrees or branches.',
+		);
+
+		foreach ( $rows as $row ) {
+			if ( ! is_array($row) || ! in_array((string) ( $row['reason_code'] ?? '' ), self::ACTIVE_REASON_CODES, true) ) {
+				continue;
+			}
+
+			++$preview['total'];
+			++$preview['by_age'][ self::age_bucket($row['created_at'] ?? null, $now) ];
+
+			$liveness = (string) ( $row['liveness'] ?? 'unknown' );
+			if ( '' === $liveness ) {
+				$liveness = 'unknown';
+			}
+			$preview['by_liveness'][ $liveness ] = (int) ( $preview['by_liveness'][ $liveness ] ?? 0 ) + 1;
+
+			$repo = (string) ( $row['repo'] ?? 'unknown' );
+			if ( '' === $repo ) {
+				$repo = 'unknown';
+			}
+			$preview['by_repo'][ $repo ] = (int) ( $preview['by_repo'][ $repo ] ?? 0 ) + 1;
+		}
+
+		arsort($preview['by_liveness']);
+		arsort($preview['by_repo']);
+		$preview['by_repo'] = array_slice($preview['by_repo'], 0, 10, true);
+
+		return $preview;
+	}
+
+	/**
+	 * @param mixed $created_at Created-at value from inventory metadata.
+	 */
+	private static function age_bucket( mixed $created_at, int $now ): string {
+		if ( ! is_string($created_at) || '' === trim($created_at) ) {
+			return 'unknown';
+		}
+
+		$created = strtotime($created_at);
+		if ( false === $created ) {
+			return 'unknown';
+		}
+
+		$age = max(0, $now - $created);
+		$day = 86400;
+		if ( $age < $day ) {
+			return 'lt_1d';
+		}
+		if ( $age < 7 * $day ) {
+			return '1_7d';
+		}
+		if ( $age < 30 * $day ) {
+			return '7_30d';
+		}
+
+		return 'gte_30d';
+	}
+
+	/**
+	 * @return array<string,string>
+	 */
+	private static function commands( int $limit ): array {
+		$base = sprintf('--limit=%d --offset=0 --until-budget=60s --format=json', $limit);
+
+		return array(
+			'report'                    => 'studio wp datamachine-code workspace worktree active-no-signal-report ' . $base,
+			'equivalent_clean_dry_run'  => 'studio wp datamachine-code workspace worktree active-no-signal-equivalent-clean-apply --dry-run ' . $base,
+			'equivalent_clean_apply'    => 'studio wp datamachine-code workspace worktree active-no-signal-equivalent-clean-apply ' . $base,
+			'merged_to_default_dry_run' => 'studio wp datamachine-code workspace worktree active-no-signal-merged-apply --dry-run ' . $base,
+			'merged_to_default_apply'   => 'studio wp datamachine-code workspace worktree active-no-signal-merged-apply ' . $base,
+			'remote_clean_dry_run'      => 'studio wp datamachine-code workspace worktree active-no-signal-remote-clean-apply --dry-run ' . $base,
+			'remote_clean_apply'        => 'studio wp datamachine-code workspace worktree active-no-signal-remote-clean-apply ' . $base,
+		);
+	}
+}

--- a/tests/worktree-active-no-signal-triage-preview.php
+++ b/tests/worktree-active-no-signal-triage-preview.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+if ( ! defined('ABSPATH') ) {
+	define('ABSPATH', __DIR__ . '/fixtures/');
+}
+
+require_once dirname(__DIR__) . '/inc/Workspace/WorktreeActiveNoSignalTriagePreview.php';
+
+use DataMachineCode\Workspace\WorktreeActiveNoSignalTriagePreview;
+
+function active_no_signal_triage_assert_same( mixed $expected, mixed $actual, string $message ): void {
+	if ( $expected !== $actual ) {
+		throw new RuntimeException(sprintf('%s Expected %s, got %s.', $message, var_export($expected, true), var_export($actual, true)));
+	}
+}
+
+$now     = strtotime('2026-06-17T00:00:00+00:00');
+$preview = WorktreeActiveNoSignalTriagePreview::build(
+	array(
+		array(
+			'reason_code' => 'active_no_signal',
+			'repo'        => 'repo-a',
+			'liveness'    => 'stale',
+			'created_at'  => '2026-06-16T12:00:00+00:00',
+		),
+		array(
+			'reason_code' => 'lifecycle_reconciliation_candidate',
+			'repo'        => 'repo-a',
+			'liveness'    => 'unknown',
+			'created_at'  => '2026-06-01T00:00:00+00:00',
+		),
+		array(
+			'reason_code' => 'active_no_signal',
+			'repo'        => 'repo-b',
+			'liveness'    => '',
+			'created_at'  => 'not-a-date',
+		),
+		array(
+			'reason_code' => 'dirty_worktree',
+			'repo'        => 'repo-b',
+			'liveness'    => 'stale',
+			'created_at'  => '2026-06-16T12:00:00+00:00',
+		),
+	),
+	10,
+	$now
+);
+
+active_no_signal_triage_assert_same(3, $preview['total'], 'active/no-signal total excludes non-active blockers');
+active_no_signal_triage_assert_same(1, $preview['by_age']['lt_1d'], 'recent rows are counted');
+active_no_signal_triage_assert_same(1, $preview['by_age']['7_30d'], 'older rows are counted');
+active_no_signal_triage_assert_same(1, $preview['by_age']['unknown'], 'invalid dates are counted as unknown age');
+active_no_signal_triage_assert_same(1, $preview['by_liveness']['stale'], 'stale liveness is counted');
+active_no_signal_triage_assert_same(2, $preview['by_liveness']['unknown'], 'blank liveness is normalized to unknown');
+active_no_signal_triage_assert_same(2, $preview['by_repo']['repo-a'], 'repo counts are aggregated');
+active_no_signal_triage_assert_same(
+	'studio wp datamachine-code workspace worktree active-no-signal-equivalent-clean-apply --dry-run --limit=10 --offset=0 --until-budget=60s --format=json',
+	$preview['commands']['equivalent_clean_dry_run'],
+	'equivalent-clean dry-run command is exact and non-destructive'
+);
+active_no_signal_triage_assert_same(
+	'studio wp datamachine-code workspace worktree active-no-signal-remote-clean-apply --limit=10 --offset=0 --until-budget=60s --format=json',
+	$preview['commands']['remote_clean_apply'],
+	'remote-clean metadata apply command is exact'
+);
+
+echo "worktree-active-no-signal-triage-preview: ok\n";


### PR DESCRIPTION
## Summary
- add a bounded cleanup active/no-signal triage preview with counts by age, liveness, and repo
- include exact non-destructive active-no-signal report/classification commands for equivalent-clean, merged-to-default, and remote-clean rows
- add standalone coverage for preview bucketing and generated command strings

## Tests
- php -l inc/Workspace/WorktreeActiveNoSignalTriagePreview.php && php -l inc/Workspace/Workspace.php && php -l inc/Workspace/WorkspaceWorktreeCleanupEngine.php && php -l inc/Cli/Commands/WorkspaceCommand.php && php -l tests/worktree-active-no-signal-triage-preview.php
- php tests/worktree-active-no-signal-triage-preview.php && php tests/worktree-cleanup-candidate-classifier.php && php tests/smoke-abandoned-cleanup-orchestrator.php
- composer install --no-interaction
- for f in tests/*.php; do php '<file>' || exit 1; done (ran across all tests/*.php)
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused implementation, test coverage, and PR description; Chris remains responsible for review and validation.