### PR TITLE
Add cleanup-eligible drain command

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -21,6 +21,7 @@ use DataMachineCode\Workspace\RemoteWorkspaceBackend;
 use DataMachineCode\Workspace\RunnerWorkspacePublisher;
 use DataMachineCode\Workspace\Workspace;
 use DataMachineCode\Workspace\WorkspaceAbandonedCleanupOrchestrator;
+use DataMachineCode\Workspace\WorkspaceCleanupEligibleDrainOrchestrator;
 use DataMachineCode\Workspace\WorkspaceReader;
 use DataMachineCode\Workspace\WorkspaceWriter;
 use DataMachineCode\Support\GitRunner;
@@ -2424,6 +2425,35 @@ class WorkspaceAbilities {
 			);
 
 			AbilityRegistry::register(
+				'datamachine-code/workspace-worktree-cleanup-eligible-drain',
+				array(
+					'label'               => 'Drain Cleanup-Eligible Worktrees',
+					'description'         => 'Repeat the bounded cleanup-eligible apply primitive until no safe candidates remain, the pass limit is reached, or the time budget expires. Defaults to preview mode and never discards unpushed commits.',
+					'category'            => 'datamachine-code-workspace',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'apply'                     => array( 'type' => 'boolean' ),
+							'force'                     => array( 'type' => 'boolean' ),
+							'limit'                     => array( 'type' => 'integer' ),
+							'passes'                    => array( 'type' => 'integer' ),
+							'until_budget'              => array( 'type' => 'string' ),
+							'older_than'                => array( 'type' => 'string' ),
+							'sort'                      => array( 'type' => 'string' ),
+							'remove_timeout'            => array( 'type' => 'integer' ),
+							'include_repaired_metadata' => array( 'type' => 'boolean' ),
+							'discard_unpushed'          => array( 'type' => 'boolean' ),
+							'source'                    => array( 'type' => 'string' ),
+						),
+					),
+					'output_schema'       => array( 'type' => 'object' ),
+					'execute_callback'    => array( self::class, 'worktreeCleanupEligibleDrain' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			AbilityRegistry::register(
 				'datamachine-code/workspace-cleanup-plan',
 				array(
 					'label'               => 'Build DB-backed Workspace Cleanup Plan',
@@ -4281,6 +4311,18 @@ class WorkspaceAbilities {
 		}
 
 		return $workspace->worktree_bounded_cleanup_eligible_apply($opts);
+	}
+
+	/**
+	 * Drain cleanup-eligible worktrees with repeated bounded apply passes.
+	 *
+	 * @param  array $input Input parameters.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public static function worktreeCleanupEligibleDrain( array $input ): array|\WP_Error {
+		$orchestrator = new WorkspaceCleanupEligibleDrainOrchestrator();
+
+		return $orchestrator->run($input);
 	}
 
 	/**

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -3640,7 +3640,7 @@ class WorkspaceCommand extends BaseCommand {
 
 		$input         = array();
 		$input_builder = (string) ( $operation_config['input_builder'] ?? '' );
-		if ( '' !== $input_builder && method_exists($this, $input_builder) ) {
+		if ( '' !== $input_builder ) {
 			$input = $this->{$input_builder}($operation, $assoc_args);
 		}
 
@@ -6059,19 +6059,47 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 
-		$summary = (array) ( $result['summary'] ?? array() );
+		$summary          = (array) ( $result['summary'] ?? array() );
+		$final_free_space = (array) ( $summary['final_free_space'] ?? array() );
 		WP_CLI::log('Cleanup-eligible drain summary:');
 		$this->format_items(
 			array(
-				array( 'metric' => 'mode', 'value' => ! empty($result['applied']) ? 'apply' : 'preview' ),
-				array( 'metric' => 'passes', 'value' => (int) ( $summary['passes'] ?? 0 ) ),
-				array( 'metric' => 'processed', 'value' => (int) ( $summary['processed'] ?? 0 ) ),
-				array( 'metric' => 'would_remove', 'value' => (int) ( $summary['would_remove'] ?? 0 ) ),
-				array( 'metric' => 'removed', 'value' => (int) ( $summary['removed'] ?? 0 ) ),
-				array( 'metric' => 'skipped', 'value' => (int) ( $summary['skipped'] ?? 0 ) ),
-				array( 'metric' => 'bytes_reclaimed', 'value' => $this->format_bytes($summary['bytes_reclaimed'] ?? 0) ),
-				array( 'metric' => 'stop_reason', 'value' => (string) ( $summary['stop_reason'] ?? '' ) ),
-				array( 'metric' => 'final_free_space', 'value' => (string) ( (array) ( $summary['final_free_space'] ?? array() )['free_human'] ?? 'unknown' ) ),
+				array(
+					'metric' => 'mode',
+					'value'  => ! empty($result['applied']) ? 'apply' : 'preview',
+				),
+				array(
+					'metric' => 'passes',
+					'value'  => (int) ( $summary['passes'] ?? 0 ),
+				),
+				array(
+					'metric' => 'processed',
+					'value'  => (int) ( $summary['processed'] ?? 0 ),
+				),
+				array(
+					'metric' => 'would_remove',
+					'value'  => (int) ( $summary['would_remove'] ?? 0 ),
+				),
+				array(
+					'metric' => 'removed',
+					'value'  => (int) ( $summary['removed'] ?? 0 ),
+				),
+				array(
+					'metric' => 'skipped',
+					'value'  => (int) ( $summary['skipped'] ?? 0 ),
+				),
+				array(
+					'metric' => 'bytes_reclaimed',
+					'value'  => $this->format_bytes( (int) ( $summary['bytes_reclaimed'] ?? 0 ) ),
+				),
+				array(
+					'metric' => 'stop_reason',
+					'value'  => (string) ( $summary['stop_reason'] ?? '' ),
+				),
+				array(
+					'metric' => 'final_free_space',
+					'value'  => (string) ( $final_free_space['free_human'] ?? 'unknown' ),
+				),
 			),
 			array( 'metric', 'value' ),
 			array( 'format' => 'table' ),

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -47,6 +47,7 @@ class WorkspaceCommand extends BaseCommand {
 		'cleanup'                                 => array( 'ability' => 'datamachine-code/workspace-worktree-cleanup' ),
 		'cleanup-artifacts'                       => array( 'ability' => 'datamachine-code/workspace-worktree-cleanup-artifacts' ),
 		'bounded-cleanup-eligible-apply'          => array( 'ability' => 'datamachine-code/workspace-worktree-bounded-cleanup-eligible-apply' ),
+		'cleanup-eligible-drain'                  => array( 'ability' => 'datamachine-code/workspace-worktree-cleanup-eligible-drain' ),
 		'emergency-cleanup'                       => array( 'ability' => 'datamachine-code/workspace-worktree-emergency-cleanup' ),
 		'reconcile-metadata'                      => array( 'ability' => 'datamachine-code/workspace-worktree-reconcile-metadata' ),
 		'active-no-signal-report'                 => array(
@@ -3190,7 +3191,7 @@ class WorkspaceCommand extends BaseCommand {
 	 *
 	 * <operation>
 	 * : Worktree operation: add, list, remove, prune, locks, cleanup, cleanup-artifacts,
-	 *   bounded-cleanup-eligible-apply, emergency-cleanup, reconcile-metadata,
+	 *   bounded-cleanup-eligible-apply, cleanup-eligible-drain, emergency-cleanup, reconcile-metadata,
 	 *   active-no-signal-report, active-no-signal-finalized-apply,
 	 *   active-no-signal-equivalent-clean-apply,
 	 *   active-no-signal-merged-apply, active-no-signal-remote-clean-apply,
@@ -3337,7 +3338,8 @@ class WorkspaceCommand extends BaseCommand {
 	 * [--discard-unpushed]
 	 * : With bounded-cleanup-eligible-apply only, explicitly discard unpushed
 	 *   commits after reviewed cleanup eligibility and fresh safety probes. This
-	 *   is a data-loss mode and is not implied by --force.
+	 *   is a data-loss mode and is not implied by --force. Cleanup-eligible-drain
+	 *   refuses this option.
 	 *
 	 * [--older-than=<duration>]
 	 * : Limit cleanup candidates to worktrees with lifecycle `created_at`
@@ -3393,7 +3395,8 @@ class WorkspaceCommand extends BaseCommand {
 	 *
 	 * [--passes=<count>]
 	 * : For `abandoned`, maximum apply passes to run after marking eligible rows.
-	 *   Preview mode always runs a single non-destructive classification pass.
+	 *   For `cleanup-eligible-drain`, maximum bounded cleanup-eligible apply
+	 *   passes to run. Preview mode always runs one non-destructive pass.
 	 *
 	 * [--stage=<stage>]
 	 * : For `abandoned`, resume from a specific orchestration stage. Supported
@@ -3406,7 +3409,7 @@ class WorkspaceCommand extends BaseCommand {
 	 *   passing the previous response's `pagination.next_offset`.
 	 *
 	 * [--until-budget=<duration>]
-	 * : For `cleanup --dry-run` and `reconcile-metadata`, enforce a compact
+	 * : For `cleanup --dry-run`, `cleanup-eligible-drain`, and `reconcile-metadata`, enforce a compact
 	 *   wall-clock budget for dry-run pages or direct-apply drains (e.g. 60s,
 	 *   10m). Also supported by `active-no-signal-report` and the active/no-signal
 	 *   apply flows. Returns continuation
@@ -3503,6 +3506,8 @@ class WorkspaceCommand extends BaseCommand {
 	 *     wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --via-jobs --limit=10 --older-than=7d
 	 *     wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --dry-run --include-repaired-metadata --older-than=7d --limit=25
 	 *     wp datamachine-code workspace worktree bounded-cleanup-eligible-apply --include-repaired-metadata --older-than=7d --limit=25
+	 *     wp datamachine-code workspace worktree cleanup-eligible-drain --limit=25 --format=json
+	 *     wp datamachine-code workspace worktree cleanup-eligible-drain --apply --limit=25 --passes=10 --until-budget=120s --format=json
 	 *
 	 *     # Local-only detection (no GitHub API call)
 	 *     wp datamachine-code workspace worktree cleanup --skip-github
@@ -3560,7 +3565,7 @@ class WorkspaceCommand extends BaseCommand {
 		$operation = $args[0] ?? '';
 
 		if ( '' === $operation ) {
-			WP_CLI::error('Usage: wp datamachine-code workspace worktree <add|list|remove|prune|locks|cleanup|cleanup-artifacts|abandoned|bounded-cleanup-eligible-apply|emergency-cleanup|reconcile-metadata|backfill-origin-session|active-no-signal-report|active-no-signal-finalized-apply|active-no-signal-equivalent-clean-apply|active-no-signal-merged-apply|active-no-signal-remote-clean-apply|refresh-context|finalize|mark-cleanup-eligible> [<repo>] [<branch>] [--flags]');
+			WP_CLI::error('Usage: wp datamachine-code workspace worktree <add|list|remove|prune|locks|cleanup|cleanup-artifacts|abandoned|bounded-cleanup-eligible-apply|cleanup-eligible-drain|emergency-cleanup|reconcile-metadata|backfill-origin-session|active-no-signal-report|active-no-signal-finalized-apply|active-no-signal-equivalent-clean-apply|active-no-signal-merged-apply|active-no-signal-remote-clean-apply|refresh-context|finalize|mark-cleanup-eligible> [<repo>] [<branch>] [--flags]');
 			return;
 		}
 
@@ -3875,6 +3880,24 @@ class WorkspaceCommand extends BaseCommand {
 				}
 				if ( isset($assoc_args['remove-timeout']) && '' !== trim( (string) $assoc_args['remove-timeout']) ) {
 					$input['remove_timeout'] = (int) $assoc_args['remove-timeout'];
+				}
+				break;
+
+			case 'cleanup-eligible-drain':
+				$input['apply']                     = ! empty($assoc_args['apply']);
+				$input['force']                     = ! empty($assoc_args['force']);
+				$input['discard_unpushed']          = ! empty($assoc_args['discard-unpushed']);
+				$input['include_repaired_metadata'] = ! empty($assoc_args['include-repaired-metadata']);
+				$input['source']                    = self::CLEANUP_CLI_SOURCE;
+				foreach ( array( 'limit', 'passes', 'remove-timeout' ) as $key ) {
+					if ( isset($assoc_args[ $key ]) ) {
+						$input[ str_replace('-', '_', $key) ] = (int) $assoc_args[ $key ];
+					}
+				}
+				foreach ( array( 'older-than', 'sort', 'until-budget' ) as $key ) {
+					if ( isset($assoc_args[ $key ]) && '' !== trim( (string) $assoc_args[ $key ]) ) {
+						$input[ str_replace('-', '_', $key) ] = trim( (string) $assoc_args[ $key ]);
+					}
 				}
 				break;
 		}
@@ -4260,6 +4283,10 @@ class WorkspaceCommand extends BaseCommand {
 
 			case 'bounded-cleanup-eligible-apply':
 				$this->render_worktree_bounded_cleanup_eligible_apply_result($result, $assoc_args);
+				return;
+
+			case 'cleanup-eligible-drain':
+				$this->render_worktree_cleanup_eligible_drain_result($result, $assoc_args);
 				return;
 
 			case 'emergency-cleanup':
@@ -6016,6 +6043,67 @@ class WorkspaceCommand extends BaseCommand {
 			WP_CLI::success(sprintf('Bounded cleanup-eligible apply scheduled %d cleanup chunk job(s).', (int) ( $summary['scheduled_jobs'] ?? 0 )));
 		} else {
 			WP_CLI::success(sprintf('Bounded cleanup-eligible apply removed %d worktree(s); reclaimed %s.', (int) ( $summary['removed'] ?? 0 ), $this->format_bytes($summary['bytes_reclaimed'] ?? 0)));
+		}
+	}
+
+	/**
+	 * Render cleanup-eligible drain output.
+	 *
+	 * @param  array $result     Drain result.
+	 * @param  array $assoc_args CLI args.
+	 * @return void
+	 */
+	private function render_worktree_cleanup_eligible_drain_result( array $result, array $assoc_args ): void {
+		if ( 'json' === (string) ( $assoc_args['format'] ?? '' ) ) {
+			$this->renderer()->json($result);
+			return;
+		}
+
+		$summary = (array) ( $result['summary'] ?? array() );
+		WP_CLI::log('Cleanup-eligible drain summary:');
+		$this->format_items(
+			array(
+				array( 'metric' => 'mode', 'value' => ! empty($result['applied']) ? 'apply' : 'preview' ),
+				array( 'metric' => 'passes', 'value' => (int) ( $summary['passes'] ?? 0 ) ),
+				array( 'metric' => 'processed', 'value' => (int) ( $summary['processed'] ?? 0 ) ),
+				array( 'metric' => 'would_remove', 'value' => (int) ( $summary['would_remove'] ?? 0 ) ),
+				array( 'metric' => 'removed', 'value' => (int) ( $summary['removed'] ?? 0 ) ),
+				array( 'metric' => 'skipped', 'value' => (int) ( $summary['skipped'] ?? 0 ) ),
+				array( 'metric' => 'bytes_reclaimed', 'value' => $this->format_bytes($summary['bytes_reclaimed'] ?? 0) ),
+				array( 'metric' => 'stop_reason', 'value' => (string) ( $summary['stop_reason'] ?? '' ) ),
+				array( 'metric' => 'final_free_space', 'value' => (string) ( (array) ( $summary['final_free_space'] ?? array() )['free_human'] ?? 'unknown' ) ),
+			),
+			array( 'metric', 'value' ),
+			array( 'format' => 'table' ),
+			'metric'
+		);
+
+		$passes = (array) ( $result['pass_results'] ?? array() );
+		if ( ! empty($passes) ) {
+			WP_CLI::log('');
+			WP_CLI::log('Pass evidence:');
+			$this->format_items(
+				array_map(
+					fn( $row ) => array(
+						'pass'            => (int) ( $row['pass'] ?? 0 ),
+						'processed'       => (int) ( $row['processed'] ?? 0 ),
+						'would_remove'    => (int) ( $row['would_remove'] ?? 0 ),
+						'removed'         => (int) ( $row['removed'] ?? 0 ),
+						'skipped'         => (int) ( $row['skipped'] ?? 0 ),
+						'remaining_total' => (int) ( $row['remaining_total'] ?? 0 ),
+						'bytes'           => $this->format_bytes($row['bytes_reclaimed'] ?? 0),
+					),
+					$passes
+				),
+				array( 'pass', 'processed', 'would_remove', 'removed', 'skipped', 'remaining_total', 'bytes' ),
+				array( 'format' => 'table' ),
+				'pass'
+			);
+		}
+
+		if ( ! empty($result['next_commands']) ) {
+			WP_CLI::log('');
+			WP_CLI::log('Next command: ' . (string) ( (array) $result['next_commands'] )[0]);
 		}
 	}
 

--- a/inc/Workspace/WorkspaceCleanupEligibleDrainOrchestrator.php
+++ b/inc/Workspace/WorkspaceCleanupEligibleDrainOrchestrator.php
@@ -1,0 +1,253 @@
+<?php
+/**
+ * Cleanup-eligible worktree drain orchestration.
+ *
+ * @package DataMachineCode\Workspace
+ */
+
+namespace DataMachineCode\Workspace;
+
+defined('ABSPATH') || exit;
+
+/**
+ * Repeats the bounded cleanup-eligible primitive until it has no safe rows left.
+ */
+class WorkspaceCleanupEligibleDrainOrchestrator {
+
+	private const DEFAULT_SOURCE = 'workspace_cleanup_eligible_drain';
+
+	/** @var callable */
+	private $ability_resolver;
+
+	/** @var callable */
+	private $clock;
+
+	/** @var callable */
+	private $disk_reporter;
+
+	/**
+	 * @param callable|null $ability_resolver Optional resolver receiving an ability name.
+	 * @param callable|null $clock            Optional clock returning microtime-style seconds.
+	 * @param callable|null $disk_reporter    Optional reporter receiving workspace path.
+	 */
+	public function __construct( ?callable $ability_resolver = null, ?callable $clock = null, ?callable $disk_reporter = null ) {
+		$this->ability_resolver = $ability_resolver ? $ability_resolver : static fn( string $name ) => function_exists('wp_get_ability') ? wp_get_ability($name) : null;
+		$this->clock            = $clock ? $clock : static fn(): float => microtime(true);
+		$this->disk_reporter    = $disk_reporter ? $disk_reporter : array( $this, 'build_disk_report' );
+	}
+
+	/**
+	 * Drain cleanup-eligible rows through the bounded cleanup primitive.
+	 *
+	 * @param  array<string,mixed> $input Orchestration input.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function run( array $input ): array|\WP_Error {
+		$apply                     = ! empty($input['apply']);
+		$force                     = ! empty($input['force']);
+		$include_repaired_metadata = ! empty($input['include_repaired_metadata']);
+		$limit                     = isset($input['limit']) ? max(1, min(200, (int) $input['limit'])) : 25;
+		$passes                    = isset($input['passes']) ? max(1, min(100, (int) $input['passes'])) : 10;
+		$source                    = isset($input['source']) && '' !== trim( (string) $input['source']) ? trim( (string) $input['source']) : self::DEFAULT_SOURCE;
+		$deadline                  = null;
+		$started_at                = $this->now();
+
+		if ( ! empty($input['discard_unpushed']) ) {
+			return new \WP_Error('cleanup_eligible_drain_refuses_unpushed_discard', 'Cleanup-eligible drain will not discard unpushed commits. Use the bounded single-batch command explicitly for that data-loss mode.', array( 'status' => 400 ));
+		}
+
+		if ( isset($input['until_budget']) && '' !== trim( (string) $input['until_budget']) ) {
+			$budget_seconds = $this->parse_budget(trim( (string) $input['until_budget']));
+			if ( is_wp_error($budget_seconds) ) {
+				return $budget_seconds;
+			}
+			$deadline = $started_at + $budget_seconds;
+		}
+
+		$ability = ( $this->ability_resolver )('datamachine-code/workspace-worktree-bounded-cleanup-eligible-apply');
+		if ( ! $ability || ! is_callable(array( $ability, 'execute' )) ) {
+			return new \WP_Error('cleanup_eligible_drain_ability_missing', 'Bounded cleanup-eligible apply ability is not available.', array( 'status' => 500 ));
+		}
+
+		$result = array(
+			'success'      => true,
+			'mode'         => 'cleanup_eligible_drain',
+			'applied'      => $apply,
+			'destructive'  => $apply,
+			'force'        => $force,
+			'limit'        => $limit,
+			'passes'       => $passes,
+			'generated_at' => gmdate('c'),
+			'pass_results' => array(),
+			'summary'      => array(
+				'passes'          => 0,
+				'processed'       => 0,
+				'would_remove'    => 0,
+				'removed'         => 0,
+				'skipped'         => 0,
+				'bytes_reclaimed' => 0,
+			),
+			'evidence'     => array(
+				'safety' => $apply
+					? 'Repeats bounded cleanup-eligible apply only; unpushed commits remain protected and discard_unpushed is refused.'
+					: 'Preview only. Re-run with --apply to drain cleanup-eligible worktrees.',
+			),
+		);
+
+		$effective_passes = $apply ? $passes : 1;
+		$workspace_path   = '';
+		$stop_reason      = 'pass_limit';
+
+		for ( $pass = 1; $pass <= $effective_passes; ++$pass ) {
+			if ( $this->budget_expired($deadline) ) {
+				$stop_reason = 'budget_exhausted';
+				break;
+			}
+
+			$pass_input = array(
+				'dry_run'                   => ! $apply,
+				'force'                     => $force,
+				'limit'                     => $limit,
+				'include_repaired_metadata' => $include_repaired_metadata,
+				'source'                    => $source,
+			);
+			foreach ( array( 'older_than', 'sort', 'remove_timeout' ) as $key ) {
+				if ( isset($input[ $key ]) && '' !== trim( (string) $input[ $key ]) ) {
+					$pass_input[ $key ] = $input[ $key ];
+				}
+			}
+
+			$pass_result = $ability->execute($pass_input);
+			if ( is_wp_error($pass_result) ) {
+				return $pass_result;
+			}
+			if ( ! is_array($pass_result) ) {
+				return new \WP_Error('cleanup_eligible_drain_invalid_result', 'Bounded cleanup-eligible apply returned an invalid result.', array( 'status' => 500 ));
+			}
+
+			$workspace_path = '' !== $workspace_path ? $workspace_path : (string) ( $pass_result['workspace_path'] ?? '' );
+			$summary        = (array) ( $pass_result['summary'] ?? array() );
+			$continuation   = (array) ( $pass_result['continuation'] ?? array() );
+			$evidence       = (array) ( $pass_result['evidence'] ?? array() );
+			$pass_summary   = array(
+				'pass'               => $pass,
+				'dry_run'            => ! empty($pass_result['dry_run']),
+				'processed'          => (int) ( $summary['processed'] ?? 0 ),
+				'would_remove'       => ! empty($pass_result['dry_run']) ? count( (array) ( $pass_result['candidates'] ?? array() ) ) : 0,
+				'removed'            => (int) ( $summary['removed'] ?? 0 ),
+				'skipped'            => (int) ( $summary['skipped'] ?? 0 ),
+				'bytes_reclaimed'    => (int) ( $summary['bytes_reclaimed'] ?? 0 ),
+				'remaining_total'    => (int) ( $continuation['remaining_total'] ?? 0 ),
+				'elapsed_ms'         => (int) ( $evidence['elapsed_ms'] ?? 0 ),
+				'removed_handles'    => array_values(array_filter(array_map(fn( $row ) => is_array($row) ? (string) ( $row['handle'] ?? '' ) : '', (array) ( $pass_result['removed'] ?? array() )))),
+				'candidate_handles'  => array_values(array_filter(array_map(fn( $row ) => is_array($row) ? (string) ( $row['handle'] ?? '' ) : '', (array) ( $pass_result['candidates'] ?? array() )))),
+				'skipped_by_reason'  => $this->summarize_skipped((array) ( $pass_result['skipped'] ?? array() )),
+			);
+
+			$result['pass_results'][] = $pass_summary;
+			++$result['summary']['passes'];
+			$result['summary']['processed']       += $pass_summary['processed'];
+			$result['summary']['would_remove']    += $pass_summary['would_remove'];
+			$result['summary']['removed']         += $pass_summary['removed'];
+			$result['summary']['skipped']         += $pass_summary['skipped'];
+			$result['summary']['bytes_reclaimed'] += $pass_summary['bytes_reclaimed'];
+
+			if ( ! $apply ) {
+				$stop_reason = 'preview';
+				break;
+			}
+			if ( 0 === $pass_summary['removed'] ) {
+				$stop_reason = 'empty';
+				break;
+			}
+			if ( 0 === $pass_summary['remaining_total'] && $pass_summary['removed'] < $limit ) {
+				$stop_reason = 'empty';
+				break;
+			}
+		}
+
+		if ( 'pass_limit' === $stop_reason && $this->budget_expired($deadline) ) {
+			$stop_reason = 'budget_exhausted';
+		}
+
+		$result['summary']['stop_reason']       = $stop_reason;
+		$result['summary']['final_free_space']  = ( $this->disk_reporter )($workspace_path);
+		$result['evidence']['elapsed_ms']       = (int) round(( $this->now() - $started_at ) * 1000);
+		$result['evidence']['budget_exhausted'] = 'budget_exhausted' === $stop_reason;
+
+		if ( ! $apply ) {
+			$result['next_commands'][] = sprintf('studio wp datamachine-code workspace worktree cleanup-eligible-drain --apply --limit=%d --passes=%d --format=json', $limit, $passes);
+		} elseif ( 'pass_limit' === $stop_reason ) {
+			$result['next_commands'][] = sprintf('studio wp datamachine-code workspace worktree cleanup-eligible-drain --apply --limit=%d --passes=%d --format=json', $limit, $passes);
+		}
+
+		return $result;
+	}
+
+	private function now(): float {
+		return (float) ( $this->clock )();
+	}
+
+	private function parse_budget( string $duration ): int|\WP_Error {
+		if ( ! preg_match('/^(\d+)([smh])$/', trim($duration), $matches) ) {
+			return new \WP_Error('invalid_cleanup_eligible_drain_budget', 'Invalid until_budget duration. Use a compact value like 60s, 10m, or 1h.', array( 'status' => 400 ));
+		}
+
+		$value = (int) $matches[1];
+		if ( $value < 1 ) {
+			return new \WP_Error('invalid_cleanup_eligible_drain_budget', 'Invalid until_budget duration. Duration must be greater than zero.', array( 'status' => 400 ));
+		}
+
+		return match ( $matches[2] ) {
+			'h' => $value * HOUR_IN_SECONDS,
+			'm' => $value * MINUTE_IN_SECONDS,
+			default => $value,
+		};
+	}
+
+	private function budget_expired( ?float $deadline ): bool {
+		return null !== $deadline && $this->now() >= $deadline;
+	}
+
+	/** @param array<int,array<string,mixed>> $rows */
+	private function summarize_skipped( array $rows ): array {
+		$summary = array();
+		foreach ( $rows as $row ) {
+			$reason = is_array($row) ? (string) ( $row['reason_code'] ?? 'unknown' ) : 'unknown';
+			$summary[ $reason ] = (int) ( $summary[ $reason ] ?? 0 ) + 1;
+		}
+		return $summary;
+	}
+
+	/** @return array<string,mixed> */
+	private function build_disk_report( string $workspace_path ): array {
+		if ( '' === $workspace_path || ! is_dir($workspace_path) ) {
+			return array(
+				'path'        => $workspace_path,
+				'free_bytes'  => null,
+				'free_human'  => 'unknown',
+				'total_bytes' => null,
+			);
+		}
+
+		$free  = disk_free_space($workspace_path); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_disk_free_space
+		$total = disk_total_space($workspace_path); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_disk_total_space
+		return array(
+			'path'        => $workspace_path,
+			'free_bytes'  => false === $free ? null : (int) $free,
+			'free_human'  => false === $free ? 'unknown' : $this->format_bytes((int) $free),
+			'total_bytes' => false === $total ? null : (int) $total,
+		);
+	}
+
+	private function format_bytes( int $bytes ): string {
+		$units = array( 'B', 'KiB', 'MiB', 'GiB', 'TiB' );
+		$value = (float) max(0, $bytes);
+		$unit  = 0;
+		while ( $value >= 1024 && $unit < count($units) - 1 ) {
+			$value /= 1024;
+			++$unit;
+		}
+		return sprintf('%.1f %s', $value, $units[ $unit ]);
+	}
+}

--- a/inc/Workspace/WorkspaceCleanupEligibleDrainOrchestrator.php
+++ b/inc/Workspace/WorkspaceCleanupEligibleDrainOrchestrator.php
@@ -65,7 +65,7 @@ class WorkspaceCleanupEligibleDrainOrchestrator {
 		}
 
 		$ability = ( $this->ability_resolver )('datamachine-code/workspace-worktree-bounded-cleanup-eligible-apply');
-		if ( ! $ability || ! is_callable(array( $ability, 'execute' )) ) {
+		if ( ! is_object($ability) || ! is_callable(array( $ability, 'execute' )) ) {
 			return new \WP_Error('cleanup_eligible_drain_ability_missing', 'Bounded cleanup-eligible apply ability is not available.', array( 'status' => 500 ));
 		}
 
@@ -130,18 +130,18 @@ class WorkspaceCleanupEligibleDrainOrchestrator {
 			$continuation   = (array) ( $pass_result['continuation'] ?? array() );
 			$evidence       = (array) ( $pass_result['evidence'] ?? array() );
 			$pass_summary   = array(
-				'pass'               => $pass,
-				'dry_run'            => ! empty($pass_result['dry_run']),
-				'processed'          => (int) ( $summary['processed'] ?? 0 ),
-				'would_remove'       => ! empty($pass_result['dry_run']) ? count( (array) ( $pass_result['candidates'] ?? array() ) ) : 0,
-				'removed'            => (int) ( $summary['removed'] ?? 0 ),
-				'skipped'            => (int) ( $summary['skipped'] ?? 0 ),
-				'bytes_reclaimed'    => (int) ( $summary['bytes_reclaimed'] ?? 0 ),
-				'remaining_total'    => (int) ( $continuation['remaining_total'] ?? 0 ),
-				'elapsed_ms'         => (int) ( $evidence['elapsed_ms'] ?? 0 ),
-				'removed_handles'    => array_values(array_filter(array_map(fn( $row ) => is_array($row) ? (string) ( $row['handle'] ?? '' ) : '', (array) ( $pass_result['removed'] ?? array() )))),
-				'candidate_handles'  => array_values(array_filter(array_map(fn( $row ) => is_array($row) ? (string) ( $row['handle'] ?? '' ) : '', (array) ( $pass_result['candidates'] ?? array() )))),
-				'skipped_by_reason'  => $this->summarize_skipped((array) ( $pass_result['skipped'] ?? array() )),
+				'pass'              => $pass,
+				'dry_run'           => ! empty($pass_result['dry_run']),
+				'processed'         => (int) ( $summary['processed'] ?? 0 ),
+				'would_remove'      => ! empty($pass_result['dry_run']) ? count( (array) ( $pass_result['candidates'] ?? array() ) ) : 0,
+				'removed'           => (int) ( $summary['removed'] ?? 0 ),
+				'skipped'           => (int) ( $summary['skipped'] ?? 0 ),
+				'bytes_reclaimed'   => (int) ( $summary['bytes_reclaimed'] ?? 0 ),
+				'remaining_total'   => (int) ( $continuation['remaining_total'] ?? 0 ),
+				'elapsed_ms'        => (int) ( $evidence['elapsed_ms'] ?? 0 ),
+				'removed_handles'   => array_values(array_filter(array_map(fn( $row ) => is_array($row) ? (string) ( $row['handle'] ?? '' ) : '', (array) ( $pass_result['removed'] ?? array() )))),
+				'candidate_handles' => array_values(array_filter(array_map(fn( $row ) => is_array($row) ? (string) ( $row['handle'] ?? '' ) : '', (array) ( $pass_result['candidates'] ?? array() )))),
+				'skipped_by_reason' => $this->summarize_skipped( (array) ( $pass_result['skipped'] ?? array() ) ),
 			);
 
 			$result['pass_results'][] = $pass_summary;
@@ -213,7 +213,7 @@ class WorkspaceCleanupEligibleDrainOrchestrator {
 	private function summarize_skipped( array $rows ): array {
 		$summary = array();
 		foreach ( $rows as $row ) {
-			$reason = is_array($row) ? (string) ( $row['reason_code'] ?? 'unknown' ) : 'unknown';
+			$reason             = (string) ( $row['reason_code'] ?? 'unknown' );
 			$summary[ $reason ] = (int) ( $summary[ $reason ] ?? 0 ) + 1;
 		}
 		return $summary;
@@ -235,16 +235,17 @@ class WorkspaceCleanupEligibleDrainOrchestrator {
 		return array(
 			'path'        => $workspace_path,
 			'free_bytes'  => false === $free ? null : (int) $free,
-			'free_human'  => false === $free ? 'unknown' : $this->format_bytes((int) $free),
+			'free_human'  => false === $free ? 'unknown' : $this->format_bytes( (int) $free ),
 			'total_bytes' => false === $total ? null : (int) $total,
 		);
 	}
 
 	private function format_bytes( int $bytes ): string {
-		$units = array( 'B', 'KiB', 'MiB', 'GiB', 'TiB' );
-		$value = (float) max(0, $bytes);
-		$unit  = 0;
-		while ( $value >= 1024 && $unit < count($units) - 1 ) {
+		$units      = array( 'B', 'KiB', 'MiB', 'GiB', 'TiB' );
+		$value      = (float) max(0, $bytes);
+		$unit       = 0;
+		$unit_count = count($units);
+		while ( $value >= 1024 && $unit < $unit_count - 1 ) {
 			$value /= 1024;
 			++$unit;
 		}

--- a/tests/smoke-cleanup-eligible-drain.php
+++ b/tests/smoke-cleanup-eligible-drain.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Standalone smoke coverage for WorkspaceCleanupEligibleDrainOrchestrator.
+ */
+
+define('ABSPATH', dirname(__DIR__));
+defined('HOUR_IN_SECONDS') || define('HOUR_IN_SECONDS', 3600);
+defined('MINUTE_IN_SECONDS') || define('MINUTE_IN_SECONDS', 60);
+
+if ( ! class_exists('WP_Error') ) {
+	class WP_Error {
+		public string $code;
+		public string $message;
+		public array $data;
+
+		public function __construct( string $code = '', string $message = '', array $data = array() ) {
+			$this->code    = $code;
+			$this->message = $message;
+			$this->data    = $data;
+		}
+	}
+}
+
+if ( ! function_exists('is_wp_error') ) {
+	function is_wp_error( mixed $thing ): bool {
+		return $thing instanceof WP_Error;
+	}
+}
+
+require_once dirname(__DIR__) . '/inc/Workspace/WorkspaceCleanupEligibleDrainOrchestrator.php';
+
+final class CleanupEligibleDrainFakeAbility {
+	/** @var array<int,array<string,mixed>> */
+	public array $calls = array();
+
+	/** @param array<int,array<string,mixed>> $responses */
+	public function __construct( private array $responses ) {}
+
+	/** @return array<string,mixed> */
+	public function execute( array $input ): array {
+		$this->calls[] = $input;
+		$response      = array_shift($this->responses) ?: array( 'processed' => 0, 'removed' => 0, 'remaining_total' => 0 );
+		$removed_count = (int) ( $response['removed'] ?? 0 );
+		$candidates    = array();
+		$removed       = array();
+		for ( $i = 0; $i < (int) ( $response['processed'] ?? $removed_count ); ++$i ) {
+			$candidates[] = array( 'handle' => 'repo@candidate-' . count($this->calls) . '-' . $i );
+		}
+		for ( $i = 0; $i < $removed_count; ++$i ) {
+			$removed[] = array(
+				'handle'     => 'repo@removed-' . count($this->calls) . '-' . $i,
+				'size_bytes' => 100,
+			);
+		}
+
+		return array(
+			'success'        => true,
+			'mode'           => 'bounded_cleanup_eligible_apply',
+			'dry_run'        => ! empty($input['dry_run']),
+			'destructive'    => empty($input['dry_run']),
+			'workspace_path' => '/tmp/workspace',
+			'candidates'     => $candidates,
+			'removed'        => $removed,
+			'skipped'        => array(),
+			'summary'        => array(
+				'processed'       => (int) ( $response['processed'] ?? count($candidates) ),
+				'removed'         => $removed_count,
+				'skipped'         => 0,
+				'bytes_reclaimed' => $removed_count * 100,
+			),
+			'continuation'   => array( 'remaining_total' => (int) ( $response['remaining_total'] ?? 0 ) ),
+			'evidence'       => array( 'elapsed_ms' => 1 ),
+		);
+	}
+}
+
+function cleanup_eligible_drain_assert( bool $condition, string $label ): void {
+	if ( ! $condition ) {
+		fwrite(STDERR, 'failed: ' . $label . PHP_EOL);
+		exit(1);
+	}
+}
+
+$disk_reporter = static fn(): array => array(
+	'path'       => '/tmp/workspace',
+	'free_bytes' => 123,
+	'free_human' => '123.0 B',
+);
+
+$preview_ability = new CleanupEligibleDrainFakeAbility(array( array( 'processed' => 2, 'removed' => 0, 'remaining_total' => 3 ) ));
+$orchestrator    = new DataMachineCode\Workspace\WorkspaceCleanupEligibleDrainOrchestrator(
+	static fn( string $name ) => 'datamachine-code/workspace-worktree-bounded-cleanup-eligible-apply' === $name ? $preview_ability : null,
+	static fn(): float => 1000.0,
+	$disk_reporter
+);
+$preview         = $orchestrator->run(array( 'passes' => 5 ));
+cleanup_eligible_drain_assert(! is_wp_error($preview), 'preview succeeds');
+cleanup_eligible_drain_assert(false === $preview['applied'], 'preview is non-destructive');
+cleanup_eligible_drain_assert(1 === count($preview_ability->calls), 'preview runs one pass');
+cleanup_eligible_drain_assert('preview' === $preview['summary']['stop_reason'], 'preview stop reason');
+cleanup_eligible_drain_assert(2 === $preview['summary']['would_remove'], 'preview counts would-remove candidates');
+
+$empty_ability = new CleanupEligibleDrainFakeAbility(
+	array(
+		array( 'processed' => 2, 'removed' => 2, 'remaining_total' => 1 ),
+		array( 'processed' => 1, 'removed' => 1, 'remaining_total' => 0 ),
+	)
+);
+$orchestrator  = new DataMachineCode\Workspace\WorkspaceCleanupEligibleDrainOrchestrator(
+	static fn() => $empty_ability,
+	static fn(): float => 1000.0,
+	$disk_reporter
+);
+$empty         = $orchestrator->run(array( 'apply' => true, 'limit' => 25, 'passes' => 5 ));
+cleanup_eligible_drain_assert(! is_wp_error($empty), 'empty drain succeeds');
+cleanup_eligible_drain_assert(2 === count($empty_ability->calls), 'drain stops after empty pass');
+cleanup_eligible_drain_assert('empty' === $empty['summary']['stop_reason'], 'empty stop reason');
+cleanup_eligible_drain_assert(3 === $empty['summary']['removed'], 'removed count accumulates');
+cleanup_eligible_drain_assert(123 === $empty['summary']['final_free_space']['free_bytes'], 'final free space included');
+
+$limit_ability = new CleanupEligibleDrainFakeAbility(
+	array(
+		array( 'processed' => 1, 'removed' => 1, 'remaining_total' => 10 ),
+		array( 'processed' => 1, 'removed' => 1, 'remaining_total' => 9 ),
+	)
+);
+$orchestrator  = new DataMachineCode\Workspace\WorkspaceCleanupEligibleDrainOrchestrator(
+	static fn() => $limit_ability,
+	static fn(): float => 1000.0,
+	$disk_reporter
+);
+$limited       = $orchestrator->run(array( 'apply' => true, 'passes' => 2 ));
+cleanup_eligible_drain_assert(! is_wp_error($limited), 'pass-limit drain succeeds');
+cleanup_eligible_drain_assert('pass_limit' === $limited['summary']['stop_reason'], 'pass-limit stop reason');
+cleanup_eligible_drain_assert(2 === count($limit_ability->calls), 'pass-limit call count');
+
+$budget_ability = new CleanupEligibleDrainFakeAbility(
+	array(
+		array( 'processed' => 1, 'removed' => 1, 'remaining_total' => 10 ),
+		array( 'processed' => 1, 'removed' => 1, 'remaining_total' => 9 ),
+	)
+);
+$ticks        = array( 1000.0, 1000.0, 1002.0, 1002.0 );
+$orchestrator = new DataMachineCode\Workspace\WorkspaceCleanupEligibleDrainOrchestrator(
+	static fn() => $budget_ability,
+	static function () use ( &$ticks ): float {
+		return array_shift($ticks) ?? 1002.0;
+	},
+	$disk_reporter
+);
+$budget      = $orchestrator->run(array( 'apply' => true, 'passes' => 5, 'until_budget' => '1s' ));
+cleanup_eligible_drain_assert(! is_wp_error($budget), 'budget drain succeeds');
+cleanup_eligible_drain_assert('budget_exhausted' === $budget['summary']['stop_reason'], 'budget stop reason');
+cleanup_eligible_drain_assert(1 === count($budget_ability->calls), 'budget stops before second pass');
+
+$discard = $orchestrator->run(array( 'apply' => true, 'discard_unpushed' => true ));
+cleanup_eligible_drain_assert(is_wp_error($discard), 'discard unpushed refused');
+cleanup_eligible_drain_assert('cleanup_eligible_drain_refuses_unpushed_discard' === $discard->code, 'discard refusal code');
+
+fwrite(STDOUT, 'cleanup eligible drain smoke passed' . PHP_EOL);


### PR DESCRIPTION
## Summary
- Add a non-destructive-by-default cleanup-eligible drain operation for worktrees.
- Reuse the existing bounded cleanup-eligible apply primitive across repeated passes until empty, pass-limited, or budget-limited.
- Report per-pass evidence and final free space, while refusing the unpushed-commit discard mode.

## Tests
- php -l inc/Workspace/WorkspaceCleanupEligibleDrainOrchestrator.php
- php -l inc/Abilities/WorkspaceAbilities.php
- php -l inc/Cli/Commands/WorkspaceCommand.php
- for test in tests/*.php; do php "$test" || exit $?; done

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused cleanup drain orchestration, CLI/ability wiring, and smoke test coverage; Chris retains responsibility for review and verification.