### PR TITLE
Fix mounted sandbox open_basedir probe

### DIFF
--- a/inc/Runtime/MountedSandboxBootstrap.php
+++ b/inc/Runtime/MountedSandboxBootstrap.php
@@ -68,9 +68,30 @@ final class MountedSandboxBootstrap {
 			return array( 'workspace_root' => $workspace_root );
 		}
 
-		return is_dir(self::DEFAULT_WORKSPACE_ROOT)
+		return self::path_allowed_by_open_basedir(self::DEFAULT_WORKSPACE_ROOT) && is_dir(self::DEFAULT_WORKSPACE_ROOT)
 			? array( 'workspace_root' => self::DEFAULT_WORKSPACE_ROOT )
 			: array();
+	}
+
+	private static function path_allowed_by_open_basedir( string $path ): bool {
+		$open_basedir = ini_get('open_basedir');
+		if ( false === $open_basedir || '' === $open_basedir ) {
+			return true;
+		}
+
+		$path = rtrim($path, '/');
+		foreach ( explode(PATH_SEPARATOR, $open_basedir) as $allowed_path ) {
+			$allowed_path = rtrim($allowed_path, '/');
+			if ( '' === $allowed_path ) {
+				continue;
+			}
+
+			if ( $path === $allowed_path || str_starts_with($path . '/', $allowed_path . '/') ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/** @param array<string,mixed> $context */

--- a/tests/mounted-sandbox-open-basedir.php
+++ b/tests/mounted-sandbox-open-basedir.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Regression test for native runtimes where /workspace is outside open_basedir.
+ */
+
+define('ABSPATH', __DIR__ . '/fixtures/wordpress/');
+require_once dirname(__DIR__) . '/inc/Runtime/MountedSandboxBootstrap.php';
+
+$warnings = array();
+set_error_handler(
+	static function (int $severity, string $message) use (&$warnings): bool {
+		if (str_contains($message, 'open_basedir')) {
+			$warnings[] = $message;
+		}
+
+		return true;
+	}
+);
+
+$method = new ReflectionMethod(DataMachineCode\Runtime\MountedSandboxBootstrap::class, 'discover_context');
+$method->setAccessible(true);
+$context = $method->invoke(null);
+
+restore_error_handler();
+
+if (array() !== $warnings) {
+	fwrite(STDERR, implode(PHP_EOL, $warnings) . PHP_EOL);
+	exit(1);
+}
+
+if (array() !== $context) {
+	fwrite(STDERR, 'Expected no mounted sandbox context when /workspace is outside open_basedir.' . PHP_EOL);
+	exit(1);
+}
+
+echo "Mounted sandbox open_basedir regression passed.\n";


### PR DESCRIPTION
## Summary
- Guard the default /workspace sandbox probe with an open_basedir allow-list check.
- Add a regression test that exercises mounted sandbox discovery while /workspace is outside open_basedir.

## Testing
- php -l inc/Runtime/MountedSandboxBootstrap.php
- php -l tests/mounted-sandbox-open-basedir.php
- php -d open_basedir="/Users/chubes/Developer/data-machine-code@fix-open-basedir-workspace-probe:/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T" tests/mounted-sandbox-open-basedir.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Studio open_basedir warning, drafted the focused DMC fix and regression test, and ran local verification. Chris requested the merge and remains responsible for the change.