### PR TITLE
Fix local worktree remove routing

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -4013,18 +4013,30 @@ class WorkspaceAbilities {
 	 * @return array
 	 */
 	public static function worktreeRemove( array $input ): array|\WP_Error {
+		$workspace = new Workspace();
+		$repo      = (string) ( $input['repo'] ?? '' );
+		$branch    = (string) ( $input['branch'] ?? '' );
+		$handle    = $repo . '@' . $workspace->slugify_branch($branch);
+
+		if ( RemoteWorkspaceBackend::should_handle() && null !== self::showLocalWorkspaceHandleIfPresent($workspace, $handle) ) {
+			return $workspace->worktree_remove(
+				$repo,
+				$branch,
+				! empty($input['force'])
+			);
+		}
+
 		if ( RemoteWorkspaceBackend::has_registered_state() && RemoteWorkspaceBackend::should_handle() ) {
 			$result = ( new RemoteWorkspaceBackend() )->worktree_remove(
-				$input['repo'] ?? '',
-				$input['branch'] ?? ''
+				$repo,
+				$branch
 			);
 			return self::decorate_remote_workspace_result('worktree_remove', $result);
 		}
 
-		$workspace = new Workspace();
 		return $workspace->worktree_remove(
-			$input['repo'] ?? '',
-			$input['branch'] ?? '',
+			$repo,
+			$branch,
 			! empty($input['force'])
 		);
 	}

--- a/tests/worktree-add-lifecycle.php
+++ b/tests/worktree-add-lifecycle.php
@@ -170,7 +170,9 @@ final class Datamachine_Code_Test_Wpdb {
 
 require_once dirname(__DIR__) . '/vendor/autoload.php';
 require_once dirname(__DIR__) . '/inc/Workspace/Workspace.php';
+require_once dirname(__DIR__) . '/inc/Abilities/WorkspaceAbilities.php';
 
+use DataMachineCode\Abilities\WorkspaceAbilities;
 use DataMachineCode\Workspace\Workspace;
 
 function run_command( string $command, ?string $cwd = null ): string {
@@ -242,6 +244,25 @@ try {
 	$list    = $workspace->worktree_list('homeboy', null, array( 'include_status' => false, 'include_disk' => false ));
 	$handles = array_map(static fn( array $row ): string => (string) $row['handle'], $list['worktrees'] ?? array());
 	assert_true(in_array('homeboy@audit-primitives-20260616', $handles, true), 'persisted worktree is not visible to worktree_list');
+
+	update_option(
+		'datamachine_code_remote_workspace_state',
+		array(
+			'repos' => array(
+				'other-repo' => array( 'repo' => 'owner/other-repo' ),
+			),
+		)
+	);
+	$removed = WorkspaceAbilities::worktreeRemove(
+		array(
+			'repo'   => 'homeboy',
+			'branch' => 'audit-primitives-20260616',
+			'force'  => true,
+		)
+	);
+	assert_true(! is_wp_error($removed), is_wp_error($removed) ? $removed->get_error_message() : 'worktreeRemove failed');
+	assert_true(! is_dir($workspace_root . '/homeboy@audit-primitives-20260616'), 'local worktree remove did not remove the fixture path');
+	assert_true(! isset($wpdb->rows['homeboy@audit-primitives-20260616']), 'local worktree remove did not delete inventory row');
 
 	$failure_wpdb = new Datamachine_Code_Test_Wpdb();
 	$failure_wpdb->fail_replace = true;


### PR DESCRIPTION
## Summary
- prefer the local filesystem worktree path when removing a handle that exists locally, even when remote workspace routing is active
- preserve remote backend removal for handles that are only registered in remote workspace state
- cover the split-brain case where list/finalize see a local worktree but remove previously routed to the remote backend

## Repro
`workspace worktree list wpcom-codebox --with-status --format=json` showed `wpcom-codebox@wire-auth-storage-state`, and `workspace worktree finalize wpcom-codebox@wire-auth-storage-state --state=merged` succeeded. But `workspace worktree remove wpcom-codebox@wire-auth-storage-state` failed with `Remote workspace worktree "wpcom-codebox@wire-auth-storage-state" is not registered.`

## Validation
- `php -l inc/Abilities/WorkspaceAbilities.php`
- `php -l tests/worktree-add-lifecycle.php`
- `composer dump-autoload && php tests/worktree-add-lifecycle.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the local/remote worktree removal routing bug, drafted the fix and focused regression coverage, and prepared the PR; Chris remains responsible for review and testing.